### PR TITLE
Add experimental/workflow package for sequential agent pipelines

### DIFF
--- a/experimental/workflow/workflow.go
+++ b/experimental/workflow/workflow.go
@@ -1,0 +1,86 @@
+// Package workflow provides sequential agent pipeline primitives.
+//
+// Usage:
+//
+//	pipeline := workflow.Sequential(classifierAgent, researchAgent, writerAgent)
+//	response, err := pipeline.Run(ctx, dive.WithInput("Research quantum computing trends"))
+//	if err != nil {
+//	    log.Fatal(err)
+//	}
+//	fmt.Println(response.OutputText())
+//
+//	// Inspect intermediate results
+//	for i, step := range pipeline.Steps() {
+//	    fmt.Printf("Step %d: %s\n", i+1, step.OutputText())
+//	}
+package workflow
+
+import (
+	"context"
+
+	"github.com/deepnoodle-ai/dive"
+)
+
+// StepMapper transforms one step's response into the next step's input option.
+type StepMapper func(ctx context.Context, resp *dive.Response) (dive.CreateResponseOption, error)
+
+// Pipeline chains a sequence of agents, passing each step's output as the
+// next step's input. It is not concurrency-safe across simultaneous Run calls.
+type Pipeline struct {
+	agents  []*dive.Agent
+	mapper  StepMapper
+	results []*dive.Response
+}
+
+// Sequential chains agents using the default mapper: OutputText() → WithInput().
+func Sequential(agents ...*dive.Agent) *Pipeline {
+	return SequentialWithMapper(agents, defaultMapper)
+}
+
+// SequentialWithMapper chains agents with a custom per-step transform.
+func SequentialWithMapper(agents []*dive.Agent, mapper StepMapper) *Pipeline {
+	return &Pipeline{
+		agents: agents,
+		mapper: mapper,
+	}
+}
+
+// Run executes the pipeline. The provided option seeds the first agent's input.
+// On the first error, Run returns immediately. The final step's Response is
+// returned on success.
+func (p *Pipeline) Run(ctx context.Context, input dive.CreateResponseOption) (*dive.Response, error) {
+	p.results = make([]*dive.Response, 0, len(p.agents))
+
+	current := input
+	var resp *dive.Response
+	for i, agent := range p.agents {
+		var err error
+		resp, err = agent.CreateResponse(ctx, current)
+		if err != nil {
+			return nil, err
+		}
+		p.results = append(p.results, resp)
+
+		// Don't call the mapper after the last step.
+		if i < len(p.agents)-1 {
+			next, mapErr := p.mapper(ctx, resp)
+			if mapErr != nil {
+				return nil, mapErr
+			}
+			current = next
+		}
+	}
+	return resp, nil
+}
+
+// Steps returns a copy of the intermediate responses from the most recent Run
+// call. Index 0 corresponds to the first agent in the pipeline.
+func (p *Pipeline) Steps() []*dive.Response {
+	out := make([]*dive.Response, len(p.results))
+	copy(out, p.results)
+	return out
+}
+
+func defaultMapper(_ context.Context, resp *dive.Response) (dive.CreateResponseOption, error) {
+	return dive.WithInput(resp.OutputText()), nil
+}

