### PR TITLE
Tools - file_read, file_write, directory_list

### DIFF
--- a/examples/directory_summary.yaml
+++ b/examples/directory_summary.yaml
@@ -1,0 +1,26 @@
+name: File Explorer Agent
+description: A single agent that can explore and read files from the filesystem.
+
+config:
+  default_provider: anthropic
+  log_level: info
+  cache_control: ephemeral
+  enabled_tools:
+    - file_read
+    - directory_list
+
+agents:
+  - name: File Explorer
+    role:
+      description: You are an expert file system explorer. You can read files and provide information about their contents. You help users understand file structures and content.
+      is_supervisor: false
+      accepts_chats: true
+    tools:
+      - file_read
+      - directory_list
+
+tasks:
+  - name: Explore Directory
+    description: Read the working directory and provide a summary of the contents.
+    assigned_agent: File Explorer
+    output_file: directory_summary.txt

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/getstingrai/dive
 go 1.23.2
 
 require (
+	github.com/bmatcuk/doublestar/v4 v4.8.1
 	github.com/dustinkirkland/golang-petname v0.0.0-20240428194347-eebcea082ee0
 	github.com/lmittmann/tint v1.0.7
 	github.com/mattn/go-isatty v0.0.20

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/bmatcuk/doublestar/v4 v4.8.1 h1:54Bopc5c2cAvhLRAzqOGCYHYyhcDHsFF4wWIR5wKP38=
+github.com/bmatcuk/doublestar/v4 v4.8.1/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dustinkirkland/golang-petname v0.0.0-20240428194347-eebcea082ee0 h1:aYo8nnk3ojoQkP5iErif5Xxv0Mo0Ga/FR5+ffl/7+Nk=

--- a/team_definitions.go
+++ b/team_definitions.go
@@ -353,6 +353,33 @@ func initializeTools(enabledTools []string, logger slogger.Logger) (map[string]l
 		}
 	}
 
+	if enabledToolsSet["file_read"] {
+		toolsMap["file_read"] = tools.NewFileReadTool(tools.FileReadToolOptions{
+			DefaultFilePath: "",
+			MaxSize:         1024 * 200,
+			RootDirectory:   "",
+		})
+		logger.Info("file_read enabled")
+	}
+
+	if enabledToolsSet["file_write"] {
+		toolsMap["file_write"] = tools.NewFileWriteTool(tools.FileWriteToolOptions{
+			DefaultFilePath: "",
+			AllowList:       []string{},
+			DenyList:        []string{},
+			RootDirectory:   "",
+		})
+		logger.Info("file_write enabled")
+	}
+
+	if enabledToolsSet["directory_list"] {
+		toolsMap["directory_list"] = tools.NewDirectoryListTool(tools.DirectoryListToolOptions{
+			DefaultPath:   "",
+			MaxEntries:    200,
+			RootDirectory: "",
+		})
+	}
+
 	// Add more tools here as needed
 
 	return toolsMap, nil

