### PR TITLE
Registered documents

### DIFF
--- a/document/repository.go
+++ b/document/repository.go
@@ -31,4 +31,7 @@ type Repository interface {
 
 	// Exists checks if a document exists by name
 	Exists(ctx context.Context, name string) (bool, error)
+
+	// RegisterDocument assigns a name to a document path
+	RegisterDocument(ctx context.Context, name, path string) error
 }

--- a/environment/environment.go
+++ b/environment/environment.go
@@ -24,7 +24,6 @@ type Environment struct {
 	logger          slogger.Logger
 	defaultWorkflow string
 	documentRepo    document.Repository
-	knownDocuments  map[string]*document.Metadata
 	actions         map[string]Action
 	started         bool
 }
@@ -41,7 +40,6 @@ type EnvironmentOptions struct {
 	Logger          slogger.Logger
 	DefaultWorkflow string
 	DocumentRepo    document.Repository
-	KnownDocuments  map[string]*document.Metadata
 	Actions         []Action
 }
 
@@ -111,7 +109,6 @@ func New(opts EnvironmentOptions) (*Environment, error) {
 		logger:          opts.Logger,
 		defaultWorkflow: opts.DefaultWorkflow,
 		documentRepo:    opts.DocumentRepo,
-		knownDocuments:  opts.KnownDocuments,
 		actions:         actions,
 	}
 	for _, trigger := range env.triggers {
@@ -137,10 +134,6 @@ func (e *Environment) Description() string {
 
 func (e *Environment) DocumentRepository() document.Repository {
 	return e.documentRepo
-}
-
-func (e *Environment) KnownDocuments() map[string]*document.Metadata {
-	return e.knownDocuments
 }
 
 func (e *Environment) Start(ctx context.Context) error {

--- a/interfaces.go
+++ b/interfaces.go
@@ -131,9 +131,6 @@ type Environment interface {
 
 	// DocumentRepository returns the DocumentRepository for this Environment
 	DocumentRepository() document.Repository
-
-	// KnownDocuments returns a map of all documents known to this Environment
-	KnownDocuments() map[string]*document.Metadata
 }
 
 // GenerateOptions contains configuration for LLM generations.


### PR DESCRIPTION
This adds support for "registered documents", which basically points at a document path and assigns that a name for easy reference in workflows. This means the full path to a document doesn't always need to be specified.