### PR TITLE
Add ToolActivityDescriber for real-time tool status

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -1759,6 +1759,11 @@ func (a *Agent) executeToolCallsParallel(
 			preview = previewer.PreviewCall(childCtx, toolCall.Input)
 		}
 
+		var activityDesc string
+		if describer, ok := tool.(ToolActivityDescriber); ok {
+			activityDesc = describer.ActivityDescription(toolCall.Input)
+		}
+
 		if err := callback(childCtx, &ResponseItem{
 			Type:     ResponseItemTypeToolCall,
 			ToolCall: toolCall,
@@ -1767,13 +1772,14 @@ func (a *Agent) executeToolCallsParallel(
 		}
 
 		preHctx := &HookContext{
-			Agent:        a,
-			Session:      hctx.Session,
-			Values:       hctx.Values,
-			SystemPrompt: hctx.SystemPrompt,
-			Messages:     hctx.Messages,
-			Tool:         tool,
-			Call:         toolCall,
+			Agent:               a,
+			Session:             hctx.Session,
+			Values:              hctx.Values,
+			SystemPrompt:        hctx.SystemPrompt,
+			Messages:            hctx.Messages,
+			Tool:                tool,
+			Call:                toolCall,
+			ActivityDescription: activityDesc,
 		}
 
 		var denialErr error
@@ -1996,6 +2002,11 @@ func (a *Agent) executeOneToolCall(
 		preview = previewer.PreviewCall(ctx, toolCall.Input)
 	}
 
+	var activityDesc string
+	if describer, ok := tool.(ToolActivityDescriber); ok {
+		activityDesc = describer.ActivityDescription(toolCall.Input)
+	}
+
 	// Emit tool call event
 	if err := callback(ctx, &ResponseItem{
 		Type:     ResponseItemTypeToolCall,
@@ -2005,13 +2016,14 @@ func (a *Agent) executeOneToolCall(
 	}
 
 	preHctx := &HookContext{
-		Agent:        a,
-		Session:      hctx.Session,
-		Values:       hctx.Values,
-		SystemPrompt: hctx.SystemPrompt,
-		Messages:     hctx.Messages,
-		Tool:         tool,
-		Call:         toolCall,
+		Agent:               a,
+		Session:             hctx.Session,
+		Values:              hctx.Values,
+		SystemPrompt:        hctx.SystemPrompt,
+		Messages:            hctx.Messages,
+		Tool:                tool,
+		Call:                toolCall,
+		ActivityDescription: activityDesc,
 	}
 
 	// Run PreToolUse hooks — any error denies the tool. All hooks run even

--- a/hooks.go
+++ b/hooks.go
@@ -117,6 +117,13 @@ type HookContext struct {
 	// provide guidance without modifying the tool result itself.
 	AdditionalContext string
 
+	// ActivityDescription is a human-readable description of what the tool is
+	// doing, populated before PreToolUse hooks run when the tool implements
+	// ToolActivityDescriber. Empty string when the tool does not implement the
+	// interface or returns an empty description.
+	// Consumers display this in TUIs, web UIs, or log streams.
+	ActivityDescription string
+
 	// Stop hook
 
 	// StopHookActive is true when this stop check was triggered by a

--- a/tool.go
+++ b/tool.go
@@ -253,6 +253,17 @@ type ToolPreviewer interface {
 	PreviewCall(ctx context.Context, input any) *ToolCallPreview
 }
 
+// ToolActivityDescriber is an optional interface that tools implement to provide
+// a human-readable description of what they are doing during execution.
+// Consumers attach a PreToolUseHook and check hctx.ActivityDescription to
+// display real-time status in TUIs, web UIs, or structured log streams.
+//
+// The input parameter is the raw JSON provided by the LLM before it is decoded.
+// Returning an empty string suppresses the description.
+type ToolActivityDescriber interface {
+	ActivityDescription(input json.RawMessage) string
+}
+
 // TypedTool is a tool that can be called with a specific type of input.
 type TypedTool[T any] interface {
 	// Name of the tool.
@@ -276,6 +287,15 @@ type TypedTool[T any] interface {
 type TypedToolPreviewer[T any] interface {
 	// PreviewCall returns a markdown description of what the tool will do.
 	PreviewCall(ctx context.Context, input T) *ToolCallPreview
+}
+
+// TypedActivityDescriber is an optional interface that typed tools implement
+// to provide human-readable activity descriptions with typed input.
+// TypedToolAdapter delegates to this when the underlying tool implements it.
+type TypedActivityDescriber[T any] interface {
+	// ActivityDescription returns a short description of what the tool is doing,
+	// e.g. "Reading src/agent.go" or "Running: go test ./...". Empty string suppresses.
+	ActivityDescription(input T) string
 }
 
 // ToolAdapter creates a new TypedToolAdapter for the given tool.
@@ -326,6 +346,20 @@ func (t *TypedToolAdapter[T]) ToolConfiguration(providerName string) map[string]
 		return toolWithConfig.ToolConfiguration(providerName)
 	}
 	return nil
+}
+
+// ActivityDescription implements ToolActivityDescriber by delegating to the
+// underlying TypedTool if it implements TypedActivityDescriber[T].
+func (t *TypedToolAdapter[T]) ActivityDescription(input json.RawMessage) string {
+	describer, ok := t.tool.(TypedActivityDescriber[T])
+	if !ok {
+		return ""
+	}
+	typedInput, err := t.convertInput(input)
+	if err != nil {
+		return ""
+	}
+	return describer.ActivityDescription(typedInput)
 }
 
 // PreviewCall implements ToolPreviewer by delegating to the underlying TypedTool

--- a/tool_test.go
+++ b/tool_test.go
@@ -109,3 +109,42 @@ func TestTypedToolAdapter_ConvertInput_EmptyObject(t *testing.T) {
 	assert.NotNil(t, result)
 	assert.False(t, result.IsError)
 }
+
+func TestToolActivityDescriber(t *testing.T) {
+	t.Run("TypedToolAdapter delegates ActivityDescription", func(t *testing.T) {
+		tool := &mockTypedActivityTool{desc: "Doing something useful"}
+		adapter := ToolAdapter[string](tool)
+
+		raw := json.RawMessage(`"test-input"`)
+		desc := adapter.ActivityDescription(raw)
+		assert.Equal(t, "Doing something useful", desc)
+	})
+
+	t.Run("TypedToolAdapter returns empty when tool does not implement interface", func(t *testing.T) {
+		tool := &mockBasicTool{}
+		adapter := ToolAdapter[string](tool)
+
+		raw := json.RawMessage(`"test-input"`)
+		desc := adapter.ActivityDescription(raw)
+		assert.Equal(t, "", desc)
+	})
+}
+
+type mockTypedActivityTool struct {
+	desc string
+}
+
+func (m *mockTypedActivityTool) Name() string                                     { return "mock" }
+func (m *mockTypedActivityTool) Description() string                              { return "mock" }
+func (m *mockTypedActivityTool) Schema() *Schema                                  { return nil }
+func (m *mockTypedActivityTool) Annotations() *ToolAnnotations                    { return nil }
+func (m *mockTypedActivityTool) Call(_ context.Context, _ string) (*ToolResult, error) { return nil, nil }
+func (m *mockTypedActivityTool) ActivityDescription(_ string) string              { return m.desc }
+
+type mockBasicTool struct{}
+
+func (m *mockBasicTool) Name() string                                             { return "mock" }
+func (m *mockBasicTool) Description() string                                      { return "mock" }
+func (m *mockBasicTool) Schema() *Schema                                          { return nil }
+func (m *mockBasicTool) Annotations() *ToolAnnotations                            { return nil }
+func (m *mockBasicTool) Call(_ context.Context, _ string) (*ToolResult, error)   { return nil, nil }

--- a/toolkit/bash.go
+++ b/toolkit/bash.go
@@ -181,6 +181,12 @@ func (t *BashTool) Annotations() *dive.ToolAnnotations {
 	}
 }
 
+// ActivityDescription returns a human-readable description of what the command is doing.
+func (t *BashTool) ActivityDescription(input *BashInput) string {
+	cmd := truncateCommand(input.Command, 60)
+	return "Running: " + cmd
+}
+
 // PreviewCall returns a summary of what the command will do, used for
 // permission prompts and logging.
 func (t *BashTool) PreviewCall(ctx context.Context, input *BashInput) *dive.ToolCallPreview {

--- a/toolkit/fetch.go
+++ b/toolkit/fetch.go
@@ -159,6 +159,11 @@ func (t *FetchTool) Schema() *schema.Schema {
 	}
 }
 
+// ActivityDescription returns a human-readable description of the fetch.
+func (t *FetchTool) ActivityDescription(req *fetch.Request) string {
+	return "Fetching " + req.URL
+}
+
 // PreviewCall returns a summary of the fetch operation for permission prompts.
 func (t *FetchTool) PreviewCall(ctx context.Context, req *fetch.Request) *dive.ToolCallPreview {
 	return &dive.ToolCallPreview{

--- a/toolkit/glob.go
+++ b/toolkit/glob.go
@@ -170,6 +170,10 @@ func (t *GlobTool) Annotations() *dive.ToolAnnotations {
 }
 
 // PreviewCall returns a summary of the search operation for permission prompts.
+func (t *GlobTool) ActivityDescription(input *GlobInput) string {
+	return "Searching " + input.Pattern
+}
+
 func (t *GlobTool) PreviewCall(ctx context.Context, input *GlobInput) *dive.ToolCallPreview {
 	searchPath := input.Path
 	if searchPath == "" {

--- a/toolkit/grep.go
+++ b/toolkit/grep.go
@@ -289,6 +289,10 @@ func (t *GrepTool) Annotations() *dive.ToolAnnotations {
 }
 
 // PreviewCall returns a summary of the search operation for permission prompts.
+func (t *GrepTool) ActivityDescription(input *GrepInput) string {
+	return fmt.Sprintf("Grepping for %q", input.Pattern)
+}
+
 func (t *GrepTool) PreviewCall(ctx context.Context, input *GrepInput) *dive.ToolCallPreview {
 	searchPath := input.Path
 	if searchPath == "" {

--- a/toolkit/list_directory.go
+++ b/toolkit/list_directory.go
@@ -144,6 +144,14 @@ func (t *ListDirectoryTool) Annotations() *dive.ToolAnnotations {
 }
 
 // PreviewCall returns a summary of the list operation for permission prompts.
+func (t *ListDirectoryTool) ActivityDescription(input *ListDirectoryInput) string {
+	path := input.Path
+	if path == "" {
+		path = t.defaultPath
+	}
+	return "Listing " + path
+}
+
 func (t *ListDirectoryTool) PreviewCall(ctx context.Context, input *ListDirectoryInput) *dive.ToolCallPreview {
 	path := input.Path
 	if path == "" {

--- a/toolkit/read_file.go
+++ b/toolkit/read_file.go
@@ -128,6 +128,10 @@ func (t *ReadFileTool) Schema() *schema.Schema {
 }
 
 // PreviewCall returns a summary of the read operation for permission prompts.
+func (t *ReadFileTool) ActivityDescription(input *ReadFileInput) string {
+	return "Reading " + input.FilePath
+}
+
 func (t *ReadFileTool) PreviewCall(ctx context.Context, input *ReadFileInput) *dive.ToolCallPreview {
 	return &dive.ToolCallPreview{
 		Summary: fmt.Sprintf("Read %s", input.FilePath),

--- a/toolkit/write_file.go
+++ b/toolkit/write_file.go
@@ -96,6 +96,10 @@ func (t *WriteFileTool) Schema() *schema.Schema {
 }
 
 // PreviewCall returns a summary of the write operation for permission prompts.
+func (t *WriteFileTool) ActivityDescription(input *WriteFileInput) string {
+	return "Writing " + input.FilePath
+}
+
 func (t *WriteFileTool) PreviewCall(ctx context.Context, input *WriteFileInput) *dive.ToolCallPreview {
 	return &dive.ToolCallPreview{
 		Summary: fmt.Sprintf("Write to %s", input.FilePath),


### PR DESCRIPTION
## Summary

- Adds `ToolActivityDescriber` optional interface (raw `json.RawMessage` input) — backward-compatible, no required method on `Tool`
- Adds `TypedActivityDescriber[T]` for typed tools to implement with strongly-typed input
- `TypedToolAdapter` delegates to the underlying tool's `ActivityDescription` when present
- Agent's tool execution path checks for `ToolActivityDescriber` before PreToolUse hooks and populates `HookContext.ActivityDescription`
- Consumers attach a `PreToolUseHook` and read `hctx.ActivityDescription` to display status

Toolkit implementations (spec table):

| Tool | Example output |
|------|----------------|
| `BashTool` | `"Running: go test ./..."` |
| `ReadFileTool` | `"Reading src/agent.go"` |
| `WriteFileTool` | `"Writing src/agent.go"` |
| `FetchTool` | `"Fetching https://example.com"` |
| `GlobTool` | `"Searching **/*.go"` |
| `GrepTool` | `"Grepping for 'CreateResponse'"` |
| `ListDirectoryTool` | `"Listing toolkit/"` |

Implements tech spec: `docs/tech-specs/tool-activity-description.md`

## Test plan

- [ ] `go test -run TestToolActivityDescriber .` — adapter delegation and fallback for non-implementing tools
- [ ] `go test ./...` — full suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)