### PR TITLE
Add MaxTurns to subagent.Definition

### DIFF
--- a/experimental/cmd/dive/main.go
+++ b/experimental/cmd/dive/main.go
@@ -214,10 +214,11 @@ func runInteractive(ctx *cli.Context) error {
 		}
 
 		return dive.NewAgent(dive.AgentOptions{
-			Name:         name,
-			SystemPrompt: def.Prompt,
-			Model:        subModel,
-			Tools:        subagent.FilterTools(def, parentTools),
+			Name:               name,
+			SystemPrompt:       def.Prompt,
+			Model:              subModel,
+			Tools:              subagent.FilterTools(def, parentTools),
+			ToolIterationLimit: def.MaxTurns,
 		})
 	}
 

--- a/experimental/subagent/loader.go
+++ b/experimental/subagent/loader.go
@@ -109,6 +109,7 @@ type frontmatter struct {
 	Description string   `yaml:"description"`
 	Model       string   `yaml:"model,omitempty"`
 	Tools       []string `yaml:"tools,omitempty"`
+	MaxTurns    int      `yaml:"max-turns,omitempty"`
 }
 
 // LoadFromDirectory loads subagent definitions from a single directory.
@@ -177,6 +178,7 @@ func loadFile(path string) (*Definition, error) {
 		Prompt:      strings.TrimSpace(body),
 		Tools:       frontm.Tools,
 		Model:       frontm.Model,
+		MaxTurns:    frontm.MaxTurns,
 	}, nil
 }
 

--- a/experimental/subagent/subagent.go
+++ b/experimental/subagent/subagent.go
@@ -63,6 +63,11 @@ type Definition struct {
 	// Model overrides the LLM model for this subagent.
 	// Valid values: "sonnet", "opus", "haiku", or "" to inherit from parent.
 	Model string
+
+	// MaxTurns limits how many tool iterations the subagent may take.
+	// When > 0, passed as AgentOptions.ToolIterationLimit. When 0, the parent's
+	// limit or the package default applies.
+	MaxTurns int
 }
 
 // GeneralPurpose is the default subagent available to all agents.

--- a/experimental/subagent/subagent_test.go
+++ b/experimental/subagent/subagent_test.go
@@ -237,6 +237,34 @@ You are a code reviewer. Analyze the code and provide feedback.`
 		assert.Equal(t, "sonnet", def.Model)
 		assert.Equal(t, []string{"Read", "Grep"}, def.Tools)
 		assert.Contains(t, def.Prompt, "code reviewer")
+		assert.Equal(t, 0, def.MaxTurns)
+	})
+
+	t.Run("Load max-turns from frontmatter", func(t *testing.T) {
+		dir := t.TempDir()
+
+		content := `---
+description: Narrow search agent
+tools:
+  - Grep
+  - Glob
+max-turns: 10
+---
+Find usages in the codebase.`
+
+		err := os.WriteFile(filepath.Join(dir, "find-usages.md"), []byte(content), 0644)
+		assert.NoError(t, err)
+
+		loader := &FileLoader{
+			Directories: []string{dir},
+		}
+
+		defs, err := loader.Load(context.Background())
+		assert.NoError(t, err)
+
+		def := defs["find-usages"]
+		assert.Equal(t, 10, def.MaxTurns)
+		assert.Equal(t, []string{"Grep", "Glob"}, def.Tools)
 	})
 
 	t.Run("Load skips non-markdown files", func(t *testing.T) {


### PR DESCRIPTION
## Summary

- Adds `MaxTurns int` to `subagent.Definition` — when >0, passed as `AgentOptions.ToolIterationLimit` when constructing the subagent
- Adds `max-turns` field to the YAML frontmatter parser so it can be set in agent markdown files
- Updates the CLI's `agentFactory` to forward `def.MaxTurns` to `ToolIterationLimit`
- When 0 (default), inherits parent limit or package default — no behavior change for existing callers

Implements tech spec: `docs/tech-specs/subagent-max-turns.md`

## Test plan

- [ ] `go test ./experimental/subagent/...` — new test `Load max-turns from frontmatter` verifies YAML parsing
- [ ] Existing tests pass unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Subagents now support configurable maximum tool iteration turns via a `max-turns` setting in configuration files, controlling how many iterations a subagent can perform during tool execution.

* **Tests**
  * Added test coverage for parsing and validating the max-turns configuration.

* **Style**
  * Code formatting improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->