### PR TITLE
Add Grok LLM provider support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,9 @@
 
 <a href="https://www.anthropic.com"><img alt="Claude" src="https://img.shields.io/badge/Claude-6B48FF.svg?style=for-the-badge&labelColor=000000"></a>
 <a href="https://www.openai.com"><img alt="GPT-4" src="https://img.shields.io/badge/GPT--4o%20|%20o1%20|%20o3-10A37F.svg?style=for-the-badge&labelColor=000000"></a>
-<a href="https://cloud.google.com/vertex-ai"><img alt="Google Gemini" src="https://img.shields.io/badge/Gemini-4285F4.svg?style=for-the-badge&labelColor=000000"></a>
-<a href="https://www.groq.com"><img alt="Groq Models" src="https://img.shields.io/badge/DeepSeek%20|%20Llama%20|%20Qwen-FF6B4A.svg?style=for-the-badge&labelColor=000000"></a>
+<a href="https://cloud.google.com/vertex-ai"><img alt="Gemini" src="https://img.shields.io/badge/Gemini-4285F4.svg?style=for-the-badge&labelColor=000000"></a>
+<a href="https://x.ai"><img alt="Grok" src="https://img.shields.io/badge/Grok-1DA1F2.svg?style=for-the-badge&labelColor=000000"></a>
+<a href="https://ollama.ai"><img alt="Ollama" src="https://img.shields.io/badge/Ollama-1E2952.svg?style=for-the-badge&labelColor=000000"></a>
 <a href="https://deepnoodle.ai"><img alt="Made by Deep Noodle" src="https://img.shields.io/badge/MADE%20BY%20Deep%20Noodle-000000.svg?style=for-the-badge&labelColor=000000"></a>
 
 </div>
@@ -41,7 +42,7 @@ Please leave a GitHub star if you're interested in the project!
 * **Agents**: Chat or assign work to specialized agents with configurable reasoning
 * **Supervisor Patterns**: Create hierarchical agent systems with work delegation
 * **Declarative Configuration**: Define agents using YAML
-* **Multiple LLMs**: Switch between Anthropic, OpenAI, Google, Groq, Ollama, and others
+* **Multiple LLMs**: Switch between Anthropic, OpenAI, Google, Grok, Ollama, and others
 * **Extended Reasoning**: Configure reasoning effort and budget for deep thinking
 * **Model Context Protocol (MCP)**: Connect to MCP servers for external tool access
 * **Advanced Model Settings**: Fine-tune temperature, penalties, caching, and tool behavior
@@ -64,7 +65,7 @@ the LLM provider and for any tools that you'd like your agents to use.
 # LLM Provider API Keys
 export ANTHROPIC_API_KEY="your-key-here"
 export OPENAI_API_KEY="your-key-here"
-export GROQ_API_KEY="your-key-here"
+export GROK_API_KEY="your-key-here"
 export GEMINI_API_KEY="your-key-here"
 
 # Tool API Keys

