### PR TITLE
Make dive cli commands wait for media generation

### DIFF
--- a/cmd/dive/cli/video.go
+++ b/cmd/dive/cli/video.go
@@ -38,7 +38,6 @@ var (
 	videoGenerateModel        string
 	videoGenerateOutput       string
 	videoGenerateDuration     float64
-	videoGenerateWait         bool
 	videoGenerateNoWait       bool
 	videoGeneratePollInterval time.Duration
 
@@ -51,11 +50,6 @@ func runVideoGenerate(cmd *cobra.Command, args []string) error {
 	// Validate required parameters
 	if videoGeneratePrompt == "" {
 		return fmt.Errorf("prompt is required")
-	}
-
-	// Validate conflicting flags
-	if videoGenerateWait && videoGenerateNoWait {
-		return fmt.Errorf("cannot specify both --wait and --no-wait flags")
 	}
 
 	// Set defaults
@@ -71,9 +65,6 @@ func runVideoGenerate(cmd *cobra.Command, args []string) error {
 
 	// Determine wait behavior: wait by default unless --no-wait is specified
 	shouldWait := !videoGenerateNoWait
-	if videoGenerateWait {
-		shouldWait = true // Explicit --wait overrides default behavior
-	}
 
 	return generateVideoWithMediaPackage(shouldWait)
 }
@@ -296,7 +287,6 @@ func init() {
 	videoGenerateCmd.Flags().StringVarP(&videoGenerateModel, "model", "m", "veo-2.0-generate-001", "Model to use for video generation")
 	videoGenerateCmd.Flags().StringVarP(&videoGenerateOutput, "output", "o", "generated_video.mp4", "Output file path")
 	videoGenerateCmd.Flags().Float64VarP(&videoGenerateDuration, "duration", "d", 0, "Duration of the video in seconds (optional)")
-	videoGenerateCmd.Flags().BoolVarP(&videoGenerateWait, "wait", "w", false, "Wait for video generation to complete (default: true)")
 	videoGenerateCmd.Flags().BoolVar(&videoGenerateNoWait, "no-wait", false, "Don't wait for video generation to complete")
 	videoGenerateCmd.Flags().DurationVar(&videoGeneratePollInterval, "poll-interval", 20*time.Second, "Polling interval when waiting")
 

--- a/cmd/dive/cli/video_test.go
+++ b/cmd/dive/cli/video_test.go
@@ -1,0 +1,135 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestVideoCommands(t *testing.T) {
+	// Test that video command is properly registered
+	rootCmd.SetArgs([]string{"video", "--help"})
+	err := rootCmd.Execute()
+	require.NoError(t, err)
+}
+
+func TestVideoGenerateCommand(t *testing.T) {
+	// Test help command
+	rootCmd.SetArgs([]string{"video", "generate", "--help"})
+	err := rootCmd.Execute()
+	require.NoError(t, err)
+}
+
+func TestVideoStatusCommand(t *testing.T) {
+	// Test help command
+	rootCmd.SetArgs([]string{"video", "status", "--help"})
+	err := rootCmd.Execute()
+	require.NoError(t, err)
+}
+
+func TestVideoGenerateValidation(t *testing.T) {
+	// Save original values
+	origPrompt := videoGeneratePrompt
+	origWait := videoGenerateWait
+	origNoWait := videoGenerateNoWait
+
+	defer func() {
+		// Restore original values
+		videoGeneratePrompt = origPrompt
+		videoGenerateWait = origWait
+		videoGenerateNoWait = origNoWait
+	}()
+
+	t.Run("missing prompt", func(t *testing.T) {
+		videoGeneratePrompt = ""
+		videoGenerateWait = false
+		videoGenerateNoWait = false
+
+		err := runVideoGenerate(nil, nil)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "prompt is required")
+	})
+
+	t.Run("conflicting wait flags", func(t *testing.T) {
+		videoGeneratePrompt = "test prompt"
+		videoGenerateWait = true
+		videoGenerateNoWait = true
+
+		err := runVideoGenerate(nil, nil)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "cannot specify both --wait and --no-wait flags")
+	})
+}
+
+func TestVideoStatusValidation(t *testing.T) {
+	// Save original values
+	origOperationID := videoStatusOperationID
+
+	defer func() {
+		// Restore original values
+		videoStatusOperationID = origOperationID
+	}()
+
+	t.Run("missing operation ID", func(t *testing.T) {
+		videoStatusOperationID = ""
+
+		err := runVideoStatus(nil, nil)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "operation-id is required")
+	})
+}
+
+func TestVideoGenerateWaitBehavior(t *testing.T) {
+	// Save original values
+	origPrompt := videoGeneratePrompt
+	origWait := videoGenerateWait
+	origNoWait := videoGenerateNoWait
+
+	defer func() {
+		// Restore original values
+		videoGeneratePrompt = origPrompt
+		videoGenerateWait = origWait
+		videoGenerateNoWait = origNoWait
+	}()
+
+	// Set a valid prompt to pass validation
+	videoGeneratePrompt = "test prompt"
+
+	t.Run("default behavior should wait", func(t *testing.T) {
+		videoGenerateWait = false
+		videoGenerateNoWait = false
+
+		// We can't easily test the actual waiting without mocking the provider,
+		// but we can test that the logic correctly determines shouldWait
+		shouldWait := !videoGenerateNoWait
+		if videoGenerateWait {
+			shouldWait = true
+		}
+
+		require.True(t, shouldWait, "default behavior should be to wait")
+	})
+
+	t.Run("--no-wait should not wait", func(t *testing.T) {
+		videoGenerateWait = false
+		videoGenerateNoWait = true
+
+		shouldWait := !videoGenerateNoWait
+		if videoGenerateWait {
+			shouldWait = true
+		}
+
+		require.False(t, shouldWait, "--no-wait should disable waiting")
+	})
+
+	t.Run("--wait should explicitly wait", func(t *testing.T) {
+		videoGenerateWait = true
+		videoGenerateNoWait = false
+
+		shouldWait := !videoGenerateNoWait
+		if videoGenerateWait {
+			shouldWait = true
+		}
+
+		require.True(t, shouldWait, "--wait should explicitly enable waiting")
+	})
+}

