### PR TITLE
Add InstructionProvider for dynamic system prompts

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -104,7 +104,14 @@ type Extension interface {
 // AgentOptions are used to configure an Agent.
 type AgentOptions struct {
 	// SystemPrompt is the system prompt sent to the LLM.
+	// Ignored when InstructionProvider is set.
 	SystemPrompt string
+
+	// InstructionProvider is called before each LLM request to produce the
+	// system prompt. Takes precedence over SystemPrompt when set.
+	// If both are set, InstructionProvider wins and a warning is logged at
+	// agent construction time.
+	InstructionProvider func(ctx context.Context, hctx *HookContext) (string, error)
 
 	// Model is the LLM to use for generation.
 	Model llm.LLM
@@ -194,6 +201,7 @@ type Agent struct {
 	parallelToolExecution bool
 	modelSettings         *ModelSettings
 	systemPrompt          string
+	instructionProvider   func(ctx context.Context, hctx *HookContext) (string, error)
 	session               Session
 	tracer                Tracer
 
@@ -242,6 +250,9 @@ func NewAgent(opts AgentOptions) (*Agent, error) {
 	if opts.Tracer == nil {
 		opts.Tracer = NopTracer{}
 	}
+	if opts.InstructionProvider != nil && opts.SystemPrompt != "" {
+		opts.Logger.Warn("both SystemPrompt and InstructionProvider are set; InstructionProvider takes precedence")
+	}
 	agent := &Agent{
 		name:                  opts.Name,
 		id:                    opts.ID,
@@ -254,6 +265,7 @@ func NewAgent(opts AgentOptions) (*Agent, error) {
 		llmHooks:              opts.LLMHooks,
 		logger:                opts.Logger,
 		systemPrompt:          opts.SystemPrompt,
+		instructionProvider:   opts.InstructionProvider,
 		modelSettings:         opts.ModelSettings,
 		hooks:                 opts.Hooks,
 		session:               opts.Session,
@@ -1421,6 +1433,22 @@ func (a *Agent) generate(ctx context.Context, hctx *HookContext, messages []*llm
 	generationLimit := a.toolIterationLimit + 1
 	lastIteration := false
 	for i := range generationLimit {
+		// InstructionProvider overrides systemPrompt before each LLM call.
+		if a.instructionProvider != nil {
+			providerHctx := &HookContext{
+				Agent:     a,
+				Session:   hctx.Session,
+				Values:    hctx.Values,
+				Messages:  updatedMessages,
+				Iteration: i,
+			}
+			provided, provErr := a.instructionProvider(ctx, providerHctx)
+			if provErr != nil {
+				return nil, fmt.Errorf("instruction provider error: %w", provErr)
+			}
+			systemPrompt = strings.TrimSpace(provided)
+		}
+
 		// Run PreIteration hooks
 		if len(a.hooks.PreIteration) > 0 {
 			hctx.Iteration = i

--- a/agent_test.go
+++ b/agent_test.go
@@ -2,6 +2,7 @@ package dive
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"sync/atomic"
@@ -959,5 +960,73 @@ func TestExtensionMerge(t *testing.T) {
 		})
 		assert.Error(t, err)
 		assert.ErrorContains(t, err, `duplicate tool name: "same_name"`)
+	})
+}
+
+func TestInstructionProvider(t *testing.T) {
+	makeModel := func() (*mockLLM, *string) {
+		var capturedSystemPrompt string
+		m := &mockLLM{
+			generateFunc: func(ctx context.Context, opts ...llm.Option) (*llm.Response, error) {
+				var cfg llm.Config
+				cfg.Apply(opts...)
+				capturedSystemPrompt = cfg.SystemPrompt
+				return &llm.Response{
+					ID:         "resp_1",
+					Model:      "test-model",
+					Role:       llm.Assistant,
+					Content:    []llm.Content{&llm.TextContent{Text: "ok"}},
+					Type:       "message",
+					StopReason: "stop",
+					Usage:      llm.Usage{InputTokens: 5, OutputTokens: 2},
+				}, nil
+			},
+			nameFunc: func() string { return "test-model" },
+		}
+		return m, &capturedSystemPrompt
+	}
+
+	t.Run("InstructionProvider overrides SystemPrompt", func(t *testing.T) {
+		m, captured := makeModel()
+		agent, err := NewAgent(AgentOptions{
+			Model:        m,
+			SystemPrompt: "static prompt",
+			InstructionProvider: func(ctx context.Context, hctx *HookContext) (string, error) {
+				return "dynamic prompt", nil
+			},
+		})
+		assert.NoError(t, err)
+
+		_, err = agent.CreateResponse(context.Background(), WithInput("hello"))
+		assert.NoError(t, err)
+		assert.Equal(t, "dynamic prompt", *captured)
+	})
+
+	t.Run("InstructionProvider error aborts CreateResponse", func(t *testing.T) {
+		m, _ := makeModel()
+		agent, err := NewAgent(AgentOptions{
+			Model: m,
+			InstructionProvider: func(ctx context.Context, hctx *HookContext) (string, error) {
+				return "", errors.New("config unavailable")
+			},
+		})
+		assert.NoError(t, err)
+
+		_, err = agent.CreateResponse(context.Background(), WithInput("hello"))
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "config unavailable")
+	})
+
+	t.Run("static SystemPrompt used when no InstructionProvider", func(t *testing.T) {
+		m, captured := makeModel()
+		agent, err := NewAgent(AgentOptions{
+			Model:        m,
+			SystemPrompt: "static only",
+		})
+		assert.NoError(t, err)
+
+		_, err = agent.CreateResponse(context.Background(), WithInput("hello"))
+		assert.NoError(t, err)
+		assert.Equal(t, "static only", *captured)
 	})
 }


### PR DESCRIPTION
## Summary

- Adds `InstructionProvider func(ctx context.Context, hctx *HookContext) (string, error)` to `AgentOptions`
- Called before each LLM request (per iteration), making it suitable for runtime-contextual prompts (branch name, user ID, project config)
- Takes precedence over `SystemPrompt` when set; both set emits a construction-time warning
- Errors abort `CreateResponse` immediately
- More discoverable than the `PreGenerationHook`/`PreIterationHook` workaround

Implements tech spec: `docs/tech-specs/instruction-provider.md`

## Test plan

- [ ] `go test -run TestInstructionProvider .` — three cases: override, error abort, static fallback
- [ ] `go test ./...` — full suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)