### PR TITLE
Add ReasoningEffortMinimal level

### DIFF
--- a/llm/options.go
+++ b/llm/options.go
@@ -205,9 +205,14 @@ func WithReasoningBudget(reasoningBudget int) Option {
 type ReasoningEffort string
 
 const (
-	ReasoningEffortLow    ReasoningEffort = "low"
-	ReasoningEffortMedium ReasoningEffort = "medium"
-	ReasoningEffortHigh   ReasoningEffort = "high"
+	// ReasoningEffortMinimal requests the smallest amount of reasoning the
+	// model supports. Useful for tasks where latency matters more than
+	// step-by-step deliberation. Supported on OpenAI gpt-5 family; other
+	// providers may map it to their lowest available level or ignore it.
+	ReasoningEffortMinimal ReasoningEffort = "minimal"
+	ReasoningEffortLow     ReasoningEffort = "low"
+	ReasoningEffortMedium  ReasoningEffort = "medium"
+	ReasoningEffortHigh    ReasoningEffort = "high"
 	// ReasoningEffortXHigh requests extended capability for long-horizon work.
 	// Supported on Claude Opus 4.7 and 4.8.
 	ReasoningEffortXHigh ReasoningEffort = "xhigh"
@@ -219,7 +224,8 @@ const (
 
 // IsValid returns true if the reasoning effort is a known, valid value.
 func (r ReasoningEffort) IsValid() bool {
-	return r == ReasoningEffortLow ||
+	return r == ReasoningEffortMinimal ||
+		r == ReasoningEffortLow ||
 		r == ReasoningEffortMedium ||
 		r == ReasoningEffortHigh ||
 		r == ReasoningEffortXHigh ||

--- a/llm/options_test.go
+++ b/llm/options_test.go
@@ -1,0 +1,34 @@
+package llm
+
+import (
+	"testing"
+
+	"github.com/deepnoodle-ai/wonton/assert"
+)
+
+func TestReasoningEffort_IsValid(t *testing.T) {
+	cases := []struct {
+		effort ReasoningEffort
+		valid  bool
+	}{
+		{ReasoningEffortMinimal, true},
+		{ReasoningEffortLow, true},
+		{ReasoningEffortMedium, true},
+		{ReasoningEffortHigh, true},
+		{ReasoningEffortXHigh, true},
+		{ReasoningEffortMax, true},
+		{ReasoningEffort(""), false},
+		{ReasoningEffort("none"), false},
+		{ReasoningEffort("nope"), false},
+	}
+	for _, c := range cases {
+		assert.Equal(t, c.valid, c.effort.IsValid(),
+			"IsValid(%q) should be %v", string(c.effort), c.valid)
+	}
+}
+
+func TestWithReasoningEffort_Minimal(t *testing.T) {
+	cfg := &Config{}
+	cfg.Apply(WithReasoningEffort(ReasoningEffortMinimal))
+	assert.Equal(t, ReasoningEffortMinimal, cfg.ReasoningEffort)
+}

--- a/providers/openaicompletions/types.go
+++ b/providers/openaicompletions/types.go
@@ -5,9 +5,10 @@ import "github.com/deepnoodle-ai/wonton/schema"
 type ReasoningEffort string
 
 const (
-	ReasoningEffortLow    ReasoningEffort = "low"
-	ReasoningEffortMedium ReasoningEffort = "medium"
-	ReasoningEffortHigh   ReasoningEffort = "high"
+	ReasoningEffortMinimal ReasoningEffort = "minimal"
+	ReasoningEffortLow     ReasoningEffort = "low"
+	ReasoningEffortMedium  ReasoningEffort = "medium"
+	ReasoningEffortHigh    ReasoningEffort = "high"
 )
 
 type StreamOptions struct {


### PR DESCRIPTION
## Summary

Adds `llm.ReasoningEffortMinimal` (`\"minimal\"`) to the unified reasoning-effort enum, matching the level OpenAI's gpt-5 family exposes.

## Why

`llm.ReasoningEffort` currently has three levels (`low`/`medium`/`high`). OpenAI's gpt-5 reasoning API supports a fourth, `\"minimal\"`, for latency-sensitive use cases where step-by-step deliberation isn't needed. Today callers reach for it by writing `llm.ReasoningEffort(\"minimal\")` — bypassing the enum, losing `IsValid()` checks, and leaving the constant undocumented.

## Change

```go
const (
    // New
    ReasoningEffortMinimal ReasoningEffort = "minimal"
    // Existing
    ReasoningEffortLow     ReasoningEffort = "low"
    ReasoningEffortMedium  ReasoningEffort = "medium"
    ReasoningEffortHigh    ReasoningEffort = "high"
)

func (r ReasoningEffort) IsValid() bool {
    return r == ReasoningEffortMinimal ||
        r == ReasoningEffortLow ||
        r == ReasoningEffortMedium ||
        r == ReasoningEffortHigh
}
```

Mirrored in `providers/openaicompletions/types.go` for symmetry with the other levels declared there.

## Provider behavior

Providers cast the dive enum value straight to their wire-protocol enum (a string), so `\"minimal\"` flows through unchanged for OpenAI Responses (`providers/openai/provider.go:194-196`) and OpenAI Chat Completions (`providers/openaicompletions/openai.go:478`). Providers that don't recognize `\"minimal\"` will pass the literal upstream, where the provider's API decides whether to accept, reject, or down-map it.

## Backwards compatibility

Pure addition. No existing constant changes value or removes. `IsValid()` strictly widens — anything that was valid before remains valid.

## Test plan

- [x] `go test ./...` — full suite green
- [x] New `TestReasoningEffort_IsValid` covers all four valid values plus several invalid strings
- [x] New `TestWithReasoningEffort_Minimal` confirms the option helper sets the value

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a new `Minimal` reasoning effort level for language models, enabling faster response times with reduced latency on supported providers.

* **Tests**
  * Added validation tests to ensure all reasoning effort levels function correctly.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/deepnoodle-ai/dive/pull/167?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->