### PR TITLE
Address review findings on a2a and a2alib

### DIFF
--- a/experimental/a2a/client.go
+++ b/experimental/a2a/client.go
@@ -251,11 +251,15 @@ func (c *Client) StreamMessage(ctx context.Context, msg *Message, cfg *MessageCo
 		msg.MessageID = uuid.NewString()
 	}
 	params := SendMessageParams{Message: msg, Configuration: cfg}
+	rawParams, err := json.Marshal(params)
+	if err != nil {
+		return fmt.Errorf("a2a: marshal stream params: %w", err)
+	}
 	body, err := json.Marshal(RPCRequest{
 		JSONRPC: "2.0",
 		ID:      c.nextID(),
 		Method:  MethodMessageStream,
-		Params:  mustMarshal(params),
+		Params:  rawParams,
 	})
 	if err != nil {
 		return err
@@ -281,11 +285,15 @@ func (c *Client) StreamMessage(ctx context.Context, msg *Message, cfg *MessageCo
 
 // call is the shared JSON-RPC round-trip helper.
 func (c *Client) call(ctx context.Context, method string, params any, out any) error {
+	rawParams, err := json.Marshal(params)
+	if err != nil {
+		return fmt.Errorf("a2a: marshal %s params: %w", method, err)
+	}
 	body, err := json.Marshal(RPCRequest{
 		JSONRPC: "2.0",
 		ID:      c.nextID(),
 		Method:  method,
-		Params:  mustMarshal(params),
+		Params:  rawParams,
 	})
 	if err != nil {
 		return err
@@ -401,10 +409,3 @@ func decodeStreamResult(raw json.RawMessage) (*StreamEvent, error) {
 	return nil, nil
 }
 
-func mustMarshal(v any) json.RawMessage {
-	b, err := json.Marshal(v)
-	if err != nil {
-		return json.RawMessage("null")
-	}
-	return b
-}

--- a/experimental/a2a/remoteagent.go
+++ b/experimental/a2a/remoteagent.go
@@ -3,6 +3,7 @@ package a2a
 import (
 	"context"
 	"fmt"
+	"sync"
 )
 
 // RemoteAgent is a higher-level wrapper around Client that lets Dive code
@@ -12,7 +13,9 @@ import (
 // persistent contextId so follow-up calls on the same conversation go
 // through as multi-turn interactions rather than fresh tasks.
 type RemoteAgent struct {
-	client    *Client
+	client *Client
+
+	mu        sync.RWMutex
 	card      *AgentCard
 	contextID string
 }
@@ -23,22 +26,38 @@ func NewRemoteAgent(client *Client) *RemoteAgent {
 }
 
 // Card returns the cached remote agent card, fetching it if it has not
-// been loaded yet.
+// been loaded yet. The card is cached for the lifetime of the
+// RemoteAgent; call RefreshCard to pick up changes from a long-lived
+// remote.
 func (r *RemoteAgent) Card(ctx context.Context) (*AgentCard, error) {
-	if r.card != nil {
-		return r.card, nil
+	r.mu.RLock()
+	cached := r.card
+	r.mu.RUnlock()
+	if cached != nil {
+		return cached, nil
 	}
+	return r.RefreshCard(ctx)
+}
+
+// RefreshCard re-fetches the remote agent card and updates the cache.
+// Use this when the remote agent's capabilities may have changed since
+// the card was first loaded.
+func (r *RemoteAgent) RefreshCard(ctx context.Context) (*AgentCard, error) {
 	card, err := r.client.FetchCard(ctx)
 	if err != nil {
 		return nil, err
 	}
+	r.mu.Lock()
 	r.card = card
+	r.mu.Unlock()
 	return card, nil
 }
 
 // ContextID returns the persistent A2A context ID this agent is using,
 // if any.
 func (r *RemoteAgent) ContextID() string {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
 	return r.contextID
 }
 
@@ -46,7 +65,9 @@ func (r *RemoteAgent) ContextID() string {
 // Useful when the caller wants to resume a prior A2A context by ID
 // instead of the one the server assigned on the first message.
 func (r *RemoteAgent) SetContextID(id string) {
+	r.mu.Lock()
 	r.contextID = id
+	r.mu.Unlock()
 }
 
 // SendText is the most common entry point: send a plain text prompt to
@@ -62,14 +83,14 @@ func (r *RemoteAgent) SendText(ctx context.Context, prompt string) (*Task, error
 	msg := &Message{
 		Role:      RoleUser,
 		Parts:     []Part{NewTextPart(prompt)},
-		ContextID: r.contextID,
+		ContextID: r.ContextID(),
 	}
 	task, err := r.client.SendMessage(ctx, msg, nil)
 	if err != nil {
 		return nil, err
 	}
 	if task != nil && task.ContextID != "" {
-		r.contextID = task.ContextID
+		r.SetContextID(task.ContextID)
 	}
 	return task, nil
 }
@@ -89,14 +110,14 @@ func (r *RemoteAgent) SendTextOnTask(ctx context.Context, taskID, prompt string)
 		Role:      RoleUser,
 		Parts:     []Part{NewTextPart(prompt)},
 		TaskID:    taskID,
-		ContextID: r.contextID,
+		ContextID: r.ContextID(),
 	}
 	task, err := r.client.SendMessage(ctx, msg, nil)
 	if err != nil {
 		return nil, err
 	}
 	if task != nil && task.ContextID != "" {
-		r.contextID = task.ContextID
+		r.SetContextID(task.ContextID)
 	}
 	return task, nil
 }
@@ -107,13 +128,13 @@ func (r *RemoteAgent) StreamText(ctx context.Context, prompt string, onEvent fun
 	msg := &Message{
 		Role:      RoleUser,
 		Parts:     []Part{NewTextPart(prompt)},
-		ContextID: r.contextID,
+		ContextID: r.ContextID(),
 	}
 	return r.client.StreamMessage(ctx, msg, nil, func(ev *StreamEvent) error {
 		if ev.Task != nil && ev.Task.ContextID != "" {
-			r.contextID = ev.Task.ContextID
+			r.SetContextID(ev.Task.ContextID)
 		} else if ev.StatusUpdate != nil && ev.StatusUpdate.ContextID != "" {
-			r.contextID = ev.StatusUpdate.ContextID
+			r.SetContextID(ev.StatusUpdate.ContextID)
 		}
 		return onEvent(ev)
 	})

--- a/experimental/a2a/review_fixes_test.go
+++ b/experimental/a2a/review_fixes_test.go
@@ -1,0 +1,170 @@
+package a2a_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/deepnoodle-ai/dive/experimental/a2a"
+	"github.com/deepnoodle-ai/dive/llm"
+	"github.com/deepnoodle-ai/wonton/assert"
+)
+
+// Part.Validate enforces mutual exclusivity (issue #4 in review).
+func TestPartValidate(t *testing.T) {
+	cases := []struct {
+		name    string
+		part    a2a.Part
+		wantErr bool
+	}{
+		{"text-only", a2a.NewTextPart("hi"), false},
+		{"raw-only", a2a.NewRawPart("AAAA", "image/png"), false},
+		{"data-only", a2a.NewDataPart(map[string]any{"k": "v"}), false},
+		{"url-only", a2a.NewURLPart("https://x", "image/png"), false},
+		{"empty", a2a.Part{}, true},
+		{"text+url", a2a.Part{Text: "hi", URL: "https://x"}, true},
+		{"text+data", a2a.Part{Text: "hi", Data: map[string]any{"k": "v"}}, true},
+		{"raw+url", a2a.Part{Raw: "AAAA", URL: "https://x"}, true},
+		{"all", a2a.Part{Text: "hi", Raw: "AAAA", Data: map[string]any{"k": "v"}, URL: "https://x"}, true},
+	}
+	for _, c := range cases {
+		err := c.part.Validate()
+		if c.wantErr {
+			assert.Error(t, err, "case %s: expected error", c.name)
+		} else {
+			assert.NoError(t, err, "case %s: unexpected error", c.name)
+		}
+	}
+}
+
+func TestSendMessageParamsValidateRejectsMixedPart(t *testing.T) {
+	params := &a2a.SendMessageParams{
+		Message: &a2a.Message{
+			MessageID: "m1",
+			Role:      a2a.RoleUser,
+			Parts: []a2a.Part{
+				{Text: "hi", URL: "https://x"},
+			},
+		},
+	}
+	err := params.Validate()
+	assert.Error(t, err)
+	assert.True(t, strings.Contains(err.Error(), "exactly one"))
+}
+
+// Server.Card returns a deep copy (issue #5).
+func TestServerCardIsDeepCopy(t *testing.T) {
+	model := &fakeLLM{generate: func(ctx context.Context, opts ...llm.Option) (*llm.Response, error) {
+		return textResponse("ok"), nil
+	}}
+	agent := buildAgent(t, model)
+
+	server, err := a2a.NewServer(a2a.ServerOptions{
+		Agent:   agent,
+		BaseURL: "https://agent.example.com",
+		Card: a2a.AgentCard{
+			Skills: []a2a.AgentSkill{{ID: "chat", Name: "chat", Description: "x", Tags: []string{"a"}}},
+		},
+	})
+	assert.NoError(t, err)
+
+	a := server.Card()
+	a.Name = "MUTATED"
+	a.Skills[0].Name = "MUTATED"
+	a.Skills[0].Tags[0] = "MUTATED"
+	a.SupportedInterfaces[0].URL = "MUTATED"
+
+	b := server.Card()
+	assert.True(t, b.Name != "MUTATED", "Server.Card() must return a deep copy")
+	assert.True(t, b.Skills[0].Name != "MUTATED", "Skills slice must be copied")
+	assert.True(t, b.Skills[0].Tags[0] != "MUTATED", "Tags slice must be copied")
+	assert.True(t, b.SupportedInterfaces[0].URL != "MUTATED", "SupportedInterfaces slice must be copied")
+}
+
+// Server enforces a request body size limit (issue #1).
+func TestServerRejectsOversizedRequest(t *testing.T) {
+	model := &fakeLLM{generate: func(ctx context.Context, opts ...llm.Option) (*llm.Response, error) {
+		return textResponse("ok"), nil
+	}}
+	agent := buildAgent(t, model)
+
+	server, err := a2a.NewServer(a2a.ServerOptions{
+		Agent:           agent,
+		MaxRequestBytes: 256,
+	})
+	assert.NoError(t, err)
+
+	ts := httptest.NewServer(server.Handler())
+	defer ts.Close()
+
+	body := bytes.Repeat([]byte("a"), 4096)
+	resp, err := http.Post(ts.URL+"/", "application/json", bytes.NewReader(body))
+	assert.NoError(t, err)
+	defer resp.Body.Close()
+
+	var env struct {
+		Error *a2a.RPCError `json:"error"`
+	}
+	assert.NoError(t, json.NewDecoder(resp.Body).Decode(&env))
+	assert.True(t, env.Error != nil, "expected RPC error envelope on oversized body")
+	assert.Equal(t, env.Error.Code, a2a.ErrorCodeParseError)
+}
+
+// MemoryTaskStore.Put rejects invalid records (issue #9).
+func TestMemoryTaskStorePutRejectsInvalidRecord(t *testing.T) {
+	store := a2a.NewMemoryTaskStore()
+	ctx := context.Background()
+
+	assert.True(t, errors.Is(store.Put(ctx, nil), a2a.ErrInvalidTaskRecord))
+	assert.True(t, errors.Is(store.Put(ctx, &a2a.TaskRecord{}), a2a.ErrInvalidTaskRecord))
+	assert.True(t, errors.Is(store.Put(ctx, &a2a.TaskRecord{Task: &a2a.Task{}}), a2a.ErrInvalidTaskRecord))
+
+	assert.NoError(t, store.Put(ctx, &a2a.TaskRecord{Task: &a2a.Task{ID: "t1"}}))
+	rec, ok, err := store.Get(ctx, "t1")
+	assert.NoError(t, err)
+	assert.True(t, ok)
+	assert.Equal(t, rec.Task.ID, "t1")
+}
+
+// RemoteAgent.RefreshCard re-fetches and updates the cache (issue #6).
+func TestRemoteAgentRefreshCard(t *testing.T) {
+	var version atomic.Value
+	version.Store("1")
+
+	mux := http.NewServeMux()
+	mux.HandleFunc(a2a.DefaultAgentCardPath, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w,
+			`{"name":"r","description":"d","supportedInterfaces":[],"version":%q,`+
+				`"defaultInputModes":[],"defaultOutputModes":[],"skills":[],"capabilities":{}}`,
+			version.Load().(string))
+	})
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	client, err := a2a.NewClient(a2a.ClientOptions{Endpoint: ts.URL + "/"})
+	assert.NoError(t, err)
+	remote := a2a.NewRemoteAgent(client)
+
+	card, err := remote.Card(context.Background())
+	assert.NoError(t, err)
+	assert.Equal(t, card.Version, "1")
+
+	// Server bumps its version. The cached card should still report 1.
+	version.Store("2")
+	card2, err := remote.Card(context.Background())
+	assert.NoError(t, err)
+	assert.Equal(t, card2.Version, "1")
+
+	// RefreshCard pulls the new version.
+	card3, err := remote.RefreshCard(context.Background())
+	assert.NoError(t, err)
+	assert.Equal(t, card3.Version, "2")
+}

--- a/experimental/a2a/server.go
+++ b/experimental/a2a/server.go
@@ -53,9 +53,19 @@ type ServerOptions struct {
 	// in-memory store. Prototype callers can leave this nil.
 	TaskStore TaskStore
 
+	// MaxRequestBytes caps the size of an inbound JSON-RPC request body.
+	// A value <= 0 selects DefaultMaxRequestBytes. Set explicitly to a
+	// large value if you intentionally accept multi-megabyte payloads,
+	// or wrap the handler with your own size-limiting middleware.
+	MaxRequestBytes int64
+
 	// Logger is an optional logger. Defaults to llm.NullLogger.
 	Logger llm.Logger
 }
+
+// DefaultMaxRequestBytes is the default cap on inbound JSON-RPC request
+// body size when ServerOptions.MaxRequestBytes is unset.
+const DefaultMaxRequestBytes = 10 * 1024 * 1024
 
 // Server exposes a Dive agent as an A2A endpoint. Wire it into an HTTP
 // mux via Handler; the returned handler serves both the well-known agent
@@ -72,10 +82,18 @@ type Server struct {
 	cardBytes []byte
 	cardMu    sync.RWMutex
 
+	// maxRequestBytes caps inbound JSON-RPC request body size.
+	maxRequestBytes int64
+
 	// inflight tracks cancel functions for in-progress turns so that
 	// tasks/cancel can interrupt a running CreateResponse.
 	inflight   map[string]context.CancelFunc
 	inflightMu sync.Mutex
+
+	// writeMu serializes terminal-state writes to the task store so a
+	// runTurn that completes just after tasks/cancel arrives cannot
+	// clobber the CANCELED record (and vice versa).
+	writeMu sync.Mutex
 }
 
 // NewServer constructs a Server from the given options. It returns an
@@ -132,14 +150,20 @@ func NewServer(opts ServerOptions) (*Server, error) {
 	// exposes an event callback.
 	card.Capabilities.Streaming = true
 
+	maxBytes := opts.MaxRequestBytes
+	if maxBytes <= 0 {
+		maxBytes = DefaultMaxRequestBytes
+	}
+
 	s := &Server{
-		agent:    opts.Agent,
-		card:     card,
-		path:     opts.Path,
-		store:    opts.TaskStore,
-		provider: opts.SessionProvider,
-		logger:   opts.Logger,
-		inflight: make(map[string]context.CancelFunc),
+		agent:           opts.Agent,
+		card:            card,
+		path:            opts.Path,
+		store:           opts.TaskStore,
+		provider:        opts.SessionProvider,
+		logger:          opts.Logger,
+		maxRequestBytes: maxBytes,
+		inflight:        make(map[string]context.CancelFunc),
 	}
 	if err := s.refreshCardBytes(); err != nil {
 		return nil, err
@@ -158,9 +182,71 @@ func (s *Server) refreshCardBytes() error {
 	return nil
 }
 
-// Card returns a copy of the server's agent card.
+// Card returns a deep copy of the server's agent card. Mutating the
+// returned value will not affect what the server serves.
 func (s *Server) Card() AgentCard {
-	return s.card
+	return cloneAgentCard(s.card)
+}
+
+// cloneAgentCard returns a deep copy of an AgentCard. Slices and maps
+// are copied so callers cannot mutate the server's authoritative card.
+func cloneAgentCard(c AgentCard) AgentCard {
+	out := c
+	if c.SupportedInterfaces != nil {
+		out.SupportedInterfaces = append([]AgentInterface(nil), c.SupportedInterfaces...)
+	}
+	if c.DefaultInputModes != nil {
+		out.DefaultInputModes = append([]string(nil), c.DefaultInputModes...)
+	}
+	if c.DefaultOutputModes != nil {
+		out.DefaultOutputModes = append([]string(nil), c.DefaultOutputModes...)
+	}
+	if c.Skills != nil {
+		out.Skills = make([]AgentSkill, len(c.Skills))
+		for i, sk := range c.Skills {
+			out.Skills[i] = cloneAgentSkill(sk)
+		}
+	}
+	if c.Provider != nil {
+		p := *c.Provider
+		out.Provider = &p
+	}
+	if c.SecuritySchemes != nil {
+		ss := make(map[string]any, len(c.SecuritySchemes))
+		for k, v := range c.SecuritySchemes {
+			ss[k] = v
+		}
+		out.SecuritySchemes = ss
+	}
+	if c.Security != nil {
+		sec := make([]map[string][]string, len(c.Security))
+		for i, m := range c.Security {
+			cm := make(map[string][]string, len(m))
+			for k, v := range m {
+				cm[k] = append([]string(nil), v...)
+			}
+			sec[i] = cm
+		}
+		out.Security = sec
+	}
+	return out
+}
+
+func cloneAgentSkill(s AgentSkill) AgentSkill {
+	out := s
+	if s.Tags != nil {
+		out.Tags = append([]string(nil), s.Tags...)
+	}
+	if s.Examples != nil {
+		out.Examples = append([]string(nil), s.Examples...)
+	}
+	if s.InputModes != nil {
+		out.InputModes = append([]string(nil), s.InputModes...)
+	}
+	if s.OutputModes != nil {
+		out.OutputModes = append([]string(nil), s.OutputModes...)
+	}
+	return out
 }
 
 // Handler returns an http.Handler that serves the well-known agent card
@@ -202,6 +288,7 @@ func (s *Server) handleRPC(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 		return
 	}
+	r.Body = http.MaxBytesReader(w, r.Body, s.maxRequestBytes)
 	var req RPCRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		writeRPCError(w, nil, newRPCError(ErrorCodeParseError, "parse error: "+err.Error(), nil))
@@ -402,6 +489,9 @@ func (s *Server) handleTasksCancel(w http.ResponseWriter, r *http.Request, req *
 		writeRPCError(w, req.ID, newRPCError(ErrorCodeInvalidParams, "missing task id", nil))
 		return
 	}
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+
 	rec, ok, err := s.store.Get(r.Context(), params.ID)
 	if err != nil {
 		writeRPCError(w, req.ID, newRPCError(ErrorCodeInternalError, err.Error(), nil))
@@ -434,7 +524,10 @@ func (s *Server) handleTasksCancel(w http.ResponseWriter, r *http.Request, req *
 		}
 	}
 
-	_ = s.store.Put(r.Context(), rec)
+	if err := s.store.Put(r.Context(), rec); err != nil {
+		writeRPCError(w, req.ID, newRPCError(ErrorCodeInternalError, "task store: "+err.Error(), nil))
+		return
+	}
 	writeRPCResult(w, req.ID, rec.Task)
 }
 
@@ -486,6 +579,11 @@ func (s *Server) runTurn(ctx context.Context, params *SendMessageParams, cb dive
 
 	resp, runErr := s.agent.CreateResponse(turnCtx, opts...)
 	if runErr != nil {
+		if errors.Is(runErr, context.Canceled) {
+			if t := s.canceledTaskFromStore(ctx, newTaskID); t != nil {
+				return t, nil
+			}
+		}
 		return nil, rpcErrorFromTurn(runErr)
 	}
 
@@ -496,10 +594,11 @@ func (s *Server) runTurn(ctx context.Context, params *SendMessageParams, cb dive
 		Suspension: resp.Suspension,
 		SessionID:  contextID,
 	}
-	if err := s.store.Put(ctx, rec); err != nil {
+	committed, err := s.commitFinalTask(ctx, rec)
+	if err != nil {
 		return nil, newRPCError(ErrorCodeInternalError, "task store: "+err.Error(), nil)
 	}
-	return task, nil
+	return committed.Task, nil
 }
 
 // resumeTurn handles a message/send or message/stream that targets an
@@ -561,6 +660,11 @@ func (s *Server) resumeTurn(ctx context.Context, params *SendMessageParams, cb d
 
 	resp, runErr := s.agent.CreateResponse(turnCtx, opts...)
 	if runErr != nil {
+		if errors.Is(runErr, context.Canceled) {
+			if t := s.canceledTaskFromStore(ctx, taskID); t != nil {
+				return t, nil
+			}
+		}
 		return nil, rpcErrorFromTurn(runErr)
 	}
 
@@ -569,10 +673,11 @@ func (s *Server) resumeTurn(ctx context.Context, params *SendMessageParams, cb d
 	updated.History = append(priorHistory, updated.History...)
 	rec.Task = updated
 	rec.Suspension = resp.Suspension
-	if err := s.store.Put(ctx, rec); err != nil {
+	committed, err := s.commitFinalTask(ctx, rec)
+	if err != nil {
 		return nil, newRPCError(ErrorCodeInternalError, "task store: "+err.Error(), nil)
 	}
-	return updated, nil
+	return committed.Task, nil
 }
 
 // resumeToolResults translates an inbound user message into ToolResults
@@ -658,6 +763,24 @@ func (s *Server) cancelInflight(taskID string) bool {
 	return ok
 }
 
+// commitFinalTask writes a non-suspended terminal TaskRecord, refusing
+// to overwrite a record that a concurrent tasks/cancel has already
+// transitioned into a terminal state. Returns the canonical record
+// (either the one passed in, or the canceled record stored in the
+// meantime).
+func (s *Server) commitFinalTask(ctx context.Context, rec *TaskRecord) (*TaskRecord, error) {
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+	if existing, ok, err := s.store.Get(ctx, rec.Task.ID); err == nil && ok &&
+		existing.Task.Status.State.IsTerminal() {
+		return existing, nil
+	}
+	if err := s.store.Put(ctx, rec); err != nil {
+		return nil, err
+	}
+	return rec, nil
+}
+
 // resolveSession calls the configured SessionProvider, falling back to
 // nil when no provider is set.
 func (s *Server) resolveSession(ctx context.Context, contextID string) (dive.Session, error) {
@@ -668,11 +791,11 @@ func (s *Server) resolveSession(ctx context.Context, contextID string) (dive.Ses
 }
 
 // rpcErrorFromTurn converts an error returned from Dive's CreateResponse
-// into an RPC error.
+// into an RPC error. context.Canceled is treated as an internal error;
+// callers that want to expose a CANCELED task to the original sender
+// should consult the store first (see runTurn/resumeTurn).
 func rpcErrorFromTurn(err error) *RPCError {
 	switch {
-	case errors.Is(err, context.Canceled):
-		return newRPCError(ErrorCodeTaskNotCancelable, "task was canceled", nil)
 	case errors.Is(err, dive.ErrNoSuspendedTurn):
 		return newRPCError(ErrorCodeInvalidRequest, "no suspended turn to resume", nil)
 	case errors.Is(err, dive.ErrUnknownPendingToolCall):
@@ -682,6 +805,24 @@ func rpcErrorFromTurn(err error) *RPCError {
 	default:
 		return newRPCError(ErrorCodeInternalError, err.Error(), nil)
 	}
+}
+
+// canceledTaskFromStore returns the CANCELED TaskRecord for the given ID
+// if a concurrent tasks/cancel transitioned the task to CANCELED while
+// the turn was running. Returns nil if no canceled record is present.
+// The store read is taken under writeMu so it observes any cancel write
+// the cancel handler completed before releasing the lock.
+func (s *Server) canceledTaskFromStore(ctx context.Context, taskID string) *Task {
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+	rec, ok, err := s.store.Get(ctx, taskID)
+	if err != nil || !ok || rec.Task == nil {
+		return nil
+	}
+	if rec.Task.Status.State == TaskStateCanceled {
+		return rec.Task
+	}
+	return nil
 }
 
 // ---------------------------------------------------------------------------

--- a/experimental/a2a/task_store.go
+++ b/experimental/a2a/task_store.go
@@ -2,10 +2,15 @@ package a2a
 
 import (
 	"context"
+	"errors"
 	"sync"
 
 	"github.com/deepnoodle-ai/dive"
 )
+
+// ErrInvalidTaskRecord is returned by TaskStore.Put when the supplied
+// record is missing required fields.
+var ErrInvalidTaskRecord = errors.New("a2a: invalid task record")
 
 // TaskStore persists A2A task state and the optional Dive SuspensionState
 // that accompanies a suspended task. The server adapter reads and writes
@@ -53,10 +58,12 @@ func NewMemoryTaskStore() *MemoryTaskStore {
 	return &MemoryTaskStore{records: make(map[string]*TaskRecord)}
 }
 
-// Put implements TaskStore.
+// Put implements TaskStore. Returns ErrInvalidTaskRecord if rec, rec.Task,
+// or rec.Task.ID is missing — silently dropping such records would mask
+// caller bugs and leave clients waiting on tasks that were never stored.
 func (s *MemoryTaskStore) Put(ctx context.Context, rec *TaskRecord) error {
 	if rec == nil || rec.Task == nil || rec.Task.ID == "" {
-		return nil
+		return ErrInvalidTaskRecord
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/experimental/a2a/types.go
+++ b/experimental/a2a/types.go
@@ -86,6 +86,32 @@ func (p Part) IsData() bool { return len(p.Data) > 0 }
 // IsURL returns true if this is a URL part.
 func (p Part) IsURL() bool { return p.URL != "" }
 
+// Validate enforces the A2A v1.0 invariant that exactly one of Text,
+// Raw, Data, or URL is populated on a Part.
+func (p Part) Validate() error {
+	count := 0
+	if p.IsText() {
+		count++
+	}
+	if p.IsRaw() {
+		count++
+	}
+	if p.IsData() {
+		count++
+	}
+	if p.IsURL() {
+		count++
+	}
+	switch count {
+	case 0:
+		return fmt.Errorf("a2a: part has no content (one of text, raw, data, url required)")
+	case 1:
+		return nil
+	default:
+		return fmt.Errorf("a2a: part must populate exactly one of text, raw, data, url")
+	}
+}
+
 // Message is a unit of conversation exchanged between an A2A client and
 // agent. It matches the A2A v1.0 Message shape.
 type Message struct {
@@ -260,6 +286,11 @@ func (p *SendMessageParams) Validate() error {
 	}
 	if len(p.Message.Parts) == 0 {
 		return fmt.Errorf("a2a: message has no parts")
+	}
+	for i, part := range p.Message.Parts {
+		if err := part.Validate(); err != nil {
+			return fmt.Errorf("a2a: parts[%d]: %w", i, err)
+		}
 	}
 	return nil
 }

--- a/experimental/a2alib/executor.go
+++ b/experimental/a2alib/executor.go
@@ -129,9 +129,12 @@ func (e *Executor) Execute(ctx context.Context, execCtx *a2asrv.ExecutorContext)
 		e.trackInflight(taskID, cancelExec)
 		defer e.untrackInflight(taskID)
 
+		type runResult struct {
+			resp *dive.Response
+			err  error
+		}
 		events := make(chan a2a.Event, 64)
-		var resp *dive.Response
-		var respErr error
+		results := make(chan runResult, 1)
 
 		go func() {
 			defer close(events)
@@ -147,26 +150,31 @@ func (e *Executor) Execute(ctx context.Context, execCtx *a2asrv.ExecutorContext)
 				return nil
 			}
 			opts = append(opts, dive.WithEventCallback(cb))
-			resp, respErr = e.agent.CreateResponse(execCtx2, opts...)
+			resp, err := e.agent.CreateResponse(execCtx2, opts...)
+			results <- runResult{resp: resp, err: err}
 		}()
 
 		// Yield intermediate streaming events.
 		for event := range events {
 			if !yield(event, nil) {
 				cancelExec()
+				// Wait for the goroutine to finish so its write to
+				// the result channel happens-before we return.
+				<-results
 				return
 			}
 		}
 
 		// CreateResponse finished. Yield final result.
-		if respErr != nil {
+		result := <-results
+		if result.err != nil {
 			yield(a2a.NewStatusUpdateEvent(execCtx, a2a.TaskStateFailed,
-				a2a.NewMessage(a2a.MessageRoleAgent, a2a.NewTextPart(respErr.Error()))), nil)
+				a2a.NewMessage(a2a.MessageRoleAgent, a2a.NewTextPart(result.err.Error()))), nil)
 			return
 		}
 
 		// Map response to final events.
-		e.yieldResponseEvents(execCtx, resp, yield)
+		e.yieldResponseEvents(execCtx, result.resp, yield)
 	}
 }
 


### PR DESCRIPTION
## Summary

Addresses nine concrete issues found while reviewing `experimental/a2a` and `experimental/a2alib`:

1. **Body size limit** — `handleRPC` now wraps `r.Body` in `http.MaxBytesReader`. Configurable via `ServerOptions.MaxRequestBytes` (10 MB default).
2. **`mustMarshal`** — removed; `Client.call` and `Client.StreamMessage` now surface marshal errors instead of silently sending `null` params.
3. **Cancel/finish race** — added `Server.writeMu` and a `commitFinalTask` helper. A `runTurn` that completes after `tasks/cancel` arrives no longer clobbers the CANCELED state. `handleTasksCancel` also stops swallowing the final `store.Put` error.
4. **`Part.Validate`** — enforces "exactly one of text/raw/data/url"; called from `SendMessageParams.Validate`.
5. **`Server.Card()` deep copy** — added `cloneAgentCard` so callers can't mutate the server's authoritative card.
6. **`RemoteAgent.RefreshCard`** — explicit re-fetch for long-lived clients; `card` and `contextID` are now mutex-guarded.
7. **a2alib executor data race** — `resp`/`respErr` moved onto a result channel so a happens-before edge exists in both the success and early-disconnect paths.
8. **`context.Canceled` mapping** — no longer mapped to `ErrorCodeTaskNotCancelable`. On cancel-mid-flight, `runTurn`/`resumeTurn` re-read the store under `writeMu` and return the CANCELED `Task` to the original sender when one exists.
9. **`MemoryTaskStore.Put` validation** — returns `ErrInvalidTaskRecord` instead of silently dropping nil/incomplete records.

Context for the review: https://github.com/deepnoodle-ai/dive/blob/main/experimental/a2a/doc.go (the package itself documents that body limits are pushed to caller middleware; this PR adds a sane default while keeping that override path open via `MaxRequestBytes`).

## Test plan

- [x] `go test -race ./experimental/a2a/...` — passes
- [x] `cd experimental/a2alib && go test -race ./...` — passes
- [x] `go vet ./...` clean in both modules
- [x] New focused tests in `experimental/a2a/review_fixes_test.go`:
  - `TestPartValidate` / `TestSendMessageParamsValidateRejectsMixedPart`
  - `TestServerCardIsDeepCopy`
  - `TestServerRejectsOversizedRequest`
  - `TestMemoryTaskStorePutRejectsInvalidRecord`
  - `TestRemoteAgentRefreshCard`
- [ ] (Optional, follow-up) integration test exercising the cancel/finish race directly — current coverage relies on existing `TestServerCancelInterruptsInflightTurn` and the new write-mutex serialization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable request body size limiting for server security.
  * Added validation for message parts and task record inputs.

* **Bug Fixes**
  * Improved thread-safety for remote agent card caching operations.
  * Enhanced error handling for parameter serialization.
  * Fixed task cancellation and server card operations.
  * Improved goroutine cleanup for streaming operations.

* **Tests**
  * Added comprehensive test coverage for validation, card caching, and request limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->