### PR TITLE
Expose Model on HookContext for mid-loop swap

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -1426,6 +1426,7 @@ func (a *Agent) generate(ctx context.Context, hctx *HookContext, messages []*llm
 			hctx.Iteration = i
 			hctx.SystemPrompt = systemPrompt
 			hctx.Messages = updatedMessages
+			hctx.Model = model
 			for _, hook := range a.hooks.PreIteration {
 				if err := hook(ctx, hctx); err != nil {
 					return nil, fmt.Errorf("pre-iteration hook error: %w", err)
@@ -1434,6 +1435,9 @@ func (a *Agent) generate(ctx context.Context, hctx *HookContext, messages []*llm
 			// Apply any modifications from hooks
 			if hctx.SystemPrompt != systemPrompt {
 				systemPrompt = hctx.SystemPrompt
+			}
+			if hctx.Model != nil && hctx.Model != model {
+				model = hctx.Model
 			}
 		}
 

--- a/hooks.go
+++ b/hooks.go
@@ -55,7 +55,7 @@ import (
 //   - PostToolUse: Agent, Session, Values, Tool, Call, Result
 //   - PostToolUseFailure: Agent, Session, Values, Tool, Call, Result
 //   - Stop: Agent, Session, Values, Response, OutputMessages, Usage, StopHookActive
-//   - PreIteration: Agent, Session, Values, SystemPrompt, Messages, Iteration
+//   - PreIteration: Agent, Session, Values, SystemPrompt, Messages, Iteration, Model
 //
 // The Values map allows hooks to communicate with each other by storing
 // arbitrary data that persists across the hook chain within a single
@@ -127,6 +127,21 @@ type HookContext struct {
 
 	// Iteration is the zero-based iteration number within the generation loop.
 	Iteration int
+
+	// Model is the LLM that will be used for the next iteration's call.
+	// PreIteration hooks may replace this with a different LLM to swap models
+	// mid-generation — e.g. escalate from a cheap model to a more capable one
+	// after the first few iterations, or downshift after tool work completes.
+	//
+	// Reading Model is safe in any PreIteration hook. Setting Model to a
+	// non-nil value takes effect for the upcoming iteration; the previous
+	// model is replaced. Setting Model to nil is a no-op (the current model
+	// is retained). The change persists for subsequent iterations unless a
+	// later PreIteration hook updates it again.
+	//
+	// Populated only in PreIteration. Reading Model in other phases returns
+	// nil and is not a supported pattern.
+	Model llm.LLM
 }
 
 // PreGenerationHook is called before the LLM generation loop begins.

--- a/hooks_test.go
+++ b/hooks_test.go
@@ -874,6 +874,117 @@ func TestPreIterationHook(t *testing.T) {
 		assert.Equal(t, 1, len(capturedPrompts))
 		assert.Equal(t, "Modified prompt", capturedPrompts[0])
 	})
+
+	t.Run("can swap model mid-loop", func(t *testing.T) {
+		// Models that report their identity via the captured opts so we can tell
+		// which one served which iteration. The cheap model emits a tool call on
+		// its first invocation; the expensive model returns a final answer.
+		var cheapCalls, expensiveCalls int
+
+		cheap := &mockLLM{
+			generateFunc: func(ctx context.Context, opts ...llm.Option) (*llm.Response, error) {
+				cheapCalls++
+				return &llm.Response{
+					ID:    "cheap_1",
+					Model: "cheap-model",
+					Role:  llm.Assistant,
+					Content: []llm.Content{
+						&llm.ToolUseContent{ID: "tool_1", Name: "test_tool", Input: []byte(`{}`)},
+					},
+					Type:       "message",
+					StopReason: "tool_use",
+					Usage:      llm.Usage{InputTokens: 10, OutputTokens: 5},
+				}, nil
+			},
+			nameFunc: func() string { return "cheap-model" },
+		}
+		expensive := &mockLLM{
+			generateFunc: func(ctx context.Context, opts ...llm.Option) (*llm.Response, error) {
+				expensiveCalls++
+				return &llm.Response{
+					ID:         "expensive_1",
+					Model:      "expensive-model",
+					Role:       llm.Assistant,
+					Content:    []llm.Content{&llm.TextContent{Text: "Final answer from expensive"}},
+					Type:       "message",
+					StopReason: "stop",
+					Usage:      llm.Usage{InputTokens: 15, OutputTokens: 3},
+				}, nil
+			},
+			nameFunc: func() string { return "expensive-model" },
+		}
+
+		tool := &mockTool{
+			name: "test_tool",
+			callFunc: func(ctx context.Context, input any) (*ToolResult, error) {
+				return NewToolResultText("tool output"), nil
+			},
+		}
+
+		var seenModels []string
+		agent, err := NewAgent(AgentOptions{
+			Model: cheap,
+			Tools: []Tool{tool},
+			Hooks: Hooks{
+				PreIteration: []PreIterationHook{
+					func(ctx context.Context, hctx *HookContext) error {
+						assert.NotNil(t, hctx.Model, "Model should be populated for PreIteration hooks")
+						seenModels = append(seenModels, hctx.Model.Name())
+						// After the cheap model's tool turn (iter 0), escalate.
+						if hctx.Iteration == 1 {
+							hctx.Model = expensive
+						}
+						return nil
+					},
+				},
+			},
+		})
+		assert.NoError(t, err)
+
+		resp, err := agent.CreateResponse(context.Background(), WithInput("Solve this"))
+		assert.NoError(t, err)
+		assert.Equal(t, "Final answer from expensive", resp.OutputText())
+
+		assert.Equal(t, []string{"cheap-model", "cheap-model"}, seenModels,
+			"hctx.Model reflects the model in effect when the hook runs (before any swap)")
+		assert.Equal(t, 1, cheapCalls, "cheap model should serve iter 0 only")
+		assert.Equal(t, 1, expensiveCalls, "expensive model should serve iter 1 only")
+	})
+
+	t.Run("nil hctx.Model preserves current model", func(t *testing.T) {
+		mockLLM := &mockLLM{
+			generateFunc: func(ctx context.Context, opts ...llm.Option) (*llm.Response, error) {
+				return &llm.Response{
+					ID:         "resp_1",
+					Model:      "test-model",
+					Role:       llm.Assistant,
+					Content:    []llm.Content{&llm.TextContent{Text: "Done"}},
+					Type:       "message",
+					StopReason: "stop",
+					Usage:      llm.Usage{InputTokens: 10, OutputTokens: 5},
+				}, nil
+			},
+			nameFunc: func() string { return "test-model" },
+		}
+
+		agent, err := NewAgent(AgentOptions{
+			Model: mockLLM,
+			Hooks: Hooks{
+				PreIteration: []PreIterationHook{
+					func(ctx context.Context, hctx *HookContext) error {
+						// Deliberately blank — no swap requested.
+						hctx.Model = nil
+						return nil
+					},
+				},
+			},
+		})
+		assert.NoError(t, err)
+
+		resp, err := agent.CreateResponse(context.Background(), WithInput("Hello"))
+		assert.NoError(t, err)
+		assert.Equal(t, "Done", resp.OutputText())
+	})
 }
 
 // newToolCallingMockLLM returns a mockLLM that issues one tool call on the


### PR DESCRIPTION
## Summary

`PreIteration` hooks now receive `hctx.Model` populated with the LLM about to serve the next iteration. Hooks can replace it with a different LLM to **swap models mid-generation** — escalate from a cheap model to a more capable one after the first few iterations, or downshift after tool work completes.

## Why

Today the model passed to `CreateResponse` is fixed for the duration of the call. To use a different model on iteration 2 than iteration 1, the caller has to detect tool completion externally, save state, and start a new `CreateResponse` — heavy machinery for what's structurally a one-line decision.

Pi exposes this via `prepareNextTurn` returning `{ model?: ... }` between turns. The dive equivalent fits naturally into the existing `PreIterationHook` — no new hook type needed, just a new field on `HookContext`.

## API

```go
type HookContext struct {
    // ... existing fields ...

    // Model is the LLM that will be used for the next iteration's call.
    // PreIteration hooks may replace this with a different LLM to swap models
    // mid-generation — e.g. escalate from a cheap model to a more capable one
    // after the first few iterations, or downshift after tool work completes.
    //
    // Reading Model is safe in any PreIteration hook. Setting Model to a
    // non-nil value takes effect for the upcoming iteration; the previous
    // model is replaced. Setting Model to nil is a no-op (the current model
    // is retained). The change persists for subsequent iterations unless a
    // later PreIteration hook updates it again.
    //
    // Populated only in PreIteration. Reading Model in other phases returns
    // nil and is not a supported pattern.
    Model llm.LLM
}
```

Usage:

```go
agent, _ := dive.NewAgent(dive.AgentOptions{
    Model: cheapModel,
    Hooks: dive.Hooks{
        PreIteration: []dive.PreIterationHook{
            func(ctx context.Context, hctx *dive.HookContext) error {
                if hctx.Iteration >= 2 && needsBigBrain(hctx.Messages) {
                    hctx.Model = expensiveModel  // escalate
                }
                return nil
            },
        },
    },
})
```

## Wiring

In `agent.go` `generate()`, the existing PreIteration block now sets `hctx.Model = model` before invoking the hooks and reads it back afterwards:

```go
if len(a.hooks.PreIteration) > 0 {
    hctx.Iteration = i
    hctx.SystemPrompt = systemPrompt
    hctx.Messages = updatedMessages
    hctx.Model = model
    for _, hook := range a.hooks.PreIteration {
        if err := hook(ctx, hctx); err != nil { ... }
    }
    if hctx.SystemPrompt != systemPrompt { systemPrompt = hctx.SystemPrompt }
    if hctx.Model != nil && hctx.Model != model { model = hctx.Model }
}
```

The local `model` variable is the same one used for both the streaming check (`model.(llm.StreamingLLM)`) and the `model.Generate(...)` / `streamingLLM.Stream(...)` call further down the iteration. Updating it once before those calls means the new model takes effect for the upcoming iteration with no other changes needed.

## Backwards compatibility

- New field on `HookContext`, default nil.
- Existing PreIteration hooks that don't touch `hctx.Model` see identical behavior.
- Setting `hctx.Model = nil` is explicitly defined as a no-op (test included).
- `HookContext` docstring updated to list `Model` for the `PreIteration` phase only.

## Test plan

- [x] `go test ./...` — full suite green, no regressions
- [x] New subtests of `TestPreIterationHook`:
  - **`can swap model mid-loop`**: starts with cheap model, escalates to expensive on iter 1. Verifies the cheap model served iter 0, expensive served iter 1, and the output came from expensive.
  - **`nil hctx.Model preserves current model`**: hook sets `hctx.Model = nil` — verifies the original model continues to serve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Agents now support dynamic language model switching during execution. Models can be changed mid-run through pre-execution hooks, with changes persisting across subsequent iterations unless overridden.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/deepnoodle-ai/dive/pull/168?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->