--- a/tools/directory_list.go
+++ b/tools/directory_list.go
@@ -1,0 +1,274 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/getstingrai/dive/llm"
+)
+
+const DefaultDirectoryListMaxEntries = 250
+
+type DirectoryListInput struct {
+	Path string `json:"path"`
+}
+
+type DirectoryEntry struct {
+	Name      string    `json:"name"`
+	Path      string    `json:"path"`
+	Size      int64     `json:"size"`
+	IsDir     bool      `json:"is_dir"`
+	Mode      string    `json:"mode"`
+	ModTime   time.Time `json:"mod_time"`
+	Extension string    `json:"extension,omitempty"`
+}
+
+type DirectoryListToolOptions struct {
+	DefaultPath   string
+	MaxEntries    int
+	RootDirectory string   // If set, all paths will be relative to this directory
+	AllowList     []string // Patterns of allowed paths
+	DenyList      []string // Patterns of denied paths
+}
+
+type DirectoryListTool struct {
+	defaultPath   string
+	maxEntries    int
+	rootDirectory string
+	allowList     []string
+	denyList      []string
+}
+
+// NewDirectoryListTool creates a new tool for listing directory contents
+func NewDirectoryListTool(options DirectoryListToolOptions) *DirectoryListTool {
+	maxEntries := options.MaxEntries
+	if maxEntries <= 0 {
+		maxEntries = DefaultDirectoryListMaxEntries
+	}
+
+	return &DirectoryListTool{
+		defaultPath:   options.DefaultPath,
+		maxEntries:    maxEntries,
+		rootDirectory: options.RootDirectory,
+		allowList:     options.AllowList,
+		denyList:      options.DenyList,
+	}
+}
+
+func (t *DirectoryListTool) Definition() *llm.ToolDefinition {
+	description := "A tool that lists the contents of a directory. To use this tool, provide a 'path' parameter with the path to the directory you want to list."
+
+	if t.defaultPath != "" {
+		description = fmt.Sprintf("A tool that lists the contents of a directory. The default directory is %s, but you can provide a different 'path' parameter to list another directory.", t.defaultPath)
+	}
+
+	if t.rootDirectory != "" {
+		description += fmt.Sprintf(" All paths are relative to %s.", t.rootDirectory)
+	}
+
+	if len(t.allowList) > 0 || len(t.denyList) > 0 {
+		description += " Directory paths are restricted based on configured allowlist and denylist patterns."
+	}
+
+	return &llm.ToolDefinition{
+		Name:        "ListDirectory",
+		Description: description,
+		Parameters: llm.Schema{
+			Type:     "object",
+			Required: []string{"path"},
+			Properties: map[string]*llm.SchemaProperty{
+				"path": {
+					Type:        "string",
+					Description: "Path to the directory to be listed",
+				},
+			},
+		},
+	}
+}
+
+// isPathAllowed checks if the given path is allowed based on allowList and denyList
+func (t *DirectoryListTool) isPathAllowed(path string) (bool, string) {
+	// Convert to absolute path for consistent checking
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return false, fmt.Sprintf("Error resolving absolute path: %s", err.Error())
+	}
+
+	// If denyList is specified, check against it first
+	if len(t.denyList) > 0 {
+		for _, pattern := range t.denyList {
+			matched, err := matchesPattern(absPath, pattern)
+			if err != nil {
+				return false, fmt.Sprintf("Error matching pattern '%s': %s", pattern, err.Error())
+			}
+			if matched {
+				return false, fmt.Sprintf("Path '%s' matches denied pattern '%s'", path, pattern)
+			}
+		}
+	}
+
+	// If allowList is specified, path must match at least one pattern
+	if len(t.allowList) > 0 {
+		allowed := false
+		for _, pattern := range t.allowList {
+			matched, err := matchesPattern(absPath, pattern)
+			if err != nil {
+				return false, fmt.Sprintf("Error matching pattern '%s': %s", pattern, err.Error())
+			}
+			if matched {
+				allowed = true
+				break
+			}
+		}
+		if !allowed {
+			return false, fmt.Sprintf("Path '%s' does not match any allowed patterns", path)
+		}
+	}
+
+	return true, ""
+}
+
+// resolvePath resolves the provided path, applying rootDirectory if configured
+// and preventing directory traversal attacks
+func (t *DirectoryListTool) resolvePath(path string) (string, error) {
+	if t.rootDirectory == "" {
+		// If no root directory is set, use the path as is
+		return path, nil
+	}
+
+	// Join the root directory and the provided path
+	resolvedPath := filepath.Join(t.rootDirectory, path)
+
+	// Get the absolute paths to check for directory traversal
+	absRoot, err := filepath.Abs(t.rootDirectory)
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve absolute path for root directory: %w", err)
+	}
+
+	absPath, err := filepath.Abs(resolvedPath)
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve absolute path: %w", err)
+	}
+
+	// Check if the resolved path is within the root directory
+	if !filepath.HasPrefix(absPath, absRoot) {
+		return "", fmt.Errorf("path attempts to access location outside of root directory")
+	}
+
+	return resolvedPath, nil
+}
+
+func (t *DirectoryListTool) Call(ctx context.Context, input string) (string, error) {
+	var params DirectoryListInput
+	if err := json.Unmarshal([]byte(input), &params); err != nil {
+		return "", err
+	}
+
+	dirPath := params.Path
+	if dirPath == "" {
+		dirPath = t.defaultPath
+	}
+
+	if dirPath == "" {
+		return "Error: No directory path provided. Please provide a directory path either in the constructor or as an argument.", nil
+	}
+
+	// Resolve the path (apply rootDirectory if configured)
+	resolvedPath, err := t.resolvePath(dirPath)
+	if err != nil {
+		return fmt.Sprintf("Error: %s", err.Error()), nil
+	}
+
+	// Check if the path is allowed
+	if len(t.allowList) > 0 || len(t.denyList) > 0 {
+		allowed, reason := t.isPathAllowed(resolvedPath)
+		if !allowed {
+			return fmt.Sprintf("Error: Access denied. %s", reason), nil
+		}
+	}
+
+	// Check if the directory exists
+	fileInfo, err := os.Stat(resolvedPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Sprintf("Error: Directory not found at path: %s", dirPath), nil
+		} else if os.IsPermission(err) {
+			return fmt.Sprintf("Error: Permission denied when trying to access directory: %s", dirPath), nil
+		}
+		return fmt.Sprintf("Error: Failed to access directory %s. %s", dirPath, err.Error()), nil
+	}
+
+	// Check if it's actually a directory
+	if !fileInfo.IsDir() {
+		return fmt.Sprintf("Error: Path %s is not a directory", dirPath), nil
+	}
+
+	// Read directory entries
+	entries, err := os.ReadDir(resolvedPath)
+	if err != nil {
+		return fmt.Sprintf("Error: Failed to read directory %s. %s", dirPath, err.Error()), nil
+	}
+
+	// Limit the number of entries to avoid overwhelming responses
+	if len(entries) > t.maxEntries {
+		entries = entries[:t.maxEntries]
+	}
+
+	// Convert to our structured format
+	result := make([]DirectoryEntry, 0, len(entries))
+	for _, entry := range entries {
+		info, err := entry.Info()
+		if err != nil {
+			continue // Skip entries we can't get info for
+		}
+
+		entryPath := filepath.Join(dirPath, entry.Name())
+
+		// For display purposes, use the path relative to rootDirectory if it was set
+		displayPath := entryPath
+		if t.rootDirectory != "" {
+			// Try to make the path relative to rootDirectory for display
+			relPath, err := filepath.Rel(t.rootDirectory, resolvedPath)
+			if err == nil {
+				displayPath = filepath.Join(relPath, entry.Name())
+			}
+		}
+
+		extension := ""
+		if !entry.IsDir() {
+			extension = filepath.Ext(entry.Name())
+		}
+
+		result = append(result, DirectoryEntry{
+			Name:      entry.Name(),
+			Path:      displayPath,
+			Size:      info.Size(),
+			IsDir:     entry.IsDir(),
+			Mode:      info.Mode().String(),
+			ModTime:   info.ModTime(),
+			Extension: extension,
+		})
+	}
+
+	// Convert to JSON for the response
+	jsonResult, err := json.MarshalIndent(result, "", "  ")
+	if err != nil {
+		return fmt.Sprintf("Error: Failed to format directory listing. %s", err.Error()), nil
+	}
+
+	// Add a message if we limited the entries
+	message := fmt.Sprintf("Directory listing for %s", dirPath)
+	if len(entries) == t.maxEntries {
+		message += fmt.Sprintf(" (limited to %d entries)", t.maxEntries)
+	}
+
+	return fmt.Sprintf("%s:\n\n%s", message, string(jsonResult)), nil
+}
+
+func (t *DirectoryListTool) ShouldReturnResult() bool {
+	return true
+}