--- a/experimental/workflow/workflow_test.go
+++ b/experimental/workflow/workflow_test.go
@@ -1,0 +1,156 @@
+package workflow_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/deepnoodle-ai/dive"
+	"github.com/deepnoodle-ai/dive/experimental/workflow"
+	"github.com/deepnoodle-ai/dive/llm"
+	"github.com/deepnoodle-ai/wonton/assert"
+)
+
+// mockLLM is a minimal LLM that returns a fixed response text.
+type mockLLM struct {
+	response string
+	err      error
+}
+
+func (m *mockLLM) Name() string { return "mock" }
+func (m *mockLLM) Generate(_ context.Context, _ ...llm.Option) (*llm.Response, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	return &llm.Response{
+		ID:         "r1",
+		Model:      "mock",
+		Role:       llm.Assistant,
+		Content:    []llm.Content{&llm.TextContent{Text: m.response}},
+		Type:       "message",
+		StopReason: "stop",
+	}, nil
+}
+
+func makeAgent(t *testing.T, response string) *dive.Agent {
+	t.Helper()
+	agent, err := dive.NewAgent(dive.AgentOptions{
+		Model: &mockLLM{response: response},
+	})
+	assert.NoError(t, err)
+	return agent
+}
+
+func TestSequential(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("single agent returns its response", func(t *testing.T) {
+		p := workflow.Sequential(makeAgent(t, "step one output"))
+		resp, err := p.Run(ctx, dive.WithInput("start"))
+		assert.NoError(t, err)
+		assert.Equal(t, "step one output", resp.OutputText())
+		assert.Equal(t, 1, len(p.Steps()))
+	})
+
+	t.Run("final step output is returned", func(t *testing.T) {
+		p := workflow.Sequential(
+			makeAgent(t, "alpha"),
+			makeAgent(t, "beta"),
+			makeAgent(t, "gamma"),
+		)
+		resp, err := p.Run(ctx, dive.WithInput("initial"))
+		assert.NoError(t, err)
+		assert.Equal(t, "gamma", resp.OutputText())
+	})
+
+	t.Run("all steps are recorded", func(t *testing.T) {
+		p := workflow.Sequential(
+			makeAgent(t, "a"),
+			makeAgent(t, "b"),
+			makeAgent(t, "c"),
+		)
+		_, err := p.Run(ctx, dive.WithInput("go"))
+		assert.NoError(t, err)
+		steps := p.Steps()
+		assert.Equal(t, 3, len(steps))
+		assert.Equal(t, "a", steps[0].OutputText())
+		assert.Equal(t, "b", steps[1].OutputText())
+		assert.Equal(t, "c", steps[2].OutputText())
+	})
+
+	t.Run("error in middle step stops execution", func(t *testing.T) {
+		errAgent, err := dive.NewAgent(dive.AgentOptions{
+			Model: &mockLLM{err: errors.New("agent failed")},
+		})
+		assert.NoError(t, err)
+
+		p := workflow.Sequential(
+			makeAgent(t, "first"),
+			errAgent,
+			makeAgent(t, "third"),
+		)
+		resp, err := p.Run(ctx, dive.WithInput("start"))
+		assert.Error(t, err)
+		assert.Nil(t, resp)
+		assert.Equal(t, 1, len(p.Steps()))
+	})
+
+	t.Run("steps resets between runs", func(t *testing.T) {
+		p := workflow.Sequential(makeAgent(t, "out"))
+		_, err := p.Run(ctx, dive.WithInput("first run"))
+		assert.NoError(t, err)
+		assert.Equal(t, 1, len(p.Steps()))
+
+		_, err = p.Run(ctx, dive.WithInput("second run"))
+		assert.NoError(t, err)
+		assert.Equal(t, 1, len(p.Steps()))
+	})
+
+	t.Run("steps returns a copy", func(t *testing.T) {
+		p := workflow.Sequential(makeAgent(t, "out"))
+		_, err := p.Run(ctx, dive.WithInput("start"))
+		assert.NoError(t, err)
+		s1 := p.Steps()
+		s2 := p.Steps()
+		assert.Equal(t, len(s1), len(s2))
+		// Mutating the copy does not affect Pipeline internals
+		s1[0] = nil
+		assert.NotNil(t, p.Steps()[0])
+	})
+}
+
+func TestSequentialWithMapper(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("custom mapper receives each step response", func(t *testing.T) {
+		var mapperOutputs []string
+		mapper := func(_ context.Context, resp *dive.Response) (dive.CreateResponseOption, error) {
+			mapperOutputs = append(mapperOutputs, resp.OutputText())
+			return dive.WithInput("mapped: " + resp.OutputText()), nil
+		}
+
+		p := workflow.SequentialWithMapper(
+			[]*dive.Agent{makeAgent(t, "step1"), makeAgent(t, "step2")},
+			mapper,
+		)
+		resp, err := p.Run(ctx, dive.WithInput("start"))
+		assert.NoError(t, err)
+		assert.Equal(t, "step2", resp.OutputText())
+		// Mapper is called between steps only (not after the last step)
+		assert.Equal(t, 1, len(mapperOutputs))
+		assert.Equal(t, "step1", mapperOutputs[0])
+	})
+
+	t.Run("mapper error stops execution", func(t *testing.T) {
+		mapper := func(_ context.Context, _ *dive.Response) (dive.CreateResponseOption, error) {
+			return nil, errors.New("mapper failed")
+		}
+		p := workflow.SequentialWithMapper(
+			[]*dive.Agent{makeAgent(t, "out"), makeAgent(t, "out2")},
+			mapper,
+		)
+		resp, err := p.Run(ctx, dive.WithInput("start"))
+		assert.Error(t, err)
+		assert.Nil(t, resp)
+	})
+}


### PR DESCRIPTION
## Summary

- Adds `experimental/workflow` package with `Sequential` and `SequentialWithMapper` constructors
- `Pipeline.Run(ctx, input)` chains agents in order, passing each step's `OutputText()` as the next step's input via the default mapper (`WithInput`)
- `SequentialWithMapper` accepts a custom `StepMapper` for richer inter-step transforms (e.g. structured output parsing, prompt wrapping)
- `Pipeline.Steps()` returns a copy of all intermediate responses after each `Run` call for debugging and auditing
- Mapper is called only between steps (not after the final step), so a mapper error cannot mask a completed pipeline

## Test plan

- [x] Single agent returns its response
- [x] Final step output is returned as the pipeline result
- [x] All step responses are recorded in `Steps()`
- [x] Error in a middle step stops execution; partial `Steps()` available
- [x] `Steps()` resets between `Run` calls
- [x] `Steps()` returns a copy (mutation-safe)
- [x] Custom mapper receives each intermediate response
- [x] Mapper error stops execution

🤖 Generated with [Claude Code](https://claude.com/claude-code)