### PR TITLE
Bump wonton from v0.0.29 to v0.0.34

### DIFF
--- a/experimental/cmd/dive/go.mod
+++ b/experimental/cmd/dive/go.mod
@@ -7,7 +7,8 @@ require (
 	github.com/deepnoodle-ai/dive/providers/google v1.4.0
 	github.com/deepnoodle-ai/dive/providers/grok v1.4.0
 	github.com/deepnoodle-ai/dive/providers/openai v1.4.0
-	github.com/deepnoodle-ai/wonton v0.0.29
+	github.com/deepnoodle-ai/wonton v0.0.34
+	github.com/mattn/go-runewidth v0.0.21
 )
 
 require (
@@ -28,7 +29,6 @@ require (
 	github.com/googleapis/enterprise-certificate-proxy v0.3.14 // indirect
 	github.com/googleapis/gax-go/v2 v2.18.0 // indirect
 	github.com/gorilla/websocket v1.5.3 // indirect
-	github.com/mattn/go-runewidth v0.0.21 // indirect
 	github.com/openai/openai-go/v3 v3.29.0 // indirect
 	github.com/tidwall/gjson v1.18.0 // indirect
 	github.com/tidwall/match v1.2.0 // indirect

--- a/experimental/cmd/dive/go.sum
+++ b/experimental/cmd/dive/go.sum
@@ -18,6 +18,8 @@ github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/deepnoodle-ai/wonton v0.0.29 h1:ypjEoD8gUCvQwjJ1O8d8FZRlXWsxM68BYyFoa2OxtI0=
 github.com/deepnoodle-ai/wonton v0.0.29/go.mod h1:oyogeHwAHPrVxZ7jtik55Jnj6CwC1jkF+PfHpCRlUGA=
+github.com/deepnoodle-ai/wonton v0.0.34 h1:0jE1KtbwZkKPuoxnV0CdYWrQdnYO+r3O3jWnFvZgV40=
+github.com/deepnoodle-ai/wonton v0.0.34/go.mod h1:rQ484HIdk0XfBACtcBuLDMTfn3keow1DspiXZv4IlL8=
 github.com/dlclark/regexp2 v1.11.5 h1:Q/sSnsKerHeCkc/jSTNq1oCm7KiVgUMZRDUoRu0JQZQ=
 github.com/dlclark/regexp2 v1.11.5/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/deepnoodle-ai/dive
 go 1.25.0
 
 require (
-	github.com/deepnoodle-ai/wonton v0.0.29
+	github.com/deepnoodle-ai/wonton v0.0.34
 	github.com/gobwas/glob v0.2.3
 	github.com/google/uuid v1.6.0
 	golang.org/x/image v0.38.0

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,8 @@
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/deepnoodle-ai/wonton v0.0.29 h1:ypjEoD8gUCvQwjJ1O8d8FZRlXWsxM68BYyFoa2OxtI0=
 github.com/deepnoodle-ai/wonton v0.0.29/go.mod h1:oyogeHwAHPrVxZ7jtik55Jnj6CwC1jkF+PfHpCRlUGA=
+github.com/deepnoodle-ai/wonton v0.0.34 h1:0jE1KtbwZkKPuoxnV0CdYWrQdnYO+r3O3jWnFvZgV40=
+github.com/deepnoodle-ai/wonton v0.0.34/go.mod h1:rQ484HIdk0XfBACtcBuLDMTfn3keow1DspiXZv4IlL8=
 github.com/gobwas/glob v0.2.3 h1:A4xDbljILXROh+kObIiy5kIaPYD8e96x1tgBhUI5J+Y=
 github.com/gobwas/glob v0.2.3/go.mod h1:d3Ez4x06l9bZtSvzIay5+Yzi0fmZzPgnTbPcKjJAkT8=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=


### PR DESCRIPTION
## Summary
- Bump `github.com/deepnoodle-ai/wonton` from v0.0.29 to v0.0.34 in the root module and the `experimental/cmd/dive` CLI module
- `mattn/go-runewidth` moves from an indirect to a direct dependency in the CLI module (it's now imported directly there)

## Test plan
- [x] `go test ./...` from root passes (firecrawl integration tests fail unrelated to this change — API quota)
- [x] `go build ./...` from root succeeds
- [x] `cd experimental/cmd/dive && go build ./...` succeeds
- [x] `cd experimental/cmd/dive && go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated `wonton` dependency from v0.0.29 to v0.0.34.
  * Updated dependency management for improved stability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/deepnoodle-ai/dive/pull/163?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->