### PR TITLE
Add experimental/memory package for cross-session memory service

### DIFF
--- a/experimental/memory/hook.go
+++ b/experimental/memory/hook.go
@@ -1,0 +1,47 @@
+package memory
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/deepnoodle-ai/dive"
+	"github.com/deepnoodle-ai/dive/llm"
+)
+
+// InjectMemoriesHook returns a PreGenerationHook that queries svc using the
+// most recent user message as the search query, then appends the top-limit
+// results as a <memory> block to the system prompt. Empty results are a no-op.
+func InjectMemoriesHook(svc Service, limit int) dive.PreGenerationHook {
+	return func(ctx context.Context, hctx *dive.HookContext) error {
+		query := lastUserText(hctx.Messages)
+		if query == "" {
+			return nil
+		}
+		entries, err := svc.Search(ctx, query, limit)
+		if err != nil || len(entries) == 0 {
+			return nil
+		}
+		var sb strings.Builder
+		sb.WriteString("<memory>\n")
+		for _, e := range entries {
+			sb.WriteString(fmt.Sprintf("- [%s] %s\n", e.ID, e.Content))
+		}
+		sb.WriteString("</memory>")
+		if hctx.SystemPrompt != "" {
+			hctx.SystemPrompt += "\n\n" + sb.String()
+		} else {
+			hctx.SystemPrompt = sb.String()
+		}
+		return nil
+	}
+}
+
+func lastUserText(messages []*llm.Message) string {
+	for i := len(messages) - 1; i >= 0; i-- {
+		if messages[i].Role == llm.User {
+			return messages[i].Text()
+		}
+	}
+	return ""
+}

--- a/experimental/memory/keyword.go
+++ b/experimental/memory/keyword.go
@@ -1,0 +1,127 @@
+package memory
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+)
+
+type memoryService struct {
+	mu      sync.RWMutex
+	entries []Entry
+	nextID  int
+}
+
+// NewMemoryService returns an in-memory keyword-search implementation of Service.
+// It is thread-safe and suitable for local development and testing.
+func NewMemoryService() Service {
+	return &memoryService{}
+}
+
+func (s *memoryService) Save(_ context.Context, entry Entry) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if entry.ID == "" {
+		s.nextID++
+		entry.ID = fmt.Sprintf("mem_%d", s.nextID)
+	}
+	if entry.CreatedAt.IsZero() {
+		entry.CreatedAt = time.Now()
+	}
+	for i, e := range s.entries {
+		if e.ID == entry.ID {
+			s.entries[i] = entry
+			return nil
+		}
+	}
+	s.entries = append(s.entries, entry)
+	return nil
+}
+
+func (s *memoryService) Search(_ context.Context, query string, limit int) ([]Entry, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if limit <= 0 {
+		return nil, nil
+	}
+	queryTokens := tokenize(query)
+	if len(queryTokens) == 0 {
+		return nil, nil
+	}
+
+	type scored struct {
+		entry Entry
+		score int
+	}
+	var results []scored
+	for _, e := range s.entries {
+		score := scoreEntry(e, queryTokens)
+		if score > 0 {
+			results = append(results, scored{e, score})
+		}
+	}
+	sort.Slice(results, func(i, j int) bool {
+		if results[i].score != results[j].score {
+			return results[i].score > results[j].score
+		}
+		return results[i].entry.CreatedAt.After(results[j].entry.CreatedAt)
+	})
+	if len(results) > limit {
+		results = results[:limit]
+	}
+	out := make([]Entry, len(results))
+	for i, r := range results {
+		out[i] = r.entry
+	}
+	return out, nil
+}
+
+func (s *memoryService) Delete(_ context.Context, id string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for i, e := range s.entries {
+		if e.ID == id {
+			s.entries = append(s.entries[:i], s.entries[i+1:]...)
+			return nil
+		}
+	}
+	return nil
+}
+
+func tokenize(s string) []string {
+	words := strings.FieldsFunc(strings.ToLower(s), func(r rune) bool {
+		return !('a' <= r && r <= 'z') && !('0' <= r && r <= '9')
+	})
+	seen := make(map[string]bool, len(words))
+	unique := words[:0]
+	for _, w := range words {
+		if len(w) > 2 && !seen[w] {
+			seen[w] = true
+			unique = append(unique, w)
+		}
+	}
+	return unique
+}
+
+func scoreEntry(e Entry, queryTokens []string) int {
+	entryTokens := tokenize(e.Content)
+	tokenSet := make(map[string]bool, len(entryTokens))
+	for _, t := range entryTokens {
+		tokenSet[t] = true
+	}
+	for _, tag := range e.Tags {
+		for _, t := range tokenize(tag) {
+			tokenSet[t] = true
+		}
+	}
+	score := 0
+	for _, qt := range queryTokens {
+		if tokenSet[qt] {
+			score++
+		}
+	}
+	return score
+}

