### PR TITLE
Add structured tool progress streaming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - **`ResponsesIncludeProvider`** interface in `providers/openai` lets a
   server-side tool request response `include` data (e.g.
   `code_interpreter_call.outputs`, `file_search_call.results`).
+- **Structured tool progress streaming** — tools can emit typed progress
+  snapshots during execution via `dive.ReportProgress(ctx, *dive.ToolProgress)`,
+  complementing the existing text-only `StreamOutput`. Each snapshot carries a
+  `Display` summary and structured `Metadata` (exit code, bytes, percent
+  complete, etc.) and is delivered to consumers as a
+  `ResponseItemTypeToolProgress` event. The two channels are independent and
+  have distinct semantics: `StreamOutput` appends text deltas, `ReportProgress`
+  replaces a latest-wins snapshot. The built-in Bash tool now reports
+  line/byte/elapsed progress, the experimental CLI renders a live progress line
+  under running tool calls, and `examples/tool_progress_example` demonstrates
+  the full producer/consumer flow.
 
 ### Fixed
 

--- a/agent.go
+++ b/agent.go
@@ -2206,12 +2206,12 @@ func (a *Agent) executeTool(
 				},
 			})
 		})
-		toolCtx = WithToolUpdateFunc(toolCtx, func(toolCallID string, update *ToolUpdate) {
+		toolCtx = WithToolProgressFunc(toolCtx, func(toolCallID string, progress *ToolProgress) {
 			_ = callback(ctx, &ResponseItem{
-				Type: ResponseItemTypeToolUpdate,
-				ToolUpdate: &ToolUpdateEvent{
+				Type: ResponseItemTypeToolProgress,
+				ToolProgress: &ToolProgressEvent{
 					ToolCallID: toolCallID,
-					Update:     update,
+					Progress:   progress,
 				},
 			})
 		})

--- a/agent.go
+++ b/agent.go
@@ -2206,6 +2206,15 @@ func (a *Agent) executeTool(
 				},
 			})
 		})
+		toolCtx = WithToolUpdateFunc(toolCtx, func(toolCallID string, update *ToolUpdate) {
+			_ = callback(ctx, &ResponseItem{
+				Type: ResponseItemTypeToolUpdate,
+				ToolUpdate: &ToolUpdateEvent{
+					ToolCallID: toolCallID,
+					Update:     update,
+				},
+			})
+		})
 	}
 
 	output, err := tool.Call(toolCtx, input)

--- a/context.go
+++ b/context.go
@@ -7,6 +7,7 @@ type contextKey string
 const (
 	toolCallIDKey   contextKey = "tool_call_id"
 	toolStreamFnKey contextKey = "tool_stream_fn"
+	toolUpdateFnKey contextKey = "tool_update_fn"
 )
 
 // WithToolCallID returns a context with the given tool call ID.
@@ -40,4 +41,38 @@ func StreamOutput(ctx context.Context, text string) {
 		return
 	}
 	fn(ToolCallID(ctx), text)
+}
+
+// WithToolUpdateFunc returns a context with a structured tool-update function.
+// This is set by the agent before calling a tool, enabling tools to emit
+// typed partial results (exit code, byte count, parsed progress) in addition
+// to or instead of text-only StreamOutput.
+//
+// Tools call UpdateTool to deliver an update; the agent re-emits it as a
+// ResponseItem of type ResponseItemTypeToolUpdate carrying the ToolUpdate.
+func WithToolUpdateFunc(ctx context.Context, fn func(toolCallID string, update *ToolUpdate)) context.Context {
+	return context.WithValue(ctx, toolUpdateFnKey, fn)
+}
+
+// UpdateTool delivers a structured partial result snapshot from a running
+// tool. Tools call this whenever they have a typed progress update worth
+// surfacing to UIs or evaluators — e.g. on each stdout chunk, after each
+// scanned file, or on a periodic percent-complete tick.
+//
+// Safe to call even if no update function is configured (it's a no-op) and
+// safe to call any number of times during a single tool execution. Nil
+// updates are dropped.
+//
+// UpdateTool and StreamOutput are independent channels: tools may use one,
+// the other, or both. StreamOutput carries text-only chunks; UpdateTool
+// carries structured ToolUpdate snapshots.
+func UpdateTool(ctx context.Context, update *ToolUpdate) {
+	if update == nil {
+		return
+	}
+	fn, ok := ctx.Value(toolUpdateFnKey).(func(string, *ToolUpdate))
+	if !ok || fn == nil {
+		return
+	}
+	fn(ToolCallID(ctx), update)
 }

--- a/context.go
+++ b/context.go
@@ -5,9 +5,9 @@ import "context"
 type contextKey string
 
 const (
-	toolCallIDKey   contextKey = "tool_call_id"
-	toolStreamFnKey contextKey = "tool_stream_fn"
-	toolUpdateFnKey contextKey = "tool_update_fn"
+	toolCallIDKey     contextKey = "tool_call_id"
+	toolStreamFnKey   contextKey = "tool_stream_fn"
+	toolProgressFnKey contextKey = "tool_progress_fn"
 )
 
 // WithToolCallID returns a context with the given tool call ID.
@@ -43,36 +43,37 @@ func StreamOutput(ctx context.Context, text string) {
 	fn(ToolCallID(ctx), text)
 }
 
