### PR TITLE
Agent now manages cache control flag on message content

### DIFF
--- a/llm/content.go
+++ b/llm/content.go
@@ -72,6 +72,12 @@ type Content interface {
 	Type() ContentType
 }
 
+// CacheControlSetter is an interface that allows setting the cache control for
+// a content block.
+type CacheControlSetter interface {
+	SetCacheControl(cacheControl *CacheControl)
+}
+
 //// TextContent ///////////////////////////////////////////////////////////////
 
 /* Examples:
@@ -151,6 +157,10 @@ func (c *TextContent) MarshalJSON() ([]byte, error) {
 	})
 }
 
+func (c *TextContent) SetCacheControl(cacheControl *CacheControl) {
+	c.CacheControl = cacheControl
+}
+
 //// ImageContent //////////////////////////////////////////////////////////////
 
 /* Examples:
@@ -190,6 +200,10 @@ func (c *ImageContent) MarshalJSON() ([]byte, error) {
 		Type:  ContentTypeImage,
 		Alias: (*Alias)(c),
 	})
+}
+
+func (c *ImageContent) SetCacheControl(cacheControl *CacheControl) {
+	c.CacheControl = cacheControl
 }
 
 //// DocumentContent ///////////////////////////////////////////////////////////
@@ -260,6 +274,10 @@ func (c *DocumentContent) MarshalJSON() ([]byte, error) {
 		Type:  ContentTypeDocument,
 		Alias: (*Alias)(c),
 	})
+}
+
+func (c *DocumentContent) SetCacheControl(cacheControl *CacheControl) {
+	c.CacheControl = cacheControl
 }
 
 //// ToolUseContent ////////////////////////////////////////////////////////////
@@ -340,6 +358,10 @@ func (c *ToolResultContent) MarshalJSON() ([]byte, error) {
 		Type:  ContentTypeToolResult,
 		Alias: (*Alias)(c),
 	})
+}
+
+func (c *ToolResultContent) SetCacheControl(cacheControl *CacheControl) {
+	c.CacheControl = cacheControl
 }
 
 //// ServerToolUseContent //////////////////////////////////////////////////////

--- a/llm/message_helpers.go
+++ b/llm/message_helpers.go
@@ -41,7 +41,7 @@ func NewToolResultMessage(outputs ...*ToolResultContent) *Message {
 		content[i] = &ToolResultContent{
 			ToolUseID: output.ToolUseID,
 			Content:   output.Content,
-			// Name:      output.Name,
+			IsError:   false,
 		}
 	}
 	return &Message{Role: User, Content: content}

--- a/llm/providers/anthropic/anthropic.go
+++ b/llm/providers/anthropic/anthropic.go
@@ -257,22 +257,9 @@ func convertMessages(messages []*llm.Message) ([]*llm.Message, error) {
 	// and omit the ID field
 	copied := make([]*llm.Message, len(messages))
 	for i, message := range messages {
-		// The "name" field in tool results can't be set either
-		var copiedContent []llm.Content
-		for _, content := range message.Content {
-			toolResultContent, ok := content.(*llm.ToolResultContent)
-			if ok {
-				copiedContent = append(copiedContent, &llm.ToolResultContent{
-					Content:   toolResultContent.Content,
-					ToolUseID: toolResultContent.ToolUseID,
-				})
-			} else {
-				copiedContent = append(copiedContent, content)
-			}
-		}
 		copied[i] = &llm.Message{
 			Role:    message.Role,
-			Content: copiedContent,
+			Content: message.Content,
 		}
 	}
 	return copied, nil

--- a/toolkit/fetch.go
+++ b/toolkit/fetch.go
@@ -51,6 +51,12 @@ type FetchToolOptions struct {
 }
 
 func NewFetchTool(options FetchToolOptions) *dive.TypedToolAdapter[*web.FetchInput] {
+	if options.MaxSize <= 0 {
+		options.MaxSize = DefaultFetchMaxSize
+	}
+	if options.Timeout <= 0 {
+		options.Timeout = DefaultFetchTimeout
+	}
 	return dive.ToolAdapter(&FetchTool{
 		fetcher:    options.Fetcher,
 		maxSize:    options.MaxSize,


### PR DESCRIPTION
This was lost in the shuffle recently. Adding it back, but managed by the agent now instead of the LLM provider.