--- a/tools/directory_list_test.go
+++ b/tools/directory_list_test.go
@@ -1,0 +1,288 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDirectoryListTool(t *testing.T) {
+	// Create a temporary directory for test files
+	tempDir, err := os.MkdirTemp("", "directory_list_test")
+	require.NoError(t, err, "Failed to create temp directory")
+	defer os.RemoveAll(tempDir)
+
+	// Create a test directory structure
+	subDir1 := filepath.Join(tempDir, "subdir1")
+	subDir2 := filepath.Join(tempDir, "subdir2")
+	hiddenDir := filepath.Join(tempDir, ".hidden")
+
+	require.NoError(t, os.Mkdir(subDir1, 0755), "Failed to create subdir1")
+	require.NoError(t, os.Mkdir(subDir2, 0755), "Failed to create subdir2")
+	require.NoError(t, os.Mkdir(hiddenDir, 0755), "Failed to create hidden dir")
+
+	// Create some test files
+	testFile1 := filepath.Join(tempDir, "test1.txt")
+	testFile2 := filepath.Join(subDir1, "test2.txt")
+	testFile3 := filepath.Join(subDir2, "test3.log")
+	hiddenFile := filepath.Join(tempDir, ".hidden_file")
+
+	require.NoError(t, os.WriteFile(testFile1, []byte("test content 1"), 0644), "Failed to create test file 1")
+	require.NoError(t, os.WriteFile(testFile2, []byte("test content 2"), 0644), "Failed to create test file 2")
+	require.NoError(t, os.WriteFile(testFile3, []byte("test content 3"), 0644), "Failed to create test file 3")
+	require.NoError(t, os.WriteFile(hiddenFile, []byte("hidden content"), 0644), "Failed to create hidden file")
+
+	t.Run("ListDirectoryWithDefaultPath", func(t *testing.T) {
+		tool := NewDirectoryListTool(DirectoryListToolOptions{
+			DefaultPath: tempDir,
+			MaxEntries:  100,
+		})
+
+		input := DirectoryListInput{
+			Path: "",
+		}
+		inputJSON, _ := json.Marshal(input)
+
+		result, err := tool.Call(context.Background(), string(inputJSON))
+		require.NoError(t, err, "Unexpected error")
+
+		// Check that the result contains all expected entries
+		require.Contains(t, result, "subdir1")
+		require.Contains(t, result, "subdir2")
+		require.Contains(t, result, ".hidden")
+		require.Contains(t, result, "test1.txt")
+		require.Contains(t, result, ".hidden_file")
+	})
+
+	t.Run("ListDirectoryWithExplicitPath", func(t *testing.T) {
+		tool := NewDirectoryListTool(DirectoryListToolOptions{
+			MaxEntries: 100,
+		})
+
+		input := DirectoryListInput{
+			Path: subDir1,
+		}
+		inputJSON, _ := json.Marshal(input)
+
+		result, err := tool.Call(context.Background(), string(inputJSON))
+		require.NoError(t, err, "Unexpected error")
+
+		// Check that the result contains only the expected entry
+		require.Contains(t, result, "test2.txt")
+		require.NotContains(t, result, "test1.txt")
+		require.NotContains(t, result, "test3.log")
+	})
+
+	t.Run("ListNonExistentDirectory", func(t *testing.T) {
+		tool := NewDirectoryListTool(DirectoryListToolOptions{
+			MaxEntries: 100,
+		})
+
+		input := DirectoryListInput{
+			Path: filepath.Join(tempDir, "nonexistent"),
+		}
+		inputJSON, _ := json.Marshal(input)
+
+		result, err := tool.Call(context.Background(), string(inputJSON))
+		require.NoError(t, err, "Expected error to be returned in result, not as an error")
+		require.Contains(t, result, "Error: Directory not found")
+	})
+
+	t.Run("ListDirectoryWithMaxEntries", func(t *testing.T) {
+		// Create many files to test MaxEntries
+		manyFilesDir := filepath.Join(tempDir, "many_files")
+		require.NoError(t, os.Mkdir(manyFilesDir, 0755), "Failed to create many_files dir")
+
+		for i := 0; i < 10; i++ {
+			filename := filepath.Join(manyFilesDir, fmt.Sprintf("file%d.txt", i))
+			require.NoError(t, os.WriteFile(filename, []byte("content"), 0644), "Failed to create file")
+		}
+
+		tool := NewDirectoryListTool(DirectoryListToolOptions{
+			MaxEntries: 5,
+		})
+
+		input := DirectoryListInput{
+			Path: manyFilesDir,
+		}
+		inputJSON, _ := json.Marshal(input)
+
+		result, err := tool.Call(context.Background(), string(inputJSON))
+		require.NoError(t, err, "Unexpected error")
+
+		// Check that the result mentions the limit
+		require.Contains(t, result, "limited to 5 entries")
+
+		// Count the number of entries in the JSON response
+		var entries []DirectoryEntry
+		jsonStart := strings.Index(result, "[")
+		jsonEnd := strings.LastIndex(result, "]") + 1
+		require.NoError(t, json.Unmarshal([]byte(result[jsonStart:jsonEnd]), &entries))
+		require.Len(t, entries, 5, "Expected exactly 5 entries due to MaxEntries limit")
+	})
+
+	t.Run("ListDirectoryWithRootDirectory", func(t *testing.T) {
+		tool := NewDirectoryListTool(DirectoryListToolOptions{
+			RootDirectory: tempDir,
+			MaxEntries:    100,
+		})
+
+		input := DirectoryListInput{
+			Path: "subdir1",
+		}
+		inputJSON, _ := json.Marshal(input)
+
+		result, err := tool.Call(context.Background(), string(inputJSON))
+		require.NoError(t, err, "Unexpected error")
+
+		// Check that the result contains the expected entry
+		require.Contains(t, result, "test2.txt")
+
+		// Check that the path is relative to the root directory
+		var entries []DirectoryEntry
+		jsonStart := strings.Index(result, "[")
+		jsonEnd := strings.LastIndex(result, "]") + 1
+		require.NoError(t, json.Unmarshal([]byte(result[jsonStart:jsonEnd]), &entries))
+
+		for _, entry := range entries {
+			require.Equal(t, "subdir1/test2.txt", entry.Path)
+		}
+	})
+
+	t.Run("ListDirectoryWithAllowList", func(t *testing.T) {
+		// Get absolute path for the allow list pattern
+		absSubDir1, err := filepath.Abs(subDir1)
+		require.NoError(t, err, "Failed to get absolute path")
+
+		tool := NewDirectoryListTool(DirectoryListToolOptions{
+			MaxEntries: 100,
+			AllowList:  []string{absSubDir1},
+		})
+
+		// This should be allowed
+		input1 := DirectoryListInput{
+			Path: subDir1,
+		}
+		inputJSON1, _ := json.Marshal(input1)
+
+		result1, err := tool.Call(context.Background(), string(inputJSON1))
+		require.NoError(t, err, "Unexpected error")
+		require.Contains(t, result1, "test2.txt")
+
+		// This should be denied
+		input2 := DirectoryListInput{
+			Path: subDir2,
+		}
+		inputJSON2, _ := json.Marshal(input2)
+
+		result2, err := tool.Call(context.Background(), string(inputJSON2))
+		require.NoError(t, err, "Expected error to be returned in result, not as an error")
+		require.Contains(t, result2, "Access denied")
+	})
+
+	t.Run("ListDirectoryWithDenyList", func(t *testing.T) {
+		tool := NewDirectoryListTool(DirectoryListToolOptions{
+			MaxEntries: 100,
+			DenyList:   []string{filepath.Join(tempDir, "**/.hidden*")},
+		})
+
+		// This should be allowed
+		input1 := DirectoryListInput{
+			Path: subDir1,
+		}
+		inputJSON1, _ := json.Marshal(input1)
+
+		result1, err := tool.Call(context.Background(), string(inputJSON1))
+		require.NoError(t, err, "Unexpected error")
+		require.Contains(t, result1, "test2.txt")
+
+		// This should be denied
+		input2 := DirectoryListInput{
+			Path: hiddenDir,
+		}
+		inputJSON2, _ := json.Marshal(input2)
+
+		result2, err := tool.Call(context.Background(), string(inputJSON2))
+		require.NoError(t, err, "Expected error to be returned in result, not as an error")
+		require.Contains(t, result2, "Access denied")
+	})
+
+	t.Run("InvalidJSON", func(t *testing.T) {
+		tool := NewDirectoryListTool(DirectoryListToolOptions{
+			MaxEntries: 100,
+		})
+
+		_, err := tool.Call(context.Background(), "{invalid json")
+		require.Error(t, err, "Expected error for invalid JSON")
+	})
+
+	t.Run("ToolDefinition", func(t *testing.T) {
+		tool := NewDirectoryListTool(DirectoryListToolOptions{
+			DefaultPath:   "/default/path",
+			RootDirectory: "/root/dir",
+			AllowList:     []string{"/allowed/*"},
+			DenyList:      []string{"/denied/*"},
+		})
+
+		def := tool.Definition()
+		require.Equal(t, "ListDirectory", def.Name)
+		require.Contains(t, def.Description, "/default/path")
+		require.Contains(t, def.Description, "/root/dir")
+		require.Contains(t, def.Description, "restricted based on configured allowlist and denylist patterns")
+		require.Equal(t, "path", def.Parameters.Required[0])
+	})
+
+	t.Run("ShouldReturnResult", func(t *testing.T) {
+		tool := NewDirectoryListTool(DirectoryListToolOptions{})
+		require.True(t, tool.ShouldReturnResult())
+	})
+}
+
+func TestDirectoryEntryFields(t *testing.T) {
+	// Create a temporary directory and file
+	tempDir, err := os.MkdirTemp("", "directory_entry_test")
+	require.NoError(t, err, "Failed to create temp directory")
+	defer os.RemoveAll(tempDir)
+
+	testFile := filepath.Join(tempDir, "test.txt")
+	require.NoError(t, os.WriteFile(testFile, []byte("test content"), 0644), "Failed to create test file")
+
+	// Create a tool and list the directory
+	tool := NewDirectoryListTool(DirectoryListToolOptions{
+		MaxEntries: 100,
+	})
+
+	input := DirectoryListInput{
+		Path: tempDir,
+	}
+	inputJSON, _ := json.Marshal(input)
+
+	result, err := tool.Call(context.Background(), string(inputJSON))
+	require.NoError(t, err, "Unexpected error")
+
+	// Parse the JSON response
+	var entries []DirectoryEntry
+	jsonStart := strings.Index(result, "[")
+	jsonEnd := strings.LastIndex(result, "]") + 1
+	require.NoError(t, json.Unmarshal([]byte(result[jsonStart:jsonEnd]), &entries))
+
+	// Verify that we have one entry for the test file
+	require.Len(t, entries, 1, "Expected one entry")
+	entry := entries[0]
+
+	// Check all fields
+	require.Equal(t, "test.txt", entry.Name)
+	require.Equal(t, filepath.Join(tempDir, "test.txt"), entry.Path)
+	require.Equal(t, int64(12), entry.Size) // "test content" is 12 bytes
+	require.False(t, entry.IsDir)
+	require.Contains(t, entry.Mode, "rw")
+	require.WithinDuration(t, time.Now(), entry.ModTime, 5*time.Second)
+	require.Equal(t, ".txt", entry.Extension)
+}

