### PR TITLE
Add per-tool SequentialOnlyHint annotation

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -1670,10 +1670,28 @@ func (a *Agent) executeToolCalls(
 	toolsByName map[string]Tool,
 	callback EventCallback,
 ) (*toolBatchResult, error) {
-	if a.parallelToolExecution && len(toolCalls) > 1 {
+	if a.parallelToolExecution && len(toolCalls) > 1 && !batchHasSequentialOnlyTool(toolCalls, toolsByName) {
 		return a.executeToolCallsParallel(ctx, hctx, toolCalls, toolsByName, callback)
 	}
 	return a.executeToolCallsSequential(ctx, hctx, toolCalls, toolsByName, callback)
+}
+
+// batchHasSequentialOnlyTool reports whether any tool in the batch carries
+// the SequentialOnlyHint annotation. When true, the agent falls back to
+// sequential execution even with ParallelToolExecution enabled, so a single
+// non-thread-safe tool doesn't force every batch to be serial globally.
+func batchHasSequentialOnlyTool(toolCalls []*llm.ToolUseContent, toolsByName map[string]Tool) bool {
+	for _, call := range toolCalls {
+		tool, ok := toolsByName[call.Name]
+		if !ok {
+			continue
+		}
+		ann := tool.Annotations()
+		if ann != nil && ann.SequentialOnlyHint {
+			return true
+		}
+	}
+	return false
 }
 
 // executeToolCallsSequential executes tool calls one at a time in order.

--- a/agent_test.go
+++ b/agent_test.go
@@ -143,14 +143,15 @@ func (m *mockLLM) Generate(ctx context.Context, opts ...llm.Option) (*llm.Respon
 
 // mockTool is a simple tool for testing tool call flows.
 type mockTool struct {
-	name     string
-	callFunc func(ctx context.Context, input any) (*ToolResult, error)
+	name        string
+	callFunc    func(ctx context.Context, input any) (*ToolResult, error)
+	annotations *ToolAnnotations
 }
 
 func (t *mockTool) Name() string                  { return t.name }
 func (t *mockTool) Description() string           { return "mock tool" }
 func (t *mockTool) Schema() *Schema               { return nil }
-func (t *mockTool) Annotations() *ToolAnnotations { return nil }
+func (t *mockTool) Annotations() *ToolAnnotations { return t.annotations }
 func (t *mockTool) Call(ctx context.Context, input any) (*ToolResult, error) {
 	return t.callFunc(ctx, input)
 }
@@ -815,6 +816,149 @@ func TestParallelToolExecution(t *testing.T) {
 
 		// Both tools should have triggered the PostToolUse hook
 		assert.Equal(t, hookCalls.Load(), int32(2))
+	})
+}
+
+// TestSequentialOnlyHint verifies that when a batch contains any tool with
+// SequentialOnlyHint set, the agent falls back to sequential execution even
+// when ParallelToolExecution is enabled.
+func TestSequentialOnlyHint(t *testing.T) {
+	t.Run("hint forces sequential fallback", func(t *testing.T) {
+		callCount := 0
+		var concurrent atomic.Int32
+		var maxConcurrent atomic.Int32
+
+		mock := &mockLLM{
+			generateFunc: func(ctx context.Context, opts ...llm.Option) (*llm.Response, error) {
+				callCount++
+				if callCount == 1 {
+					return &llm.Response{
+						ID:    "resp_1",
+						Model: "test-model",
+						Role:  llm.Assistant,
+						Content: []llm.Content{
+							&llm.ToolUseContent{ID: "t1", Name: "parallel_tool", Input: []byte(`{}`)},
+							&llm.ToolUseContent{ID: "t2", Name: "serial_tool", Input: []byte(`{}`)},
+							&llm.ToolUseContent{ID: "t3", Name: "parallel_tool", Input: []byte(`{}`)},
+						},
+						Type:       "message",
+						StopReason: "tool_use",
+						Usage:      llm.Usage{InputTokens: 10, OutputTokens: 5},
+					}, nil
+				}
+				return &llm.Response{
+					ID:         "resp_2",
+					Model:      "test-model",
+					Role:       llm.Assistant,
+					Content:    []llm.Content{&llm.TextContent{Text: "Done"}},
+					Type:       "message",
+					StopReason: "stop",
+					Usage:      llm.Usage{InputTokens: 15, OutputTokens: 3},
+				}, nil
+			},
+			nameFunc: func() string { return "test-model" },
+		}
+
+		trackConcurrency := func(ctx context.Context, input any) (*ToolResult, error) {
+			cur := concurrent.Add(1)
+			defer concurrent.Add(-1)
+			for {
+				old := maxConcurrent.Load()
+				if cur <= old || maxConcurrent.CompareAndSwap(old, cur) {
+					break
+				}
+			}
+			time.Sleep(20 * time.Millisecond)
+			return NewToolResultText("done"), nil
+		}
+
+		parallelTool := &mockTool{name: "parallel_tool", callFunc: trackConcurrency}
+		serialTool := &mockTool{
+			name:        "serial_tool",
+			callFunc:    trackConcurrency,
+			annotations: &ToolAnnotations{SequentialOnlyHint: true},
+		}
+
+		agent, err := NewAgent(AgentOptions{
+			Model:                 mock,
+			Tools:                 []Tool{parallelTool, serialTool},
+			ParallelToolExecution: true,
+		})
+		assert.NoError(t, err)
+
+		resp, err := agent.CreateResponse(context.Background(), WithInput("Use tools"))
+		assert.NoError(t, err)
+		assert.Equal(t, resp.OutputText(), "Done")
+		assert.Len(t, resp.ToolCallResults(), 3)
+
+		assert.Equal(t, int32(1), maxConcurrent.Load(),
+			"sequential-only tool in batch should force sequential execution, max concurrent was %d", maxConcurrent.Load())
+	})
+
+	t.Run("no hint preserves parallel execution", func(t *testing.T) {
+		callCount := 0
+		var concurrent atomic.Int32
+		var maxConcurrent atomic.Int32
+
+		mock := &mockLLM{
+			generateFunc: func(ctx context.Context, opts ...llm.Option) (*llm.Response, error) {
+				callCount++
+				if callCount == 1 {
+					return &llm.Response{
+						ID:    "resp_1",
+						Model: "test-model",
+						Role:  llm.Assistant,
+						Content: []llm.Content{
+							&llm.ToolUseContent{ID: "t1", Name: "tool_a", Input: []byte(`{}`)},
+							&llm.ToolUseContent{ID: "t2", Name: "tool_a", Input: []byte(`{}`)},
+							&llm.ToolUseContent{ID: "t3", Name: "tool_a", Input: []byte(`{}`)},
+						},
+						Type:       "message",
+						StopReason: "tool_use",
+						Usage:      llm.Usage{InputTokens: 10, OutputTokens: 5},
+					}, nil
+				}
+				return &llm.Response{
+					ID:         "resp_2",
+					Model:      "test-model",
+					Role:       llm.Assistant,
+					Content:    []llm.Content{&llm.TextContent{Text: "Done"}},
+					Type:       "message",
+					StopReason: "stop",
+					Usage:      llm.Usage{InputTokens: 15, OutputTokens: 3},
+				}, nil
+			},
+			nameFunc: func() string { return "test-model" },
+		}
+
+		tool := &mockTool{
+			name: "tool_a",
+			callFunc: func(ctx context.Context, input any) (*ToolResult, error) {
+				cur := concurrent.Add(1)
+				defer concurrent.Add(-1)
+				for {
+					old := maxConcurrent.Load()
+					if cur <= old || maxConcurrent.CompareAndSwap(old, cur) {
+						break
+					}
+				}
+				time.Sleep(20 * time.Millisecond)
+				return NewToolResultText("done"), nil
+			},
+		}
+
+		agent, err := NewAgent(AgentOptions{
+			Model:                 mock,
+			Tools:                 []Tool{tool},
+			ParallelToolExecution: true,
+		})
+		assert.NoError(t, err)
+
+		resp, err := agent.CreateResponse(context.Background(), WithInput("Use tools"))
+		assert.NoError(t, err)
+		assert.Equal(t, resp.OutputText(), "Done")
+		assert.True(t, maxConcurrent.Load() > 1,
+			"expected concurrent execution without the hint, max concurrent was %d", maxConcurrent.Load())
 	})
 }
 

