### PR TITLE
Add agentskills.io standard fields to SkillConfig

### DIFF
--- a/skill/parser_test.go
+++ b/skill/parser_test.go
@@ -275,6 +275,28 @@ Deploy instructions.`
 	assert.False(t, *s.Config.UserInvocable)
 }
 
+func TestParseContent_AgentskillsFields(t *testing.T) {
+	content := `---
+name: my-skill
+description: A skill with ecosystem metadata.
+license: MIT
+compatibility:
+  - claude
+  - gpt-4o
+metadata:
+  author: Acme Corp
+  version: 1.2.0
+---
+
+Instructions.`
+
+	s, err := ParseContent([]byte(content), "/path/to/my-skill.md")
+	assert.NoError(t, err)
+	assert.Equal(t, "MIT", s.Config.License)
+	assert.Equal(t, []string{"claude", "gpt-4o"}, s.Config.Compatibility)
+	assert.Equal(t, map[string]string{"author": "Acme Corp", "version": "1.2.0"}, s.Config.Metadata)
+}
+
 func TestParseContent_AllowedToolsInlineArray(t *testing.T) {
 	content := `---
 name: inline-tools

--- a/skill/skill.go
+++ b/skill/skill.go
@@ -109,6 +109,18 @@ type SkillConfig struct {
 	// true = always a command (user-invocable only).
 	// false = always a skill (agent-invocable, even without description).
 	UserInvocable *bool `yaml:"user-invocable,omitempty"`
+
+	// agentskills.io standard fields (informational only, no runtime effect).
+
+	// License is the SPDX identifier or URL for this skill (e.g. "MIT", "Apache-2.0").
+	License string `yaml:"license,omitempty"`
+
+	// Compatibility lists agent runtimes or model identifiers this skill is known
+	// to work with (e.g. ["claude", "gpt-4o"]). No Dive behavior depends on this.
+	Compatibility []string `yaml:"compatibility,omitempty"`
+
+	// Metadata holds arbitrary string key-value pairs for ecosystem tooling.
+	Metadata map[string]string `yaml:"metadata,omitempty"`
 }
 
 // Trigger defines a pattern that causes automatic skill suggestion.


### PR DESCRIPTION
## Summary

Adds three optional fields to `SkillConfig` aligned with the [agentskills.io](https://agentskills.io) spec:

- `License string` — SPDX identifier or URL (e.g. `"MIT"`, `"Apache-2.0"`)
- `Compatibility []string` — agent runtimes or model identifiers the skill is known to work with
- `Metadata map[string]string` — arbitrary string key-value pairs for ecosystem tooling

All three are informational only — no Dive runtime behavior depends on them. Dive's existing load-bearing fields (`triggers`, `model`, `user-invocable`, etc.) are retained, making Dive a superset of the spec.

Implements tech spec: `docs/tech-specs/skill-frontmatter-agentskills.md`

## Test plan

- [ ] `go test ./skill/...` — new `TestParseContent_AgentskillsFields` verifies all three fields parse from YAML frontmatter
- [ ] Existing skill tests pass unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Skills now support optional license specification for licensing clarity
  * Skills can declare compatibility with specific runtimes and model identifiers
  * Skills can include custom metadata as key-value pairs for additional context

* **Tests**
  * Added comprehensive test coverage for new optional skill configuration fields

<!-- end of auto-generated comment: release notes by coderabbit.ai -->