### PR TITLE
Add SessionStart hook and model-judgment hook helpers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,7 @@ Library-first approach — the CLI in `experimental/cmd/dive/` is secondary.
 - **Session** (`dive.go`): `Session` interface (`ID`, `Messages`, `SaveTurn`). Set on `AgentOptions.Session` or per-call via `WithSession`. The `session` package provides `New()` (in-memory) and store-backed implementations.
 - **LLM** (`llm/llm.go`): `LLM` and `StreamingLLM` interfaces abstract over providers.
 - **Tool** (`tool.go`): `Tool` and `TypedTool[T]` interfaces. `FuncTool[T]()` creates tools from functions with auto-generated schemas. `Toolset` interface provides dynamic tool resolution per LLM request. Tool panics are auto-recovered. All toolkit constructors return `*dive.TypedToolAdapter[T]` (satisfies `dive.Tool`).
-- **Hooks** (`hooks.go`): `Hooks` struct groups hook slices on `AgentOptions`. Hook types: `PreGenerationHook`, `PostGenerationHook`, `PreToolUseHook`, `PostToolUseHook`, `PostToolUseFailureHook`, `StopHook`, `PreIterationHook`, `OnSuspendHook`. All hooks receive `*HookContext`. PreToolUse hooks can set `HookContext.UpdatedInput` to rewrite the tool args.
+- **Hooks** (`hooks.go`): `Hooks` struct groups hook slices on `AgentOptions`. Hook types: `SessionStartHook`, `PreGenerationHook`, `PostGenerationHook`, `PreToolUseHook`, `PostToolUseHook`, `PostToolUseFailureHook`, `StopHook`, `PreIterationHook`, `OnSuspendHook`. All hooks receive `*HookContext`. PreToolUse hooks can set `HookContext.UpdatedInput` to rewrite the tool args. `SessionStartHook` fires once at the start of a fresh conversation (no prior messages, non-resume) and returns a `*SessionStartResult` to seed it (durable or ephemeral via `Persist`).
 - **Tracer** (`tracer.go`): `Tracer` interface for observation (tracing, metrics, audit logging). Three methods (`StartAgentRun`, `StartChat`, `StartToolCall`) return `(ctx, span)`; the agent threads ctx through downstream calls so spans nest naturally. `NopTracer` (default) and `MultiTracer` live in core; the OpenTelemetry adapter is `otel.NewTracer` in the `dive/otel` module.
 - **Suspend/Resume** (`tool.go`, `response.go`, `dive.go`): A tool can pause the agent mid-turn by returning `NewSuspendResult(prompt, metadata)` or `NewSuspendResultWithReason(prompt, reason, metadata)` (sets `ToolResult.Suspend`). `SuspendReason` classifies why: `SuspendReasonInput` (default) or `SuspendReasonAuth`. `CreateResponse` returns `(*Response, nil)` with `Status == ResponseStatusSuspended` and `Response.Suspension *SuspensionState`. Resume via `WithToolResults` (session-backed) or `WithResume(state, results)` (stateless). `SuspendableSession` is an optional `Session` extension for auto-persistence with `CancelSuspension(ctx)` to abandon a suspended turn. `OnSuspend` hooks fire before persistence. See `docs/guides/suspend-resume.md`.
 
@@ -42,7 +42,7 @@ Anthropic's tuning of Claude for these tool patterns.
 
 ### Hook Flow
 
-SessionLoad → PreGeneration → [PreIteration → LLM → PreToolUse → Execute → PostToolUse]* → Stop → PostGeneration → SessionSave
+SessionLoad → SessionStart (first turn only) → PreGeneration → [PreIteration → LLM → PreToolUse → Execute → PostToolUse]* → Stop → PostGeneration → SessionSave
 
 On suspend: OnSuspend → PostGeneration → SaveSuspendedTurn → return `Status=Suspended`.
 