-// WithToolUpdateFunc returns a context with a structured tool-update function.
-// This is set by the agent before calling a tool, enabling tools to emit
-// typed partial results (exit code, byte count, parsed progress) in addition
-// to or instead of text-only StreamOutput.
+// WithToolProgressFunc returns a context with a structured progress function.
+// This is set by the agent before calling a tool, enabling tools to emit typed
+// progress snapshots (exit code, byte count, parsed progress) in addition to
+// or instead of text-only StreamOutput.
 //
-// Tools call UpdateTool to deliver an update; the agent re-emits it as a
-// ResponseItem of type ResponseItemTypeToolUpdate carrying the ToolUpdate.
-func WithToolUpdateFunc(ctx context.Context, fn func(toolCallID string, update *ToolUpdate)) context.Context {
-	return context.WithValue(ctx, toolUpdateFnKey, fn)
+// Tools call ReportProgress to deliver a snapshot; the agent re-emits it as a
+// ResponseItem of type ResponseItemTypeToolProgress carrying the ToolProgress.
+func WithToolProgressFunc(ctx context.Context, fn func(toolCallID string, progress *ToolProgress)) context.Context {
+	return context.WithValue(ctx, toolProgressFnKey, fn)
 }
 
-// UpdateTool delivers a structured partial result snapshot from a running
-// tool. Tools call this whenever they have a typed progress update worth
-// surfacing to UIs or evaluators — e.g. on each stdout chunk, after each
-// scanned file, or on a periodic percent-complete tick.
+// ReportProgress delivers a structured progress snapshot from a running tool.
+// Tools call this whenever they have a typed progress update worth surfacing to
+// UIs or evaluators — e.g. on each stdout chunk, after each scanned file, or on
+// a periodic percent-complete tick. Each call replaces the previous snapshot;
+// it is not a delta.
 //
-// Safe to call even if no update function is configured (it's a no-op) and
+// Safe to call even if no progress function is configured (it's a no-op) and
 // safe to call any number of times during a single tool execution. Nil
-// updates are dropped.
+// snapshots are dropped.
 //
-// UpdateTool and StreamOutput are independent channels: tools may use one,
-// the other, or both. StreamOutput carries text-only chunks; UpdateTool
-// carries structured ToolUpdate snapshots.
-func UpdateTool(ctx context.Context, update *ToolUpdate) {
-	if update == nil {
+// ReportProgress and StreamOutput are independent channels: tools may use one,
+// the other, or both. StreamOutput carries text deltas (append); ReportProgress
+// carries structured ToolProgress snapshots (replace).
+func ReportProgress(ctx context.Context, progress *ToolProgress) {
+	if progress == nil {
 		return
 	}
-	fn, ok := ctx.Value(toolUpdateFnKey).(func(string, *ToolUpdate))
+	fn, ok := ctx.Value(toolProgressFnKey).(func(string, *ToolProgress))
 	if !ok || fn == nil {
 		return
 	}
-	fn(ToolCallID(ctx), update)
+	fn(ToolCallID(ctx), progress)
 }

--- a/context_test.go
+++ b/context_test.go
@@ -1,0 +1,73 @@
+package dive
+
+import (
+	"context"
+	"testing"
+
+	"github.com/deepnoodle-ai/wonton/assert"
+)
+
+// TestUpdateTool_NoOpWithoutContextFunc verifies UpdateTool is safe to call
+// when no update function is configured — tools should not need to check.
+func TestUpdateTool_NoOpWithoutContextFunc(t *testing.T) {
+	ctx := context.Background()
+	// No panic, no error — just a no-op.
+	UpdateTool(ctx, &ToolUpdate{Display: "ignored"})
+}
+
+// TestUpdateTool_NilUpdateDropped verifies nil updates are silently dropped.
+func TestUpdateTool_NilUpdateDropped(t *testing.T) {
+	var called bool
+	ctx := WithToolCallID(context.Background(), "call-1")
+	ctx = WithToolUpdateFunc(ctx, func(string, *ToolUpdate) { called = true })
+	UpdateTool(ctx, nil)
+	assert.False(t, called, "nil update should be dropped")
+}
+
+// TestUpdateTool_DeliversStructuredSnapshot verifies that an update flows
+// through the configured function with the tool-call ID injected.
+func TestUpdateTool_DeliversStructuredSnapshot(t *testing.T) {
+	var gotID string
+	var gotUpdate *ToolUpdate
+
+	ctx := WithToolCallID(context.Background(), "call-42")
+	ctx = WithToolUpdateFunc(ctx, func(id string, u *ToolUpdate) {
+		gotID = id
+		gotUpdate = u
+	})
+
+	UpdateTool(ctx, &ToolUpdate{
+		Display: "scanning… 12/100 files",
+		Metadata: map[string]any{
+			"files_scanned":   12,
+			"files_total":     100,
+			"bytes_processed": 4096,
+		},
+	})
+
+	assert.Equal(t, "call-42", gotID)
+	assert.NotNil(t, gotUpdate)
+	assert.Equal(t, "scanning… 12/100 files", gotUpdate.Display)
+	assert.Equal(t, 12, gotUpdate.Metadata["files_scanned"])
+	assert.Equal(t, 100, gotUpdate.Metadata["files_total"])
+	assert.Equal(t, 4096, gotUpdate.Metadata["bytes_processed"])
+}
+
+// TestStreamOutputAndUpdateTool_AreIndependent verifies the text-only and
+// structured channels coexist: a tool can use either, both, or neither, and
+// they don't interfere.
+func TestStreamOutputAndUpdateTool_AreIndependent(t *testing.T) {
+	var streamCalls int
+	var updateCalls int
+
+	ctx := WithToolCallID(context.Background(), "call-99")
+	ctx = WithToolStreamFunc(ctx, func(string, string) { streamCalls++ })
+	ctx = WithToolUpdateFunc(ctx, func(string, *ToolUpdate) { updateCalls++ })
+
+	StreamOutput(ctx, "stdout line 1\n")
+	StreamOutput(ctx, "stdout line 2\n")
+	UpdateTool(ctx, &ToolUpdate{Metadata: map[string]any{"exit_code": nil}})
+
+	assert.Equal(t, 2, streamCalls)
+	assert.Equal(t, 1, updateCalls)
+}

--- a/context_test.go
+++ b/context_test.go
@@ -7,36 +7,36 @@ import (
 	"github.com/deepnoodle-ai/wonton/assert"
 )
 
-// TestUpdateTool_NoOpWithoutContextFunc verifies UpdateTool is safe to call
-// when no update function is configured — tools should not need to check.
-func TestUpdateTool_NoOpWithoutContextFunc(t *testing.T) {
+// TestReportProgress_NoOpWithoutContextFunc verifies ReportProgress is safe to
+// call when no progress function is configured — tools should not need to check.
+func TestReportProgress_NoOpWithoutContextFunc(t *testing.T) {
 	ctx := context.Background()
 	// No panic, no error — just a no-op.
-	UpdateTool(ctx, &ToolUpdate{Display: "ignored"})
+	ReportProgress(ctx, &ToolProgress{Display: "ignored"})
 }
 
-// TestUpdateTool_NilUpdateDropped verifies nil updates are silently dropped.
-func TestUpdateTool_NilUpdateDropped(t *testing.T) {
+// TestReportProgress_NilProgressDropped verifies nil snapshots are silently dropped.
+func TestReportProgress_NilProgressDropped(t *testing.T) {
 	var called bool
 	ctx := WithToolCallID(context.Background(), "call-1")
-	ctx = WithToolUpdateFunc(ctx, func(string, *ToolUpdate) { called = true })
-	UpdateTool(ctx, nil)
-	assert.False(t, called, "nil update should be dropped")
+	ctx = WithToolProgressFunc(ctx, func(string, *ToolProgress) { called = true })
+	ReportProgress(ctx, nil)
+	assert.False(t, called, "nil progress should be dropped")
 }
 
-// TestUpdateTool_DeliversStructuredSnapshot verifies that an update flows
-// through the configured function with the tool-call ID injected.
-func TestUpdateTool_DeliversStructuredSnapshot(t *testing.T) {
+// TestReportProgress_DeliversSnapshot verifies that a snapshot flows through the
+// configured function with the tool-call ID injected.
+func TestReportProgress_DeliversSnapshot(t *testing.T) {
 	var gotID string
-	var gotUpdate *ToolUpdate
+	var gotProgress *ToolProgress
 
 	ctx := WithToolCallID(context.Background(), "call-42")
-	ctx = WithToolUpdateFunc(ctx, func(id string, u *ToolUpdate) {
+	ctx = WithToolProgressFunc(ctx, func(id string, p *ToolProgress) {
 		gotID = id
-		gotUpdate = u
+		gotProgress = p
 	})
 
-	UpdateTool(ctx, &ToolUpdate{
+	ReportProgress(ctx, &ToolProgress{
 		Display: "scanning… 12/100 files",
 		Metadata: map[string]any{
 			"files_scanned":   12,
@@ -46,28 +46,28 @@ func TestUpdateTool_DeliversStructuredSnapshot(t *testing.T) {
 	})
 
 	assert.Equal(t, "call-42", gotID)
-	assert.NotNil(t, gotUpdate)
-	assert.Equal(t, "scanning… 12/100 files", gotUpdate.Display)
-	assert.Equal(t, 12, gotUpdate.Metadata["files_scanned"])
-	assert.Equal(t, 100, gotUpdate.Metadata["files_total"])
-	assert.Equal(t, 4096, gotUpdate.Metadata["bytes_processed"])
+	assert.NotNil(t, gotProgress)
+	assert.Equal(t, "scanning… 12/100 files", gotProgress.Display)
+	assert.Equal(t, 12, gotProgress.Metadata["files_scanned"])
+	assert.Equal(t, 100, gotProgress.Metadata["files_total"])
+	assert.Equal(t, 4096, gotProgress.Metadata["bytes_processed"])
 }
 
-// TestStreamOutputAndUpdateTool_AreIndependent verifies the text-only and
+// TestStreamOutputAndReportProgress_AreIndependent verifies the text-only and
 // structured channels coexist: a tool can use either, both, or neither, and
 // they don't interfere.
-func TestStreamOutputAndUpdateTool_AreIndependent(t *testing.T) {
+func TestStreamOutputAndReportProgress_AreIndependent(t *testing.T) {
 	var streamCalls int
-	var updateCalls int
+	var progressCalls int
 
 	ctx := WithToolCallID(context.Background(), "call-99")
 	ctx = WithToolStreamFunc(ctx, func(string, string) { streamCalls++ })
-	ctx = WithToolUpdateFunc(ctx, func(string, *ToolUpdate) { updateCalls++ })
+	ctx = WithToolProgressFunc(ctx, func(string, *ToolProgress) { progressCalls++ })
 
 	StreamOutput(ctx, "stdout line 1\n")
 	StreamOutput(ctx, "stdout line 2\n")
-	UpdateTool(ctx, &ToolUpdate{Metadata: map[string]any{"exit_code": nil}})
+	ReportProgress(ctx, &ToolProgress{Metadata: map[string]any{"exit_code": nil}})
 
 	assert.Equal(t, 2, streamCalls)
-	assert.Equal(t, 1, updateCalls)
+	assert.Equal(t, 1, progressCalls)
 }

--- a/examples/README.md
+++ b/examples/README.md
@@ -25,6 +25,7 @@ cd examples
 | `ollama_example` | Ollama | Local model usage |
 | `openrouter_example` | OpenRouter | Multi-provider routing |
 | `skills_example` | Anthropic | Agent with skill loading and auto-invocation |
+| `tool_progress_example` | Anthropic | Tool streaming structured progress via ReportProgress |
 | `firecrawl_example` | Anthropic + Firecrawl | Agent with web search and fetch via Firecrawl |
 | `oauth_client` | — | OAuth client credential flow |
 

--- a/examples/tool_progress_example/main.go
+++ b/examples/tool_progress_example/main.go
@@ -1,0 +1,100 @@
+// tool_progress_example demonstrates structured tool progress streaming.
+//
+// A "process_dataset" tool simulates a long-running job and emits typed
+// progress snapshots with dive.ReportProgress(ctx, *dive.ToolProgress) while it
+// runs. The caller observes them through WithEventCallback as
+// ResponseItemTypeToolProgress items and renders a live status line.
+//
+// ReportProgress (structured, latest-wins snapshots) is independent of
+// StreamOutput (text deltas) — a tool may use either, both, or neither. This
+// example focuses on the structured channel.
+//
+// Run: cd examples && go run ./tool_progress_example
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/deepnoodle-ai/dive"
+	"github.com/deepnoodle-ai/dive/providers/anthropic"
+	"github.com/deepnoodle-ai/dive/session"
+)
+
+type ProcessInput struct {
+	Dataset string `json:"dataset" description:"Name of the dataset to process"`
+}
+
+func main() {
+	ctx := context.Background()
+
+	// A tool that simulates record-by-record processing. It reports a typed
+	// progress snapshot after each record — percent complete, bytes processed,
+	// and elapsed time — none of which a text-only stream could convey cleanly.
+	processTool := dive.FuncTool("process_dataset",
+		"Processes the named dataset record by record, reporting progress as it goes.",
+		func(ctx context.Context, in *ProcessInput) (*dive.ToolResult, error) {
+			const total = 40
+			start := time.Now()
+			var bytes int
+			for i := 1; i <= total; i++ {
+				select {
+				case <-time.After(35 * time.Millisecond): // simulate work
+				case <-ctx.Done():
+					return nil, ctx.Err()
+				}
+				bytes += 1024 + i*13 // pretend each record is ~1 KB
+
+				// Structured, latest-wins snapshot of in-progress state.
+				dive.ReportProgress(ctx, &dive.ToolProgress{
+					Display: fmt.Sprintf("processed %d/%d records (%d%%)", i, total, i*100/total),
+					Metadata: map[string]any{
+						"records_done":    i,
+						"records_total":   total,
+						"percent":         i * 100 / total,
+						"bytes_processed": bytes,
+						"elapsed_ms":      time.Since(start).Milliseconds(),
+					},
+				})
+			}
+			return dive.NewToolResultText(fmt.Sprintf(
+				"Processed %d records from %q (%d bytes) in %s.",
+				total, in.Dataset, bytes, time.Since(start).Round(time.Millisecond),
+			)), nil
+		})
+
+	agent, err := dive.NewAgent(dive.AgentOptions{
+		SystemPrompt: "You are a data assistant. Use the process_dataset tool when asked to process a dataset.",
+		Model:        anthropic.New(),
+		Tools:        []dive.Tool{processTool},
+		Session:      session.New("tool-progress-demo"),
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Println("Asking agent to process a dataset...")
+	fmt.Println()
+
+	resp, err := agent.CreateResponse(ctx,
+		dive.WithInput(`Process the dataset named "events-2026" and tell me how many records it had.`),
+		dive.WithEventCallback(func(ctx context.Context, item *dive.ResponseItem) error {
+			if item.Type == dive.ResponseItemTypeToolProgress && item.ToolProgress != nil {
+				p := item.ToolProgress.Progress
+				// Each snapshot replaces the previous one — overwrite a single
+				// status line rather than scrolling.
+				fmt.Printf("\r  ⟳ %-32s bytes=%-7v elapsed_ms=%v   ",
+					p.Display, p.Metadata["bytes_processed"], p.Metadata["elapsed_ms"])
+			}
+			return nil
+		}),
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Printf("\r%-72s\r", "") // clear the status line
+	fmt.Printf("Agent: %s\n", resp.OutputText())
+}

--- a/experimental/cmd/dive/app.go
+++ b/experimental/cmd/dive/app.go
@@ -99,6 +99,15 @@ type toolStreamEvent struct {
 	text       string
 }
 
+// toolProgressEvent carries a structured progress snapshot for a tool call.
+// Distinct from toolStreamEvent (text deltas): each snapshot is latest-wins and
+// surfaces a short status line while the tool runs (e.g. "47 lines · 2.2 KB").
+type toolProgressEvent struct {
+	baseEvent
+	toolCallID string
+	display    string
+}
+
 // nativeBgTasksReadyEvent is sent when one or more native dive.BackgroundTaskHandle
 // goroutines have all completed, signaling the agent should re-enter with results.
 type nativeBgTasksReadyEvent struct {
@@ -152,6 +161,7 @@ type Message struct {
 	ToolResult      string   // Display summary (first line or truncated)
 	ToolResultLines []string // Full result lines for expansion display
 	ToolReadLines   int      // Line count for read_file results
+	ToolProgress    string   // Transient structured-progress line (live view only)
 	ToolError       bool
 	ToolDone        bool
 }
@@ -740,6 +750,8 @@ func (a *App) HandleEvent(event tui.Event) []tui.Cmd {
 		a.handleCompaction(e.event)
 	case toolStreamEvent:
 		a.handleToolStream(e)
+	case toolProgressEvent:
+		a.handleToolProgress(e)
 	case nativeBgTasksReadyEvent:
 		a.handleNativeBgTasksReady(e)
 	case monitorNotificationEvent:
@@ -1074,6 +1086,14 @@ func (a *App) agentEventCallback(lastUsage **llm.Usage) dive.EventCallback {
 					baseEvent:  newBaseEvent(),
 					toolCallID: item.ToolStream.ToolCallID,
 					text:       item.ToolStream.Text,
+				})
+			}
+		case dive.ResponseItemTypeToolProgress:
+			if item.ToolProgress != nil && item.ToolProgress.Progress != nil {
+				a.runner.SendEvent(toolProgressEvent{
+					baseEvent:  newBaseEvent(),
+					toolCallID: item.ToolProgress.ToolCallID,
+					display:    item.ToolProgress.Progress.Display,
 				})
 			}
 		}
@@ -1486,6 +1506,22 @@ func (a *App) handleToolStream(e toolStreamEvent) {
 		}
 		a.messages[idx].ToolResultLines = []string{last}
 	}
+}
+
+// handleToolProgress stores a tool's latest structured-progress snapshot so the
+// live view can render a transient status line while the tool runs. The
+// snapshot is latest-wins (each event replaces the prior one) and is dropped
+// from the static scrollback once the tool completes.
+func (a *App) handleToolProgress(e toolProgressEvent) {
+	idx, ok := a.toolCallIndex[e.toolCallID]
+	if !ok {
+		return
+	}
+	display := e.display
+	if len(display) > 80 {
+		display = display[:77] + "..."
+	}
+	a.messages[idx].ToolProgress = display
 }
 
 // startNativeBgTaskWatcher starts a goroutine that awaits all tasks and sends

--- a/experimental/cmd/dive/render.go
+++ b/experimental/cmd/dive/render.go
@@ -337,14 +337,25 @@ func (a *App) toolCallView(msg Message) tui.View {
 	toolCall := formatToolCall(msg.ToolTitle, msg.ToolName, msg.ToolInput)
 	header := tui.Group(statusView, tui.Text(" %s", toolCall))
 
+	views := []tui.View{header}
+
+	// While the tool is still running, surface its latest structured-progress
+	// snapshot. This is the ReportProgress channel — distinct from the streamed
+	// result line below — and is dropped once the tool completes.
+	if !msg.ToolDone && msg.ToolProgress != "" {
+		views = append(views, tui.Text("  ↳ %s", msg.ToolProgress).Hint())
+	}
+
 	if len(msg.ToolResultLines) > 0 {
-		resultView := a.formatToolResultView(msg)
-		if resultView != nil {
-			return tui.Stack(header, resultView).Gap(0)
+		if resultView := a.formatToolResultView(msg); resultView != nil {
+			views = append(views, resultView)
 		}
 	}
 
-	return header
+	if len(views) == 1 {
+		return header
+	}
+	return tui.Stack(views...).Gap(0)
 }
 
 // toolResultStyle returns the style for tool result text (brighter than muted)

--- a/response.go
+++ b/response.go
@@ -35,6 +35,13 @@ const (
 	// The ToolStream field contains the tool call ID and a chunk of text.
 	ResponseItemTypeToolStream ResponseItemType = "tool_stream"
 
+	// ResponseItemTypeToolUpdate indicates a structured partial result from a
+	// tool during execution. The ToolUpdate field contains the tool call ID
+	// and a *ToolUpdate snapshot (Content/Display/Metadata). Use this when
+	// text-only ToolStream isn't enough — e.g. to render a live progress
+	// widget with structured fields like exit_code or files_scanned.
+	ResponseItemTypeToolUpdate ResponseItemType = "tool_update"
+
 	// ResponseItemTypeSuspended is a terminal item emitted when the agent
 	// transitions into a suspended state. The Suspension field carries the
 	// same SuspensionState as Response.Suspension. Stream consumers should
@@ -205,6 +212,9 @@ type ResponseItem struct {
 	// ToolStream is set if the response item is streaming tool output
 	ToolStream *ToolStreamEvent `json:"tool_stream,omitempty"`
 
+	// ToolUpdate is set if the response item is a structured tool update.
+	ToolUpdate *ToolUpdateEvent `json:"tool_update,omitempty"`
+
 	// Suspension is set on a ResponseItemTypeSuspended item. It mirrors
 	// Response.Suspension.
 	Suspension *SuspensionState `json:"suspension,omitempty"`
@@ -221,6 +231,15 @@ type ResponseItem struct {
 type ToolStreamEvent struct {
 	ToolCallID string `json:"tool_call_id"`
 	Text       string `json:"text"`
+}
+
+// ToolUpdateEvent contains a structured partial result emitted by a tool
+// during execution via UpdateTool. The Update snapshot mirrors the shape of
+// a final ToolResult (Content/Display/Metadata) but reflects in-progress
+// state. Distinct from ToolStreamEvent, which carries text-only chunks.
+type ToolUpdateEvent struct {
+	ToolCallID string      `json:"tool_call_id"`
+	Update     *ToolUpdate `json:"update"`
 }
 
 // Response represents the output from an Agent's response generation.

--- a/response.go
+++ b/response.go
@@ -35,12 +35,12 @@ const (
 	// The ToolStream field contains the tool call ID and a chunk of text.
 	ResponseItemTypeToolStream ResponseItemType = "tool_stream"
 
-	// ResponseItemTypeToolUpdate indicates a structured partial result from a
-	// tool during execution. The ToolUpdate field contains the tool call ID
-	// and a *ToolUpdate snapshot (Content/Display/Metadata). Use this when
+	// ResponseItemTypeToolProgress indicates a structured progress snapshot
+	// from a tool during execution. The ToolProgress field contains the tool
+	// call ID and a *ToolProgress snapshot (Display/Metadata). Use this when
 	// text-only ToolStream isn't enough — e.g. to render a live progress
 	// widget with structured fields like exit_code or files_scanned.
-	ResponseItemTypeToolUpdate ResponseItemType = "tool_update"
+	ResponseItemTypeToolProgress ResponseItemType = "tool_progress"
 
 	// ResponseItemTypeSuspended is a terminal item emitted when the agent
 	// transitions into a suspended state. The Suspension field carries the
@@ -212,8 +212,8 @@ type ResponseItem struct {
 	// ToolStream is set if the response item is streaming tool output
 	ToolStream *ToolStreamEvent `json:"tool_stream,omitempty"`
 
-	// ToolUpdate is set if the response item is a structured tool update.
-	ToolUpdate *ToolUpdateEvent `json:"tool_update,omitempty"`
+	// ToolProgress is set if the response item is a structured progress snapshot.
+	ToolProgress *ToolProgressEvent `json:"tool_progress,omitempty"`
 
 	// Suspension is set on a ResponseItemTypeSuspended item. It mirrors
 	// Response.Suspension.
@@ -233,13 +233,12 @@ type ToolStreamEvent struct {
 	Text       string `json:"text"`
 }
 
-// ToolUpdateEvent contains a structured partial result emitted by a tool
-// during execution via UpdateTool. The Update snapshot mirrors the shape of
-// a final ToolResult (Content/Display/Metadata) but reflects in-progress
-// state. Distinct from ToolStreamEvent, which carries text-only chunks.
-type ToolUpdateEvent struct {
-	ToolCallID string      `json:"tool_call_id"`
-	Update     *ToolUpdate `json:"update"`
+// ToolProgressEvent contains a structured progress snapshot emitted by a tool
+// during execution via ReportProgress. Distinct from ToolStreamEvent, which
+// carries text deltas; each snapshot is latest-wins in-progress state.
+type ToolProgressEvent struct {
+	ToolCallID string        `json:"tool_call_id"`
+	Progress   *ToolProgress `json:"progress"`
 }
 
 // Response represents the output from an Agent's response generation.

--- a/tool.go
+++ b/tool.go
@@ -219,6 +219,38 @@ func NewToolResultText(text string) *ToolResult {
 	})
 }
 
+// ToolUpdate is a structured partial result a tool may emit during execution
+// via UpdateTool(ctx, *ToolUpdate). It carries the same shape consumers expect
+// from a final ToolResult, minus terminal-only fields (IsError, Suspend,
+// Background). Use this when text-only StreamOutput isn't enough — e.g. to
+// surface a running exit code, byte count, or other typed progress data to
+// UIs and evaluators before the tool returns.
+//
+// Each call to UpdateTool delivers one snapshot. The agent re-emits it as a
+// ResponseItem of type ResponseItemTypeToolUpdate; consumers receive it
+// through the EventCallback configured on the CreateResponse call.
+//
+// Metadata values are round-tripped through JSON whenever the event is
+// persisted or crosses a process boundary. Stick to JSON-friendly values and
+// expect that numeric types come back as float64 and custom struct types
+// become generic map[string]any after a round trip.
+type ToolUpdate struct {
+	// Content is a partial view of the tool's content blocks. Same shape as
+	// ToolResult.Content; populated with whatever the tool has produced so
+	// far (e.g. accumulated stdout, image previews).
+	Content []*ToolResultContent `json:"content,omitempty"`
+
+	// Display is a partial human-readable markdown summary. Same role as
+	// ToolResult.Display, but reflecting the in-progress state.
+	Display string `json:"display,omitempty"`
+
+	// Metadata is arbitrary structured progress data: exit_code, duration_ms,
+	// files_scanned, bytes_read, percent_complete, etc. Consumers (TUIs,
+	// audit logs, eval harnesses) read this to render live progress widgets
+	// or score partial outputs. JSON-friendly values only.
+	Metadata map[string]any `json:"metadata,omitempty"`
+}
+
 // Tool is an interface for a tool that can be called by an LLM.
 type Tool interface {
 	// Name of the tool.

--- a/tool.go
+++ b/tool.go
@@ -219,29 +219,24 @@ func NewToolResultText(text string) *ToolResult {
 	})
 }
 
-// ToolUpdate is a structured partial result a tool may emit during execution
-// via UpdateTool(ctx, *ToolUpdate). It carries the same shape consumers expect
-// from a final ToolResult, minus terminal-only fields (IsError, Suspend,
-// Background). Use this when text-only StreamOutput isn't enough — e.g. to
-// surface a running exit code, byte count, or other typed progress data to
-// UIs and evaluators before the tool returns.
+// ToolProgress is a structured progress snapshot a tool may emit during
+// execution via ReportProgress(ctx, *ToolProgress). Use it when text-only
+// StreamOutput isn't enough — e.g. to surface a running exit code, byte count,
+// or percent-complete to UIs and evaluators before the tool returns.
 //
-// Each call to UpdateTool delivers one snapshot. The agent re-emits it as a
-// ResponseItem of type ResponseItemTypeToolUpdate; consumers receive it
-// through the EventCallback configured on the CreateResponse call.
+// Each snapshot is latest-wins, NOT a delta: every Display/Metadata replaces
+// the previous one. Text deltas belong on StreamOutput, which appends. The two
+// are independent channels — a tool may use either, both, or neither. The
+// agent re-emits each snapshot as a ResponseItem of type
+// ResponseItemTypeToolProgress; consumers receive it through the EventCallback
+// configured on the CreateResponse call.
 //
-// Metadata values are round-tripped through JSON whenever the event is
-// persisted or crosses a process boundary. Stick to JSON-friendly values and
-// expect that numeric types come back as float64 and custom struct types
-// become generic map[string]any after a round trip.
-type ToolUpdate struct {
-	// Content is a partial view of the tool's content blocks. Same shape as
-	// ToolResult.Content; populated with whatever the tool has produced so
-	// far (e.g. accumulated stdout, image previews).
-	Content []*ToolResultContent `json:"content,omitempty"`
-
-	// Display is a partial human-readable markdown summary. Same role as
-	// ToolResult.Display, but reflecting the in-progress state.
+// Delivered in-process, Metadata preserves its Go types. A consumer that
+// serializes the event itself gets JSON's usual coercions (numbers become
+// float64, structs become map[string]any), so stick to JSON-friendly values.
+type ToolProgress struct {
+	// Display is a human-readable markdown summary of the latest progress
+	// state, e.g. "47/100 files scanned, 2.3 MB".
 	Display string `json:"display,omitempty"`
 
 	// Metadata is arbitrary structured progress data: exit_code, duration_ms,

--- a/toolkit/bash.go
+++ b/toolkit/bash.go
@@ -304,10 +304,31 @@ func (t *BashTool) execute(ctx context.Context, command, workingDir string, time
 	if stdoutPipe != nil {
 		scanner := bufio.NewScanner(stdoutPipe)
 		scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+		start := time.Now()
+		var lineCount, byteCount int
+		var lastProgress time.Time
 		for scanner.Scan() {
 			line := scanner.Text() + "\n"
 			stdoutBuf.WriteString(line)
 			dive.StreamOutput(ctx, line)
+
+			// StreamOutput above carries the raw text deltas. ReportProgress is
+			// the parallel structured channel: a latest-wins snapshot of how far
+			// the command has gotten. Throttled to ~10/sec so the cadence tracks
+			// elapsed time rather than output volume.
+			lineCount++
+			byteCount += len(line)
+			if now := time.Now(); now.Sub(lastProgress) >= 100*time.Millisecond {
+				lastProgress = now
+				dive.ReportProgress(ctx, &dive.ToolProgress{
+					Display: fmt.Sprintf("%d lines · %s", lineCount, humanizeBytes(byteCount)),
+					Metadata: map[string]any{
+						"lines":      lineCount,
+						"bytes":      byteCount,
+						"elapsed_ms": time.Since(start).Milliseconds(),
+					},
+				})
+			}
 		}
 	}
 
@@ -335,6 +356,21 @@ func shellCommand() (string, []string) {
 		return "cmd", []string{"/C"}
 	}
 	return "/bin/bash", []string{"-c"}
+}
+
+// humanizeBytes formats a byte count as a compact human-readable string
+// (e.g. 2300 -> "2.2 KB"). Used for ReportProgress display summaries.
+func humanizeBytes(n int) string {
+	const unit = 1024
+	if n < unit {
+		return fmt.Sprintf("%d B", n)
+	}
+	div, exp := int64(unit), 0
+	for v := int64(n) / unit; v >= unit; v /= unit {
+		div *= unit
+		exp++
+	}
+	return fmt.Sprintf("%.1f %cB", float64(n)/float64(div), "KMGTPE"[exp])
 }
 
 // truncateOutput limits output length to prevent overwhelming the LLM.


### PR DESCRIPTION
## Summary

Tools can now stream **typed progress snapshots** during execution via `ReportProgress(ctx, *ToolProgress)`, complementing the existing text-only `StreamOutput`. A `ToolProgress` carries a `Display` summary and structured `Metadata` (exit code, bytes processed, files scanned, percent complete, etc.) — letting tools surface structured progress to UIs and evaluators before the tool returns its final result.

## Why

A tool can already stream its stdout via `dive.StreamOutput(ctx, line)`, and consumers see `ResponseItemTypeToolStream` events carrying `Text: "..."`. That's enough for a scrolling log pane but not for a live progress widget that wants structured fields. A TUI that wants to render "47/100 files scanned, 2.3 MB processed" had to parse those numbers back out of the text stream.

This adds a parallel channel for **structured** snapshots, with cleanly separated semantics:

- **`StreamOutput`** → text deltas (**append**) — the scrolling log.
- **`ReportProgress`** → structured snapshots (**latest-wins replace**) — the status widget.

A tool may use either, both, or neither.

## API

**`ToolProgress`** (in `tool.go`):

```go
type ToolProgress struct {
    Display  string         // human-readable markdown summary (latest-wins)
    Metadata map[string]any // structured progress data (latest-wins)
}
```

**Context helpers** (in `context.go`, mirroring `WithToolStreamFunc` / `StreamOutput`):

```go
func WithToolProgressFunc(ctx context.Context, fn func(toolCallID string, progress *ToolProgress)) context.Context
func ReportProgress(ctx context.Context, progress *ToolProgress)
```

**Response item** (in `response.go`):

```go
const ResponseItemTypeToolProgress ResponseItemType = "tool_progress"

type ToolProgressEvent struct {
    ToolCallID string        `json:"tool_call_id"`
    Progress   *ToolProgress `json:"progress"`
}

// ResponseItem gains:
ToolProgress *ToolProgressEvent `json:"tool_progress,omitempty"`
```

**Agent wiring** (in `agent.go`): when an `EventCallback` is configured, the agent injects both `WithToolStreamFunc` and `WithToolProgressFunc` into the tool's context. The two are independent.

## Tool-author view

```go
for scanner.Scan() {
    line := scanner.Text()
    dive.StreamOutput(ctx, line)                 // text delta → log pane

    dive.ReportProgress(ctx, &dive.ToolProgress{ // structured snapshot → widget
        Display: fmt.Sprintf("%d lines · %s", lineCount, humanizeBytes(byteCount)),
        Metadata: map[string]any{
            "lines":      lineCount,
            "bytes":      byteCount,
            "elapsed_ms": time.Since(start).Milliseconds(),
        },
    })
}
```

## Consumer view

```go
agent.CreateResponse(ctx,
    dive.WithInput("run the build"),
    dive.WithEventCallback(func(ctx context.Context, item *dive.ResponseItem) error {
        switch item.Type {
        case dive.ResponseItemTypeToolStream:
            fmt.Print(item.ToolStream.Text)

        case dive.ResponseItemTypeToolProgress:
            p := item.ToolProgress.Progress
            ui.SetStatus(p.Display)
            ui.SetMetric("bytes", p.Metadata["bytes"])
        }
        return nil
    }),
)
```

## What's included

- **Core API** — `ToolProgress`, `ReportProgress` / `WithToolProgressFunc`, `ToolProgressEvent`, `ResponseItemTypeToolProgress`.
- **Producer** — the built-in **Bash tool** (`toolkit/bash.go`) now emits a throttled (~10/sec) structured snapshot of lines/bytes/elapsed alongside its existing per-line `StreamOutput`, showing both channels in use on one tool.
- **Consumer** — the **experimental CLI** consumes `ResponseItemTypeToolProgress` and renders a transient `↳ <progress>` line under a running tool call (live view only; dropped from scrollback once the tool completes, matching the latest-wins/transient semantics).
- **Example** — `examples/tool_progress_example`: a `process_dataset` tool emits percent/bytes/elapsed snapshots while running and the caller renders them via `WithEventCallback`.

While Bash runs, the two channels show up together:

```
⏺ Bash(go test ./...)
  ↳ 47 lines · 2.2 KB        ← ReportProgress (structured snapshot)
  ⎿  ok  github.com/...      ← StreamOutput (text tail)
```

## Design notes

The first revision had a `Content []*ToolResultContent` field on the struct. It was dropped: it overlapped with `StreamOutput` (text content already has a home there) and carried ambiguous snapshot-vs-delta semantics — and no caller populated it. Narrowing to `Display` + `Metadata` keeps the two channels cleanly orthogonal. If streaming non-text partial content (e.g. image previews) is ever needed, it can be added back additively when there's a concrete consumer.

`Metadata` is delivered with Go types intact in-process; a consumer that serializes the event itself gets JSON's usual coercions (numbers → `float64`), so tools should stick to JSON-friendly values.

## Backwards compatibility

Fully additive. `WithToolStreamFunc`, `StreamOutput`, `ToolStreamEvent`, and `ResponseItemTypeToolStream` are untouched. Existing tools (e.g. `toolkit/bash.go`) keep working; existing event consumers see the same stream they always did, plus a new optional case to handle if they want structured progress.

## Test plan

- [x] `go test ./...` — core suite green
- [x] Experimental CLI module builds and vets
- [x] `examples/` module builds and vets (`tool_progress_example`)
- [x] `context_test.go` covers:
  - `ReportProgress` is a no-op when no context function is configured (tools needn't check)
  - Nil snapshots are silently dropped
  - Snapshots flow through with the tool-call ID injected and `Metadata` preserved
  - `StreamOutput` and `ReportProgress` are independent channels (using one doesn't fire the other)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tools can emit structured, latest-wins progress snapshots during execution; progress updates are delivered alongside streaming text.

* **UI**
  * Experimental CLI shows a live, transient status line reflecting tool progress.

* **Examples**
  * Added an example demonstrating live structured tool progress and consumer handling.

* **Tests**
  * Added tests covering progress delivery, nil/drop behavior, independence from text streaming, and mixed-callback scenarios.

* **Documentation**
  * CHANGELOG and examples updated to document structured tool progress support.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/deepnoodle-ai/dive/pull/165?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->