--- a/tool.go
+++ b/tool.go
@@ -12,12 +12,12 @@ import (
 // ToolAnnotations contains optional metadata hints that describe a tool's behavior.
 // These hints help agents and permission systems make decisions about tool usage.
 type ToolAnnotations struct {
-	Title           string         `json:"title,omitempty"`
-	ReadOnlyHint    bool           `json:"readOnlyHint,omitempty"`
-	DestructiveHint bool           `json:"destructiveHint,omitempty"`
-	IdempotentHint  bool           `json:"idempotentHint,omitempty"`
-	OpenWorldHint   bool           `json:"openWorldHint,omitempty"`
-	EditHint        bool           `json:"editHint,omitempty"` // Indicates file edit operations for acceptEdits mode
+	Title           string `json:"title,omitempty"`
+	ReadOnlyHint    bool   `json:"readOnlyHint,omitempty"`
+	DestructiveHint bool   `json:"destructiveHint,omitempty"`
+	IdempotentHint  bool   `json:"idempotentHint,omitempty"`
+	OpenWorldHint   bool   `json:"openWorldHint,omitempty"`
+	EditHint        bool   `json:"editHint,omitempty"` // Indicates file edit operations for acceptEdits mode
 	// SequentialOnlyHint marks a tool as unsafe for parallel execution.
 	// When the agent has ParallelToolExecution enabled and a batch of tool
 	// calls includes ANY tool with this hint set, the entire batch falls back
@@ -30,13 +30,15 @@ type ToolAnnotations struct {
 
 func (a *ToolAnnotations) MarshalJSON() ([]byte, error) {
 	data := map[string]any{
-		"title":              a.Title,
-		"readOnlyHint":       a.ReadOnlyHint,
-		"destructiveHint":    a.DestructiveHint,
-		"idempotentHint":     a.IdempotentHint,
-		"openWorldHint":      a.OpenWorldHint,
-		"editHint":           a.EditHint,
-		"sequentialOnlyHint": a.SequentialOnlyHint,
+		"title":           a.Title,
+		"readOnlyHint":    a.ReadOnlyHint,
+		"destructiveHint": a.DestructiveHint,
+		"idempotentHint":  a.IdempotentHint,
+		"openWorldHint":   a.OpenWorldHint,
+		"editHint":        a.EditHint,
+	}
+	if a.SequentialOnlyHint {
+		data["sequentialOnlyHint"] = a.SequentialOnlyHint
 	}
 	if a.Extra != nil {
 		for k, v := range a.Extra {
@@ -67,7 +69,9 @@ func (a *ToolAnnotations) UnmarshalJSON(data []byte) error {
 	}
 	for name, field := range boolFields {
 		if val, ok := rawMap[name]; ok {
-			json.Unmarshal(val, field)
+			if err := json.Unmarshal(val, field); err != nil {
+				return fmt.Errorf("tool annotations: invalid value for %q: %w", name, err)
+			}
 			delete(rawMap, name)
 		}
 	}

--- a/tool.go
+++ b/tool.go
@@ -18,17 +18,25 @@ type ToolAnnotations struct {
 	IdempotentHint  bool           `json:"idempotentHint,omitempty"`
 	OpenWorldHint   bool           `json:"openWorldHint,omitempty"`
 	EditHint        bool           `json:"editHint,omitempty"` // Indicates file edit operations for acceptEdits mode
-	Extra           map[string]any `json:"extra,omitempty"`
+	// SequentialOnlyHint marks a tool as unsafe for parallel execution.
+	// When the agent has ParallelToolExecution enabled and a batch of tool
+	// calls includes ANY tool with this hint set, the entire batch falls back
+	// to sequential execution. Use for tools that mutate shared state (a
+	// working-directory chdir, a non-thread-safe SDK, a singleton resource).
+	// Default false = parallel-safe, matching the existing behavior.
+	SequentialOnlyHint bool           `json:"sequentialOnlyHint,omitempty"`
+	Extra              map[string]any `json:"extra,omitempty"`
 }
 
 func (a *ToolAnnotations) MarshalJSON() ([]byte, error) {
 	data := map[string]any{
-		"title":           a.Title,
-		"readOnlyHint":    a.ReadOnlyHint,
-		"destructiveHint": a.DestructiveHint,
-		"idempotentHint":  a.IdempotentHint,
-		"openWorldHint":   a.OpenWorldHint,
-		"editHint":        a.EditHint,
+		"title":              a.Title,
+		"readOnlyHint":       a.ReadOnlyHint,
+		"destructiveHint":    a.DestructiveHint,
+		"idempotentHint":     a.IdempotentHint,
+		"openWorldHint":      a.OpenWorldHint,
+		"editHint":           a.EditHint,
+		"sequentialOnlyHint": a.SequentialOnlyHint,
 	}
 	if a.Extra != nil {
 		for k, v := range a.Extra {
@@ -50,11 +58,12 @@ func (a *ToolAnnotations) UnmarshalJSON(data []byte) error {
 	}
 	// Handle boolean hints
 	boolFields := map[string]*bool{
-		"readOnlyHint":    &a.ReadOnlyHint,
-		"destructiveHint": &a.DestructiveHint,
-		"idempotentHint":  &a.IdempotentHint,
-		"openWorldHint":   &a.OpenWorldHint,
-		"editHint":        &a.EditHint,
+		"readOnlyHint":       &a.ReadOnlyHint,
+		"destructiveHint":    &a.DestructiveHint,
+		"idempotentHint":     &a.IdempotentHint,
+		"openWorldHint":      &a.OpenWorldHint,
+		"editHint":           &a.EditHint,
+		"sequentialOnlyHint": &a.SequentialOnlyHint,
 	}
 	for name, field := range boolFields {
 		if val, ok := rawMap[name]; ok {

--- a/tool_test.go
+++ b/tool_test.go
@@ -109,3 +109,40 @@ func TestTypedToolAdapter_ConvertInput_EmptyObject(t *testing.T) {
 	assert.NotNil(t, result)
 	assert.False(t, result.IsError)
 }
+
+func TestToolAnnotations_MarshalSequentialOnlyHint(t *testing.T) {
+	// The key is omitted when false so existing serialized annotations are
+	// unchanged by the new hint.
+	data, err := json.Marshal(&ToolAnnotations{Title: "t"})
+	assert.NoError(t, err)
+	var m map[string]any
+	assert.NoError(t, json.Unmarshal(data, &m))
+	_, present := m["sequentialOnlyHint"]
+	assert.False(t, present)
+
+	data, err = json.Marshal(&ToolAnnotations{Title: "t", SequentialOnlyHint: true})
+	assert.NoError(t, err)
+	m = nil
+	assert.NoError(t, json.Unmarshal(data, &m))
+	assert.Equal(t, true, m["sequentialOnlyHint"])
+}
+
+func TestToolAnnotations_UnmarshalInvalidBoolHint(t *testing.T) {
+	// Non-boolean hint values must fail fast instead of being silently
+	// ignored (which would leave the zero-value default in place).
+	var ann ToolAnnotations
+	err := json.Unmarshal([]byte(`{"sequentialOnlyHint":"true"}`), &ann)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "sequentialOnlyHint")
+
+	err = json.Unmarshal([]byte(`{"readOnlyHint":1}`), &ann)
+	assert.Error(t, err)
+
+	// Valid booleans still round-trip, with unknown keys going to Extra.
+	ann = ToolAnnotations{}
+	err = json.Unmarshal([]byte(`{"sequentialOnlyHint":true,"editHint":false,"custom":"x"}`), &ann)
+	assert.NoError(t, err)
+	assert.True(t, ann.SequentialOnlyHint)
+	assert.False(t, ann.EditHint)
+	assert.Equal(t, "x", ann.Extra["custom"])
+}


### PR DESCRIPTION
## Summary

Tools that mutate shared state can opt out of parallel execution by setting `ToolAnnotations.SequentialOnlyHint`. When the agent has `ParallelToolExecution` enabled and a batch of tool calls contains **any** tool with this hint set, the entire batch falls back to sequential execution.

## Why

Today `parallelToolExecution` is all-or-nothing per agent. If even one tool in your toolbox isn't thread-safe (chdir, singleton SDK client, etc.), you have to disable parallel execution globally — penalizing every other tool. Pi has per-tool `executionMode?: "sequential" | "parallel"` for exactly this reason. This PR adds the equivalent in dive.

## API

```go
type ToolAnnotations struct {
    // ... existing fields ...
    SequentialOnlyHint bool `json:"sequentialOnlyHint,omitempty"`
}
```

Tools opt in by returning annotations with the hint set:

```go
func (t *MyChdirTool) Annotations() *dive.ToolAnnotations {
    return &dive.ToolAnnotations{SequentialOnlyHint: true}
}
```

The agent's dispatch logic (`executeToolCalls`):

```go
if a.parallelToolExecution && len(toolCalls) > 1 && !batchHasSequentialOnlyTool(toolCalls, toolsByName) {
    return a.executeToolCallsParallel(...)
}
return a.executeToolCallsSequential(...)
```

## Semantics

- One sequential-only tool in a batch → whole batch goes sequential. This matches pi's behavior (`hasSequentialToolCall` in pi's `executeToolCalls`) and keeps the contract simple: a tool that says "I can't run alongside others" never does.
- If `ParallelToolExecution` is already false, the hint is a no-op.
- If a batch has only one tool call, the hint is a no-op (already sequential by definition).

## Backwards compatibility

Default `false` = parallel-safe = existing behavior. No existing tool needs changes; no caller needs changes. `ToolAnnotations` JSON gains one optional field.

## Test plan

- [x] `go test ./...` — full suite green
- [x] New `TestSequentialOnlyHint` covers two scenarios:
  - **`hint forces sequential fallback`**: batch of 3 tool calls where one tool has the hint set → `maxConcurrent == 1` (sequential)
  - **`no hint preserves parallel execution`**: identical scenario without the hint → `maxConcurrent > 1` (parallel)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a sequential-only hint annotation for tools that enforces sequential execution, overriding parallel execution settings when present in any tool within a batch.

* **Tests**
  * Added test coverage for sequential-only hint behavior, validating execution mode switching and result correctness.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/deepnoodle-ai/dive/pull/166?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->