### PR TITLE
Add MaxResultSizeHint to ToolAnnotations for agent-level result truncation

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -2263,12 +2263,61 @@ func (a *Agent) executeTool(
 			Error: errors.New(msg),
 		}
 	}
+	// Apply MaxResultSizeHint truncation if the tool declares one.
+	if ann := tool.Annotations(); ann != nil && ann.MaxResultSizeHint > 0 {
+		output = applyResultSizeHint(tool.Name(), output, ann.MaxResultSizeHint)
+	}
 	return &ToolCallResult{
 		ID:      call.ID,
 		Name:    call.Name,
 		Input:   call.Input,
 		Preview: preview,
 		Result:  output,
+	}
+}
+
+// applyResultSizeHint checks all text content blocks in a ToolResult and
+// truncates any that exceed max characters, writing the full text to a temp
+// file so the model can access it via ReadFile if needed.
+func applyResultSizeHint(toolName string, result *ToolResult, max int) *ToolResult {
+	if result == nil || result.Suspend != nil || result.Background != nil || result.IsError {
+		return result
+	}
+	modified := false
+	newContent := make([]*ToolResultContent, len(result.Content))
+	for i, block := range result.Content {
+		if block.Type != ToolResultContentTypeText {
+			newContent[i] = block
+			continue
+		}
+		truncated, _, err := TruncateResult(block.Text, max)
+		if err != nil {
+			// If we can't write a temp file, fall back to a simple truncation.
+			runes := []rune(block.Text)
+			if len(runes) > max {
+				truncated = string(runes[:max]) + fmt.Sprintf("\n[Output truncated at %d chars. Full output unavailable: %v]", max, err)
+			} else {
+				newContent[i] = block
+				continue
+			}
+		}
+		if truncated == block.Text {
+			newContent[i] = block
+			continue
+		}
+		newContent[i] = &ToolResultContent{
+			Type: ToolResultContentTypeText,
+			Text: truncated,
+		}
+		modified = true
+	}
+	if !modified {
+		return result
+	}
+	return &ToolResult{
+		Content: newContent,
+		Display: result.Display,
+		IsError: result.IsError,
 	}
 }
 