--- a/experimental/memory/memory.go
+++ b/experimental/memory/memory.go
@@ -1,0 +1,47 @@
+// Package memory provides a cross-session memory service for Dive agents.
+//
+// The Service interface is designed to accommodate both keyword-based and
+// vector-backed implementations without API changes. NewMemoryService returns
+// an in-memory keyword implementation suitable for local development.
+//
+// Usage:
+//
+//	svc := memory.NewMemoryService()
+//
+//	agent, _ := dive.NewAgent(dive.AgentOptions{
+//	    Model: anthropic.New(),
+//	    Tools: memory.MemoryTools(svc),
+//	    Hooks: dive.Hooks{
+//	        PreGeneration: []dive.PreGenerationHook{
+//	            memory.InjectMemoriesHook(svc, 5),
+//	        },
+//	    },
+//	})
+package memory
+
+import (
+	"context"
+	"time"
+)
+
+// Entry is a single memory stored in the service.
+type Entry struct {
+	ID        string
+	Content   string
+	Tags      []string
+	SessionID string
+	CreatedAt time.Time
+	Metadata  map[string]any
+}
+
+// Service stores and retrieves memory entries across sessions.
+type Service interface {
+	// Save persists an entry. If the entry has no ID, one is assigned.
+	Save(ctx context.Context, entry Entry) error
+
+	// Search returns up to limit entries relevant to the query.
+	Search(ctx context.Context, query string, limit int) ([]Entry, error)
+
+	// Delete removes the entry with the given ID.
+	Delete(ctx context.Context, id string) error
+}