--- a/cmd/dive/cli/video_test.go
+++ b/cmd/dive/cli/video_test.go
@@ -30,34 +30,21 @@ func TestVideoStatusCommand(t *testing.T) {
 func TestVideoGenerateValidation(t *testing.T) {
 	// Save original values
 	origPrompt := videoGeneratePrompt
-	origWait := videoGenerateWait
 	origNoWait := videoGenerateNoWait
 
 	defer func() {
 		// Restore original values
 		videoGeneratePrompt = origPrompt
-		videoGenerateWait = origWait
 		videoGenerateNoWait = origNoWait
 	}()
 
 	t.Run("missing prompt", func(t *testing.T) {
 		videoGeneratePrompt = ""
-		videoGenerateWait = false
 		videoGenerateNoWait = false
 
 		err := runVideoGenerate(nil, nil)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "prompt is required")
-	})
-
-	t.Run("conflicting wait flags", func(t *testing.T) {
-		videoGeneratePrompt = "test prompt"
-		videoGenerateWait = true
-		videoGenerateNoWait = true
-
-		err := runVideoGenerate(nil, nil)
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "cannot specify both --wait and --no-wait flags")
 	})
 }
 
@@ -82,13 +69,11 @@ func TestVideoStatusValidation(t *testing.T) {
 func TestVideoGenerateWaitBehavior(t *testing.T) {
 	// Save original values
 	origPrompt := videoGeneratePrompt
-	origWait := videoGenerateWait
 	origNoWait := videoGenerateNoWait
 
 	defer func() {
 		// Restore original values
 		videoGeneratePrompt = origPrompt
-		videoGenerateWait = origWait
 		videoGenerateNoWait = origNoWait
 	}()
 
@@ -96,40 +81,20 @@ func TestVideoGenerateWaitBehavior(t *testing.T) {
 	videoGeneratePrompt = "test prompt"
 
 	t.Run("default behavior should wait", func(t *testing.T) {
-		videoGenerateWait = false
 		videoGenerateNoWait = false
 
 		// We can't easily test the actual waiting without mocking the provider,
 		// but we can test that the logic correctly determines shouldWait
 		shouldWait := !videoGenerateNoWait
-		if videoGenerateWait {
-			shouldWait = true
-		}
 
 		require.True(t, shouldWait, "default behavior should be to wait")
 	})
 
 	t.Run("--no-wait should not wait", func(t *testing.T) {
-		videoGenerateWait = false
 		videoGenerateNoWait = true
 
 		shouldWait := !videoGenerateNoWait
-		if videoGenerateWait {
-			shouldWait = true
-		}
 
 		require.False(t, shouldWait, "--no-wait should disable waiting")
-	})
-
-	t.Run("--wait should explicitly wait", func(t *testing.T) {
-		videoGenerateWait = true
-		videoGenerateNoWait = false
-
-		shouldWait := !videoGenerateNoWait
-		if videoGenerateWait {
-			shouldWait = true
-		}
-
-		require.True(t, shouldWait, "--wait should explicitly enable waiting")
 	})
 }


### PR DESCRIPTION
Make `dive video generate` wait by default for media generation, aligning its behavior with image commands and adding a `--no-wait` option.

Previously, `dive video generate` returned immediately, requiring an explicit `--wait` flag, while image generation commands were synchronous. This change standardizes the default behavior across all media generation commands.

---
<a href="https://cursor.com/background-agent?bcId=bc-53896c23-800e-47ab-b6de-ef9282e9770a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-53896c23-800e-47ab-b6de-ef9282e9770a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