--- a/tools/file_read.go
+++ b/tools/file_read.go
@@ -1,31 +1,43 @@
 package tools
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/getstingrai/dive/llm"
 )
+
+const DefaultFileReadMaxSize = 1024 * 200 // 200KB
 
 type FileReadInput struct {
 	Path string `json:"path"`
 }
 
+type FileReadToolOptions struct {
+	DefaultFilePath string
+	MaxSize         int
+	RootDirectory   string
+}
+
 type FileReadTool struct {
 	defaultFilePath string
 	maxSize         int
+	rootDirectory   string
 }
 
 // NewFileReadTool creates a new tool for reading file contents
-func NewFileReadTool(defaultFilePath string, maxSize int) *FileReadTool {
-	if maxSize <= 0 {
-		maxSize = 10000
+func NewFileReadTool(options FileReadToolOptions) *FileReadTool {
+	if options.MaxSize <= 0 {
+		options.MaxSize = DefaultFileReadMaxSize
 	}
 	return &FileReadTool{
-		defaultFilePath: defaultFilePath,
-		maxSize:         maxSize,
+		defaultFilePath: options.DefaultFilePath,
+		maxSize:         options.MaxSize,
+		rootDirectory:   options.RootDirectory,
 	}
 }
 
@@ -34,6 +46,10 @@ func (t *FileReadTool) Definition() *llm.ToolDefinition {
 
 	if t.defaultFilePath != "" {
 		description = fmt.Sprintf("A tool that reads file content. The default file is %s, but you can provide a different 'path' parameter to read another file.", t.defaultFilePath)
+	}
+
+	if t.rootDirectory != "" {
+		description += fmt.Sprintf(" All paths are relative to %s.", t.rootDirectory)
 	}
 
 	return &llm.ToolDefinition{
@@ -52,6 +68,36 @@ func (t *FileReadTool) Definition() *llm.ToolDefinition {
 	}
 }
 
+// resolvePath resolves the provided path, applying rootDirectory if configured
+// and preventing directory traversal attacks
+func (t *FileReadTool) resolvePath(path string) (string, error) {
+	if t.rootDirectory == "" {
+		// If no root directory is set, use the path as is
+		return path, nil
+	}
+
+	// Join the root directory and the provided path
+	resolvedPath := filepath.Join(t.rootDirectory, path)
+
+	// Get the absolute paths to check for directory traversal
+	absRoot, err := filepath.Abs(t.rootDirectory)
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve absolute path for root directory: %w", err)
+	}
+
+	absPath, err := filepath.Abs(resolvedPath)
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve absolute path: %w", err)
+	}
+
+	// Check if the resolved path is within the root directory
+	if !filepath.HasPrefix(absPath, absRoot) {
+		return "", fmt.Errorf("path attempts to access location outside of root directory")
+	}
+
+	return resolvedPath, nil
+}
+
 func (t *FileReadTool) Call(ctx context.Context, input string) (string, error) {
 	var params FileReadInput
 	if err := json.Unmarshal([]byte(input), &params); err != nil {
@@ -67,23 +113,69 @@ func (t *FileReadTool) Call(ctx context.Context, input string) (string, error) {
 		return "Error: No file path provided. Please provide a file path either in the constructor or as an argument.", nil
 	}
 
-	content, err := os.ReadFile(filePath)
+	// Resolve the path (apply rootDirectory if configured)
+	resolvedPath, err := t.resolvePath(filePath)
+	if err != nil {
+		return fmt.Sprintf("Error: %s", err.Error()), nil
+	}
+
+	// Get file info to check size before reading
+	fileInfo, err := os.Stat(resolvedPath)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return fmt.Sprintf("Error: File not found at path: %s", filePath), nil
 		} else if os.IsPermission(err) {
-			return fmt.Sprintf("Error: Permission denied when trying to read file: %s", filePath), nil
+			return fmt.Sprintf("Error: Permission denied when trying to access file: %s", filePath), nil
 		}
+		return fmt.Sprintf("Error: Failed to access file %s. %s", filePath, err.Error()), nil
+	}
+
+	// Check if file size exceeds the maximum size before reading it
+	if fileInfo.Size() > int64(t.maxSize) {
+		return fmt.Sprintf("Error: File %s is too large (%d bytes). Maximum allowed size is %d bytes.", filePath, fileInfo.Size(), t.maxSize), nil
+	}
+
+	// Now that we know the file is not too large, read its content
+	content, err := os.ReadFile(resolvedPath)
+	if err != nil {
 		return fmt.Sprintf("Error: Failed to read file %s. %s", filePath, err.Error()), nil
 	}
 
-	// Truncate content if it exceeds the maximum size
-	result := string(content)
-	if len(result) > t.maxSize {
-		result = result[:t.maxSize] + " ..."
+	// Check if the file appears to be binary
+	if isBinaryContent(content) {
+		return fmt.Sprintf("Warning: File %s appears to be a binary file. The content may not display correctly:\n\n%s",
+			filePath, string(content)), nil
 	}
 
-	return result, nil
+	return string(content), nil
+}
+
+// isBinaryContent attempts to determine if the content is binary by checking for null bytes
+// and examining the ratio of control characters to printable characters
+func isBinaryContent(content []byte) bool {
+	// Quick check: if there are null bytes, it's likely binary
+	if bytes.Contains(content, []byte{0}) {
+		return true
+	}
+
+	// Check a sample of the file (up to first 512 bytes)
+	sampleSize := 512
+	if len(content) < sampleSize {
+		sampleSize = len(content)
+	}
+
+	sample := content[:sampleSize]
+	controlCount := 0
+
+	for _, b := range sample {
+		// Count control characters (except common whitespace)
+		if (b < 32 && b != 9 && b != 10 && b != 13) || b > 126 {
+			controlCount++
+		}
+	}
+
+	// If more than 10% are control characters, likely binary
+	return controlCount > sampleSize/10
 }
 
 func (t *FileReadTool) ShouldReturnResult() bool {

--- a/tools/file_tools_test.go
+++ b/tools/file_tools_test.go
@@ -1,0 +1,542 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestFileReadTool(t *testing.T) {
+	// Create a temporary directory for test files
+	tempDir, err := os.MkdirTemp("", "file_read_test")
+	require.NoError(t, err, "Failed to create temp directory")
+	defer os.RemoveAll(tempDir)
+
+	// Create a test file
+	testContent := "This is test content for FileReadTool"
+	testFilePath := filepath.Join(tempDir, "test_read.txt")
+	err = os.WriteFile(testFilePath, []byte(testContent), 0644)
+	require.NoError(t, err, "Failed to create test file")
+
+	// Create a large test file
+	largeContent := strings.Repeat("Large content line\n", 1000)
+	largeFilePath := filepath.Join(tempDir, "large_test.txt")
+	err = os.WriteFile(largeFilePath, []byte(largeContent), 0644)
+	require.NoError(t, err, "Failed to create large test file")
+
+	t.Run("ReadExistingFile", func(t *testing.T) {
+		tool := NewFileReadTool(FileReadToolOptions{
+			MaxSize: 10000,
+		})
+		input := FileReadInput{
+			Path: testFilePath,
+		}
+		inputJSON, _ := json.Marshal(input)
+
+		result, err := tool.Call(context.Background(), string(inputJSON))
+
+		require.NoError(t, err, "Unexpected error")
+		require.Equal(t, testContent, result, "Content mismatch")
+	})
+
+	t.Run("ReadWithDefaultPath", func(t *testing.T) {
+		tool := NewFileReadTool(FileReadToolOptions{
+			DefaultFilePath: testFilePath,
+			MaxSize:         10000,
+		})
+		input := FileReadInput{
+			Path: "",
+		}
+		inputJSON, _ := json.Marshal(input)
+
+		result, err := tool.Call(context.Background(), string(inputJSON))
+
+		require.NoError(t, err, "Unexpected error")
+		require.Equal(t, testContent, result, "Content mismatch")
+	})
+
+	t.Run("ReadNonExistentFile", func(t *testing.T) {
+		tool := NewFileReadTool(FileReadToolOptions{
+			MaxSize: 10000,
+		})
+		input := FileReadInput{
+			Path: filepath.Join(tempDir, "nonexistent.txt"),
+		}
+		inputJSON, _ := json.Marshal(input)
+
+		result, err := tool.Call(context.Background(), string(inputJSON))
+
+		require.NoError(t, err, "Unexpected error")
+		require.Contains(t, result, "Error: File not found", "Expected 'file not found' error")
+	})
+
+	t.Run("ReadLargeFileTruncated", func(t *testing.T) {
+		maxSize := 100
+		tool := NewFileReadTool(FileReadToolOptions{
+			MaxSize: maxSize,
+		})
+		input := FileReadInput{
+			Path: largeFilePath,
+		}
+		inputJSON, _ := json.Marshal(input)
+
+		result, err := tool.Call(context.Background(), string(inputJSON))
+
+		require.NoError(t, err, "Unexpected error")
+		require.Contains(t, result, "Error: File", "Expected error about file size")
+		require.Contains(t, result, "is too large", "Expected error about file size")
+	})
+
+	t.Run("InvalidJSON", func(t *testing.T) {
+		tool := NewFileReadTool(FileReadToolOptions{
+			MaxSize: 10000,
+		})
+
+		_, err := tool.Call(context.Background(), "{invalid json")
+
+		require.Error(t, err, "Expected error for invalid JSON")
+	})
+
+	t.Run("NoPathProvided", func(t *testing.T) {
+		tool := NewFileReadTool(FileReadToolOptions{
+			MaxSize: 10000,
+		})
+		input := FileReadInput{
+			Path: "",
+		}
+		inputJSON, _ := json.Marshal(input)
+
+		result, err := tool.Call(context.Background(), string(inputJSON))
+
+		require.NoError(t, err, "Unexpected error")
+		require.Contains(t, result, "Error: No file path provided", "Expected 'no file path provided' error")
+	})
+
+	t.Run("ToolDefinition", func(t *testing.T) {
+		tool := NewFileReadTool(FileReadToolOptions{
+			DefaultFilePath: "default.txt",
+			MaxSize:         10000,
+		})
+		def := tool.Definition()
+
+		require.Equal(t, "ReadFile", def.Name, "Tool name mismatch")
+		require.Contains(t, def.Description, "default.txt", "Description should contain default file path")
+	})
+
+	t.Run("RootDirectoryBehavior", func(t *testing.T) {
+		// Create a subdirectory for testing root directory behavior
+		rootDir := filepath.Join(tempDir, "root")
+		require.NoError(t, os.MkdirAll(rootDir, 0755), "Failed to create root directory")
+
+		// Create a test file inside the root directory
+		rootFileContent := "This is a file inside the root directory"
+		rootFilePath := "test_in_root.txt"
+		fullRootFilePath := filepath.Join(rootDir, rootFilePath)
+		require.NoError(t, os.WriteFile(fullRootFilePath, []byte(rootFileContent), 0644), "Failed to create test file in root")
+
+		// Test reading a file inside the root directory
+		tool := NewFileReadTool(FileReadToolOptions{
+			RootDirectory: rootDir,
+			MaxSize:       10000,
+		})
+		input := FileReadInput{
+			Path: rootFilePath, // Only the relative path
+		}
+		inputJSON, _ := json.Marshal(input)
+
+		result, err := tool.Call(context.Background(), string(inputJSON))
+		require.NoError(t, err, "Unexpected error")
+		require.Equal(t, rootFileContent, result, "Content mismatch")
+
+		// Test attempting to read a file outside the root directory
+		input = FileReadInput{
+			Path: "../test_read.txt", // Try to access parent directory
+		}
+		inputJSON, _ = json.Marshal(input)
+
+		result, err = tool.Call(context.Background(), string(inputJSON))
+		require.NoError(t, err, "Unexpected error")
+		require.Contains(t, result, "Error:", "Expected error for path outside root")
+		require.Contains(t, result, "outside of root directory", "Expected error about path outside root")
+	})
+}
+
+func TestFileWriteTool(t *testing.T) {
+	// Create a temporary directory for test files
+	tempDir, err := os.MkdirTemp("", "file_write_test")
+	require.NoError(t, err, "Failed to create temp directory")
+	defer os.RemoveAll(tempDir)
+
+	// Create subdirectories for testing
+	allowedDir := filepath.Join(tempDir, "allowed")
+	deniedDir := filepath.Join(tempDir, "denied")
+	nestedDir := filepath.Join(allowedDir, "nested")
+
+	for _, dir := range []string{allowedDir, deniedDir, nestedDir} {
+		require.NoError(t, os.MkdirAll(dir, 0755), "Failed to create directory")
+	}
+
+	t.Run("WriteToNewFile", func(t *testing.T) {
+		tool := NewFileWriteTool(FileWriteToolOptions{})
+		testFilePath := filepath.Join(tempDir, "test_write.txt")
+		testContent := "This is test content for FileWriteTool"
+
+		input := FileWriteInput{
+			Path:    testFilePath,
+			Content: testContent,
+		}
+		inputJSON, _ := json.Marshal(input)
+
+		result, err := tool.Call(context.Background(), string(inputJSON))
+
+		require.NoError(t, err, "Unexpected error")
+		require.Contains(t, result, "Successfully wrote", "Expected success message")
+
+		// Verify file was created with correct content
+		content, err := os.ReadFile(testFilePath)
+		require.NoError(t, err, "Failed to read written file")
+		require.Equal(t, testContent, string(content), "Content mismatch")
+	})
+
+	t.Run("WriteWithDefaultPath", func(t *testing.T) {
+		defaultPath := filepath.Join(tempDir, "default_write.txt")
+		tool := NewFileWriteTool(FileWriteToolOptions{
+			DefaultFilePath: defaultPath,
+		})
+		testContent := "This is default path content"
+
+		input := FileWriteInput{
+			Path:    "",
+			Content: testContent,
+		}
+		inputJSON, _ := json.Marshal(input)
+
+		result, err := tool.Call(context.Background(), string(inputJSON))
+
+		require.NoError(t, err, "Unexpected error")
+		require.Contains(t, result, "Successfully wrote", "Expected success message")
+
+		// Verify file was created with correct content
+		content, err := os.ReadFile(defaultPath)
+		require.NoError(t, err, "Failed to read written file")
+		require.Equal(t, testContent, string(content), "Content mismatch")
+	})
+
+	t.Run("WriteToNonExistentDirectory", func(t *testing.T) {
+		tool := NewFileWriteTool(FileWriteToolOptions{})
+		testFilePath := filepath.Join(tempDir, "new_dir", "test_write.txt")
+		testContent := "This should create the directory"
+
+		input := FileWriteInput{
+			Path:    testFilePath,
+			Content: testContent,
+		}
+		inputJSON, _ := json.Marshal(input)
+
+		result, err := tool.Call(context.Background(), string(inputJSON))
+
+		require.NoError(t, err, "Unexpected error")
+		require.Contains(t, result, "Successfully wrote", "Expected success message")
+
+		// Verify file was created with correct content
+		content, err := os.ReadFile(testFilePath)
+		require.NoError(t, err, "Failed to read written file")
+		require.Equal(t, testContent, string(content), "Content mismatch")
+	})
+
+	t.Run("NoPathProvided", func(t *testing.T) {
+		tool := NewFileWriteTool(FileWriteToolOptions{})
+		input := FileWriteInput{
+			Path:    "",
+			Content: "Some content",
+		}
+		inputJSON, _ := json.Marshal(input)
+
+		result, err := tool.Call(context.Background(), string(inputJSON))
+
+		require.NoError(t, err, "Unexpected error")
+		require.Contains(t, result, "Error: No file path provided", "Expected 'no file path provided' error")
+	})
+
+	t.Run("InvalidJSON", func(t *testing.T) {
+		tool := NewFileWriteTool(FileWriteToolOptions{})
+
+		_, err := tool.Call(context.Background(), "{invalid json")
+
+		require.Error(t, err, "Expected error for invalid JSON")
+	})
+
+	t.Run("AllowlistExactMatch", func(t *testing.T) {
+		allowedPath := filepath.Join(allowedDir, "allowed.txt")
+		deniedPath := filepath.Join(deniedDir, "denied.txt")
+
+		tool := NewFileWriteTool(FileWriteToolOptions{
+			AllowList: []string{allowedPath},
+		})
+		testContent := "This should be allowed"
+
+		// Test allowed path
+		input := FileWriteInput{
+			Path:    allowedPath,
+			Content: testContent,
+		}
+		inputJSON, _ := json.Marshal(input)
+
+		result, err := tool.Call(context.Background(), string(inputJSON))
+
+		require.NoError(t, err, "Unexpected error")
+		require.Contains(t, result, "Successfully wrote", "Expected success message")
+
+		// Test denied path
+		input = FileWriteInput{
+			Path:    deniedPath,
+			Content: testContent,
+		}
+		inputJSON, _ = json.Marshal(input)
+
+		result, err = tool.Call(context.Background(), string(inputJSON))
+
+		require.NoError(t, err, "Unexpected error")
+		require.Contains(t, result, "Error: Access denied", "Expected access denied error")
+	})
+
+	t.Run("DenylistExactMatch", func(t *testing.T) {
+		allowedPath := filepath.Join(allowedDir, "allowed.txt")
+		deniedPath := filepath.Join(deniedDir, "denied.txt")
+
+		tool := NewFileWriteTool(FileWriteToolOptions{
+			DenyList: []string{deniedPath},
+		})
+		testContent := "This should be denied"
+
+		// Test allowed path
+		input := FileWriteInput{
+			Path:    allowedPath,
+			Content: testContent,
+		}
+		inputJSON, _ := json.Marshal(input)
+
+		result, err := tool.Call(context.Background(), string(inputJSON))
+
+		require.NoError(t, err, "Unexpected error")
+		require.Contains(t, result, "Successfully wrote", "Expected success message")
+
+		// Test denied path
+		input = FileWriteInput{
+			Path:    deniedPath,
+			Content: testContent,
+		}
+		inputJSON, _ = json.Marshal(input)
+
+		result, err = tool.Call(context.Background(), string(inputJSON))
+
+		require.NoError(t, err, "Unexpected error")
+		require.Contains(t, result, "Error: Access denied", "Expected access denied error")
+	})
+
+	t.Run("AllowlistWildcard", func(t *testing.T) {
+		// Test with * wildcard
+		tool := NewFileWriteTool(FileWriteToolOptions{
+			AllowList: []string{filepath.Join(allowedDir, "*.txt")},
+		})
+		testContent := "Testing wildcard"
+
+		// Should be allowed
+		allowedPath := filepath.Join(allowedDir, "wildcard.txt")
+		input := FileWriteInput{
+			Path:    allowedPath,
+			Content: testContent,
+		}
+		inputJSON, _ := json.Marshal(input)
+
+		result, err := tool.Call(context.Background(), string(inputJSON))
+
+		require.NoError(t, err, "Unexpected error")
+		require.Contains(t, result, "Successfully wrote", "Expected success message")
+
+		// Should be denied (wrong extension)
+		deniedPath := filepath.Join(allowedDir, "wildcard.json")
+		input = FileWriteInput{
+			Path:    deniedPath,
+			Content: testContent,
+		}
+		inputJSON, _ = json.Marshal(input)
+
+		result, err = tool.Call(context.Background(), string(inputJSON))
+
+		require.NoError(t, err, "Unexpected error")
+		require.Contains(t, result, "Error: Access denied", "Expected access denied error")
+	})
+
+	t.Run("AllowlistDoubleWildcard", func(t *testing.T) {
+		// Test with ** wildcard
+		tool := NewFileWriteTool(FileWriteToolOptions{
+			AllowList: []string{filepath.Join(allowedDir, "**")},
+		})
+		testContent := "Testing double wildcard"
+
+		// Should be allowed (in allowed dir)
+		allowedPath := filepath.Join(allowedDir, "double_wildcard.txt")
+		input := FileWriteInput{
+			Path:    allowedPath,
+			Content: testContent,
+		}
+		inputJSON, _ := json.Marshal(input)
+
+		result, err := tool.Call(context.Background(), string(inputJSON))
+
+		require.NoError(t, err, "Unexpected error")
+		require.Contains(t, result, "Successfully wrote", "Expected success message")
+
+		// Should be allowed (in nested dir)
+		nestedPath := filepath.Join(nestedDir, "nested_wildcard.txt")
+		input = FileWriteInput{
+			Path:    nestedPath,
+			Content: testContent,
+		}
+		inputJSON, _ = json.Marshal(input)
+
+		result, err = tool.Call(context.Background(), string(inputJSON))
+
+		require.NoError(t, err, "Unexpected error")
+		require.Contains(t, result, "Successfully wrote", "Expected success message")
+
+		// Should be denied (outside allowed dir)
+		deniedPath := filepath.Join(deniedDir, "outside_wildcard.txt")
+		input = FileWriteInput{
+			Path:    deniedPath,
+			Content: testContent,
+		}
+		inputJSON, _ = json.Marshal(input)
+
+		result, err = tool.Call(context.Background(), string(inputJSON))
+
+		require.NoError(t, err, "Unexpected error")
+		require.Contains(t, result, "Error: Access denied", "Expected access denied error")
+	})
+
+	t.Run("DenylistOverridesAllowlist", func(t *testing.T) {
+		// Allow all files in allowed dir, but deny specific file
+		specificPath := filepath.Join(allowedDir, "specific.txt")
+		tool := NewFileWriteTool(FileWriteToolOptions{
+			AllowList: []string{filepath.Join(allowedDir, "**")},
+			DenyList:  []string{specificPath},
+		})
+		testContent := "Testing deny override"
+
+		// Should be allowed (in allowed dir)
+		allowedPath := filepath.Join(allowedDir, "not_denied.txt")
+		input := FileWriteInput{
+			Path:    allowedPath,
+			Content: testContent,
+		}
+		inputJSON, _ := json.Marshal(input)
+
+		result, err := tool.Call(context.Background(), string(inputJSON))
+
+		require.NoError(t, err, "Unexpected error")
+		require.Contains(t, result, "Successfully wrote", "Expected success message")
+
+		// Should be denied (specifically denied)
+		input = FileWriteInput{
+			Path:    specificPath,
+			Content: testContent,
+		}
+		inputJSON, _ = json.Marshal(input)
+
+		result, err = tool.Call(context.Background(), string(inputJSON))
+
+		require.NoError(t, err, "Unexpected error")
+		require.Contains(t, result, "Error: Access denied", "Expected access denied error")
+	})
+
+	t.Run("ToolDefinition", func(t *testing.T) {
+		tool := NewFileWriteTool(FileWriteToolOptions{
+			DefaultFilePath: "default.txt",
+			AllowList:       []string{"/allowed/**"},
+			DenyList:        []string{"/denied/**"},
+		})
+		def := tool.Definition()
+
+		require.Equal(t, "WriteFile", def.Name, "Tool name mismatch")
+		require.Contains(t, def.Description, "default.txt", "Description should contain default file path")
+		require.Contains(t, def.Description, "restricted", "Description should mention path restrictions")
+	})
+
+	t.Run("RootDirectoryBehavior", func(t *testing.T) {
+		// Create a subdirectory for testing root directory behavior
+		rootDir := filepath.Join(tempDir, "write_root")
+		require.NoError(t, os.MkdirAll(rootDir, 0755), "Failed to create root directory")
+
+		// Test writing a file inside the root directory
+		tool := NewFileWriteTool(FileWriteToolOptions{
+			RootDirectory: rootDir,
+		})
+
+		// Write to a file using a relative path
+		relativeFilePath := "test_in_root.txt"
+		testContent := "This is a file inside the root directory"
+
+		input := FileWriteInput{
+			Path:    relativeFilePath,
+			Content: testContent,
+		}
+		inputJSON, _ := json.Marshal(input)
+
+		result, err := tool.Call(context.Background(), string(inputJSON))
+		require.NoError(t, err, "Unexpected error")
+		require.Contains(t, result, "Successfully wrote", "Expected success message")
+
+		// Verify the file was created in the root directory
+		fullPath := filepath.Join(rootDir, relativeFilePath)
+		content, err := os.ReadFile(fullPath)
+		require.NoError(t, err, "Failed to read written file")
+		require.Equal(t, testContent, string(content), "Content mismatch")
+
+		// Test attempting to write a file outside the root directory
+		input = FileWriteInput{
+			Path:    "../outside_root.txt", // Try to access parent directory
+			Content: "This should be denied",
+		}
+		inputJSON, _ = json.Marshal(input)
+
+		result, err = tool.Call(context.Background(), string(inputJSON))
+		require.NoError(t, err, "Unexpected error")
+		require.Contains(t, result, "Error:", "Expected error for path outside root")
+		require.Contains(t, result, "outside of root directory", "Expected error about path outside root")
+	})
+}
+
+func TestMatchesPattern(t *testing.T) {
+	tests := []struct {
+		name     string
+		path     string
+		pattern  string
+		expected bool
+	}{
+		{"ExactMatch", "/path/to/file.txt", "/path/to/file.txt", true},
+		{"ExactMismatch", "/path/to/file.txt", "/path/to/other.txt", false},
+		{"SingleWildcard", "/path/to/file.txt", "/path/to/*.txt", true},
+		{"SingleWildcardMismatch", "/path/to/file.txt", "/path/to/*.json", false},
+		{"DoubleWildcardPrefix", "/path/to/subdir/file.txt", "/path/to/**", true},
+		{"DoubleWildcardPrefixMismatch", "/other/path/file.txt", "/path/to/**", false},
+		{"DoubleWildcardSuffix", "/path/to/subdir/file.txt", "**/file.txt", true},
+		{"DoubleWildcardSuffixMismatch", "/path/to/subdir/other.txt", "**/file.txt", false},
+		{"DoubleWildcardMiddle", "/path/to/subdir/file.txt", "/path/**/*.txt", true},
+		{"DoubleWildcardMiddleMismatch", "/path/to/subdir/file.json", "/path/**/*.txt", false},
+		{"DoubleDoubleWildcard", "/path/to/file.txt", "/path/**/to/some/**/file.txt", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := matchesPattern(tt.path, tt.pattern)
+			require.NoError(t, err, "Unexpected error")
+			require.Equal(t, tt.expected, result, "Pattern matching result mismatch")
+		})
+	}
+}

--- a/tools/file_write.go
+++ b/tools/file_write.go
@@ -1,0 +1,201 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/bmatcuk/doublestar/v4"
+	"github.com/getstingrai/dive/llm"
+)
+
+type FileWriteInput struct {
+	Path    string `json:"path"`
+	Content string `json:"content"`
+}
+
+type FileWriteToolOptions struct {
+	DefaultFilePath string
+	AllowList       []string // Patterns of allowed paths
+	DenyList        []string // Patterns of denied paths
+	RootDirectory   string   // If set, all paths will be relative to this directory
+}
+
+type FileWriteTool struct {
+	defaultFilePath string
+	allowList       []string // Patterns of allowed paths
+	denyList        []string // Patterns of denied paths
+	rootDirectory   string   // If set, all paths will be relative to this directory
+}
+
+// NewFileWriteTool creates a new tool for writing content to files
+func NewFileWriteTool(options FileWriteToolOptions) *FileWriteTool {
+	return &FileWriteTool{
+		defaultFilePath: options.DefaultFilePath,
+		allowList:       options.AllowList,
+		denyList:        options.DenyList,
+		rootDirectory:   options.RootDirectory,
+	}
+}
+
+// resolvePath resolves the provided path, applying rootDirectory if configured
+// and preventing directory traversal attacks
+func (t *FileWriteTool) resolvePath(path string) (string, error) {
+	if t.rootDirectory == "" {
+		// If no root directory is set, use the path as is
+		return path, nil
+	}
+
+	// Join the root directory and the provided path
+	resolvedPath := filepath.Join(t.rootDirectory, path)
+
+	// Get the absolute paths to check for directory traversal
+	absRoot, err := filepath.Abs(t.rootDirectory)
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve absolute path for root directory: %w", err)
+	}
+
+	absPath, err := filepath.Abs(resolvedPath)
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve absolute path: %w", err)
+	}
+
+	// Check if the resolved path is within the root directory
+	if !filepath.HasPrefix(absPath, absRoot) {
+		return "", fmt.Errorf("path attempts to access location outside of root directory")
+	}
+
+	return resolvedPath, nil
+}
+
+// isPathAllowed checks if the given path is allowed based on allowList and denyList
+func (t *FileWriteTool) isPathAllowed(path string) (bool, string) {
+	// Convert to absolute path for consistent checking
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return false, fmt.Sprintf("Error resolving absolute path: %s", err.Error())
+	}
+
+	// If denyList is specified, check against it first
+	if len(t.denyList) > 0 {
+		for _, pattern := range t.denyList {
+			matched, err := matchesPattern(absPath, pattern)
+			if err != nil {
+				return false, fmt.Sprintf("Error matching pattern '%s': %s", pattern, err.Error())
+			}
+			if matched {
+				return false, fmt.Sprintf("Path '%s' matches denied pattern '%s'", path, pattern)
+			}
+		}
+	}
+
+	// If allowList is specified, path must match at least one pattern
+	if len(t.allowList) > 0 {
+		allowed := false
+		for _, pattern := range t.allowList {
+			matched, err := matchesPattern(absPath, pattern)
+			if err != nil {
+				return false, fmt.Sprintf("Error matching pattern '%s': %s", pattern, err.Error())
+			}
+			if matched {
+				allowed = true
+				break
+			}
+		}
+		if !allowed {
+			return false, fmt.Sprintf("Path '%s' does not match any allowed patterns", path)
+		}
+	}
+
+	return true, ""
+}
+
+func matchesPattern(path, pattern string) (bool, error) {
+	return doublestar.PathMatch(pattern, path)
+}
+
+func (t *FileWriteTool) Definition() *llm.ToolDefinition {
+	description := "A tool that writes content to a file. To use this tool, provide a 'path' parameter with the path to the file you want to write to, and a 'content' parameter with the content to write."
+
+	if t.defaultFilePath != "" {
+		description = fmt.Sprintf("A tool that writes content to a file. The default file is %s, but you can provide a different 'path' parameter to write to another file.", t.defaultFilePath)
+	}
+
+	if t.rootDirectory != "" {
+		description += fmt.Sprintf(" All paths are relative to %s.", t.rootDirectory)
+	}
+
+	if len(t.allowList) > 0 || len(t.denyList) > 0 {
+		description += " File paths are restricted based on configured allowlist and denylist patterns."
+	}
+
+	return &llm.ToolDefinition{
+		Name:        "WriteFile",
+		Description: description,
+		Parameters: llm.Schema{
+			Type:     "object",
+			Required: []string{"path", "content"},
+			Properties: map[string]*llm.SchemaProperty{
+				"path": {
+					Type:        "string",
+					Description: "Path to the file to be written",
+				},
+				"content": {
+					Type:        "string",
+					Description: "Content to write to the file",
+				},
+			},
+		},
+	}
+}
+
+func (t *FileWriteTool) Call(ctx context.Context, input string) (string, error) {
+	var params FileWriteInput
+	if err := json.Unmarshal([]byte(input), &params); err != nil {
+		return "", err
+	}
+
+	filePath := params.Path
+	if filePath == "" {
+		filePath = t.defaultFilePath
+	}
+
+	if filePath == "" {
+		return "Error: No file path provided. Please provide a file path either in the constructor or as an argument.", nil
+	}
+
+	// Resolve the path (apply rootDirectory if configured)
+	resolvedPath, err := t.resolvePath(filePath)
+	if err != nil {
+		return fmt.Sprintf("Error: %s", err.Error()), nil
+	}
+
+	// Check if the path is allowed
+	allowed, reason := t.isPathAllowed(resolvedPath)
+	if !allowed {
+		return fmt.Sprintf("Error: Access denied. %s", reason), nil
+	}
+
+	// Ensure the directory exists
+	dir := filepath.Dir(resolvedPath)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return fmt.Sprintf("Error: Failed to create directory structure for %s. %s", filePath, err.Error()), nil
+	}
+
+	// Write the content to the file
+	err = os.WriteFile(resolvedPath, []byte(params.Content), 0644)
+	if err != nil {
+		if os.IsPermission(err) {
+			return fmt.Sprintf("Error: Permission denied when trying to write to file: %s", filePath), nil
+		}
+		return fmt.Sprintf("Error: Failed to write to file %s. %s", filePath, err.Error()), nil
+	}
+
+	return fmt.Sprintf("Successfully wrote %d bytes to %s", len(params.Content), filePath), nil
+}
+
+func (t *FileWriteTool) ShouldReturnResult() bool {
+	return true
+}


### PR DESCRIPTION
These can be scoped to a specified root directory. Path traversal out of root is prohibited.

There is a max file size allowed for file_read.

And there's a max directory items limit for directory_list. Currently there is not a way to paginate.