### PR TITLE
Add experimental/autotitle package for automatic session titling

### DIFF
--- a/experimental/autotitle/autotitle.go
+++ b/experimental/autotitle/autotitle.go
@@ -1,0 +1,113 @@
+// Package autotitle provides a PostGenerationHook that automatically generates
+// and sets a session title after the first completed turn.
+//
+// Usage:
+//
+//	agent, _ := dive.NewAgent(dive.AgentOptions{
+//	    Model:   anthropic.New(),
+//	    Session: sess,
+//	    Hooks: dive.Hooks{
+//	        PostGeneration: []dive.PostGenerationHook{
+//	            autotitle.AutoTitleHook(anthropic.NewModel("claude-haiku-4-5-20251001")),
+//	        },
+//	    },
+//	})
+package autotitle
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/deepnoodle-ai/dive"
+	"github.com/deepnoodle-ai/dive/llm"
+	"github.com/deepnoodle-ai/dive/session"
+)
+
+const (
+	titleTimeout  = 5 * time.Second
+	maxContextLen = 200
+)
+
+var titlePrompt = `Generate a short title (3-7 words) for a conversation that begins with:
+
+User: %s
+Assistant: %s
+
+Reply with only the title, no punctuation.`
+
+// AutoTitleHook returns a PostGenerationHook that generates and sets a session
+// title after the first completed turn. Subsequent turns are no-ops.
+//
+// The provided LLM is used only for title generation — use a cheap, fast model
+// such as claude-haiku-4-5-20251001. A 5-second timeout is applied to the
+// title LLM call so a slow response does not delay the main hook chain.
+func AutoTitleHook(titleLLM llm.LLM) dive.PostGenerationHook {
+	return func(ctx context.Context, hctx *dive.HookContext) error {
+		sess, ok := hctx.Session.(*session.Session)
+		if !ok || sess == nil {
+			return nil
+		}
+
+		// Skip if the session already has a title.
+		if sess.Title() != "" {
+			return nil
+		}
+
+		// Extract the first user message and first response text.
+		firstUserText := firstUserText(hctx.Messages)
+		firstResponseText := firstResponseText(hctx.Response)
+		if firstUserText == "" || firstResponseText == "" {
+			return nil
+		}
+
+		prompt := fmt.Sprintf(titlePrompt,
+			truncate(firstUserText, maxContextLen),
+			truncate(firstResponseText, maxContextLen),
+		)
+
+		tctx, cancel := context.WithTimeout(ctx, titleTimeout)
+		defer cancel()
+
+		resp, err := titleLLM.Generate(tctx, llm.WithMessages(llm.NewUserTextMessage(prompt)))
+		if err != nil {
+			// Title generation failure is non-fatal — log and continue.
+			return nil
+		}
+		title := strings.TrimSpace(resp.Message().Text())
+		if title != "" {
+			sess.SetTitle(title)
+		}
+		return nil
+	}
+}
+
+func firstUserText(messages []*llm.Message) string {
+	for _, msg := range messages {
+		if msg.Role == llm.User {
+			return msg.Text()
+		}
+	}
+	return ""
+}
+
+func firstResponseText(resp *dive.Response) string {
+	if resp == nil {
+		return ""
+	}
+	for _, msg := range resp.OutputMessages {
+		if msg.Role == llm.Assistant {
+			return msg.Text()
+		}
+	}
+	return ""
+}
+
+func truncate(s string, max int) string {
+	runes := []rune(s)
+	if len(runes) <= max {
+		return s
+	}
+	return string(runes[:max]) + "..."
+}

