### PR TITLE
Add RequestPermissionsTool and turn-scoped permission allowlist

### DIFF
--- a/permission/permission.go
+++ b/permission/permission.go
@@ -105,6 +105,7 @@ type Manager struct {
 	config         *Config
 	dialog         dive.Dialog
 	sessionAllowed map[string]bool
+	turnAllowed    map[string]bool
 }
 
 // NewManager creates a new permission manager.
@@ -116,6 +117,7 @@ func NewManager(config *Config, dialog dive.Dialog) *Manager {
 		config:         config,
 		dialog:         dialog,
 		sessionAllowed: make(map[string]bool),
+		turnAllowed:    make(map[string]bool),
 	}
 }
 
@@ -136,11 +138,11 @@ func (pm *Manager) EvaluateToolUse(
 	tool dive.Tool,
 	call *llm.ToolUseContent,
 ) error {
-	// Check session allowlist
+	// Check session and turn allowlists
 	if tool != nil {
 		category := GetToolCategory(tool.Name())
 		pm.mu.RLock()
-		allowed := pm.sessionAllowed[category.Key]
+		allowed := pm.sessionAllowed[category.Key] || pm.turnAllowed[category.Key]
 		pm.mu.RUnlock()
 		if allowed {
 			return nil
@@ -383,6 +385,30 @@ func (pm *Manager) ClearSessionAllowlist() {
 	pm.mu.Lock()
 	defer pm.mu.Unlock()
 	pm.sessionAllowed = make(map[string]bool)
+}
+
+// AllowForTurn marks a tool category as allowed for the current turn only.
+// Turn-scoped grants are cleared by calling ClearTurnAllowlist, typically
+// in a PreGenerationHook at the start of each CreateResponse call.
+func (pm *Manager) AllowForTurn(categoryKey string) {
+	pm.mu.Lock()
+	defer pm.mu.Unlock()
+	pm.turnAllowed[categoryKey] = true
+}
+
+// IsTurnAllowed checks if a tool category is allowed for the current turn.
+func (pm *Manager) IsTurnAllowed(categoryKey string) bool {
+	pm.mu.RLock()
+	defer pm.mu.RUnlock()
+	return pm.turnAllowed[categoryKey]
+}
+
+// ClearTurnAllowlist removes all turn-scoped allowlist entries.
+// Call this in a PreGenerationHook to reset grants at the start of each turn.
+func (pm *Manager) ClearTurnAllowlist() {
+	pm.mu.Lock()
+	defer pm.mu.Unlock()
+	pm.turnAllowed = make(map[string]bool)
 }
 
 // Category represents a tool's category for session allowlist purposes.

--- a/permission/request_permissions.go
+++ b/permission/request_permissions.go
@@ -1,0 +1,87 @@
+package permission
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/deepnoodle-ai/dive"
+)
+
+// GrantScope controls how long granted permissions last.
+type GrantScope int
+
+const (
+	// GrantScopeTurn grants access for the current turn only. The consumer
+	// must call Manager.ClearTurnAllowlist() (e.g. in a PreGenerationHook)
+	// to reset grants at the start of the next turn. This is the default.
+	GrantScopeTurn GrantScope = iota
+
+	// GrantScopeSession grants access for the lifetime of the session.
+	// Use when re-prompting on every turn would be disruptive.
+	GrantScopeSession
+)
+
+// PermissionRequest is the request the model sends when asking for elevated access.
+type PermissionRequest struct {
+	// Tools lists the tool names the model is requesting access to.
+	Tools []string
+
+	// Reason is the model-authored explanation of why access is needed.
+	Reason string
+}
+
+// PermissionRequestHandler is called when the model invokes request_permissions.
+// It returns true if access is granted and an error to surface to the model.
+type PermissionRequestHandler func(ctx context.Context, req PermissionRequest) (granted bool, err error)
+
+type requestPermissionsInput struct {
+	Tools  []string `json:"tools" jsonschema:"description=Tool names the model is requesting access to,required"`
+	Reason string   `json:"reason" jsonschema:"description=Explanation of why access is needed,required"`
+}
+
+// RequestPermissionsTool returns a Tool named "request_permissions" that the
+// model can call to ask the host for elevated access before performing
+// sensitive operations.
+//
+// When granted, the requested tools are added to the Manager's allowlist using
+// the provided scope. With GrantScopeTurn (default), grants apply for the
+// current turn only; call Manager.ClearTurnAllowlist() in a PreGenerationHook
+// to reset at the start of each new turn.
+func RequestPermissionsTool(manager *Manager, handler PermissionRequestHandler, scope ...GrantScope) dive.Tool {
+	s := GrantScopeTurn
+	if len(scope) > 0 {
+		s = scope[0]
+	}
+	return dive.FuncTool("request_permissions",
+		"Request permission to use one or more tools before performing a sensitive operation. "+
+			"Provide the tool names you need and explain why the access is required.",
+		func(ctx context.Context, input *requestPermissionsInput) (*dive.ToolResult, error) {
+			req := PermissionRequest{
+				Tools:  input.Tools,
+				Reason: input.Reason,
+			}
+			granted, err := handler(ctx, req)
+			if err != nil {
+				return dive.NewToolResultError(fmt.Sprintf("Permission request failed: %v", err)), nil
+			}
+			if !granted {
+				return dive.NewToolResultText(
+					fmt.Sprintf("Permission denied for: %s", strings.Join(input.Tools, ", ")),
+				), nil
+			}
+			// Grant access for each requested tool.
+			for _, toolName := range input.Tools {
+				category := GetToolCategory(toolName)
+				switch s {
+				case GrantScopeSession:
+					manager.AllowForSession(category.Key)
+				default:
+					manager.AllowForTurn(category.Key)
+				}
+			}
+			return dive.NewToolResultText(
+				fmt.Sprintf("Permission granted for: %s", strings.Join(input.Tools, ", ")),
+			), nil
+		})
+}

--- a/permission/request_permissions_test.go
+++ b/permission/request_permissions_test.go
@@ -1,0 +1,181 @@
+package permission_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/deepnoodle-ai/dive"
+	"github.com/deepnoodle-ai/dive/permission"
+	"github.com/deepnoodle-ai/wonton/assert"
+)
+
+// callTool invokes a dive.Tool with raw JSON input bytes.
+func callTool(ctx context.Context, tool dive.Tool, rawJSON string) (*dive.ToolResult, error) {
+	return tool.Call(ctx, []byte(rawJSON))
+}
+
+func resultText(r *dive.ToolResult) string {
+	for _, c := range r.Content {
+		if c.Text != "" {
+			return c.Text
+		}
+	}
+	return ""
+}
+
+func contains(s, sub string) bool {
+	return strings.Contains(strings.ToLower(s), strings.ToLower(sub))
+}
+
+func TestRequestPermissionsToolTurnScope(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("grants turn-scoped access when approved", func(t *testing.T) {
+		manager := permission.NewManager(nil, nil)
+		tool := permission.RequestPermissionsTool(manager, func(_ context.Context, req permission.PermissionRequest) (bool, error) {
+			return true, nil
+		})
+
+		result, err := callTool(ctx, tool, `{"tools":["Bash","Edit"],"reason":"need to run tests"}`)
+		assert.NoError(t, err)
+		assert.False(t, result.IsError)
+		assert.True(t, contains(resultText(result), "granted"))
+
+		assert.True(t, manager.IsTurnAllowed("bash"))
+		assert.True(t, manager.IsTurnAllowed("edit"))
+		assert.False(t, manager.IsSessionAllowed("bash"))
+	})
+
+	t.Run("denied when handler returns false", func(t *testing.T) {
+		manager := permission.NewManager(nil, nil)
+		tool := permission.RequestPermissionsTool(manager, func(_ context.Context, _ permission.PermissionRequest) (bool, error) {
+			return false, nil
+		})
+
+		result, err := callTool(ctx, tool, `{"tools":["Bash"],"reason":"risky operation"}`)
+		assert.NoError(t, err)
+		assert.False(t, result.IsError)
+		assert.True(t, contains(resultText(result), "denied"))
+
+		assert.False(t, manager.IsTurnAllowed("bash"))
+		assert.False(t, manager.IsSessionAllowed("bash"))
+	})
+
+	t.Run("ClearTurnAllowlist revokes turn grants", func(t *testing.T) {
+		manager := permission.NewManager(nil, nil)
+		tool := permission.RequestPermissionsTool(manager, func(_ context.Context, _ permission.PermissionRequest) (bool, error) {
+			return true, nil
+		})
+
+		_, err := callTool(ctx, tool, `{"tools":["Bash"],"reason":"run tests"}`)
+		assert.NoError(t, err)
+		assert.True(t, manager.IsTurnAllowed("bash"))
+
+		manager.ClearTurnAllowlist()
+		assert.False(t, manager.IsTurnAllowed("bash"))
+	})
+}
+
+func TestRequestPermissionsToolSessionScope(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("grants session-scoped access when approved", func(t *testing.T) {
+		manager := permission.NewManager(nil, nil)
+		tool := permission.RequestPermissionsTool(manager,
+			func(_ context.Context, _ permission.PermissionRequest) (bool, error) {
+				return true, nil
+			},
+			permission.GrantScopeSession,
+		)
+
+		result, err := callTool(ctx, tool, `{"tools":["Bash"],"reason":"need bash"}`)
+		assert.NoError(t, err)
+		assert.False(t, result.IsError)
+
+		assert.True(t, manager.IsSessionAllowed("bash"))
+		assert.False(t, manager.IsTurnAllowed("bash"))
+	})
+}
+
+func TestRequestPermissionsToolHandlerError(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("handler error surfaces as error result", func(t *testing.T) {
+		manager := permission.NewManager(nil, nil)
+		tool := permission.RequestPermissionsTool(manager, func(_ context.Context, _ permission.PermissionRequest) (bool, error) {
+			return false, context.DeadlineExceeded
+		})
+
+		result, err := callTool(ctx, tool, `{"tools":["Bash"],"reason":"test"}`)
+		assert.NoError(t, err)
+		assert.True(t, result.IsError)
+		assert.True(t, contains(resultText(result), "failed"))
+	})
+}
+
+func TestRequestPermissionsToolReceivesRequest(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("handler receives correct request fields", func(t *testing.T) {
+		manager := permission.NewManager(nil, nil)
+		var capturedReq permission.PermissionRequest
+		tool := permission.RequestPermissionsTool(manager, func(_ context.Context, req permission.PermissionRequest) (bool, error) {
+			capturedReq = req
+			return false, nil
+		})
+
+		_, err := callTool(ctx, tool, `{"tools":["Bash","Edit"],"reason":"I need to modify config files"}`)
+		assert.NoError(t, err)
+
+		assert.Equal(t, 2, len(capturedReq.Tools))
+		assert.Equal(t, "Bash", capturedReq.Tools[0])
+		assert.Equal(t, "Edit", capturedReq.Tools[1])
+		assert.Equal(t, "I need to modify config files", capturedReq.Reason)
+	})
+}
+
+func TestTurnAllowlistIntegrationWithEvaluate(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("turn-granted tool passes EvaluateToolUse", func(t *testing.T) {
+		manager := permission.NewManager(&permission.Config{Mode: permission.ModeDontAsk}, nil)
+		tool := permission.RequestPermissionsTool(manager, func(_ context.Context, _ permission.PermissionRequest) (bool, error) {
+			return true, nil
+		})
+
+		// Grant Bash via the request_permissions tool
+		_, err := callTool(ctx, tool, `{"tools":["Bash"],"reason":"need bash"}`)
+		assert.NoError(t, err)
+		assert.True(t, manager.IsTurnAllowed("bash"))
+
+		// A Bash tool call should now be allowed
+		bashTool := &stubTool{name: "Bash"}
+		err = manager.EvaluateToolUse(ctx, bashTool, nil)
+		assert.NoError(t, err)
+	})
+
+	t.Run("turn grants are not session grants", func(t *testing.T) {
+		manager := permission.NewManager(nil, nil)
+		tool := permission.RequestPermissionsTool(manager, func(_ context.Context, _ permission.PermissionRequest) (bool, error) {
+			return true, nil
+		})
+
+		_, err := callTool(ctx, tool, `{"tools":["Bash"],"reason":"temp access"}`)
+		assert.NoError(t, err)
+
+		assert.True(t, manager.IsTurnAllowed("bash"))
+		assert.False(t, manager.IsSessionAllowed("bash"))
+	})
+}
+
+// stubTool is a minimal dive.Tool for testing.
+type stubTool struct {
+	name string
+}
+
+func (s *stubTool) Name() string                                            { return s.name }
+func (s *stubTool) Description() string                                      { return "" }
+func (s *stubTool) Schema() *dive.Schema                                     { return nil }
+func (s *stubTool) Annotations() *dive.ToolAnnotations                      { return nil }
+func (s *stubTool) Call(_ context.Context, _ any) (*dive.ToolResult, error) { return nil, nil }


### PR DESCRIPTION
## Summary

- Adds `permission.RequestPermissionsTool(manager, handler, scope...)` — a built-in `request_permissions` tool the model can call to ask the host for elevated access with a model-authored rationale
- Handler is host-defined (prompt user, evaluate policy, or auto-deny)
- `GrantScopeTurn` (default): grants apply until `Manager.ClearTurnAllowlist()` is called (e.g. in a `PreGenerationHook` at the start of each turn)
- `GrantScopeSession`: grants persist for the lifetime of the session, using the existing session allowlist
- `Manager` gains `AllowForTurn(key)`, `IsTurnAllowed(key)`, and `ClearTurnAllowlist()` methods
- `EvaluateToolUse` now checks both session and turn allowlists

## Test plan

- [x] Handler receives correct `PermissionRequest` fields (tools + reason)
- [x] Turn-scoped grant allows tool access; does NOT add to session allowlist
- [x] Handler denial returns a denial result without modifying allowlists
- [x] `ClearTurnAllowlist` revokes turn grants
- [x] Session-scoped grant adds to session allowlist; does NOT add to turn allowlist
- [x] Handler error surfaces as an error `ToolResult` (non-fatal to the agent)
- [x] `EvaluateToolUse` allows a tool after turn grant (`ModeDontAsk` baseline)
- [x] Full permission test suite passes without regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)