### PR TITLE
Make risor builtins available to scripts

### DIFF
--- a/environment/environment.go
+++ b/environment/environment.go
@@ -9,6 +9,7 @@ import (
 	"github.com/diveagents/dive/objects"
 	"github.com/diveagents/dive/slogger"
 	"github.com/diveagents/dive/workflow"
+	"github.com/risor-io/risor/modules/all"
 )
 
 // Environment is a container for running agents and workflow executions
@@ -280,6 +281,11 @@ func (e *Environment) ExecuteWorkflow(ctx context.Context, opts ExecutionOptions
 		execution.scriptGlobals["documents"] = objects.NewDocumentRepository(e.documentRepo)
 	}
 	e.executions[execution.ID()] = execution
+
+	// Make Risor's default builtins available to embedded scripts
+	for k, v := range all.Builtins() {
+		execution.scriptGlobals[k] = v
+	}
 
 	if err := execution.Run(ctx); err != nil {
 		logger.Error("failed to start workflow", "error", err)

--- a/environment/execution.go
+++ b/environment/execution.go
@@ -22,7 +22,6 @@ import (
 
 var (
 	colorGreen = color.New(color.FgGreen)
-	colorBold  = color.New(color.Bold)
 )
 
 // PathStatus represents the current state of an execution path


### PR DESCRIPTION
This allows reading files, among other things, when building prompts for the agents.

For example:

```yaml
    Steps:
      - Name: Initial Research
        Agent: Engineer
        Prompt: |
          You are researching a codebase to understand and document a specific topic for other engineers and future refactoring efforts.

          **RESEARCH TOPIC:**
          ${inputs.topic}

          **CODEBASE LOCATION:**
          ${inputs.directory}

          **CONTEXT:**
          ${cat("documentation/overview.md")}
```