--- a/tool.go
+++ b/tool.go
@@ -12,13 +12,14 @@ import (
 // ToolAnnotations contains optional metadata hints that describe a tool's behavior.
 // These hints help agents and permission systems make decisions about tool usage.
 type ToolAnnotations struct {
-	Title           string         `json:"title,omitempty"`
-	ReadOnlyHint    bool           `json:"readOnlyHint,omitempty"`
-	DestructiveHint bool           `json:"destructiveHint,omitempty"`
-	IdempotentHint  bool           `json:"idempotentHint,omitempty"`
-	OpenWorldHint   bool           `json:"openWorldHint,omitempty"`
-	EditHint        bool           `json:"editHint,omitempty"` // Indicates file edit operations for acceptEdits mode
-	Extra           map[string]any `json:"extra,omitempty"`
+	Title              string         `json:"title,omitempty"`
+	ReadOnlyHint       bool           `json:"readOnlyHint,omitempty"`
+	DestructiveHint    bool           `json:"destructiveHint,omitempty"`
+	IdempotentHint     bool           `json:"idempotentHint,omitempty"`
+	OpenWorldHint      bool           `json:"openWorldHint,omitempty"`
+	EditHint           bool           `json:"editHint,omitempty"` // Indicates file edit operations for acceptEdits mode
+	MaxResultSizeHint  int            `json:"maxResultSizeHint,omitempty"`
+	Extra              map[string]any `json:"extra,omitempty"`
 }
 
 func (a *ToolAnnotations) MarshalJSON() ([]byte, error) {
@@ -29,6 +30,9 @@ func (a *ToolAnnotations) MarshalJSON() ([]byte, error) {
 		"idempotentHint":  a.IdempotentHint,
 		"openWorldHint":   a.OpenWorldHint,
 		"editHint":        a.EditHint,
+	}
+	if a.MaxResultSizeHint > 0 {
+		data["maxResultSizeHint"] = a.MaxResultSizeHint
 	}
 	if a.Extra != nil {
 		for k, v := range a.Extra {
@@ -61,6 +65,10 @@ func (a *ToolAnnotations) UnmarshalJSON(data []byte) error {
 			json.Unmarshal(val, field)
 			delete(rawMap, name)
 		}
+	}
+	if val, ok := rawMap["maxResultSizeHint"]; ok {
+		json.Unmarshal(val, &a.MaxResultSizeHint)
+		delete(rawMap, "maxResultSizeHint")
 	}
 	// Remaining fields go to Extra
 	a.Extra = make(map[string]any)

--- a/toolkit/bash.go
+++ b/toolkit/bash.go
@@ -173,11 +173,12 @@ func (t *BashTool) Schema() *schema.Schema {
 // (interacts with external systems).
 func (t *BashTool) Annotations() *dive.ToolAnnotations {
 	return &dive.ToolAnnotations{
-		Title:           "Bash",
-		ReadOnlyHint:    false,
-		IdempotentHint:  false,
-		DestructiveHint: true,
-		OpenWorldHint:   true,
+		Title:             "Bash",
+		ReadOnlyHint:      false,
+		IdempotentHint:    false,
+		DestructiveHint:   true,
+		OpenWorldHint:     true,
+		MaxResultSizeHint: 50_000,
 	}
 }
 

--- a/toolkit/fetch.go
+++ b/toolkit/fetch.go
@@ -236,11 +236,12 @@ func (t *FetchTool) Call(ctx context.Context, req *fetch.Request) (*dive.ToolRes
 // WebFetch is marked as read-only, idempotent, and open-world (accesses external systems).
 func (t *FetchTool) Annotations() *dive.ToolAnnotations {
 	return &dive.ToolAnnotations{
-		Title:           "WebFetch",
-		ReadOnlyHint:    true,
-		DestructiveHint: false,
-		IdempotentHint:  true,
-		OpenWorldHint:   true,
+		Title:             "WebFetch",
+		ReadOnlyHint:      true,
+		DestructiveHint:   false,
+		IdempotentHint:    true,
+		OpenWorldHint:     true,
+		MaxResultSizeHint: 100_000,
 	}
 }
 

--- a/toolkit/read_file.go
+++ b/toolkit/read_file.go
@@ -272,10 +272,11 @@ func isBinaryContent(content []byte) bool {
 // Read is marked as read-only and idempotent.
 func (t *ReadFileTool) Annotations() *dive.ToolAnnotations {
 	return &dive.ToolAnnotations{
-		Title:           "Read",
-		ReadOnlyHint:    true,
-		DestructiveHint: false,
-		IdempotentHint:  true,
-		OpenWorldHint:   false,
+		Title:             "Read",
+		ReadOnlyHint:      true,
+		DestructiveHint:   false,
+		IdempotentHint:    true,
+		OpenWorldHint:     false,
+		MaxResultSizeHint: 100_000,
 	}
 }

--- a/truncate_result.go
+++ b/truncate_result.go
@@ -1,0 +1,27 @@
+package dive
+
+import (
+	"fmt"
+	"os"
+)
+
+// TruncateResult truncates s if it exceeds max chars, writes the full content
+// to a temp file, and returns the truncated string and the temp file path.
+// If len(s) <= max, returns s unchanged and an empty path.
+func TruncateResult(s string, max int) (result string, tmpPath string, err error) {
+	runes := []rune(s)
+	if len(runes) <= max {
+		return s, "", nil
+	}
+	f, err := os.CreateTemp("", "dive-tool-result-*")
+	if err != nil {
+		return s, "", fmt.Errorf("truncate result: create temp file: %w", err)
+	}
+	defer f.Close()
+	if _, err := f.WriteString(s); err != nil {
+		return s, "", fmt.Errorf("truncate result: write temp file: %w", err)
+	}
+	truncated := string(runes[:max])
+	truncated += fmt.Sprintf("\n[Output truncated at %d chars. Full output written to %s.]", max, f.Name())
+	return truncated, f.Name(), nil
+}

--- a/truncate_result_test.go
+++ b/truncate_result_test.go
@@ -1,0 +1,67 @@
+package dive_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/deepnoodle-ai/dive"
+	"github.com/deepnoodle-ai/wonton/assert"
+)
+
+func TestTruncateResult(t *testing.T) {
+	t.Run("short string is unchanged", func(t *testing.T) {
+		result, path, err := dive.TruncateResult("hello", 100)
+		assert.NoError(t, err)
+		assert.Equal(t, "hello", result)
+		assert.Equal(t, "", path)
+	})
+
+	t.Run("exact limit is unchanged", func(t *testing.T) {
+		s := strings.Repeat("a", 100)
+		result, path, err := dive.TruncateResult(s, 100)
+		assert.NoError(t, err)
+		assert.Equal(t, s, result)
+		assert.Equal(t, "", path)
+	})
+
+	t.Run("over limit is truncated with footer", func(t *testing.T) {
+		s := strings.Repeat("a", 200)
+		result, path, err := dive.TruncateResult(s, 100)
+		assert.NoError(t, err)
+		assert.NotEqual(t, "", path)
+		assert.True(t, strings.HasPrefix(result, strings.Repeat("a", 100)))
+		assert.True(t, strings.Contains(result, "truncated at 100 chars"))
+		assert.True(t, strings.Contains(result, path))
+	})
+
+	t.Run("unicode is truncated by rune count", func(t *testing.T) {
+		s := strings.Repeat("😀", 10)
+		result, path, err := dive.TruncateResult(s, 5)
+		assert.NoError(t, err)
+		assert.NotEqual(t, "", path)
+		assert.True(t, strings.HasPrefix(result, strings.Repeat("😀", 5)))
+		assert.False(t, strings.HasPrefix(result, strings.Repeat("😀", 6)))
+	})
+}
+
+func TestToolAnnotationsMaxResultSizeHint(t *testing.T) {
+	ann := &dive.ToolAnnotations{MaxResultSizeHint: 50_000}
+	assert.Equal(t, 50_000, ann.MaxResultSizeHint)
+
+	// Round-trip through JSON
+	data, err := ann.MarshalJSON()
+	assert.NoError(t, err)
+	assert.True(t, strings.Contains(string(data), "maxResultSizeHint"))
+
+	var ann2 dive.ToolAnnotations
+	err = ann2.UnmarshalJSON(data)
+	assert.NoError(t, err)
+	assert.Equal(t, 50_000, ann2.MaxResultSizeHint)
+}
+
+func TestToolAnnotationsZeroHintOmitted(t *testing.T) {
+	ann := &dive.ToolAnnotations{Title: "test"}
+	data, err := ann.MarshalJSON()
+	assert.NoError(t, err)
+	assert.False(t, strings.Contains(string(data), "maxResultSizeHint"))
+}


### PR DESCRIPTION
## Summary

- Adds `MaxResultSizeHint int` to `ToolAnnotations`; when > 0, the agent truncates oversized text content blocks after tool execution
- Truncated results are written in full to a temp file (OS-managed cleanup); a footer appended to the result tells the model where to find the full output
- Exports `TruncateResult(s string, max int) (result, tmpPath string, err error)` for toolkit authors to use directly
- Default hints: `ReadFile` and `Fetch` → 100,000 chars; `Bash` → 50,000 chars
- Truncation is skipped for error results, suspend results, background results, and non-text content blocks

## Test plan

- [x] `TestTruncateResult/short_string_is_unchanged` — no-op below limit
- [x] `TestTruncateResult/exact_limit_is_unchanged` — boundary case
- [x] `TestTruncateResult/over_limit_is_truncated_with_footer` — footer contains char count and temp file path
- [x] `TestTruncateResult/unicode_is_truncated_by_rune_count` — multi-byte chars counted correctly
- [x] `TestToolAnnotationsMaxResultSizeHint` — JSON round-trip preserves the field
- [x] `TestToolAnnotationsZeroHintOmitted` — zero value omitted from JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)