--- a/experimental/memory/memory_test.go
+++ b/experimental/memory/memory_test.go
@@ -1,0 +1,197 @@
+package memory_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/deepnoodle-ai/dive"
+	"github.com/deepnoodle-ai/dive/experimental/memory"
+	"github.com/deepnoodle-ai/dive/llm"
+	"github.com/deepnoodle-ai/wonton/assert"
+)
+
+func TestMemoryService(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("save and search", func(t *testing.T) {
+		svc := memory.NewMemoryService()
+		err := svc.Save(ctx, memory.Entry{Content: "The user prefers dark mode in all applications"})
+		assert.NoError(t, err)
+		err = svc.Save(ctx, memory.Entry{Content: "The user speaks French fluently"})
+		assert.NoError(t, err)
+
+		results, err := svc.Search(ctx, "dark mode UI preferences", 5)
+		assert.NoError(t, err)
+		assert.Equal(t, 1, len(results))
+		assert.Equal(t, "The user prefers dark mode in all applications", results[0].Content)
+	})
+
+	t.Run("ID is auto-assigned when empty", func(t *testing.T) {
+		svc := memory.NewMemoryService()
+		err := svc.Save(ctx, memory.Entry{Content: "test"})
+		assert.NoError(t, err)
+
+		results, err := svc.Search(ctx, "test", 5)
+		assert.NoError(t, err)
+		assert.Equal(t, 1, len(results))
+		assert.NotEqual(t, "", results[0].ID)
+	})
+
+	t.Run("delete removes entry", func(t *testing.T) {
+		svc := memory.NewMemoryService()
+		err := svc.Save(ctx, memory.Entry{ID: "e1", Content: "something memorable"})
+		assert.NoError(t, err)
+
+		err = svc.Delete(ctx, "e1")
+		assert.NoError(t, err)
+
+		results, err := svc.Search(ctx, "memorable", 5)
+		assert.NoError(t, err)
+		assert.Equal(t, 0, len(results))
+	})
+
+	t.Run("delete unknown ID is a no-op", func(t *testing.T) {
+		svc := memory.NewMemoryService()
+		err := svc.Delete(ctx, "nonexistent")
+		assert.NoError(t, err)
+	})
+
+	t.Run("search respects limit", func(t *testing.T) {
+		svc := memory.NewMemoryService()
+		for i := range 10 {
+			err := svc.Save(ctx, memory.Entry{Content: "user likes golang programming"})
+			assert.NoError(t, err)
+			_ = i
+		}
+		results, err := svc.Search(ctx, "golang programming", 3)
+		assert.NoError(t, err)
+		assert.Equal(t, 3, len(results))
+	})
+
+	t.Run("search returns empty on no match", func(t *testing.T) {
+		svc := memory.NewMemoryService()
+		err := svc.Save(ctx, memory.Entry{Content: "user prefers coffee"})
+		assert.NoError(t, err)
+
+		results, err := svc.Search(ctx, "quantum physics", 5)
+		assert.NoError(t, err)
+		assert.Equal(t, 0, len(results))
+	})
+
+	t.Run("tags improve search relevance", func(t *testing.T) {
+		svc := memory.NewMemoryService()
+		err := svc.Save(ctx, memory.Entry{
+			Content: "User is an expert cook",
+			Tags:    []string{"cooking", "food", "skills"},
+		})
+		assert.NoError(t, err)
+
+		results, err := svc.Search(ctx, "cooking skills", 5)
+		assert.NoError(t, err)
+		assert.Equal(t, 1, len(results))
+	})
+
+	t.Run("update existing entry by ID", func(t *testing.T) {
+		svc := memory.NewMemoryService()
+		err := svc.Save(ctx, memory.Entry{ID: "e1", Content: "old content"})
+		assert.NoError(t, err)
+		err = svc.Save(ctx, memory.Entry{ID: "e1", Content: "updated content"})
+		assert.NoError(t, err)
+
+		results, err := svc.Search(ctx, "updated content", 5)
+		assert.NoError(t, err)
+		assert.Equal(t, 1, len(results))
+		assert.Equal(t, "updated content", results[0].Content)
+	})
+}
+
+func TestInjectMemoriesHook(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("injects relevant memories into system prompt", func(t *testing.T) {
+		svc := memory.NewMemoryService()
+		svc.Save(ctx, memory.Entry{ID: "m1", Content: "User prefers dark mode themes"})
+
+		hook := memory.InjectMemoriesHook(svc, 5)
+		hctx := dive.NewHookContext()
+		hctx.SystemPrompt = "You are helpful."
+		hctx.Messages = []*llm.Message{
+			llm.NewUserTextMessage("What dark mode themes are available?"),
+		}
+
+		err := hook(ctx, hctx)
+		assert.NoError(t, err)
+		assert.True(t, len(hctx.SystemPrompt) > len("You are helpful."))
+		assert.True(t, contains(hctx.SystemPrompt, "User prefers dark mode themes"))
+		assert.True(t, contains(hctx.SystemPrompt, "<memory>"))
+	})
+
+	t.Run("no-op when no messages", func(t *testing.T) {
+		svc := memory.NewMemoryService()
+		hook := memory.InjectMemoriesHook(svc, 5)
+		hctx := dive.NewHookContext()
+		hctx.SystemPrompt = "original"
+		hctx.Messages = []*llm.Message{}
+
+		err := hook(ctx, hctx)
+		assert.NoError(t, err)
+		assert.Equal(t, "original", hctx.SystemPrompt)
+	})
+
+	t.Run("no-op when no relevant memories", func(t *testing.T) {
+		svc := memory.NewMemoryService()
+		svc.Save(ctx, memory.Entry{Content: "user likes jazz music"})
+
+		hook := memory.InjectMemoriesHook(svc, 5)
+		hctx := dive.NewHookContext()
+		hctx.SystemPrompt = "original"
+		hctx.Messages = []*llm.Message{
+			llm.NewUserTextMessage("quantum physics question"),
+		}
+
+		err := hook(ctx, hctx)
+		assert.NoError(t, err)
+		assert.Equal(t, "original", hctx.SystemPrompt)
+	})
+
+	t.Run("works with empty initial system prompt", func(t *testing.T) {
+		svc := memory.NewMemoryService()
+		svc.Save(ctx, memory.Entry{ID: "m1", Content: "user is a developer"})
+
+		hook := memory.InjectMemoriesHook(svc, 5)
+		hctx := dive.NewHookContext()
+		hctx.SystemPrompt = ""
+		hctx.Messages = []*llm.Message{
+			llm.NewUserTextMessage("developer tools"),
+		}
+
+		err := hook(ctx, hctx)
+		assert.NoError(t, err)
+		assert.True(t, contains(hctx.SystemPrompt, "<memory>"))
+	})
+}
+
+func TestMemoryTools(t *testing.T) {
+	tools := memory.MemoryTools(memory.NewMemoryService())
+	assert.Equal(t, 2, len(tools))
+
+	names := make([]string, len(tools))
+	for i, tool := range tools {
+		names[i] = tool.Name()
+	}
+	assert.Contains(t, names, "memory_save")
+	assert.Contains(t, names, "memory_search")
+}
+
+func contains(s, sub string) bool {
+	return len(s) >= len(sub) && (s == sub || len(s) > 0 && containsStr(s, sub))
+}
+
+func containsStr(s, sub string) bool {
+	for i := range s {
+		if i+len(sub) <= len(s) && s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}

--- a/experimental/memory/tool.go
+++ b/experimental/memory/tool.go
@@ -1,0 +1,71 @@
+package memory
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/deepnoodle-ai/dive"
+)
+
+type memorySaveInput struct {
+	Content string   `json:"content" jsonschema:"description=The fact or information to remember,required"`
+	Tags    []string `json:"tags,omitempty" jsonschema:"description=Optional tags for categorization"`
+}
+
+type memorySearchInput struct {
+	Query string `json:"query" jsonschema:"description=The query to search memories for,required"`
+	Limit int    `json:"limit,omitempty" jsonschema:"description=Maximum number of results to return (default 5)"`
+}
+
+// MemoryTools returns the memory_save and memory_search tools backed by svc.
+// Include both in AgentOptions.Tools to let the model explicitly manage memories.
+func MemoryTools(svc Service) []dive.Tool {
+	return []dive.Tool{
+		memorySaveTool(svc),
+		memorySearchTool(svc),
+	}
+}
+
+func memorySaveTool(svc Service) dive.Tool {
+	return dive.FuncTool("memory_save", "Save a fact or piece of information to long-term memory.",
+		func(ctx context.Context, input *memorySaveInput) (*dive.ToolResult, error) {
+			entry := Entry{
+				Content: input.Content,
+				Tags:    input.Tags,
+			}
+			if err := svc.Save(ctx, entry); err != nil {
+				return dive.NewToolResultError(fmt.Sprintf("Failed to save memory: %v", err)), nil
+			}
+			return dive.NewToolResultText("Memory saved."), nil
+		})
+}
+
+func memorySearchTool(svc Service) dive.Tool {
+	return dive.FuncTool("memory_search", "Search long-term memory for relevant information.",
+		func(ctx context.Context, input *memorySearchInput) (*dive.ToolResult, error) {
+			limit := input.Limit
+			if limit <= 0 {
+				limit = 5
+			}
+			entries, err := svc.Search(ctx, input.Query, limit)
+			if err != nil {
+				return dive.NewToolResultError(fmt.Sprintf("Failed to search memories: %v", err)), nil
+			}
+			if len(entries) == 0 {
+				return dive.NewToolResultText("No relevant memories found."), nil
+			}
+			var sb strings.Builder
+			for i, e := range entries {
+				if i > 0 {
+					sb.WriteString("\n")
+				}
+				tags := ""
+				if len(e.Tags) > 0 {
+					tags = " [" + strings.Join(e.Tags, ", ") + "]"
+				}
+				sb.WriteString(fmt.Sprintf("%d. [%s]%s %s", i+1, e.ID, tags, e.Content))
+			}
+			return dive.NewToolResultText(sb.String()), nil
+		})
+}