--- a/agent.go
+++ b/agent.go
@@ -48,6 +48,11 @@ func acquireSessionLock(id string) func() {
 
 // Hooks groups all agent hook slices.
 type Hooks struct {
+	// SessionStart hooks fire once per session, before the first LLM call, when
+	// the loaded session has no prior messages. Returned messages are prepended
+	// to the conversation as seed messages. Errors abort CreateResponse.
+	SessionStart []SessionStartHook
+
 	// PreGeneration hooks are called before the LLM generation loop.
 	PreGeneration []PreGenerationHook
 
@@ -226,6 +231,7 @@ func NewAgent(opts AgentOptions) (*Agent, error) {
 		}
 		opts.Tools = append(opts.Tools, ext.Tools()...)
 		extHooks := ext.Hooks()
+		opts.Hooks.SessionStart = append(opts.Hooks.SessionStart, extHooks.SessionStart...)
 		opts.Hooks.PreGeneration = append(opts.Hooks.PreGeneration, extHooks.PreGeneration...)
 		opts.Hooks.PostGeneration = append(opts.Hooks.PostGeneration, extHooks.PostGeneration...)
 		opts.Hooks.PreToolUse = append(opts.Hooks.PreToolUse, extHooks.PreToolUse...)
@@ -445,6 +451,47 @@ func (a *Agent) CreateResponse(ctx context.Context, opts ...CreateResponseOption
 	// out rather than silently no-op re-saving the suspended turn.
 	if suspState != nil && !hasResumeIntent {
 		return nil, ErrResumeRequired
+	}
+
+	// Fire SessionStart hooks at the start of a fresh conversation: the session
+	// has no prior messages and this turn is not resuming a suspended one. The
+	// resume guards above guarantee suspState == nil here when hasResumeIntent
+	// is false, so seeds always flow into the non-resume history branch below.
+	// Returned messages are prepended to the conversation; those marked Persist
+	// are saved as a pre-turn so they survive later turns and resumes.
+	if !hasResumeIntent && len(sessionMsgs) == 0 && len(a.hooks.SessionStart) > 0 {
+		startHctx := NewHookContext()
+		startHctx.Agent = a
+		startHctx.Session = sess
+		startHctx.SystemPrompt = systemPrompt
+		startHctx.SessionStartSource = SessionStartStartup
+		maps.Copy(startHctx.Values, options.Values)
+
+		var persistentSeeds []*llm.Message
+		for _, hook := range a.hooks.SessionStart {
+			result, hookErr := hook(ctx, startHctx)
+			if hookErr != nil {
+				logger.Error("session start hook error", "error", hookErr)
+				return nil, fmt.Errorf("session start hook error: %w", hookErr)
+			}
+			if result == nil || len(result.Messages) == 0 {
+				continue
+			}
+			sessionMsgs = append(sessionMsgs, result.Messages...)
+			if result.Persist {
+				persistentSeeds = append(persistentSeeds, result.Messages...)
+			}
+		}
+
+		// Persist durable seeds as their own pre-turn so they remain in history
+		// on later turns and on resume, without polluting the turn delta below.
+		// Stateless calls (sess == nil) have nowhere to save, so Persist is a
+		// no-op there and the seeds stay ephemeral.
+		if len(persistentSeeds) > 0 && sess != nil {
+			if err := sess.SaveTurn(ctx, persistentSeeds, nil); err != nil {
+				return nil, fmt.Errorf("session start seed save error: %w", err)
+			}
+		}
 	}
 
 	// Build the full history the agent will operate on.

--- a/agent_suspend_test.go
+++ b/agent_suspend_test.go
@@ -241,6 +241,48 @@ func TestResumeSimple(t *testing.T) {
 	assert.True(t, foundResult, "resumed tool_result should reference toolu_a")
 }
 
+func TestSessionStartHookNotFiredOnResume(t *testing.T) {
+	fireCount := 0
+	mock := &scriptedLLM{
+		script: []scriptedTurn{
+			toolUseAssistantTurn(newScriptedToolUse("toolu_a", "approve", `{}`)),
+			finalTextTurn("done"),
+		},
+	}
+	tool := &scriptedTool{
+		name:     "approve",
+		outcomes: []toolOutcome{{result: NewSuspendResult("waiting", nil)}},
+	}
+	sess := session.New("resume-sess")
+	agent, err := NewAgent(AgentOptions{
+		Model:   mock,
+		Tools:   []Tool{tool},
+		Session: sess,
+		Hooks: Hooks{
+			SessionStart: []SessionStartHook{
+				func(ctx context.Context, hctx *HookContext) (*SessionStartResult, error) {
+					fireCount++
+					return nil, nil
+				},
+			},
+		},
+	})
+	assert.NoError(t, err)
+
+	// Turn 1: fresh session — SessionStart fires once, then the turn suspends.
+	resp, err := agent.CreateResponse(context.Background(), WithInput("hi"))
+	assert.NoError(t, err)
+	assert.Equal(t, resp.Status, ResponseStatusSuspended)
+	assert.Equal(t, fireCount, 1)
+
+	// Resume: SessionStart must NOT re-fire — resuming is not a session start.
+	resp, err = agent.CreateResponse(context.Background(),
+		WithToolResults(map[string]*ToolResult{"toolu_a": NewToolResultText("approved")}))
+	assert.NoError(t, err)
+	assert.Equal(t, resp.Status, ResponseStatusCompleted)
+	assert.Equal(t, fireCount, 1, "SessionStart must not fire on resume")
+}
+
 func TestSuspendResumeSuspendAgain(t *testing.T) {
 	mock := &scriptedLLM{
 		script: []scriptedTurn{

--- a/docs/design/hooks.md
+++ b/docs/design/hooks.md
@@ -29,23 +29,28 @@ lifecycle is CLI-centric while Dive's is API-centric.
 
 ## Hook Types
 
-| Hook Type                | When it fires                       | Claude Code equivalent   |
-| :----------------------- | :---------------------------------- | :----------------------- |
-| `PreGenerationHook`      | Before the LLM generation loop      | `SessionStart` (loosely) |
-| `PostGenerationHook`     | After the generation loop completes | —                        |
-| `PreToolUseHook`         | Before a tool call executes         | `PreToolUse`             |
-| `PostToolUseHook`        | After a tool call succeeds          | `PostToolUse`            |
-| `PostToolUseFailureHook` | After a tool call fails             | `PostToolUseFailure`     |
-| `StopHook`               | When the agent is about to stop     | `Stop`                   |
-| `PreIterationHook`       | Before each LLM call in the loop    | —                        |
+| Hook Type                | When it fires                                         | Claude Code equivalent |
+| :----------------------- | :---------------------------------------------------- | :--------------------- |
+| `SessionStartHook`       | Start of a fresh conversation, before the first LLM call | `SessionStart`      |
+| `PreGenerationHook`      | Before the LLM generation loop                        | —                      |
+| `PostGenerationHook`     | After the generation loop completes                   | —                      |
+| `PreToolUseHook`         | Before a tool call executes                           | `PreToolUse`           |
+| `PostToolUseHook`        | After a tool call succeeds                            | `PostToolUse`          |
+| `PostToolUseFailureHook` | After a tool call fails                               | `PostToolUseFailure`   |
+| `StopHook`               | When the agent is about to stop                       | `Stop`                 |
+| `PreIterationHook`       | Before each LLM call in the loop                      | —                      |
 
-All hook types are `func(ctx context.Context, hctx *HookContext) error` except
-`StopHook` which returns `(*StopDecision, error)`.
+Most hook types are `func(ctx context.Context, hctx *HookContext) error`. The
+exceptions return richer values: `StopHook` returns `(*StopDecision, error)` and
+`SessionStartHook` returns `(*SessionStartResult, error)`.
 
 ## Hook Flow
 
 ```text
 CreateResponse
+│
+├─ load session history
+├─ SessionStart hooks   (only when no prior messages AND not a resume)
 │
 ├─ PreGeneration hooks
 │
@@ -75,6 +80,8 @@ type HookContext struct {
     SystemPrompt string               // PreGeneration, PreIteration
     Messages     []*llm.Message       // PreGeneration, PreIteration
 
+    SessionStartSource SessionStartSource // SessionStart (why it fired)
+
     Response       *Response           // PostGeneration, Stop
     OutputMessages []*llm.Message      // PostGeneration, Stop
     Usage          *llm.Usage          // PostGeneration, Stop
@@ -93,6 +100,79 @@ type HookContext struct {
 
 The `Values` map persists across all phases within one `CreateResponse` call,
 enabling hooks to pass data to each other.
+
+## SessionStart Hook
+
+`SessionStartHook` seeds a conversation from external state — project config,
+user preferences, memory — at the moment it begins, without forcing callers to
+write a `PreGenerationHook` that manually inspects the history for emptiness.
+
+```go
+type SessionStartHook func(ctx context.Context, hctx *HookContext) (*SessionStartResult, error)
+
+type SessionStartResult struct {
+    Messages []*llm.Message // prepended to the conversation, ahead of user input
+    Persist  bool           // save to the session (durable) vs first-turn-only (ephemeral)
+}
+```
+
+### Trigger
+
+The hook fires when **both** conditions hold:
+
+1. The loaded session has **no prior messages**, and
+2. The turn is **not** resuming a suspended one (`hasResumeIntent == false`).
+
+This placement is deliberate. The block runs *after* the suspend/resume guards
+in `CreateResponse`, so a resume — including a stateless `WithResume` call,
+whose synthetic empty history would otherwise look like a fresh start — never
+re-fires it. Resuming a turn is not starting a session; firing seed logic there
+would re-run side effects (config loads, external lookups) and then discard the
+result, since the resume path rebuilds history from the suspended turn rather
+than `sessionMsgs`.
+
+Because the trigger is "no prior messages," a **stateless** agent (no `Session`)
+fires the hook on every `CreateResponse` — there is never any prior history.
+That is intended and documented on the type; the trigger is not "first ever call
+for this session object."
+
+### Source
+
+`HookContext.SessionStartSource` tells the hook *why* it fired, mirroring Claude
+Code's `SessionStart` source matcher. Today the agent emits only
+`SessionStartStartup`. Carrying the source on the context (rather than gating
+behavior with a bare boolean) keeps the API open to future sources — e.g.
+re-seeding after compaction, or `resume`/`clear`-style starts — without a
+signature change.
+
+### Persist vs ephemeral
+
+`SessionStartResult.Persist` chooses how long the seed lives:
+
+- **`Persist: true`** — durable context. The seed messages are written to the
+  session as their own *pre-turn* via a `SaveTurn` call before generation, so
+  they remain in `Messages()` on every later turn and survive suspend/resume.
+  Saving them as a separate pre-turn (rather than splicing them into the first
+  turn's input→output delta) keeps the persistence path simple: the normal turn
+  delta and the suspend path are untouched, and resume reads the seeds back
+  naturally from session history.
+- **`Persist: false`** — ephemeral priming. The messages are appended to the
+  in-memory history for this call only and influence the first generation, but
+  are never saved; later turns do not see them.
+
+`Persist` requires a `Session`. Stateless calls have nowhere to save to, so
+seeds are always ephemeral there regardless of the flag.
+
+This maps onto Claude Code's two SessionStart outputs: `Persist: true` is the
+analogue of `additionalContext` (context that persists for the session), and
+`Persist: false` is closer to `initialUserMessage` (priming for the first turn).
+
+### Errors
+
+A hook error aborts `CreateResponse` immediately (it is logged and returned
+wrapped as `session start hook error`). The session has not been written at that
+point — for a persistent seed the pre-turn `SaveTurn` happens only after all
+hooks succeed — so an aborted start leaves the session untouched.
 
 ## PostToolUse vs PostToolUseFailure
 
@@ -130,6 +210,7 @@ PreToolUse hooks can do more than allow/deny:
 
 | Hook type          | Regular error              | `*HookAbortError`     |
 | :----------------- | :------------------------- | :-------------------- |
+| SessionStart       | Aborts generation          | Aborts generation     |
 | PreGeneration      | Aborts generation          | Aborts generation     |
 | PostGeneration     | Logged, response preserved | Aborts, returns error |
 | PreToolUse         | Denies tool call           | Aborts generation     |
@@ -158,6 +239,7 @@ Hooks are grouped on `AgentOptions` in the `Hooks` struct:
 
 ```go
 type Hooks struct {
+    SessionStart       []SessionStartHook
     PreGeneration      []PreGenerationHook
     PostGeneration     []PostGenerationHook
     PreToolUse         []PreToolUseHook

--- a/docs/design/hooks.md
+++ b/docs/design/hooks.md
@@ -230,8 +230,53 @@ PreToolUse hooks can do more than allow/deny:
 | `MatchTool`            | `PreToolUseHook`         | Runs only for matching tool names     |
 | `MatchToolPost`        | `PostToolUseHook`        | Runs only for matching tool names     |
 | `MatchToolPostFailure` | `PostToolUseFailureHook` | Runs only for matching tool names     |
+| `PromptStopHook`       | `StopHook`               | Model judges whether the task is done; continues if not (fails open) |
+| `PromptToolGate`       | `PreToolUseHook`         | Model judges whether a tool call is safe; denies if not (fails closed) |
 
 All `Match*` helpers accept a Go regexp pattern compiled once at construction.
+
+## Judgment-Based Hooks
+
+`PromptStopHook` and `PromptToolGate` (`hookjudgment.go`) let a *model* make a
+hook decision that is hard to express as deterministic code — "is the task
+actually done?", "is this tool call safe in context?". They are constructors in
+the same spirit as `MatchTool`/`InjectContext`: the core hook types stay plain
+Go functions, which is the "prompt/agent hooks can be built on top" Non-Goal
+realized.
+
+### Decision contract
+
+Both force a single `{ ok bool, reason string }` verdict from the model. `ok`
+means "let it proceed"; on `!ok` the `reason` is surfaced back to the agent
+(Stop → next instruction; PreToolUse → tool denial). Structured output is
+guaranteed across providers by exposing a one-field `submit_decision` tool and
+forcing `ToolChoice{Type: tool, Name: "submit_decision"}`, then decoding the
+tool-call arguments — no JSON-from-free-text parsing. Evidence is rendered into
+a single user message rather than replaying the raw conversation, which keeps
+the judge call cheap and avoids provider validation of historical tool blocks.
+
+### The two helpers
+
+- `PromptStopHook(model, prompt)` — a `StopHook`. Asks whether the agent's
+  output satisfies `prompt`; if not, returns `StopDecision{Continue, Reason}`.
+  Honors `hctx.StopHookActive` (steps aside after one continuation, so it cannot
+  loop) and **fails open**: a model error is returned and logged, leaving the
+  agent free to stop.
+- `PromptToolGate(model, prompt)` — a `PreToolUseHook`. Judges the pending tool
+  call (`hctx.Call`); denies by returning an error and **fails closed**: a model
+  error denies, since a gate that allows-on-error is the worse failure. Scope it
+  with `MatchTool`.
+
+Pass a cheap model — each adds one LLM call per stop / matched tool invocation.
+
+### Future: agent-backed variant
+
+These judge from the hook's own data in one call. A planned
+`AgentStopHook(verifier *Agent, prompt)` would instead run a subagent with tools
+to verify against real state (run the test suite, read files) before deciding —
+same `{ok, reason}` contract. Pi's only structured-decision path is exactly
+this shape (a subagent run in JSON mode), which validates the approach. It
+likely belongs with `experimental/subagent`.
 
 ## Hooks Struct
 

--- a/docs/guides/hooks.md
+++ b/docs/guides/hooks.md
@@ -342,6 +342,29 @@ dive.MatchToolPostFailure("Bash", postToolUseFailureHook)
 The pattern is compiled once when the helper is called, not on every
 invocation.
 
+### Judgment-based helpers
+
+When a decision needs judgment rather than a fixed rule, let a model make it.
+These helpers force a `{ok, reason}` verdict from the model and plug into an
+ordinary hook. Pass a cheap model — each adds one LLM call.
+
+```go
+Hooks: dive.Hooks{
+    // Keep working until the model agrees the task is done (fails open).
+    Stop: []dive.StopHook{
+        dive.PromptStopHook(haiku, "Are all of the user's requests fully satisfied?"),
+    },
+    // Let the model veto risky shell commands (fails closed). Scope with MatchTool.
+    PreToolUse: []dive.PreToolUseHook{
+        dive.MatchTool("Bash", dive.PromptToolGate(haiku, "Is this command safe on a dev machine?")),
+    },
+},
+```
+
+`PromptStopHook` honors `hctx.StopHookActive` so it cannot loop. `PromptToolGate`
+denies by returning an error and fails closed on model errors. See the design
+doc for the agent-backed variant.
+
 ## Error Handling
 
 How errors are handled depends on the hook type:

--- a/docs/guides/hooks.md
+++ b/docs/guides/hooks.md
@@ -32,13 +32,15 @@ agent, _ := dive.NewAgent(dive.AgentOptions{
 ## Hook Flow
 
 ```text
-PreGeneration → [PreIteration → LLM → PreToolUse → Execute → PostToolUse / PostToolUseFailure]* → Stop → PostGeneration
-                                                                              ↓
-                                                                   (tool returned SuspendResult)
-                                                                              ↓
-                                                                   OnSuspend → PostGeneration
+SessionStart → PreGeneration → [PreIteration → LLM → PreToolUse → Execute → PostToolUse / PostToolUseFailure]* → Stop → PostGeneration
+                                                                                             ↓
+                                                                                  (tool returned SuspendResult)
+                                                                                             ↓
+                                                                                  OnSuspend → PostGeneration
 ```
 
+0. **SessionStart** runs once at the very beginning, only when the session has
+   no prior messages and the turn is not a resume. See [SessionStart](#sessionstart).
 1. **PreGeneration** runs once before the loop starts.
 2. Inside the loop, **PreIteration** runs before each LLM call.
 3. After the LLM responds with tool calls, **PreToolUse** runs before each tool, then
@@ -73,6 +75,46 @@ The `Values` map persists across all phases within one `CreateResponse` call, so
 hooks can pass data to each other.
 
 ## Generation Hooks
+
+### SessionStart
+
+Runs once at the start of a fresh conversation — before the first LLM call —
+when the loaded session has **no prior messages** and the turn is **not** a
+resume. Use it to seed a conversation from external state (project config, user
+preferences, memory) instead of writing a `PreGeneration` hook that checks for
+an empty history itself. It does not fire on later turns of an existing session
+or on resume.
+
+Return a `*dive.SessionStartResult` whose `Messages` are prepended to the
+conversation, ahead of the user input. Set `Persist` to choose how long the
+seed lives:
+
+- `Persist: true` — durable. The messages are saved to the session and stay in
+  the conversation on every later turn and on resume.
+- `Persist: false` — ephemeral. The messages influence only the first
+  generation and are not saved (`Persist` is always ephemeral for stateless
+  agents with no session).
+
+Returning a `nil` result is a no-op. Errors abort generation.
+`hctx.SessionStartSource` reports why the hook fired (currently always
+`dive.SessionStartStartup`).
+
+```go
+Hooks: dive.Hooks{
+    SessionStart: []dive.SessionStartHook{
+        func(ctx context.Context, hctx *dive.HookContext) (*dive.SessionStartResult, error) {
+            cfg, err := loadProjectConfig(ctx)
+            if err != nil {
+                return nil, err
+            }
+            return &dive.SessionStartResult{
+                Persist:  true, // keep the context for the whole conversation
+                Messages: []*llm.Message{llm.NewUserTextMessage("Project context:\n" + cfg)},
+            }, nil
+        },
+    },
+},
+```
 
 ### PreGeneration
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -26,6 +26,7 @@ cd examples
 | `openrouter_example` | OpenRouter | Multi-provider routing |
 | `skills_example` | Anthropic | Agent with skill loading and auto-invocation |
 | `tool_progress_example` | Anthropic | Tool streaming structured progress via ReportProgress |
+| `hooks_example` | Anthropic | SessionStart context seeding + model-judgment Stop/PreToolUse hooks |
 | `firecrawl_example` | Anthropic + Firecrawl | Agent with web search and fetch via Firecrawl |
 | `oauth_client` | — | OAuth client credential flow |
 

--- a/examples/hooks_example/main.go
+++ b/examples/hooks_example/main.go
@@ -1,0 +1,135 @@
+// hooks_example demonstrates three additions to Dive's hook system, printing a
+// line each time a hook fires so you can watch them work:
+//
+//   - SessionStart hook — seeds a fresh conversation with durable project
+//     context (Persist: true), so it stays in history on every later turn.
+//   - PromptToolGate — a cheap model vets each shell command and denies
+//     anything that would change production (fails closed).
+//   - PromptStopHook — a cheap model checks whether the task is actually done
+//     and nudges the agent to keep going if not (fails open).
+//
+// The main agent runs on a capable model; the two judgment hooks run on a small,
+// fast model to keep the extra calls cheap. The gate and stop hooks are each
+// wrapped in a few lines of logging purely so the demo is observable — in real
+// code you would use the helper directly.
+//
+// Requires ANTHROPIC_API_KEY.
+// Run: cd examples && go run ./hooks_example
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/deepnoodle-ai/dive"
+	"github.com/deepnoodle-ai/dive/llm"
+	"github.com/deepnoodle-ai/dive/providers/anthropic"
+	"github.com/deepnoodle-ai/dive/session"
+)
+
+type ShellInput struct {
+	Command string `json:"command" description:"The shell command to run"`
+}
+
+func main() {
+	ctx := context.Background()
+
+	// A small, fast model for the judgment hooks — they only return a verdict.
+	judge := anthropic.New(anthropic.WithModel(anthropic.ModelClaudeHaiku45))
+
+	// SessionStart: seed durable project context the agent should always know.
+	// Persist: true saves it as a pre-turn so it survives later turns and resume.
+	seedContext := func(ctx context.Context, hctx *dive.HookContext) (*dive.SessionStartResult, error) {
+		fmt.Println("[SessionStart] seeding durable project context")
+		return &dive.SessionStartResult{
+			Persist: true,
+			Messages: []*llm.Message{
+				llm.NewUserTextMessage("Project context: Acme API (Go), currently on version v1.4.0. " +
+					"Builds always use the `make build` command."),
+			},
+		}, nil
+	}
+
+	// A stub shell tool so the agent has something to call. It does not actually
+	// execute anything — PromptToolGate still vets every command first.
+	shellTool := dive.FuncTool("run_shell",
+		"Runs a shell command and returns its output.",
+		func(ctx context.Context, in *ShellInput) (*dive.ToolResult, error) {
+			return dive.NewToolResultText(fmt.Sprintf("(demo) ran: %s", in.Command)), nil
+		})
+
+	// The judgment helpers, each wrapped in a tiny logging closure for the demo.
+	gate := dive.PromptToolGate(judge,
+		"Is this shell command safe to run on a developer's machine? "+
+			"Approve ordinary local build and inspection commands; "+
+			"deny anything that changes production systems.")
+	stopJudge := dive.PromptStopHook(judge,
+		"Has the user's request been fully completed? If not, briefly say what remains.")
+
+	sess := session.New("hooks-demo")
+
+	agent, err := dive.NewAgent(dive.AgentOptions{
+		Name:         "Release Assistant",
+		SystemPrompt: "You are a release assistant. Use run_shell for any shell work.",
+		Model:        anthropic.New(),
+		Tools:        []dive.Tool{shellTool},
+		Session:      sess,
+		Hooks: dive.Hooks{
+			SessionStart: []dive.SessionStartHook{seedContext},
+			PreToolUse: []dive.PreToolUseHook{
+				dive.MatchTool("run_shell", func(ctx context.Context, hctx *dive.HookContext) error {
+					err := gate(ctx, hctx)
+					if err != nil {
+						fmt.Printf("[PromptToolGate] denied %s\n", string(hctx.Call.Input))
+					} else {
+						fmt.Printf("[PromptToolGate] allowed %s\n", string(hctx.Call.Input))
+					}
+					return err
+				}),
+			},
+			Stop: []dive.StopHook{
+				func(ctx context.Context, hctx *dive.HookContext) (*dive.StopDecision, error) {
+					dec, err := stopJudge(ctx, hctx)
+					if dec != nil && dec.Continue {
+						fmt.Printf("[PromptStopHook] work remains, nudging agent: %s\n", dec.Reason)
+					} else {
+						fmt.Println("[PromptStopHook] task complete, allowing stop")
+					}
+					return dec, err
+				},
+			},
+		},
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Explicit commands so the gate is exercised both ways: `make build` is an
+	// ordinary local command (approved), while the production deploy is denied —
+	// and the denial reason is fed back to the agent.
+	resp, err := agent.CreateResponse(ctx, dive.WithInput(
+		"What version are we on? Build the project with `make build`, then deploy it "+
+			"to production with `make deploy ENV=production`."))
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Printf("\nAgent: %s\n", resp.OutputText())
+
+	// Show that the durable seed was persisted: it leads the saved history and
+	// would be visible to the model on every subsequent turn of this session.
+	msgs, err := sess.Messages(ctx)
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Printf("\nSession holds %d messages; the first is the durable seed:\n  %q\n",
+		len(msgs), truncate(msgs[0].Text(), 80))
+}
+
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "…"
+}

--- a/hookjudgment.go
+++ b/hookjudgment.go
@@ -1,0 +1,137 @@
+package dive
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/deepnoodle-ai/dive/llm"
+	"github.com/deepnoodle-ai/wonton/schema"
+)
+
+// Judgment-based hook helpers wrap a single LLM call inside an ordinary hook,
+// letting a model make a decision that is hard to express as deterministic
+// code: "is the task actually done?", "is this tool call safe in context?".
+// They are constructors in the same spirit as InjectContext and MatchTool —
+// the core hook types stay plain Go functions. See docs/design/hooks.md
+// ("Judgment-Based Hooks").
+
+// JudgmentDecision is the structured verdict a model returns from a judgment
+// hook. OK reports whether the action may proceed; Reason explains a block and
+// is surfaced back to the agent.
+type JudgmentDecision struct {
+	OK     bool   `json:"ok"`
+	Reason string `json:"reason"`
+}
+
+// judgmentToolName is the name of the synthetic tool the model is forced to
+// call so its decision arrives as structured arguments rather than free text.
+const judgmentToolName = "submit_decision"
+
+var judgmentDecisionSchema = schema.NewSchema(
+	map[string]*schema.Property{
+		"ok":     schema.BooleanProp("true if the action may proceed; false to block it"),
+		"reason": schema.StringProp("brief justification for the verdict; required when ok is false"),
+	},
+	"ok", "reason",
+)
+
+// askJudgment makes one LLM call that forces the model to answer via the
+// submit_decision tool, guaranteeing structured output across providers. The
+// prompt frames the question (used as the system prompt) and evidence supplies
+// the material to judge as a single user message — deliberately rendered text
+// rather than a replay of the raw conversation, so the judge call stays cheap
+// and never trips provider validation of historical tool blocks.
+func askJudgment(ctx context.Context, model llm.LLM, prompt, evidence string) (*JudgmentDecision, error) {
+	tool := llm.NewToolDefinition().
+		WithName(judgmentToolName).
+		WithDescription("Record your verdict on whether the action may proceed.").
+		WithSchema(judgmentDecisionSchema)
+
+	resp, err := model.Generate(ctx,
+		llm.WithSystemPrompt(prompt),
+		llm.WithMessages(llm.NewUserTextMessage(evidence)),
+		llm.WithTools(tool),
+		llm.WithToolChoice(&llm.ToolChoice{Type: llm.ToolChoiceTypeTool, Name: judgmentToolName}),
+	)
+	if err != nil {
+		return nil, err
+	}
+	for _, call := range resp.ToolCalls() {
+		if call.Name != judgmentToolName {
+			continue
+		}
+		var d JudgmentDecision
+		if err := json.Unmarshal(call.Input, &d); err != nil {
+			return nil, fmt.Errorf("judgment hook: decode decision: %w", err)
+		}
+		return &d, nil
+	}
+	return nil, fmt.Errorf("judgment hook: model returned no %s decision", judgmentToolName)
+}
+
+// PromptStopHook returns a StopHook that asks model whether the agent's work so
+// far satisfies the task described by prompt. If the model answers ok=false,
+// the agent keeps working with the model's reason as its next instruction.
+//
+// It fails open: on a model or transport error the error is returned (Dive logs
+// it and lets the agent stop), so a flaky judge never traps a turn. It honors
+// hctx.StopHookActive — after forcing one continuation it steps aside, so the
+// agent cannot loop forever on the judge's say-so.
+//
+// Pass a cheap model (e.g. a small/fast one); this adds one call per stop.
+func PromptStopHook(model llm.LLM, prompt string) StopHook {
+	return func(ctx context.Context, hctx *HookContext) (*StopDecision, error) {
+		if hctx.StopHookActive {
+			return nil, nil
+		}
+		evidence := "The agent produced the following output this turn:\n\n" +
+			messagesText(hctx.OutputMessages)
+		d, err := askJudgment(ctx, model, prompt, evidence)
+		if err != nil {
+			return nil, err // fail open: logged by the agent, stop is allowed
+		}
+		if d.OK {
+			return nil, nil
+		}
+		return &StopDecision{Continue: true, Reason: d.Reason}, nil
+	}
+}
+
+// PromptToolGate returns a PreToolUseHook that asks model whether the pending
+// tool call is acceptable per prompt. If the model answers ok=false the call is
+// denied (a returned error denies a tool in Dive) and the reason is sent back
+// to the agent.
+//
+// It fails closed: a model or transport error denies the call, because a safety
+// gate that silently allows on error is worse than an occasional false deny.
+// Pair it with MatchTool to scope the gate to specific tools, and pass a cheap
+// model — this adds one call per matched tool invocation.
+func PromptToolGate(model llm.LLM, prompt string) PreToolUseHook {
+	return func(ctx context.Context, hctx *HookContext) error {
+		evidence := fmt.Sprintf("The agent wants to call tool %q with input:\n%s",
+			hctx.Call.Name, string(hctx.Call.Input))
+		d, err := askJudgment(ctx, model, prompt, evidence)
+		if err != nil {
+			return fmt.Errorf("tool gate: judgment failed, denying %q: %w", hctx.Call.Name, err)
+		}
+		if d.OK {
+			return nil
+		}
+		return fmt.Errorf("blocked by PromptToolGate: %s", d.Reason)
+	}
+}
+
+// messagesText concatenates the text of a message slice, skipping non-text
+// content (tool calls, etc.). Used to render evidence for a judgment call.
+func messagesText(msgs []*llm.Message) string {
+	var b strings.Builder
+	for _, m := range msgs {
+		if t := m.Text(); t != "" {
+			b.WriteString(t)
+			b.WriteByte('\n')
+		}
+	}
+	return b.String()
+}

--- a/hookjudgment_test.go
+++ b/hookjudgment_test.go
@@ -1,0 +1,144 @@
+package dive
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/deepnoodle-ai/dive/llm"
+	"github.com/deepnoodle-ai/wonton/assert"
+)
+
+// decisionModel returns a mockLLM that answers a judgment call with the given
+// verdict via the forced submit_decision tool.
+func decisionModel(ok bool, reason string) *mockLLM {
+	return &mockLLM{
+		nameFunc: func() string { return "judge" },
+		generateFunc: func(ctx context.Context, opts ...llm.Option) (*llm.Response, error) {
+			input, _ := json.Marshal(JudgmentDecision{OK: ok, Reason: reason})
+			return &llm.Response{
+				ID:         "j",
+				Model:      "judge",
+				Role:       llm.Assistant,
+				Type:       "message",
+				StopReason: "tool_use",
+				Content:    []llm.Content{&llm.ToolUseContent{ID: "t1", Name: judgmentToolName, Input: input}},
+			}, nil
+		},
+	}
+}
+
+func erroringModel() *mockLLM {
+	return &mockLLM{
+		nameFunc: func() string { return "judge" },
+		generateFunc: func(ctx context.Context, opts ...llm.Option) (*llm.Response, error) {
+			return nil, errors.New("transport boom")
+		},
+	}
+}
+
+func TestPromptToolGate(t *testing.T) {
+	call := &llm.ToolUseContent{ID: "c1", Name: "Bash", Input: json.RawMessage(`{"command":"rm -rf /"}`)}
+
+	t.Run("allows when model approves", func(t *testing.T) {
+		hctx := NewHookContext()
+		hctx.Call = call
+		err := PromptToolGate(decisionModel(true, ""), "Is this safe?")(context.Background(), hctx)
+		assert.NoError(t, err)
+	})
+
+	t.Run("denies and surfaces the reason", func(t *testing.T) {
+		hctx := NewHookContext()
+		hctx.Call = call
+		err := PromptToolGate(decisionModel(false, "rm -rf is destructive"), "Is this safe?")(context.Background(), hctx)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "rm -rf is destructive")
+	})
+
+	t.Run("fails closed on model error", func(t *testing.T) {
+		hctx := NewHookContext()
+		hctx.Call = call
+		err := PromptToolGate(erroringModel(), "Is this safe?")(context.Background(), hctx)
+		assert.Error(t, err) // a returned error denies the tool
+	})
+
+	t.Run("forces the submit_decision tool choice", func(t *testing.T) {
+		var gotChoice *llm.ToolChoice
+		var gotTools []llm.Tool
+		model := &mockLLM{
+			nameFunc: func() string { return "judge" },
+			generateFunc: func(ctx context.Context, opts ...llm.Option) (*llm.Response, error) {
+				var cfg llm.Config
+				cfg.Apply(opts...)
+				gotChoice = cfg.ToolChoice
+				gotTools = cfg.Tools
+				input, _ := json.Marshal(JudgmentDecision{OK: true})
+				return &llm.Response{
+					ID: "j", Role: llm.Assistant, Type: "message",
+					Content: []llm.Content{&llm.ToolUseContent{Name: judgmentToolName, Input: input}},
+				}, nil
+			},
+		}
+		hctx := NewHookContext()
+		hctx.Call = call
+		err := PromptToolGate(model, "ok?")(context.Background(), hctx)
+		assert.NoError(t, err)
+		assert.NotNil(t, gotChoice)
+		assert.Equal(t, llm.ToolChoiceTypeTool, gotChoice.Type)
+		assert.Equal(t, judgmentToolName, gotChoice.Name)
+		assert.Equal(t, 1, len(gotTools))
+		assert.Equal(t, judgmentToolName, gotTools[0].Name())
+	})
+}
+
+func TestPromptStopHook(t *testing.T) {
+	prompt := "Is the user's request fully satisfied?"
+	output := []*llm.Message{llm.NewAssistantTextMessage("I did half the task.")}
+
+	t.Run("allows stop when model says done", func(t *testing.T) {
+		hctx := NewHookContext()
+		hctx.OutputMessages = output
+		dec, err := PromptStopHook(decisionModel(true, ""), prompt)(context.Background(), hctx)
+		assert.NoError(t, err)
+		assert.Nil(t, dec)
+	})
+
+	t.Run("continues with reason when model says not done", func(t *testing.T) {
+		hctx := NewHookContext()
+		hctx.OutputMessages = output
+		dec, err := PromptStopHook(decisionModel(false, "finish the second half"), prompt)(context.Background(), hctx)
+		assert.NoError(t, err)
+		assert.NotNil(t, dec)
+		assert.True(t, dec.Continue)
+		assert.Equal(t, "finish the second half", dec.Reason)
+	})
+
+	t.Run("steps aside once StopHookActive (loop guard)", func(t *testing.T) {
+		consulted := false
+		model := &mockLLM{
+			nameFunc: func() string { return "judge" },
+			generateFunc: func(ctx context.Context, opts ...llm.Option) (*llm.Response, error) {
+				consulted = true
+				return nil, errors.New("should not be called")
+			},
+		}
+		hctx := NewHookContext()
+		hctx.OutputMessages = output
+		hctx.StopHookActive = true
+		dec, err := PromptStopHook(model, prompt)(context.Background(), hctx)
+		assert.NoError(t, err)
+		assert.Nil(t, dec)
+		assert.False(t, consulted, "judge must not be consulted once a continuation already happened")
+	})
+
+	t.Run("fails open on model error", func(t *testing.T) {
+		hctx := NewHookContext()
+		hctx.OutputMessages = output
+		dec, err := PromptStopHook(erroringModel(), prompt)(context.Background(), hctx)
+		// The error is returned so the agent logs it; Dive treats a Stop-hook
+		// error as no-decision, i.e. the agent is allowed to stop (fail open).
+		assert.Error(t, err)
+		assert.Nil(t, dec)
+	})
+}

--- a/hooks.go
+++ b/hooks.go
@@ -84,6 +84,12 @@ type HookContext struct {
 	// Messages contains the conversation history plus new input messages.
 	Messages []*llm.Message
 
+	// SessionStart
+
+	// SessionStartSource is set for SessionStart hooks and reports why the hook
+	// is firing (see SessionStartSource). Empty for all other hook types.
+	SessionStartSource SessionStartSource
+
 	// Response (available in PostGeneration, Stop)
 
 	// Response is the complete Response object returned by CreateResponse.
@@ -220,6 +226,61 @@ type PreIterationHook func(ctx context.Context, hctx *HookContext) error
 //
 // Errors are logged but do not affect the response.
 type PostBackgroundToolUseHook func(ctx context.Context, hctx *HookContext) error
+
+// SessionStartSource describes why SessionStart hooks are firing for a turn.
+// It is reported on HookContext.SessionStartSource so a hook can tailor its
+// seeding to the situation.
+type SessionStartSource string
+
+const (
+	// SessionStartStartup is a brand-new conversation: the active session has
+	// no prior messages and the turn is not resuming a suspended one. It is the
+	// only source the agent emits today; the field exists so future sources
+	// (e.g. re-seeding after compaction) can reuse this hook without an API
+	// change.
+	SessionStartStartup SessionStartSource = "startup"
+)
+
+// SessionStartResult is returned by a SessionStartHook to seed a conversation
+// before its first LLM call.
+type SessionStartResult struct {
+	// Messages are prepended to the conversation, ahead of the user input, so
+	// the model sees them on the first generation. An empty slice is a no-op.
+	Messages []*llm.Message
+
+	// Persist controls whether Messages are written to the session so they
+	// survive beyond the first generation:
+	//
+	//   - true  — durable seed context. Messages are saved as a pre-turn and
+	//             remain in the conversation on every later turn and on resume
+	//             (e.g. project config, user preferences, long-lived memory).
+	//   - false — ephemeral priming. Messages influence only the first
+	//             generation and are never saved; later turns do not see them.
+	//
+	// Persist requires a Session. Stateless calls (no Session) have nowhere to
+	// save to, so seeds are always ephemeral regardless of this flag.
+	Persist bool
+}
+
+// SessionStartHook fires once at the start of a conversation — before the first
+// LLM call — when the active session has no prior messages and the turn is NOT
+// resuming a suspended one. It is not called on later turns of an existing
+// session, nor on resume.
+//
+// Use it to bootstrap a conversation from external state (project config, user
+// preferences, memory) without a PreGenerationHook that manually inspects the
+// history for emptiness. Return a *SessionStartResult whose Messages are
+// prepended to the conversation; set Persist to choose durable vs ephemeral
+// seeding (see SessionStartResult). Returning a nil result is a no-op. If a
+// hook returns an error, CreateResponse returns that error immediately.
+//
+// HookContext.SessionStartSource reports why the hook fired (see
+// SessionStartSource).
+//
+// Note: a stateless agent (no Session) has no prior messages on any call, so
+// the hook fires on every CreateResponse. The trigger is "no prior messages on
+// a non-resume turn", not "first ever call for this session object".
+type SessionStartHook func(ctx context.Context, hctx *HookContext) (*SessionStartResult, error)
 
 // OnSuspendHook fires when the agent transitions into a suspended state,
 // BEFORE PostGeneration runs and BEFORE the suspended turn is persisted to

--- a/hooks_test.go
+++ b/hooks_test.go
@@ -10,6 +10,21 @@ import (
 	"github.com/deepnoodle-ai/wonton/assert"
 )
 
+// seededSession is a minimal Session implementation that returns a fixed message list.
+type seededSession struct {
+	id       string
+	messages []*llm.Message
+}
+
+func (s *seededSession) ID() string { return s.id }
+func (s *seededSession) Messages(_ context.Context) ([]*llm.Message, error) {
+	return s.messages, nil
+}
+func (s *seededSession) SaveTurn(_ context.Context, msgs []*llm.Message, _ *llm.Usage) error {
+	s.messages = append(s.messages, msgs...)
+	return nil
+}
+
 func TestPreGenerationHooks(t *testing.T) {
 	t.Run("hooks can modify system prompt", func(t *testing.T) {
 		var capturedSystemPrompt string
@@ -1509,5 +1524,267 @@ func TestPreIterationHookErrors(t *testing.T) {
 		var abortErr *HookAbortError
 		assert.ErrorAs(t, err, &abortErr)
 		assert.Equal(t, "abort from pre-iteration", abortErr.Reason)
+	})
+}
+
+func TestSessionStartHook(t *testing.T) {
+	makeModel := func(responseText string) *mockLLM {
+		return &mockLLM{
+			generateFunc: func(ctx context.Context, opts ...llm.Option) (*llm.Response, error) {
+				return &llm.Response{
+					ID:         "resp_123",
+					Model:      "test-model",
+					Role:       llm.Assistant,
+					Content:    []llm.Content{&llm.TextContent{Text: responseText}},
+					Type:       "message",
+					StopReason: "stop",
+					Usage:      llm.Usage{InputTokens: 10, OutputTokens: 5},
+				}, nil
+			},
+			nameFunc: func() string { return "test-model" },
+		}
+	}
+
+	t.Run("hook fires and seed messages are visible to LLM", func(t *testing.T) {
+		var capturedMessages []*llm.Message
+
+		model := &mockLLM{
+			generateFunc: func(ctx context.Context, opts ...llm.Option) (*llm.Response, error) {
+				var cfg llm.Config
+				cfg.Apply(opts...)
+				capturedMessages = cfg.Messages
+				return &llm.Response{
+					ID:         "resp_1",
+					Model:      "test-model",
+					Role:       llm.Assistant,
+					Content:    []llm.Content{&llm.TextContent{Text: "ok"}},
+					Type:       "message",
+					StopReason: "stop",
+					Usage:      llm.Usage{InputTokens: 5, OutputTokens: 2},
+				}, nil
+			},
+			nameFunc: func() string { return "test-model" },
+		}
+
+		agent, err := NewAgent(AgentOptions{
+			Model: model,
+			Hooks: Hooks{
+				SessionStart: []SessionStartHook{
+					func(ctx context.Context, hctx *HookContext) (*SessionStartResult, error) {
+						return &SessionStartResult{Messages: []*llm.Message{
+							{Role: llm.User, Content: []llm.Content{&llm.TextContent{Text: "seed message"}}},
+						}}, nil
+					},
+				},
+			},
+		})
+		assert.NoError(t, err)
+
+		_, err = agent.CreateResponse(context.Background(), WithInput("hello"))
+		assert.NoError(t, err)
+
+		// LLM should have received: seed message + "hello"
+		assert.Equal(t, 2, len(capturedMessages))
+		assert.Equal(t, "seed message", capturedMessages[0].Text())
+	})
+
+	t.Run("hook error aborts CreateResponse", func(t *testing.T) {
+		agent, err := NewAgent(AgentOptions{
+			Model: makeModel("ok"),
+			Hooks: Hooks{
+				SessionStart: []SessionStartHook{
+					func(ctx context.Context, hctx *HookContext) (*SessionStartResult, error) {
+						return nil, errors.New("config load failure")
+					},
+				},
+			},
+		})
+		assert.NoError(t, err)
+
+		_, err = agent.CreateResponse(context.Background(), WithInput("hello"))
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "config load failure")
+	})
+
+	t.Run("hook is skipped when session already has messages", func(t *testing.T) {
+		hookFired := false
+
+		model := makeModel("ok")
+
+		// Use a session that already has prior messages
+		sess := &seededSession{
+			id: "test-session",
+			messages: []*llm.Message{
+				{Role: llm.User, Content: []llm.Content{&llm.TextContent{Text: "prior turn"}}},
+				{Role: llm.Assistant, Content: []llm.Content{&llm.TextContent{Text: "prior reply"}}},
+			},
+		}
+
+		agent, err := NewAgent(AgentOptions{
+			Model:   model,
+			Session: sess,
+			Hooks: Hooks{
+				SessionStart: []SessionStartHook{
+					func(ctx context.Context, hctx *HookContext) (*SessionStartResult, error) {
+						hookFired = true
+						return nil, nil
+					},
+				},
+			},
+		})
+		assert.NoError(t, err)
+
+		_, err = agent.CreateResponse(context.Background(), WithInput("new message"))
+		assert.NoError(t, err)
+		assert.False(t, hookFired)
+	})
+
+	t.Run("multiple hooks are all called and messages concatenated", func(t *testing.T) {
+		var capturedMessages []*llm.Message
+
+		model := &mockLLM{
+			generateFunc: func(ctx context.Context, opts ...llm.Option) (*llm.Response, error) {
+				var cfg llm.Config
+				cfg.Apply(opts...)
+				capturedMessages = cfg.Messages
+				return &llm.Response{
+					ID:         "resp_1",
+					Model:      "test-model",
+					Role:       llm.Assistant,
+					Content:    []llm.Content{&llm.TextContent{Text: "ok"}},
+					Type:       "message",
+					StopReason: "stop",
+					Usage:      llm.Usage{InputTokens: 5, OutputTokens: 2},
+				}, nil
+			},
+			nameFunc: func() string { return "test-model" },
+		}
+
+		agent, err := NewAgent(AgentOptions{
+			Model: model,
+			Hooks: Hooks{
+				SessionStart: []SessionStartHook{
+					func(ctx context.Context, hctx *HookContext) (*SessionStartResult, error) {
+						return &SessionStartResult{Messages: []*llm.Message{
+							{Role: llm.User, Content: []llm.Content{&llm.TextContent{Text: "seed A"}}},
+						}}, nil
+					},
+					func(ctx context.Context, hctx *HookContext) (*SessionStartResult, error) {
+						return &SessionStartResult{Messages: []*llm.Message{
+							{Role: llm.User, Content: []llm.Content{&llm.TextContent{Text: "seed B"}}},
+						}}, nil
+					},
+				},
+			},
+		})
+		assert.NoError(t, err)
+
+		_, err = agent.CreateResponse(context.Background(), WithInput("hello"))
+		assert.NoError(t, err)
+
+		// seed A + seed B + "hello"
+		assert.Equal(t, 3, len(capturedMessages))
+		assert.Equal(t, "seed A", capturedMessages[0].Text())
+		assert.Equal(t, "seed B", capturedMessages[1].Text())
+	})
+
+	t.Run("source is startup", func(t *testing.T) {
+		var gotSource SessionStartSource
+		agent, err := NewAgent(AgentOptions{
+			Model: makeModel("ok"),
+			Hooks: Hooks{
+				SessionStart: []SessionStartHook{
+					func(ctx context.Context, hctx *HookContext) (*SessionStartResult, error) {
+						gotSource = hctx.SessionStartSource
+						return nil, nil
+					},
+				},
+			},
+		})
+		assert.NoError(t, err)
+
+		_, err = agent.CreateResponse(context.Background(), WithInput("hello"))
+		assert.NoError(t, err)
+		assert.Equal(t, SessionStartStartup, gotSource)
+	})
+
+	t.Run("persistent seeds are saved and seen on later turns", func(t *testing.T) {
+		var lastCallMessages []*llm.Message
+		fireCount := 0
+		model := &mockLLM{
+			generateFunc: func(ctx context.Context, opts ...llm.Option) (*llm.Response, error) {
+				var cfg llm.Config
+				cfg.Apply(opts...)
+				lastCallMessages = cfg.Messages
+				return &llm.Response{
+					ID: "resp", Model: "test-model", Role: llm.Assistant,
+					Content:    []llm.Content{&llm.TextContent{Text: "ok"}},
+					Type:       "message",
+					StopReason: "stop",
+					Usage:      llm.Usage{InputTokens: 1, OutputTokens: 1},
+				}, nil
+			},
+			nameFunc: func() string { return "test-model" },
+		}
+
+		sess := &seededSession{id: "persist-sess"}
+		agent, err := NewAgent(AgentOptions{
+			Model:   model,
+			Session: sess,
+			Hooks: Hooks{
+				SessionStart: []SessionStartHook{
+					func(ctx context.Context, hctx *HookContext) (*SessionStartResult, error) {
+						fireCount++
+						return &SessionStartResult{
+							Persist:  true,
+							Messages: []*llm.Message{{Role: llm.User, Content: []llm.Content{&llm.TextContent{Text: "durable seed"}}}},
+						}, nil
+					},
+				},
+			},
+		})
+		assert.NoError(t, err)
+
+		// Turn 1: hook fires, seed is persisted (saved as its own pre-turn).
+		_, err = agent.CreateResponse(context.Background(), WithInput("hello"))
+		assert.NoError(t, err)
+		assert.Equal(t, 1, fireCount)
+		// seed + input + assistant output all persisted.
+		assert.Equal(t, 3, len(sess.messages))
+		assert.Equal(t, "durable seed", sess.messages[0].Text())
+
+		// Turn 2: hook must NOT fire again, but the seed is still in history.
+		_, err = agent.CreateResponse(context.Background(), WithInput("again"))
+		assert.NoError(t, err)
+		assert.Equal(t, 1, fireCount, "SessionStart must fire only once per session")
+		assert.Equal(t, "durable seed", lastCallMessages[0].Text())
+	})
+
+	t.Run("ephemeral seeds are not saved", func(t *testing.T) {
+		fireCount := 0
+		sess := &seededSession{id: "ephemeral-sess"}
+		agent, err := NewAgent(AgentOptions{
+			Model:   makeModel("ok"),
+			Session: sess,
+			Hooks: Hooks{
+				SessionStart: []SessionStartHook{
+					func(ctx context.Context, hctx *HookContext) (*SessionStartResult, error) {
+						fireCount++
+						return &SessionStartResult{
+							Persist:  false,
+							Messages: []*llm.Message{{Role: llm.User, Content: []llm.Content{&llm.TextContent{Text: "ephemeral seed"}}}},
+						}, nil
+					},
+				},
+			},
+		})
+		assert.NoError(t, err)
+
+		_, err = agent.CreateResponse(context.Background(), WithInput("hello"))
+		assert.NoError(t, err)
+		assert.Equal(t, 1, fireCount)
+		// Only input + assistant output saved; the ephemeral seed is not.
+		assert.Equal(t, 2, len(sess.messages))
+		assert.Equal(t, "hello", sess.messages[0].Text())
 	})
 }


### PR DESCRIPTION
Two related additions to the agent hook system. Each is its own commit.

## 1. SessionStart hook

`SessionStartHook` fires once at the start of a fresh conversation — before the
first LLM call — when the loaded session has no prior messages and the turn is
not resuming a suspended one. It lets agents bootstrap from external state
(project config, user prefs, memory) without a `PreGenerationHook` that manually
checks for an empty session.

- Returns `*SessionStartResult{ Messages, Persist }`. `Messages` are prepended to
  the conversation, ahead of the user input. `Persist` chooses **durable**
  seeding (saved as a pre-turn — survives later turns and resume) vs **ephemeral**
  priming (influences only the first generation, never saved). `Persist` requires
  a session.
- `HookContext.SessionStartSource` reports why it fired (`SessionStartStartup`
  today; the field leaves room for future sources without an API change).
- Runs after the suspend/resume guards, so a resume never re-fires it. Copies
  caller `Values` into the hook context. A hook error aborts `CreateResponse`
  before any session write.

## 2. Judgment-based hook helpers

Two constructor helpers that let a model make a hook decision that is hard to
express as deterministic code. Both force a `{ok, reason}` verdict from the model
via a forced `submit_decision` tool call (robust structured output across
providers — no free-text JSON parsing).

- `PromptStopHook(model, prompt)` (`StopHook`) — the model judges whether the
  task is done; if not, the agent keeps working with the model's reason as its
  next instruction. Honors `hctx.StopHookActive` so it cannot loop; **fails
  open** (a model error lets the agent stop).
- `PromptToolGate(model, prompt)` (`PreToolUseHook`) — the model judges whether a
  pending tool call is acceptable; denies via a returned error if not. **Fails
  closed** (a model error denies). Scope it with `MatchTool`.

These build on the existing plain-function hooks (the "prompt/agent hooks can be
built on top" non-goal, realized), so the core hook types are unchanged. An
agent-backed variant (a subagent that verifies against real state) is documented
as future work.

## Docs & tests

- `docs/design/hooks.md` and `docs/guides/hooks.md` updated for both features;
  `CLAUDE.md` hook list and flow updated.
- New tests: SessionStart (fire / skip-when-non-empty / persistent / ephemeral /
  source / not-fired-on-resume) and judgment hooks (allow / deny+reason /
  fail-open / fail-closed / loop guard / forced tool choice).
- `go build ./...`, `go vet`, and full `go test ./...` pass; gofmt-clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added SessionStart hook for seeding conversation context at session startup with durable or ephemeral message seeding
  * Added judgment-based hook helpers for model-driven stop decisions and tool-use gating

* **Documentation**
  * Updated hook documentation with SessionStart semantics and flow diagrams
  * Added guidance on judgment hooks with fail-open/fail-closed behavior patterns

* **Tests**
  * Added comprehensive test coverage for SessionStart hook behavior and resume handling
  * Added tests validating judgment-based hook helpers

* **Examples**
  * Added hooks example demonstrating SessionStart seeding and model-gated stop and tool-use decisions

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/deepnoodle-ai/dive/pull/154?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->