--- a/cmd/dive/cli/root.go
+++ b/cmd/dive/cli/root.go
@@ -56,7 +56,7 @@ func init() {
 
 	rootCmd.PersistentFlags().StringVarP(
 		&llmProvider, "provider", "", "",
-		"LLM provider to use (e.g., 'anthropic', 'openai', 'groq', 'ollama', 'google')")
+		"LLM provider to use (e.g., 'anthropic', 'openai', 'groq', 'grok', 'ollama', 'google')")
 
 	rootCmd.PersistentFlags().StringVarP(
 		&llmModel, "model", "m", "",

--- a/config/get_model.go
+++ b/config/get_model.go
@@ -6,6 +6,7 @@ import (
 	"github.com/deepnoodle-ai/dive/llm"
 	"github.com/deepnoodle-ai/dive/llm/providers/anthropic"
 	"github.com/deepnoodle-ai/dive/llm/providers/google"
+	"github.com/deepnoodle-ai/dive/llm/providers/grok"
 	"github.com/deepnoodle-ai/dive/llm/providers/groq"
 	"github.com/deepnoodle-ai/dive/llm/providers/ollama"
 	"github.com/deepnoodle-ai/dive/llm/providers/openai"
@@ -49,6 +50,13 @@ func GetModel(providerName, modelName string) (llm.LLM, error) {
 			opts = append(opts, groq.WithModel(modelName))
 		}
 		return groq.New(opts...), nil
+
+	case "grok":
+		opts := []grok.Option{}
+		if modelName != "" {
+			opts = append(opts, grok.WithModel(modelName))
+		}
+		return grok.New(opts...), nil
 
 	case "ollama":
 		opts := []ollama.Option{}

--- a/config/get_model_test.go
+++ b/config/get_model_test.go
@@ -1,0 +1,40 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetModel_GrokProvider(t *testing.T) {
+	// Test default grok model
+	provider, err := GetModel("grok", "")
+	require.NoError(t, err)
+	require.NotNil(t, provider)
+	require.Equal(t, "grok-grok-4", provider.Name())
+
+	// Test custom grok model
+	provider, err = GetModel("grok", "grok-3")
+	require.NoError(t, err)
+	require.NotNil(t, provider)
+	require.Equal(t, "grok-grok-3", provider.Name())
+
+	// Test grok-code-fast-1 model
+	provider, err = GetModel("grok", "grok-code-fast-1")
+	require.NoError(t, err)
+	require.NotNil(t, provider)
+	require.Equal(t, "grok-grok-code-fast-1", provider.Name())
+}
+
+func TestGetModel_AllProviders(t *testing.T) {
+	providers := []string{"anthropic", "openai", "openai-completions", "groq", "grok", "ollama", "google"}
+	
+	for _, providerName := range providers {
+		t.Run(providerName, func(t *testing.T) {
+			provider, err := GetModel(providerName, "")
+			require.NoError(t, err, "provider %s should be supported", providerName)
+			require.NotNil(t, provider, "provider %s should return a valid instance", providerName)
+			require.NotEmpty(t, provider.Name(), "provider %s should have a non-empty name", providerName)
+		})
+	}
+}

--- a/config/get_model_test.go
+++ b/config/get_model_test.go
@@ -11,7 +11,7 @@ func TestGetModel_GrokProvider(t *testing.T) {
 	provider, err := GetModel("grok", "")
 	require.NoError(t, err)
 	require.NotNil(t, provider)
-	require.Equal(t, "grok-grok-4", provider.Name())
+	require.Equal(t, "grok-grok-4-0709", provider.Name())
 
 	// Test custom grok model
 	provider, err = GetModel("grok", "grok-3")

--- a/llm/providers/grok/grok.go
+++ b/llm/providers/grok/grok.go
@@ -1,0 +1,69 @@
+package grok
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/deepnoodle-ai/dive/llm"
+	openaic "github.com/deepnoodle-ai/dive/llm/providers/openaicompletions"
+)
+
+var (
+	DefaultModel     = "grok-4"
+	DefaultEndpoint  = "https://api.x.ai/v1/chat/completions"
+	DefaultMaxTokens = 4096
+	DefaultClient    = &http.Client{Timeout: 300 * time.Second}
+)
+
+var _ llm.StreamingLLM = &Provider{}
+
+type Provider struct {
+	apiKey    string
+	endpoint  string
+	model     string
+	maxTokens int
+	client    *http.Client
+
+	// Embedded OpenAI completions provider
+	*openaic.Provider
+}
+
+func New(opts ...Option) *Provider {
+	p := &Provider{
+		apiKey:    getAPIKey(),
+		endpoint:  DefaultEndpoint,
+		client:    DefaultClient,
+		model:     DefaultModel,
+		maxTokens: DefaultMaxTokens,
+	}
+	for _, opt := range opts {
+		opt(p)
+	}
+	// Pass the options through to the wrapped OpenAI provider
+	p.Provider = openaic.New(
+		openaic.WithAPIKey(p.apiKey),
+		openaic.WithClient(p.client),
+		openaic.WithEndpoint(p.endpoint),
+		openaic.WithMaxTokens(p.maxTokens),
+		openaic.WithModel(p.model),
+		openaic.WithSystemRole("system"),
+	)
+	return p
+}
+
+func getAPIKey() string {
+	if key := os.Getenv("XAI_API_KEY"); key != "" {
+		return key
+	}
+	// Also check for GROK_API_KEY as an alternative
+	if key := os.Getenv("GROK_API_KEY"); key != "" {
+		return key
+	}
+	return ""
+}
+
+func (p *Provider) Name() string {
+	return fmt.Sprintf("grok-%s", p.model)
+}

--- a/llm/providers/grok/grok.go
+++ b/llm/providers/grok/grok.go
@@ -11,7 +11,7 @@ import (
 )
 
 var (
-	DefaultModel     = "grok-4"
+	DefaultModel     = ModelGrok40709
 	DefaultEndpoint  = "https://api.x.ai/v1/chat/completions"
 	DefaultMaxTokens = 4096
 	DefaultClient    = &http.Client{Timeout: 300 * time.Second}

--- a/llm/providers/grok/grok_test.go
+++ b/llm/providers/grok/grok_test.go
@@ -1,6 +1,7 @@
 package grok
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/deepnoodle-ai/dive/llm"
@@ -20,7 +21,7 @@ func TestProvider_ImplementsInterfaces(t *testing.T) {
 func TestProvider_Name(t *testing.T) {
 	provider := New()
 	name := provider.Name()
-	expected := "grok-grok-4"
+	expected := "grok-grok-4-0709"
 	require.Equal(t, expected, name)
 }
 
@@ -36,6 +37,26 @@ func TestProvider_WithOptions(t *testing.T) {
 	require.Equal(t, "https://custom.x.ai/v1/chat/completions", provider.endpoint)
 	require.Equal(t, "custom-key", provider.apiKey)
 	require.Equal(t, 8192, provider.maxTokens)
+}
+
+func TestProvider_ModelConstants(t *testing.T) {
+	tests := []struct {
+		name     string
+		model    string
+		expected string
+	}{
+		{"default model", ModelGrok40709, "grok-4-0709"},
+		{"code fast model", ModelGrokCodeFast1, "grok-code-fast-1"},
+		{"grok-3 model", ModelGrok3, "grok-3"},
+		{"grok-3-mini model", ModelGrok3Mini, "grok-3-mini"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			provider := New(WithModel(tt.model))
+			require.Equal(t, fmt.Sprintf("grok-%s", tt.expected), provider.Name())
+		})
+	}
 }
 
 func TestProvider_GetAPIKey(t *testing.T) {

--- a/llm/providers/grok/grok_test.go
+++ b/llm/providers/grok/grok_test.go
@@ -1,0 +1,60 @@
+package grok
+
+import (
+	"testing"
+
+	"github.com/deepnoodle-ai/dive/llm"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProvider_ImplementsInterfaces(t *testing.T) {
+	provider := New()
+
+	// Test that it implements LLM interface
+	var _ llm.LLM = provider
+
+	// Test that it implements StreamingLLM interface
+	var _ llm.StreamingLLM = provider
+}
+
+func TestProvider_Name(t *testing.T) {
+	provider := New()
+	name := provider.Name()
+	expected := "grok-grok-4"
+	require.Equal(t, expected, name)
+}
+
+func TestProvider_WithOptions(t *testing.T) {
+	provider := New(
+		WithModel("grok-3"),
+		WithEndpoint("https://custom.x.ai/v1/chat/completions"),
+		WithAPIKey("custom-key"),
+		WithMaxTokens(8192),
+	)
+
+	require.Equal(t, "grok-3", provider.model)
+	require.Equal(t, "https://custom.x.ai/v1/chat/completions", provider.endpoint)
+	require.Equal(t, "custom-key", provider.apiKey)
+	require.Equal(t, 8192, provider.maxTokens)
+}
+
+func TestProvider_GetAPIKey(t *testing.T) {
+	// Test with no env vars set
+	t.Setenv("XAI_API_KEY", "")
+	t.Setenv("GROK_API_KEY", "")
+	require.Equal(t, "", getAPIKey())
+
+	// Test with XAI_API_KEY
+	t.Setenv("XAI_API_KEY", "xai-key")
+	require.Equal(t, "xai-key", getAPIKey())
+
+	// Test with GROK_API_KEY as fallback
+	t.Setenv("XAI_API_KEY", "")
+	t.Setenv("GROK_API_KEY", "grok-key")
+	require.Equal(t, "grok-key", getAPIKey())
+
+	// Test XAI_API_KEY takes priority
+	t.Setenv("XAI_API_KEY", "xai-key")
+	t.Setenv("GROK_API_KEY", "grok-key")
+	require.Equal(t, "xai-key", getAPIKey())
+}

--- a/llm/providers/grok/models.go
+++ b/llm/providers/grok/models.go
@@ -1,0 +1,8 @@
+package grok
+
+const (
+	ModelGrok40709     = "grok-4-0709"
+	ModelGrokCodeFast1 = "grok-code-fast-1"
+	ModelGrok3         = "grok-3"
+	ModelGrok3Mini     = "grok-3-mini"
+)

--- a/llm/providers/grok/options.go
+++ b/llm/providers/grok/options.go
@@ -1,0 +1,41 @@
+package grok
+
+import "net/http"
+
+// Option is a function that configures the Provider
+type Option func(*Provider)
+
+// WithAPIKey sets the API key for the provider
+func WithAPIKey(apiKey string) Option {
+	return func(p *Provider) {
+		p.apiKey = apiKey
+	}
+}
+
+// WithEndpoint sets the API endpoint URL for the provider
+func WithEndpoint(endpoint string) Option {
+	return func(p *Provider) {
+		p.endpoint = endpoint
+	}
+}
+
+// WithClient sets the HTTP client used for all API requests
+func WithClient(client *http.Client) Option {
+	return func(p *Provider) {
+		p.client = client
+	}
+}
+
+// WithMaxTokens sets the maximum number of tokens to generate
+func WithMaxTokens(maxTokens int) Option {
+	return func(p *Provider) {
+		p.maxTokens = maxTokens
+	}
+}
+
+// WithModel sets the LLM model name to use for the provider
+func WithModel(model string) Option {
+	return func(p *Provider) {
+		p.model = model
+	}
+}


### PR DESCRIPTION
Add Grok as a new LLM provider, leveraging its OpenAI API compatibility to expand supported models.

---
<a href="https://cursor.com/background-agent?bcId=bc-0f5da96f-74db-44b7-98aa-dfade317c200">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0f5da96f-74db-44b7-98aa-dfade317c200">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