### PR DESCRIPTION
## Summary

- Adds `experimental/memory` package with `Service` interface (`Save`, `Search`, `Delete`) and `Entry` type
- `NewMemoryService()` returns a thread-safe in-memory keyword implementation (suitable for local dev and testing)
- `InjectMemoriesHook(svc, limit)` returns a `PreGenerationHook` that queries the service using the latest user message and injects relevant entries as a `<memory>` block appended to the system prompt
- `MemoryTools(svc)` returns `memory_save` and `memory_search` tools for explicit model-driven memory management
- Interface is designed to accommodate vector-backed implementations (pgvector, Qdrant) without API changes

## Test plan

- [x] Save and search basic round-trip
- [x] ID is auto-assigned when empty
- [x] Delete removes entry from search results
- [x] Delete unknown ID is a no-op
- [x] Search respects the `limit` parameter
- [x] Search returns empty when no tokens match
- [x] Tags improve search relevance scoring
- [x] Updating by ID replaces the existing entry
- [x] InjectMemoriesHook injects `<memory>` block with relevant entries
- [x] InjectMemoriesHook is a no-op when there are no messages
- [x] InjectMemoriesHook is a no-op when no memories match
- [x] InjectMemoriesHook works with an empty initial system prompt
- [x] MemoryTools returns two tools: `memory_save` and `memory_search`

🤖 Generated with [Claude Code](https://claude.com/claude-code)