--- a/experimental/autotitle/autotitle_test.go
+++ b/experimental/autotitle/autotitle_test.go
@@ -1,0 +1,105 @@
+package autotitle_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/deepnoodle-ai/dive"
+	"github.com/deepnoodle-ai/dive/experimental/autotitle"
+	"github.com/deepnoodle-ai/dive/llm"
+	"github.com/deepnoodle-ai/dive/session"
+	"github.com/deepnoodle-ai/wonton/assert"
+)
+
+type mockLLM struct {
+	response string
+	err      error
+}
+
+func (m *mockLLM) Name() string { return "mock" }
+func (m *mockLLM) Generate(_ context.Context, _ ...llm.Option) (*llm.Response, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	return &llm.Response{
+		ID:         "resp_1",
+		Model:      "mock",
+		Role:       llm.Assistant,
+		Content:    []llm.Content{&llm.TextContent{Text: m.response}},
+		Type:       "message",
+		StopReason: "stop",
+		Usage:      llm.Usage{},
+	}, nil
+}
+
+func makeHookContext(sess *session.Session, userText, responseText string) *dive.HookContext {
+	hctx := dive.NewHookContext()
+	hctx.Session = sess
+	hctx.Messages = []*llm.Message{
+		llm.NewUserTextMessage(userText),
+		llm.NewAssistantTextMessage("ignored"),
+	}
+	// Build a minimal Response with the expected output text
+	resp := &dive.Response{}
+	resp.OutputMessages = []*llm.Message{
+		llm.NewAssistantTextMessage(responseText),
+	}
+	hctx.Response = resp
+	return hctx
+}
+
+func TestAutoTitleHook(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("sets title on first turn", func(t *testing.T) {
+		titleLLM := &mockLLM{response: "Capital of France"}
+		sess := session.New("s1")
+
+		hook := autotitle.AutoTitleHook(titleLLM)
+		hctx := makeHookContext(sess, "What is the capital of France?", "Paris is the capital of France.")
+
+		err := hook(ctx, hctx)
+		assert.NoError(t, err)
+		assert.Equal(t, "Capital of France", sess.Title())
+	})
+
+	t.Run("skips if title already set", func(t *testing.T) {
+		called := false
+		titleLLM := &mockLLM{response: "Should Not Be Called"}
+		_ = called
+
+		sess := session.New("s2")
+		sess.SetTitle("Existing Title")
+
+		hook := autotitle.AutoTitleHook(titleLLM)
+		hctx := makeHookContext(sess, "hello", "world")
+
+		err := hook(ctx, hctx)
+		assert.NoError(t, err)
+		assert.Equal(t, "Existing Title", sess.Title())
+	})
+
+	t.Run("title LLM error is non-fatal", func(t *testing.T) {
+		titleLLM := &mockLLM{err: fmt.Errorf("title LLM unavailable")}
+		sess := session.New("s3")
+
+		hook := autotitle.AutoTitleHook(titleLLM)
+		hctx := makeHookContext(sess, "hello", "world")
+
+		err := hook(ctx, hctx)
+		assert.NoError(t, err) // hook does not surface LLM errors
+		assert.Equal(t, "", sess.Title())
+	})
+
+	t.Run("no-op when session is nil", func(t *testing.T) {
+		titleLLM := &mockLLM{response: "Title"}
+		hook := autotitle.AutoTitleHook(titleLLM)
+
+		hctx := dive.NewHookContext()
+		hctx.Session = nil
+
+		err := hook(ctx, hctx)
+		assert.NoError(t, err)
+	})
+}


### PR DESCRIPTION
## Summary

- Adds `experimental/autotitle` package with `AutoTitleHook(titleLLM llm.LLM) dive.PostGenerationHook`
- Hook fires after the first completed turn, generates a 3-7 word title via a cheap/fast LLM (e.g. claude-haiku-4-5), and sets it on the session
- Subsequent turns are no-ops (title already set); title LLM errors are non-fatal
- Uses a 5-second timeout on the title LLM call to avoid delaying the main hook chain

## Test plan

- [x] `TestAutoTitleHook/sets_title_on_first_turn` — title is set from LLM response
- [x] `TestAutoTitleHook/skips_if_title_already_set` — existing title is not overwritten
- [x] `TestAutoTitleHook/title_LLM_error_is_non-fatal` — hook returns nil on LLM error
- [x] `TestAutoTitleHook/no-op_when_session_is_nil` — no panic on nil session

🤖 Generated with [Claude Code](https://claude.com/claude-code)