### PR TITLE
Add Claude Opus 4.8 + latest models and unlock new capabilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,36 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [Unreleased]
+
+### Added
+
+- **Claude Opus 4.8 and 4.7** model constants (`anthropic.ModelClaudeOpus48`,
+  `ModelClaudeOpus47`) and pricing; the Anthropic and OpenRouter provider
+  defaults are now Opus 4.8. Added a `FastModeTextPricing` table.
+- **Native Anthropic effort parameter** — `WithReasoningEffort` now maps to
+  `output_config.effort` on Opus 4.5+ and Sonnet 4.6 (older models keep the
+  legacy effort→budget mapping). New effort levels `ReasoningEffortXHigh` and
+  `ReasoningEffortMax`.
+- **Adaptive thinking** — `WithAdaptiveThinking()` / `WithThinking(...)` and
+  `WithThinkingDisplay(...)`. On Opus 4.7/4.8 (adaptive-only models) a manual
+  `WithReasoningBudget` transparently falls back to adaptive thinking.
+- **Fast mode** — `WithSpeed(llm.SpeedFast)` sets `speed: "fast"` and the
+  `fast-mode-2026-02-01` beta header; `Usage.Speed` reports the speed used.
+- **Refusal `stop_details`** on `llm.Response` (`StopDetails`).
+- `dive.ModelSettings` gains `Thinking`, `ThinkingDisplay`, and `Speed`.
+- **Gemini**: `gemini-3.5-flash`, `gemini-3.1-flash-lite` (stable),
+  `gemini-3.1-pro-image`, `gemini-3.1-flash-image`, `gemini-3.1-flash-live-preview`,
+  `gemini-3.1-pro-preview-customtools`, plus pricing.
+- **Grok**: `grok-4.3` (new default), `grok-build-0.1`,
+  `grok-imagine-image-quality`, plus pricing.
+
+### Fixed
+
+- Effort/thinking requests no longer fail with a 400 on Claude Opus 4.7/4.8,
+  which reject manual thinking budgets.
+- Corrected Grok 4.20 pricing to $1.25/$2.50 per 1M tokens.
+
 ## [1.5.0] - 2026-05-15
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 - Effort/thinking requests no longer fail with a 400 on Claude Opus 4.7/4.8,
   which reject manual thinking budgets.
+- Setting `ReasoningEffort` together with `Thinking: disabled` on a legacy
+  Claude model (no native effort parameter) now returns an error instead of
+  silently re-enabling thinking via the emulated budget.
 - Corrected Grok 4.20 pricing to $1.25/$2.50 per 1M tokens.
 
 ## [1.5.0] - 2026-05-15

--- a/a2a/go.mod
+++ b/a2a/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 require (
 	github.com/a2aproject/a2a-go/v2 v2.2.0
 	github.com/deepnoodle-ai/dive v1.5.0
-	github.com/deepnoodle-ai/wonton v0.0.29
+	github.com/deepnoodle-ai/wonton v0.0.34
 )
 
 require (

--- a/a2a/go.sum
+++ b/a2a/go.sum
@@ -1,7 +1,7 @@
 github.com/a2aproject/a2a-go/v2 v2.2.0 h1:eayiNXYpyTOLVhhQrGmIHlcy8GnOdnwaNdYQPvS84Ik=
 github.com/a2aproject/a2a-go/v2 v2.2.0/go.mod h1:htTxMwicNXXXEwwfjuB/Pd1g7UHDrswhSievncmTVcE=
-github.com/deepnoodle-ai/wonton v0.0.29 h1:ypjEoD8gUCvQwjJ1O8d8FZRlXWsxM68BYyFoa2OxtI0=
-github.com/deepnoodle-ai/wonton v0.0.29/go.mod h1:oyogeHwAHPrVxZ7jtik55Jnj6CwC1jkF+PfHpCRlUGA=
+github.com/deepnoodle-ai/wonton v0.0.34 h1:0jE1KtbwZkKPuoxnV0CdYWrQdnYO+r3O3jWnFvZgV40=
+github.com/deepnoodle-ai/wonton v0.0.34/go.mod h1:rQ484HIdk0XfBACtcBuLDMTfn3keow1DspiXZv4IlL8=
 github.com/gobwas/glob v0.2.3 h1:A4xDbljILXROh+kObIiy5kIaPYD8e96x1tgBhUI5J+Y=
 github.com/gobwas/glob v0.2.3/go.mod h1:d3Ez4x06l9bZtSvzIay5+Yzi0fmZzPgnTbPcKjJAkT8=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=

--- a/docs/design/model-update-may-2026.md
+++ b/docs/design/model-update-may-2026.md
@@ -1,0 +1,119 @@
+# Model & Capability Update — May 2026
+
+_Last updated: 2026-05-28_
+
+This document records the latest models and pricing across providers (verified
+against official docs) and the changes made to Dive to add the new models and
+unlock new capabilities, especially **Claude Opus 4.8**.
+
+## Summary
+
+Dive was already current on OpenAI (GPT-5.4), Gemini (3.1 Pro), and Grok (4.20).
+The gaps closed here:
+
+- **Anthropic**: added Opus 4.7 and 4.8; fixed a bug that made effort/thinking
+  unusable on 4.7/4.8; added the native `effort` parameter, adaptive thinking,
+  fast mode, thinking-display control, and refusal `stop_details`.
+- **Google**: added Gemini 3.5 Flash, 3.1 Flash-Lite (stable), 3.1 Pro Image
+  (Nano Banana Pro), 3.1 Flash Image (Nano Banana 2), 3.1 Flash Live, and the
+  custom-tools Pro endpoint.
+- **xAI/Grok**: added Grok 4.3 (new default) and grok-build-0.1; corrected
+  Grok 4.20 pricing; added Grok Imagine image pricing.
+
+## Latest models & pricing (per 1M tokens, USD)
+
+### Anthropic (Claude API)
+
+| Model | API ID | Input | Output | Context | Max output | Thinking |
+|-------|--------|-------|--------|---------|------------|----------|
+| **Opus 4.8** | `claude-opus-4-8` | $5 | $25 | 1M (default) | 128k | Adaptive only |
+| Opus 4.7 | `claude-opus-4-7` | $5 | $25 | 1M | 128k | Adaptive only |
+| Opus 4.6 | `claude-opus-4-6` | $5 | $25 | 1M | 128k | Adaptive + manual (deprecated) |
+| Sonnet 4.6 | `claude-sonnet-4-6` | $3 | $15 | 1M | 64k | Adaptive + manual (deprecated) |
+| Haiku 4.5 | `claude-haiku-4-5` | $1 | $5 | 200k | 64k | Manual |
+
+Cache (Opus): 5m write $6.25, 1h write $10, hit $0.50. Batch: $2.50 / $12.50.
+**Fast mode**: Opus 4.8 $10/$50; Opus 4.6/4.7 $30/$150 (research preview, beta
+header `fast-mode-2026-02-01`, requires account access).
+
+### Google (Gemini)
+
+| Model | Input | Output | Notes |
+|-------|-------|--------|-------|
+| `gemini-3.5-flash` | $1.50 | $9.00 | New stable frontier Flash |
+| `gemini-3.1-pro-preview` | $2.00 / $4.00 (>200k) | $12.00 / $18.00 | Flagship preview |
+| `gemini-3.1-flash-lite` | $0.25 | $1.50 | Stable; low-latency |
+| `gemini-3.1-flash-live-preview` | $0.75 (text) | $4.50 (text) | Live API, audio-to-audio |
+| `gemini-3.1-pro-image` | $2.00 | $120 (img tokens) | Nano Banana Pro, ~$0.134/image |
+| `gemini-3.1-flash-image` | $0.50 | $60 (img tokens) | Nano Banana 2, ~$0.067/image |
+
+### xAI (Grok)
+
+| Model | Input | Output | Context |
+|-------|-------|--------|---------|
+| `grok-4.3` | $1.25 | $2.50 | 1M (new flagship/default) |
+| `grok-4.20-*` | $1.25 | $2.50 | 1M (corrected from $2/$6) |
+| `grok-build-0.1` | $1.00 | $2.00 | 256k (coding) |
+| `grok-imagine-image` | $0.02/image | — | — |
+| `grok-imagine-image-quality` | $0.05/image | — | — |
+
+### OpenAI
+
+Already current: GPT-5.4 / 5.4-mini / 5.3-codex etc. (default `gpt-5.4`). No
+changes this pass.
+
+## The critical bug (fixed)
+
+Dive mapped `WithReasoningEffort` and `WithReasoningBudget` to
+`thinking: {type: "enabled", budget_tokens: N}`. On Opus 4.7/4.8 the Messages
+API **rejects manual thinking budgets with a 400 error** — meaning Dive could
+not use effort or thinking at all against the new default model.
+
+The provider is now model-aware:
+
+| Model class | Effort | Thinking |
+|-------------|--------|----------|
+| Opus 4.5+, Sonnet 4.6 | `output_config.effort` (native) | per below |
+| Opus 4.6, Sonnet 4.6 | native | adaptive or manual budget (manual deprecated) |
+| **Opus 4.7 / 4.8** | native | **adaptive only**; manual budget auto-falls-back to adaptive |
+| Older (3.x, 4, 4.5 Sonnet) | emulated via budget (back-compat) | manual budget |
+
+## New capabilities unlocked
+
+Core (`llm` package), provider-neutral where possible:
+
+- `ReasoningEffortXHigh`, `ReasoningEffortMax` effort levels.
+- `WithAdaptiveThinking()` / `WithThinking(llm.ThinkingTypeAdaptive)`.
+- `WithThinkingDisplay(summarized|omitted)` — note Opus 4.7/4.8 default to
+  `omitted`, so set `summarized` if you surface thinking text.
+- `WithSpeed(llm.SpeedFast)` — fast mode; adds the beta header automatically.
+- `Usage.Speed` — reports which speed served the request.
+- `Response.StopDetails` — refusal category on declined requests.
+
+Agent-level: the same knobs are exposed on `dive.ModelSettings`
+(`Thinking`, `ThinkingDisplay`, `Speed`).
+
+### Not requiring code changes
+
+- **Mid-conversation system messages** (Opus 4.8): already supported — send a
+  message with `llm.System` role in the messages array.
+- **1M context on Opus 4.7/4.8**: on by default, no beta header required (unlike
+  Opus 4.6, which still needs `context-1m-2025-08-07`).
+- **Lower prompt-cache minimum** (1,024 tokens on Opus 4.8): server-side, no
+  client change.
+
+## Decisions
+
+- **Default model → Opus 4.8** for the Anthropic and OpenRouter providers
+  (matches the "latest and most capable" convention; same standard price as 4.6).
+- **`WithReasoningBudget` on Opus 4.7/4.8 auto-converts to adaptive thinking**
+  (logs a warning if a logger is set) rather than erroring, so existing
+  budget-based callers keep working against the new default.
+
+## Sources
+
+- Claude Opus 4.8 launch notes; Models overview & Pricing
+  (platform.claude.com/docs/en/about-claude/models/overview, /pricing).
+- Effort, Adaptive thinking, Fast mode docs (platform.claude.com/docs/en/build-with-claude/*).
+- Gemini API pricing (ai.google.dev/gemini-api/docs/pricing) and model cards (provided).
+- xAI model & pricing tables (provided).

--- a/docs/guides/llm-guide.md
+++ b/docs/guides/llm-guide.md
@@ -119,11 +119,32 @@ agent, _ := dive.NewAgent(dive.AgentOptions{
 | `MaxTokens`         | `*int`            | Maximum response length                 |
 | `PresencePenalty`   | `*float64`        | Reduce repetition                       |
 | `FrequencyPenalty`  | `*float64`        | Encourage topic variety                 |
-| `ReasoningBudget`   | `*int`            | Tokens for reasoning (o-series, Claude) |
-| `ReasoningEffort`   | `string`          | low, medium, high                       |
+| `ReasoningBudget`   | `*int`            | Manual thinking budget (o-series, older Claude) |
+| `ReasoningEffort`   | `string`          | low, medium, high, xhigh, max (Claude Opus 4.6+) |
+| `Thinking`          | `llm.ThinkingType` | adaptive, enabled, or disabled extended thinking |
+| `ThinkingDisplay`   | `llm.ThinkingDisplay` | summarized or omitted thinking content      |
+| `Speed`             | `llm.Speed`       | fast or standard (Claude fast mode)     |
 | `Caching`           | `*bool`           | Enable prompt caching (Claude)          |
 | `ParallelToolCalls` | `*bool`           | Allow simultaneous tool calls           |
 | `ToolChoice`        | `*llm.ToolChoice` | auto, any, none, or specific tool       |
+
+### Reasoning on Claude Opus 4.7 / 4.8
+
+Opus 4.7 and 4.8 support **only adaptive thinking** — the model decides when and
+how much to think — and reject manual `budget_tokens`. Use the `effort`
+parameter to guide depth:
+
+```go
+ModelSettings: &dive.ModelSettings{
+    ReasoningEffort: llm.ReasoningEffortXHigh,   // -> output_config.effort
+    Thinking:        llm.ThinkingTypeAdaptive,   // -> thinking: {type: adaptive}
+}
+```
+
+`WithReasoningBudget` still works against these models for backward
+compatibility — it transparently falls back to adaptive thinking. Fast mode
+(`Speed: llm.SpeedFast`) requires fast-mode access on your account and applies
+the `fast-mode-2026-02-01` beta header automatically.
 
 ## Provider Registry
 

--- a/docs/guides/llm-guide.md
+++ b/docs/guides/llm-guide.md
@@ -113,20 +113,20 @@ agent, _ := dive.NewAgent(dive.AgentOptions{
 
 ### Settings Reference
 
-| Setting             | Type              | Description                             |
-| ------------------- | ----------------- | --------------------------------------- |
-| `Temperature`       | `*float64`        | Creativity vs consistency (0.0-1.0)     |
-| `MaxTokens`         | `*int`            | Maximum response length                 |
-| `PresencePenalty`   | `*float64`        | Reduce repetition                       |
-| `FrequencyPenalty`  | `*float64`        | Encourage topic variety                 |
-| `ReasoningBudget`   | `*int`            | Manual thinking budget (o-series, older Claude) |
-| `ReasoningEffort`   | `string`          | low, medium, high, xhigh, max (Claude Opus 4.6+) |
-| `Thinking`          | `llm.ThinkingType` | adaptive, enabled, or disabled extended thinking |
-| `ThinkingDisplay`   | `llm.ThinkingDisplay` | summarized or omitted thinking content      |
-| `Speed`             | `llm.Speed`       | fast or standard (Claude fast mode)     |
-| `Caching`           | `*bool`           | Enable prompt caching (Claude)          |
-| `ParallelToolCalls` | `*bool`           | Allow simultaneous tool calls           |
-| `ToolChoice`        | `*llm.ToolChoice` | auto, any, none, or specific tool       |
+| Setting             | Type                  | Description                                      |
+| ------------------- | --------------------- | ------------------------------------------------ |
+| `Temperature`       | `*float64`            | Creativity vs consistency (0.0-1.0)              |
+| `MaxTokens`         | `*int`                | Maximum response length                          |
+| `PresencePenalty`   | `*float64`            | Reduce repetition                                |
+| `FrequencyPenalty`  | `*float64`            | Encourage topic variety                          |
+| `ReasoningBudget`   | `*int`                | Manual thinking budget (o-series, older Claude)  |
+| `ReasoningEffort`   | `llm.ReasoningEffort` | low, medium, high, xhigh, max (Claude Opus 4.6+) |
+| `Thinking`          | `llm.ThinkingType`    | adaptive, enabled, or disabled extended thinking |
+| `ThinkingDisplay`   | `llm.ThinkingDisplay` | summarized or omitted thinking content           |
+| `Speed`             | `llm.Speed`           | fast or standard (Claude fast mode)              |
+| `Caching`           | `*bool`               | Enable prompt caching (Claude)                   |
+| `ParallelToolCalls` | `*bool`               | Allow simultaneous tool calls                    |
+| `ToolChoice`        | `*llm.ToolChoice`     | auto, any, none, or specific tool                |
 
 ### Reasoning on Claude Opus 4.7 / 4.8
 

--- a/examples/go.mod
+++ b/examples/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/deepnoodle-ai/dive/otel v1.5.0
 	github.com/deepnoodle-ai/dive/providers/google v1.5.0
 	github.com/deepnoodle-ai/dive/providers/openai v1.5.0
-	github.com/deepnoodle-ai/wonton v0.0.29
+	github.com/deepnoodle-ai/wonton v0.0.34
 	github.com/fatih/color v1.18.0
 	github.com/mark3labs/mcp-go v0.45.0
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.67.0

--- a/examples/go.sum
+++ b/examples/go.sum
@@ -16,8 +16,8 @@ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UF
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/deepnoodle-ai/wonton v0.0.29 h1:ypjEoD8gUCvQwjJ1O8d8FZRlXWsxM68BYyFoa2OxtI0=
-github.com/deepnoodle-ai/wonton v0.0.29/go.mod h1:oyogeHwAHPrVxZ7jtik55Jnj6CwC1jkF+PfHpCRlUGA=
+github.com/deepnoodle-ai/wonton v0.0.34 h1:0jE1KtbwZkKPuoxnV0CdYWrQdnYO+r3O3jWnFvZgV40=
+github.com/deepnoodle-ai/wonton v0.0.34/go.mod h1:rQ484HIdk0XfBACtcBuLDMTfn3keow1DspiXZv4IlL8=
 github.com/fatih/color v1.18.0 h1:S8gINlzdQ840/4pfAwic/ZE0djQEH3wM94VfqLTZcOM=
 github.com/fatih/color v1.18.0/go.mod h1:4FelSpRwEGDpQ12mAdzqdOukCy4u8WUtOY6lkT/6HfU=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=

--- a/experimental/cmd/dive/models.go
+++ b/experimental/cmd/dive/models.go
@@ -16,6 +16,8 @@ type modelInfo struct {
 // More specific patterns must appear before broader ones.
 var modelCatalog = []modelInfo{
 	// Anthropic models
+	{"claude-opus-4-8", "Opus 4.8", 1_000_000},
+	{"claude-opus-4-7", "Opus 4.7", 1_000_000},
 	{"claude-opus-4-6", "Opus 4.6", 1_000_000},
 	{"claude-opus-4-5", "Opus 4.5", 1_000_000},
 	{"claude-opus-4", "", 1_000_000},
@@ -32,6 +34,7 @@ var modelCatalog = []modelInfo{
 	{"gemini-3.1-pro-preview", "Gemini 3.1 Pro", 1_000_000},
 	{"gemini-3.1-pro", "Gemini 3.1 Pro", 1_000_000},
 	{"gemini-3.1-flash", "Gemini 3.1 Flash", 1_000_000},
+	{"gemini-3.5-flash", "Gemini 3.5 Flash", 1_000_000},
 	{"gemini-3-flash-preview", "Gemini 3 Flash", 1_000_000},
 	{"gemini-3-flash", "Gemini 3 Flash", 1_000_000},
 	{"gemini-3", "", 1_000_000},
@@ -60,8 +63,10 @@ var modelCatalog = []modelInfo{
 	{"o3", "o3", 200_000},
 
 	// Grok models
-	{"grok-4.20-0309-reasoning", "Grok 4.20", 131_072},
-	{"grok-4.20", "Grok 4.20", 131_072},
+	{"grok-4.3", "Grok 4.3", 1_000_000},
+	{"grok-build-0.1", "Grok Build", 256_000},
+	{"grok-4.20-0309-reasoning", "Grok 4.20", 1_000_000},
+	{"grok-4.20", "Grok 4.20", 1_000_000},
 	{"grok-4-1-fast", "Grok 4.1 Fast", 131_072},
 	{"grok-4", "Grok 4", 131_072},
 	{"grok-3-mini", "Grok 3 Mini", 131_072},
@@ -126,7 +131,7 @@ var providerCatalog = []providerInfo{
 		Name:    "Anthropic",
 		EnvVars: []string{"ANTHROPIC_API_KEY"},
 		Models: []modelChoice{
-			{"claude-opus-4-6", "Opus 4.6", "Most capable for complex work"},
+			{"claude-opus-4-8", "Opus 4.8", "Most capable for complex work"},
 			{"claude-sonnet-4-6", "Sonnet 4.6", "Best for everyday tasks"},
 			{"claude-haiku-4-5", "Haiku 4.5", "Fastest for quick answers"},
 		},
@@ -137,7 +142,7 @@ var providerCatalog = []providerInfo{
 		Models: []modelChoice{
 			{"gemini-3.1-pro-preview", "Gemini 3.1 Pro", "Google's latest flagship model"},
 			{"gemini-2.5-pro", "Gemini 2.5 Pro", "Strong all-around model"},
-			{"gemini-2.5-flash", "Gemini 2.5 Flash", "Fast and efficient"},
+			{"gemini-3.5-flash", "Gemini 3.5 Flash", "Frontier intelligence at high speed"},
 		},
 	},
 	{
@@ -153,8 +158,9 @@ var providerCatalog = []providerInfo{
 		Name:    "Grok",
 		EnvVars: []string{"XAI_API_KEY", "GROK_API_KEY"},
 		Models: []modelChoice{
-			{"grok-4.20-0309-reasoning", "Grok 4.20", "xAI's latest reasoning model"},
-			{"grok-4", "Grok 4", "Strong general-purpose model"},
+			{"grok-4.3", "Grok 4.3", "xAI's most intelligent and fastest model"},
+			{"grok-4.20-0309-reasoning", "Grok 4.20", "Reasoning model with 1M context"},
+			{"grok-build-0.1", "Grok Build", "Optimized for coding tasks"},
 		},
 	},
 	{

--- a/experimental/mcp/go.mod
+++ b/experimental/mcp/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/deepnoodle-ai/dive v1.5.0
-	github.com/deepnoodle-ai/wonton v0.0.29
+	github.com/deepnoodle-ai/wonton v0.0.34
 	github.com/mark3labs/mcp-go v0.45.0
 )
 

--- a/experimental/mcp/go.sum
+++ b/experimental/mcp/go.sum
@@ -4,8 +4,8 @@ github.com/buger/jsonparser v1.1.2 h1:frqHqw7otoVbk5M8LlE/L7HTnIq2v9RX6EJ48i9AxJ
 github.com/buger/jsonparser v1.1.2/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/deepnoodle-ai/wonton v0.0.29 h1:ypjEoD8gUCvQwjJ1O8d8FZRlXWsxM68BYyFoa2OxtI0=
-github.com/deepnoodle-ai/wonton v0.0.29/go.mod h1:oyogeHwAHPrVxZ7jtik55Jnj6CwC1jkF+PfHpCRlUGA=
+github.com/deepnoodle-ai/wonton v0.0.34 h1:0jE1KtbwZkKPuoxnV0CdYWrQdnYO+r3O3jWnFvZgV40=
+github.com/deepnoodle-ai/wonton v0.0.34/go.mod h1:rQ484HIdk0XfBACtcBuLDMTfn3keow1DspiXZv4IlL8=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/gobwas/glob v0.2.3 h1:A4xDbljILXROh+kObIiy5kIaPYD8e96x1tgBhUI5J+Y=

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,4 @@
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/deepnoodle-ai/wonton v0.0.29 h1:ypjEoD8gUCvQwjJ1O8d8FZRlXWsxM68BYyFoa2OxtI0=
-github.com/deepnoodle-ai/wonton v0.0.29/go.mod h1:oyogeHwAHPrVxZ7jtik55Jnj6CwC1jkF+PfHpCRlUGA=
 github.com/deepnoodle-ai/wonton v0.0.34 h1:0jE1KtbwZkKPuoxnV0CdYWrQdnYO+r3O3jWnFvZgV40=
 github.com/deepnoodle-ai/wonton v0.0.34/go.mod h1:rQ484HIdk0XfBACtcBuLDMTfn3keow1DspiXZv4IlL8=
 github.com/gobwas/glob v0.2.3 h1:A4xDbljILXROh+kObIiy5kIaPYD8e96x1tgBhUI5J+Y=

--- a/llm/options.go
+++ b/llm/options.go
@@ -24,6 +24,9 @@ type Config struct {
 	ReasoningBudget    *int                     `json:"reasoning_budget,omitempty"`
 	ReasoningEffort    ReasoningEffort          `json:"reasoning_effort,omitempty"`
 	ReasoningSummary   ReasoningSummary         `json:"reasoning_summary,omitempty"`
+	Thinking           ThinkingType             `json:"thinking,omitempty"`
+	ThinkingDisplay    ThinkingDisplay          `json:"thinking_display,omitempty"`
+	Speed              Speed                    `json:"speed,omitempty"`
 	ContextManagement  *ContextManagementConfig `json:"context_management,omitempty"`
 	Tools              []Tool                   `json:"tools,omitempty"`
 	ToolChoice         *ToolChoice              `json:"tool_choice,omitempty"`
@@ -196,19 +199,31 @@ func WithReasoningBudget(reasoningBudget int) Option {
 }
 
 // ReasoningEffort defines the effort level for reasoning aka extended thinking.
+// It controls how eagerly the model spends tokens on a response, including
+// thinking, tool calls, and text. Not all providers support all levels:
+// ReasoningEffortXHigh and ReasoningEffortMax are Anthropic-specific (Opus 4.6+).
 type ReasoningEffort string
 
 const (
 	ReasoningEffortLow    ReasoningEffort = "low"
 	ReasoningEffortMedium ReasoningEffort = "medium"
 	ReasoningEffortHigh   ReasoningEffort = "high"
+	// ReasoningEffortXHigh requests extended capability for long-horizon work.
+	// Supported on Claude Opus 4.7 and 4.8.
+	ReasoningEffortXHigh ReasoningEffort = "xhigh"
+	// ReasoningEffortMax requests the absolute maximum capability with no
+	// constraints on token spend. Supported on Claude Opus 4.6, 4.7, 4.8 and
+	// Sonnet 4.6.
+	ReasoningEffortMax ReasoningEffort = "max"
 )
 
 // IsValid returns true if the reasoning effort is a known, valid value.
 func (r ReasoningEffort) IsValid() bool {
 	return r == ReasoningEffortLow ||
 		r == ReasoningEffortMedium ||
-		r == ReasoningEffortHigh
+		r == ReasoningEffortHigh ||
+		r == ReasoningEffortXHigh ||
+		r == ReasoningEffortMax
 }
 
 // WithReasoningEffort sets the reasoning effort for the interaction.
@@ -231,6 +246,77 @@ const (
 func WithReasoningSummary(reasoningSummary ReasoningSummary) Option {
 	return func(config *Config) {
 		config.ReasoningSummary = reasoningSummary
+	}
+}
+
+// ThinkingType controls the extended thinking mode used by the model.
+type ThinkingType string
+
+const (
+	// ThinkingTypeAdaptive lets the model decide when and how much to think
+	// based on request complexity. Recommended for Claude Opus 4.6+ and
+	// Sonnet 4.6, and the only supported thinking mode on Opus 4.7 and 4.8.
+	// Combine with WithReasoningEffort to guide thinking depth.
+	ThinkingTypeAdaptive ThinkingType = "adaptive"
+	// ThinkingTypeEnabled requests manual extended thinking with a fixed token
+	// budget (see WithReasoningBudget). Not supported on Opus 4.7 and 4.8.
+	ThinkingTypeEnabled ThinkingType = "enabled"
+	// ThinkingTypeDisabled explicitly turns thinking off.
+	ThinkingTypeDisabled ThinkingType = "disabled"
+)
+
+// ThinkingDisplay controls how thinking content is returned in responses.
+type ThinkingDisplay string
+
+const (
+	// ThinkingDisplaySummarized returns a summary of the model's thinking. This
+	// is the default on Claude Opus 4.6 and earlier 4.x models.
+	ThinkingDisplaySummarized ThinkingDisplay = "summarized"
+	// ThinkingDisplayOmitted returns thinking blocks with an empty thinking
+	// field (the encrypted signature is still present for multi-turn
+	// continuity). This is the default on Claude Opus 4.7 and 4.8 and reduces
+	// time-to-first text token when streaming.
+	ThinkingDisplayOmitted ThinkingDisplay = "omitted"
+)
+
+// WithThinking sets the extended thinking mode for the interaction.
+func WithThinking(thinking ThinkingType) Option {
+	return func(config *Config) {
+		config.Thinking = thinking
+	}
+}
+
+// WithAdaptiveThinking enables adaptive thinking, where the model decides when
+// and how much to think. Equivalent to WithThinking(ThinkingTypeAdaptive).
+func WithAdaptiveThinking() Option {
+	return func(config *Config) {
+		config.Thinking = ThinkingTypeAdaptive
+	}
+}
+
+// WithThinkingDisplay controls how thinking content is returned in responses.
+func WithThinkingDisplay(display ThinkingDisplay) Option {
+	return func(config *Config) {
+		config.ThinkingDisplay = display
+	}
+}
+
+// Speed controls the inference speed of the model.
+type Speed string
+
+const (
+	// SpeedFast requests fast mode: significantly higher output tokens per
+	// second at premium pricing. Anthropic research preview; supported on
+	// Claude Opus 4.6, 4.7, and 4.8 (requires fast-mode access).
+	SpeedFast Speed = "fast"
+	// SpeedStandard requests standard inference speed (the default).
+	SpeedStandard Speed = "standard"
+)
+
+// WithSpeed sets the inference speed for the interaction.
+func WithSpeed(speed Speed) Option {
+	return func(config *Config) {
+		config.Speed = speed
 	}
 }
 

--- a/llm/response.go
+++ b/llm/response.go
@@ -17,9 +17,19 @@ type Response struct {
 	Content           []Content                  `json:"content"`
 	StopReason        string                     `json:"stop_reason"`
 	StopSequence      *string                    `json:"stop_sequence,omitempty"`
+	StopDetails       *StopDetails               `json:"stop_details,omitempty"`
 	Type              string                     `json:"type"`
 	Usage             Usage                      `json:"usage"`
 	ContextManagement *ContextManagementResponse `json:"context_management,omitempty"`
+}
+
+// StopDetails provides additional structured detail about why generation
+// stopped. It is populated alongside StopReason — most notably on refusals,
+// where Type categorizes the kind of refusal so applications can route the
+// user to the right next step.
+type StopDetails struct {
+	// Type categorizes the stop reason (e.g. the refusal category).
+	Type string `json:"type,omitempty"`
 }
 
 // ContextManagementResponse contains information about applied context edits.
@@ -84,6 +94,7 @@ func (r *Response) UnmarshalJSON(data []byte) error {
 		Content           []json.RawMessage          `json:"content"`
 		StopReason        string                     `json:"stop_reason"`
 		StopSequence      *string                    `json:"stop_sequence,omitempty"`
+		StopDetails       *StopDetails               `json:"stop_details,omitempty"`
 		Type              string                     `json:"type"`
 		Usage             Usage                      `json:"usage"`
 		ContextManagement *ContextManagementResponse `json:"context_management,omitempty"`
@@ -101,6 +112,7 @@ func (r *Response) UnmarshalJSON(data []byte) error {
 	r.Role = tmp.Role
 	r.StopReason = tmp.StopReason
 	r.StopSequence = tmp.StopSequence
+	r.StopDetails = tmp.StopDetails
 	r.Type = tmp.Type
 	r.Usage = tmp.Usage
 	r.ContextManagement = tmp.ContextManagement

--- a/llm/usage.go
+++ b/llm/usage.go
@@ -6,6 +6,9 @@ type Usage struct {
 	OutputTokens             int `json:"output_tokens"`
 	CacheCreationInputTokens int `json:"cache_creation_input_tokens,omitempty"`
 	CacheReadInputTokens     int `json:"cache_read_input_tokens,omitempty"`
+	// Speed indicates which inference speed served the request, either "fast"
+	// or "standard". Populated by Anthropic when fast mode is requested.
+	Speed string `json:"speed,omitempty"`
 }
 
 // Copy returns a deep copy of the usage data.
@@ -15,6 +18,7 @@ func (u *Usage) Copy() *Usage {
 		OutputTokens:             u.OutputTokens,
 		CacheCreationInputTokens: u.CacheCreationInputTokens,
 		CacheReadInputTokens:     u.CacheReadInputTokens,
+		Speed:                    u.Speed,
 	}
 }
 

--- a/model_settings.go
+++ b/model_settings.go
@@ -16,6 +16,9 @@ type ModelSettings struct {
 	MaxTokens         *int
 	ReasoningBudget   *int
 	ReasoningEffort   llm.ReasoningEffort
+	Thinking          llm.ThinkingType
+	ThinkingDisplay   llm.ThinkingDisplay
+	Speed             llm.Speed
 	ToolChoice        *llm.ToolChoice
 	Features          []string
 	RequestHeaders    http.Header
@@ -42,6 +45,15 @@ func (m *ModelSettings) Options() []llm.Option {
 	}
 	if m.ReasoningEffort != "" {
 		opts = append(opts, llm.WithReasoningEffort(m.ReasoningEffort))
+	}
+	if m.Thinking != "" {
+		opts = append(opts, llm.WithThinking(m.Thinking))
+	}
+	if m.ThinkingDisplay != "" {
+		opts = append(opts, llm.WithThinkingDisplay(m.ThinkingDisplay))
+	}
+	if m.Speed != "" {
+		opts = append(opts, llm.WithSpeed(m.Speed))
 	}
 	if m.MaxTokens != nil {
 		opts = append(opts, llm.WithMaxTokens(*m.MaxTokens))

--- a/otel/go.mod
+++ b/otel/go.mod
@@ -13,7 +13,7 @@ require (
 
 require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
-	github.com/deepnoodle-ai/wonton v0.0.29 // indirect
+	github.com/deepnoodle-ai/wonton v0.0.34 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/google/uuid v1.6.0 // indirect

--- a/otel/go.sum
+++ b/otel/go.sum
@@ -2,8 +2,8 @@ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UF
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/deepnoodle-ai/wonton v0.0.29 h1:ypjEoD8gUCvQwjJ1O8d8FZRlXWsxM68BYyFoa2OxtI0=
-github.com/deepnoodle-ai/wonton v0.0.29/go.mod h1:oyogeHwAHPrVxZ7jtik55Jnj6CwC1jkF+PfHpCRlUGA=
+github.com/deepnoodle-ai/wonton v0.0.34 h1:0jE1KtbwZkKPuoxnV0CdYWrQdnYO+r3O3jWnFvZgV40=
+github.com/deepnoodle-ai/wonton v0.0.34/go.mod h1:rQ484HIdk0XfBACtcBuLDMTfn3keow1DspiXZv4IlL8=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
 github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=

--- a/providers/anthropic/anthropic.go
+++ b/providers/anthropic/anthropic.go
@@ -410,6 +410,12 @@ func applyReasoningConfig(req *Request, config *llm.Config) error {
 			req.OutputConfig = &OutputConfig{Effort: string(config.ReasoningEffort)}
 		} else {
 			// Legacy: emulate the effort parameter with a thinking budget.
+			// This model lacks the native effort parameter, so honoring effort
+			// here would re-enable thinking — don't silently override an
+			// explicit disable.
+			if config.Thinking == llm.ThinkingTypeDisabled {
+				return fmt.Errorf("cannot set reasoning effort with thinking disabled on model %s: it has no native effort parameter and effort is emulated with a thinking budget", model)
+			}
 			if thinking != nil && config.ReasoningBudget != nil {
 				return fmt.Errorf("cannot set both reasoning budget and effort on model %s", model)
 			}

--- a/providers/anthropic/anthropic.go
+++ b/providers/anthropic/anthropic.go
@@ -19,7 +19,7 @@ import (
 const ProviderName = "anthropic"
 
 var (
-	DefaultModel         = ModelClaudeOpus46
+	DefaultModel         = ModelClaudeOpus48
 	DefaultEndpoint      = "https://api.anthropic.com/v1/messages"
 	DefaultMaxTokens     = 32768
 	DefaultClient        = &http.Client{Timeout: 300 * time.Second}
@@ -333,33 +333,12 @@ func (p *Provider) applyRequestConfig(req *Request, config *llm.Config) error {
 		req.MaxTokens = &p.maxTokens
 	}
 
-	if config.ReasoningBudget != nil {
-		budget := *config.ReasoningBudget
-		if budget < 1024 {
-			return fmt.Errorf("reasoning budget must be at least 1024")
-		}
-		req.Thinking = &Thinking{
-			Type:         "enabled",
-			BudgetTokens: budget,
-		}
+	if err := applyReasoningConfig(req, config); err != nil {
+		return err
 	}
 
-	// Compatibility with the OpenAI "effort" parameter
-	if config.ReasoningEffort != "" {
-		if req.Thinking != nil {
-			return fmt.Errorf("cannot set both reasoning budget and effort")
-		}
-		req.Thinking = &Thinking{Type: "enabled"}
-		switch config.ReasoningEffort {
-		case llm.ReasoningEffortLow:
-			req.Thinking.BudgetTokens = 1024
-		case llm.ReasoningEffortMedium:
-			req.Thinking.BudgetTokens = 4096
-		case llm.ReasoningEffortHigh:
-			req.Thinking.BudgetTokens = 16384
-		default:
-			return fmt.Errorf("invalid reasoning effort: %s", config.ReasoningEffort)
-		}
+	if config.Speed != "" {
+		req.Speed = string(config.Speed)
 	}
 
 	if len(config.Tools) > 0 {
@@ -411,6 +390,120 @@ func (p *Provider) applyRequestConfig(req *Request, config *llm.Config) error {
 	return nil
 }
 
+// applyReasoningConfig maps Dive's reasoning/thinking options onto the Anthropic
+// request, accounting for per-model differences:
+//   - Opus 4.5+ and Sonnet 4.6 take the native effort parameter via
+//     output_config; older models emulate effort with a thinking budget.
+//   - Opus 4.6/4.7/4.8 and Sonnet 4.6 support adaptive thinking. Opus 4.7/4.8
+//     reject manual budgets, so a budget set against them transparently falls
+//     back to adaptive thinking.
+func applyReasoningConfig(req *Request, config *llm.Config) error {
+	model := req.Model
+
+	thinking, err := resolveThinking(model, config)
+	if err != nil {
+		return err
+	}
+
+	if config.ReasoningEffort != "" {
+		if modelSupportsEffortParam(model) {
+			req.OutputConfig = &OutputConfig{Effort: string(config.ReasoningEffort)}
+		} else {
+			// Legacy: emulate the effort parameter with a thinking budget.
+			if thinking != nil && config.ReasoningBudget != nil {
+				return fmt.Errorf("cannot set both reasoning budget and effort on model %s", model)
+			}
+			budget, err := legacyEffortBudget(config.ReasoningEffort)
+			if err != nil {
+				return err
+			}
+			thinking = &Thinking{Type: "enabled", BudgetTokens: budget}
+		}
+	}
+
+	if thinking != nil {
+		if config.ThinkingDisplay != "" {
+			thinking.Display = string(config.ThinkingDisplay)
+		}
+		req.Thinking = thinking
+	}
+	return nil
+}
+
+// resolveThinking determines the thinking configuration from the budget and
+// explicit thinking-type options, independent of the effort parameter.
+func resolveThinking(model string, config *llm.Config) (*Thinking, error) {
+	adaptiveOnly := modelRejectsManualThinking(model) // Opus 4.7/4.8
+
+	switch config.Thinking {
+	case llm.ThinkingTypeDisabled:
+		return nil, nil
+	case llm.ThinkingTypeAdaptive:
+		return &Thinking{Type: "adaptive"}, nil
+	case llm.ThinkingTypeEnabled:
+		if adaptiveOnly {
+			return &Thinking{Type: "adaptive"}, nil
+		}
+		if config.ReasoningBudget == nil {
+			return nil, fmt.Errorf("thinking type %q requires a reasoning budget; use WithReasoningBudget or WithAdaptiveThinking", llm.ThinkingTypeEnabled)
+		}
+		// Budget provided: handled by the block below.
+	}
+
+	if config.ReasoningBudget != nil {
+		budget := *config.ReasoningBudget
+		if budget < 1024 {
+			return nil, fmt.Errorf("reasoning budget must be at least 1024")
+		}
+		if adaptiveOnly {
+			if config.Logger != nil {
+				config.Logger.Warn("model does not support manual thinking budgets; using adaptive thinking",
+					"model", model)
+			}
+			return &Thinking{Type: "adaptive"}, nil
+		}
+		return &Thinking{Type: "enabled", BudgetTokens: budget}, nil
+	}
+
+	return nil, nil
+}
+
+// legacyEffortBudget maps a reasoning effort level to a thinking token budget
+// for older models that lack the native effort parameter.
+func legacyEffortBudget(effort llm.ReasoningEffort) (int, error) {
+	switch effort {
+	case llm.ReasoningEffortLow:
+		return 1024, nil
+	case llm.ReasoningEffortMedium:
+		return 4096, nil
+	case llm.ReasoningEffortHigh, llm.ReasoningEffortXHigh, llm.ReasoningEffortMax:
+		return 16384, nil
+	default:
+		return 0, fmt.Errorf("invalid reasoning effort: %s", effort)
+	}
+}
+
+// modelSupportsEffortParam reports whether the model accepts the native
+// output_config.effort parameter (Opus 4.5+ and Sonnet 4.6).
+func modelSupportsEffortParam(model string) bool {
+	switch {
+	case strings.HasPrefix(model, "claude-opus-4-5"),
+		strings.HasPrefix(model, "claude-opus-4-6"),
+		strings.HasPrefix(model, "claude-opus-4-7"),
+		strings.HasPrefix(model, "claude-opus-4-8"),
+		strings.HasPrefix(model, "claude-sonnet-4-6"):
+		return true
+	}
+	return false
+}
+
+// modelRejectsManualThinking reports whether the model rejects manual extended
+// thinking budgets and supports only adaptive thinking (Opus 4.7 and 4.8).
+func modelRejectsManualThinking(model string) bool {
+	return strings.HasPrefix(model, "claude-opus-4-7") ||
+		strings.HasPrefix(model, "claude-opus-4-8")
+}
+
 // createRequest creates an HTTP request with appropriate headers for Anthropic API calls
 func (p *Provider) createRequest(ctx context.Context, body []byte, config *llm.Config, isStreaming bool) (*http.Request, error) {
 	req, err := http.NewRequestWithContext(ctx, "POST", p.endpoint, bytes.NewBuffer(body))
@@ -454,6 +547,10 @@ func (p *Provider) createRequest(ctx context.Context, body []byte, config *llm.C
 
 	if config.IsFeatureEnabled(FeatureContext1M) {
 		betaFeatures = append(betaFeatures, FeatureContext1M)
+	}
+
+	if config.Speed == llm.SpeedFast || config.IsFeatureEnabled(FeatureFastMode) {
+		betaFeatures = append(betaFeatures, FeatureFastMode)
 	}
 
 	if config.IsFeatureEnabled(FeatureCompact) {

--- a/providers/anthropic/features.go
+++ b/providers/anthropic/features.go
@@ -22,8 +22,19 @@ const (
 	// Deprecated: Use FeatureComputerUse45_46 instead.
 	FeatureComputerUseOpus45 = FeatureComputerUse45_46
 
-	// 1M context window beta (Opus 4.6, Sonnet 4.6, Sonnet 4.5, Sonnet 4)
+	// 1M context window beta (Opus 4.6, Sonnet 4.6, Sonnet 4.5, Sonnet 4).
+	// Opus 4.7 and 4.8 include the 1M context window by default with no beta
+	// header required.
 	FeatureContext1M = "context-1m-2025-08-07"
+
+	// Fast mode: higher output tokens per second at premium pricing (research
+	// preview). Supported on Opus 4.6, 4.7, and 4.8. Sent automatically when
+	// llm.WithSpeed(llm.SpeedFast) is used.
+	FeatureFastMode = "fast-mode-2026-02-01"
+
+	// Extended output up to 300k tokens on the Message Batches API (Opus 4.6,
+	// 4.7, 4.8, Sonnet 4.6).
+	FeatureOutput300k = "output-300k-2026-03-24"
 
 	// Server-side compaction (Opus 4.6, Sonnet 4.6)
 	FeatureCompact = "compact-2026-01-12"

--- a/providers/anthropic/models.go
+++ b/providers/anthropic/models.go
@@ -24,4 +24,10 @@ const (
 	// Claude 4.6 models
 	ModelClaudeSonnet46 = "claude-sonnet-4-6"
 	ModelClaudeOpus46   = "claude-opus-4-6"
+
+	// Claude 4.7 models
+	ModelClaudeOpus47 = "claude-opus-4-7"
+
+	// Claude 4.8 models (latest)
+	ModelClaudeOpus48 = "claude-opus-4-8"
 )

--- a/providers/anthropic/pricing.go
+++ b/providers/anthropic/pricing.go
@@ -79,6 +79,47 @@ var TextModelPricing = map[string]llm.PricingInfo{
 		InputPrice:  5.00,
 		OutputPrice: 25.00,
 		Currency:    "USD",
-		UpdatedAt:   "2026-02-09",
+		UpdatedAt:   "2026-05-28",
+	},
+	ModelClaudeOpus47: {
+		Model:       ModelClaudeOpus47,
+		InputPrice:  5.00,
+		OutputPrice: 25.00,
+		Currency:    "USD",
+		UpdatedAt:   "2026-05-28",
+	},
+	ModelClaudeOpus48: {
+		Model:       ModelClaudeOpus48,
+		InputPrice:  5.00,
+		OutputPrice: 25.00,
+		Currency:    "USD",
+		UpdatedAt:   "2026-05-28",
+	},
+}
+
+// FastModeTextPricing contains premium pricing for models when fast mode
+// (llm.SpeedFast) is used. Fast mode is a research preview; see
+// https://platform.claude.com/docs/en/build-with-claude/fast-mode.
+var FastModeTextPricing = map[string]llm.PricingInfo{
+	ModelClaudeOpus46: {
+		Model:       ModelClaudeOpus46,
+		InputPrice:  30.00,
+		OutputPrice: 150.00,
+		Currency:    "USD",
+		UpdatedAt:   "2026-05-28",
+	},
+	ModelClaudeOpus47: {
+		Model:       ModelClaudeOpus47,
+		InputPrice:  30.00,
+		OutputPrice: 150.00,
+		Currency:    "USD",
+		UpdatedAt:   "2026-05-28",
+	},
+	ModelClaudeOpus48: {
+		Model:       ModelClaudeOpus48,
+		InputPrice:  10.00,
+		OutputPrice: 50.00,
+		Currency:    "USD",
+		UpdatedAt:   "2026-05-28",
 	},
 }

--- a/providers/anthropic/reasoning_test.go
+++ b/providers/anthropic/reasoning_test.go
@@ -1,0 +1,114 @@
+package anthropic
+
+import (
+	"context"
+	"testing"
+
+	"github.com/deepnoodle-ai/dive/llm"
+	"github.com/deepnoodle-ai/wonton/assert"
+)
+
+// buildReq applies the given options to a config for the given model and
+// returns the resulting Anthropic request (without messages).
+func buildReq(t *testing.T, model string, opts ...llm.Option) *Request {
+	t.Helper()
+	cfg := &llm.Config{}
+	cfg.Apply(append([]llm.Option{llm.WithModel(model)}, opts...)...)
+	p := New()
+	var req Request
+	assert.NoError(t, p.applyRequestConfig(&req, cfg))
+	return &req
+}
+
+func TestReasoningEffortOpus48UsesOutputConfig(t *testing.T) {
+	// On Opus 4.8 effort maps to output_config.effort (no thinking implied),
+	// and the new xhigh level is passed through.
+	req := buildReq(t, ModelClaudeOpus48, llm.WithReasoningEffort(llm.ReasoningEffortXHigh))
+	assert.NotNil(t, req.OutputConfig)
+	assert.Equal(t, "xhigh", req.OutputConfig.Effort)
+	assert.Nil(t, req.Thinking)
+}
+
+func TestReasoningBudgetOpus48FallsBackToAdaptive(t *testing.T) {
+	// Opus 4.7/4.8 reject manual budgets; a budget transparently becomes
+	// adaptive thinking so existing callers keep working.
+	req := buildReq(t, ModelClaudeOpus48, llm.WithReasoningBudget(8000))
+	assert.NotNil(t, req.Thinking)
+	assert.Equal(t, "adaptive", req.Thinking.Type)
+	assert.Equal(t, 0, req.Thinking.BudgetTokens)
+}
+
+func TestAdaptiveThinkingOpus48(t *testing.T) {
+	req := buildReq(t, ModelClaudeOpus48, llm.WithAdaptiveThinking())
+	assert.NotNil(t, req.Thinking)
+	assert.Equal(t, "adaptive", req.Thinking.Type)
+}
+
+func TestThinkingDisplay(t *testing.T) {
+	req := buildReq(t, ModelClaudeOpus48,
+		llm.WithAdaptiveThinking(),
+		llm.WithThinkingDisplay(llm.ThinkingDisplaySummarized))
+	assert.NotNil(t, req.Thinking)
+	assert.Equal(t, "summarized", req.Thinking.Display)
+}
+
+func TestReasoningEffortAndAdaptiveCombine(t *testing.T) {
+	// Effort and adaptive thinking are orthogonal on Opus 4.8.
+	req := buildReq(t, ModelClaudeOpus48,
+		llm.WithReasoningEffort(llm.ReasoningEffortMax),
+		llm.WithAdaptiveThinking())
+	assert.NotNil(t, req.OutputConfig)
+	assert.Equal(t, "max", req.OutputConfig.Effort)
+	assert.NotNil(t, req.Thinking)
+	assert.Equal(t, "adaptive", req.Thinking.Type)
+}
+
+func TestReasoningBudgetOpus46KeepsManual(t *testing.T) {
+	// Opus 4.6 still accepts manual budgets (deprecated but functional).
+	req := buildReq(t, ModelClaudeOpus46, llm.WithReasoningBudget(8000))
+	assert.NotNil(t, req.Thinking)
+	assert.Equal(t, "enabled", req.Thinking.Type)
+	assert.Equal(t, 8000, req.Thinking.BudgetTokens)
+	assert.Nil(t, req.OutputConfig)
+}
+
+func TestReasoningEffortLegacyModelMapsToBudget(t *testing.T) {
+	// Models without the native effort parameter emulate it with a budget.
+	req := buildReq(t, ModelClaude37Sonnet20250219, llm.WithReasoningEffort(llm.ReasoningEffortMedium))
+	assert.NotNil(t, req.Thinking)
+	assert.Equal(t, "enabled", req.Thinking.Type)
+	assert.Equal(t, 4096, req.Thinking.BudgetTokens)
+	assert.Nil(t, req.OutputConfig)
+}
+
+func TestThinkingDisabled(t *testing.T) {
+	req := buildReq(t, ModelClaudeOpus48,
+		llm.WithReasoningBudget(8000),
+		llm.WithThinking(llm.ThinkingTypeDisabled))
+	assert.Nil(t, req.Thinking)
+}
+
+func TestSpeedFastSetsRequestField(t *testing.T) {
+	req := buildReq(t, ModelClaudeOpus48, llm.WithSpeed(llm.SpeedFast))
+	assert.Equal(t, "fast", req.Speed)
+}
+
+func TestSpeedFastAddsBetaHeader(t *testing.T) {
+	p := New()
+	cfg := &llm.Config{Speed: llm.SpeedFast}
+	httpReq, err := p.createRequest(context.Background(), []byte("{}"), cfg, false)
+	assert.NoError(t, err)
+	assert.Contains(t, httpReq.Header.Get("anthropic-beta"), FeatureFastMode)
+}
+
+func TestModelCapabilityHelpers(t *testing.T) {
+	assert.True(t, modelSupportsEffortParam(ModelClaudeOpus48))
+	assert.True(t, modelSupportsEffortParam(ModelClaudeSonnet46))
+	assert.True(t, modelSupportsEffortParam(ModelClaudeOpus45))
+	assert.False(t, modelSupportsEffortParam(ModelClaude37Sonnet20250219))
+
+	assert.True(t, modelRejectsManualThinking(ModelClaudeOpus47))
+	assert.True(t, modelRejectsManualThinking(ModelClaudeOpus48))
+	assert.False(t, modelRejectsManualThinking(ModelClaudeOpus46))
+	assert.False(t, modelRejectsManualThinking(ModelClaudeSonnet46))
+}

--- a/providers/anthropic/reasoning_test.go
+++ b/providers/anthropic/reasoning_test.go
@@ -88,6 +88,32 @@ func TestThinkingDisabled(t *testing.T) {
 	assert.Nil(t, req.Thinking)
 }
 
+func TestEffortWithThinkingDisabledLegacyModelErrors(t *testing.T) {
+	// On a model without the native effort parameter, effort is emulated with a
+	// thinking budget — which would override an explicit thinking disable. That
+	// conflict must error rather than silently re-enable thinking.
+	cfg := &llm.Config{}
+	cfg.Apply(
+		llm.WithModel(ModelClaude37Sonnet20250219),
+		llm.WithReasoningEffort(llm.ReasoningEffortHigh),
+		llm.WithThinking(llm.ThinkingTypeDisabled),
+	)
+	var req Request
+	err := New().applyRequestConfig(&req, cfg)
+	assert.Error(t, err)
+}
+
+func TestEffortWithThinkingDisabledNativeModelOK(t *testing.T) {
+	// On a native-effort model, effort and a thinking disable are orthogonal:
+	// effort goes to output_config and thinking stays off, with no error.
+	req := buildReq(t, ModelClaudeOpus48,
+		llm.WithReasoningEffort(llm.ReasoningEffortHigh),
+		llm.WithThinking(llm.ThinkingTypeDisabled))
+	assert.Nil(t, req.Thinking)
+	assert.NotNil(t, req.OutputConfig)
+	assert.Equal(t, "high", req.OutputConfig.Effort)
+}
+
 func TestSpeedFastSetsRequestField(t *testing.T) {
 	req := buildReq(t, ModelClaudeOpus48, llm.WithSpeed(llm.SpeedFast))
 	assert.Equal(t, "fast", req.Speed)

--- a/providers/anthropic/types.go
+++ b/providers/anthropic/types.go
@@ -17,8 +17,22 @@ type ImageSource struct {
 }
 
 type Thinking struct {
-	Type         string `json:"type"` // "enabled"
-	BudgetTokens int    `json:"budget_tokens"`
+	// Type is "adaptive" (recommended for Opus 4.6+ and Sonnet 4.6, and the
+	// only supported mode on Opus 4.7/4.8), "enabled" (manual budget mode), or
+	// "disabled".
+	Type string `json:"type"`
+	// BudgetTokens is only used with Type "enabled".
+	BudgetTokens int `json:"budget_tokens,omitempty"`
+	// Display controls how thinking content is returned: "summarized" or
+	// "omitted". Defaults vary by model (omitted on Opus 4.7/4.8).
+	Display string `json:"display,omitempty"`
+}
+
+// OutputConfig carries the effort parameter, which controls how eagerly the
+// model spends tokens (thinking, tool calls, and text). Supported on Opus 4.5+
+// and Sonnet 4.6 with no beta header required.
+type OutputConfig struct {
+	Effort string `json:"effort,omitempty"`
 }
 
 type Request struct {
@@ -28,9 +42,11 @@ type Request struct {
 	Temperature       *float64                     `json:"temperature,omitempty"`
 	System            string                       `json:"system,omitempty"`
 	Stream            bool                         `json:"stream,omitempty"`
+	Speed             string                       `json:"speed,omitempty"`
 	Tools             []map[string]any             `json:"tools,omitempty"`
 	ToolChoice        *ToolChoice                  `json:"tool_choice,omitempty"`
 	Thinking          *Thinking                    `json:"thinking,omitempty"`
+	OutputConfig      *OutputConfig                `json:"output_config,omitempty"`
 	MCPServers        []llm.MCPServerConfig        `json:"mcp_servers,omitempty"`
 	ContextManagement *llm.ContextManagementConfig `json:"context_management,omitempty"`
 }

--- a/providers/google/go.mod
+++ b/providers/google/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/deepnoodle-ai/dive v1.5.0
-	github.com/deepnoodle-ai/wonton v0.0.29
+	github.com/deepnoodle-ai/wonton v0.0.34
 	google.golang.org/genai v1.51.0
 )
 

--- a/providers/google/go.sum
+++ b/providers/google/go.sum
@@ -8,8 +8,8 @@ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UF
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/deepnoodle-ai/wonton v0.0.29 h1:ypjEoD8gUCvQwjJ1O8d8FZRlXWsxM68BYyFoa2OxtI0=
-github.com/deepnoodle-ai/wonton v0.0.29/go.mod h1:oyogeHwAHPrVxZ7jtik55Jnj6CwC1jkF+PfHpCRlUGA=
+github.com/deepnoodle-ai/wonton v0.0.34 h1:0jE1KtbwZkKPuoxnV0CdYWrQdnYO+r3O3jWnFvZgV40=
+github.com/deepnoodle-ai/wonton v0.0.34/go.mod h1:rQ484HIdk0XfBACtcBuLDMTfn3keow1DspiXZv4IlL8=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=

--- a/providers/google/models.go
+++ b/providers/google/models.go
@@ -1,14 +1,22 @@
 package google
 
 const (
-	// Gemini 3.1 models (preview)
-	ModelGemini31ProPreview       = "gemini-3.1-pro-preview"
-	ModelGemini31FlashLitePreview = "gemini-3.1-flash-lite-preview"
-	ModelGemini31FlashImagePrev   = "gemini-3.1-flash-image-preview"
+	// Gemini 3.5 models (stable)
+	ModelGemini35Flash = "gemini-3.5-flash"
+
+	// Gemini 3.1 models
+	ModelGemini31ProPreview            = "gemini-3.1-pro-preview"
+	ModelGemini31ProPreviewCustomTools = "gemini-3.1-pro-preview-customtools" // optimized for custom tools + bash
+	ModelGemini31FlashLite             = "gemini-3.1-flash-lite"              // stable
+	ModelGemini31FlashLitePreview      = "gemini-3.1-flash-lite-preview"
+	ModelGemini31FlashLivePreview      = "gemini-3.1-flash-live-preview" // Live API (audio-to-audio)
+	ModelGemini31ProImage              = "gemini-3.1-pro-image"          // Nano Banana Pro (stable)
+	ModelGemini31FlashImage            = "gemini-3.1-flash-image"        // Nano Banana 2 (stable)
+	ModelGemini31FlashImagePrev        = "gemini-3.1-flash-image-preview"
 
 	// Gemini 3 models (preview)
 	ModelGemini3ProImagePreview = "gemini-3-pro-image-preview"
-	ModelGemini3FlashPreview    = "gemini-3-flash-preview"
+	ModelGemini3FlashPreview    = "gemini-3-flash-preview" // preview alias for Gemini 3.5 Flash
 
 	// Deprecated: Model was shut down March 9, 2026. Use ModelGemini31ProPreview instead.
 	ModelGemini3ProPreview = "gemini-3-pro-preview"

--- a/providers/google/pricing.go
+++ b/providers/google/pricing.go
@@ -4,12 +4,40 @@ import "github.com/deepnoodle-ai/dive/llm"
 
 // TextModelPricing contains pricing for all text generation models
 var TextModelPricing = map[string]llm.PricingInfo{
+	ModelGemini35Flash: {
+		Model:       ModelGemini35Flash,
+		InputPrice:  1.50,
+		OutputPrice: 9.00,
+		Currency:    "USD",
+		UpdatedAt:   "2026-05-28",
+	},
 	ModelGemini31ProPreview: {
 		Model:       ModelGemini31ProPreview,
-		InputPrice:  2.00, // Up to 200K tokens
-		OutputPrice: 12.00,
+		InputPrice:  2.00,  // Up to 200K tokens ($4.00 over 200K)
+		OutputPrice: 12.00, // $18.00 over 200K tokens
 		Currency:    "USD",
-		UpdatedAt:   "2026-03-10",
+		UpdatedAt:   "2026-05-28",
+	},
+	ModelGemini31ProPreviewCustomTools: {
+		Model:       ModelGemini31ProPreviewCustomTools,
+		InputPrice:  2.00,  // Up to 200K tokens ($4.00 over 200K)
+		OutputPrice: 12.00, // $18.00 over 200K tokens
+		Currency:    "USD",
+		UpdatedAt:   "2026-05-28",
+	},
+	ModelGemini31FlashLite: {
+		Model:       ModelGemini31FlashLite,
+		InputPrice:  0.25, // text/image/video ($0.50 audio)
+		OutputPrice: 1.50,
+		Currency:    "USD",
+		UpdatedAt:   "2026-05-28",
+	},
+	ModelGemini31FlashLivePreview: {
+		Model:       ModelGemini31FlashLivePreview,
+		InputPrice:  0.75, // text input
+		OutputPrice: 4.50, // text output
+		Currency:    "USD",
+		UpdatedAt:   "2026-05-28",
 	},
 	ModelGemini31FlashLitePreview: {
 		Model:       ModelGemini31FlashLitePreview,
@@ -91,6 +119,20 @@ var ImageModelPricing = map[string]llm.ImagePricingInfo{
 		MaxSize:   "1024x1024",
 		Currency:  "USD",
 		UpdatedAt: "2025-01-15",
+	},
+	ModelGemini31FlashImage: {
+		Model:     ModelGemini31FlashImage,
+		Price:     0.067, // $60 per 1M output tokens; ~$0.067 per 1K-resolution image
+		MaxSize:   "1024x1024",
+		Currency:  "USD",
+		UpdatedAt: "2026-05-28",
+	},
+	ModelGemini31ProImage: {
+		Model:     ModelGemini31ProImage,
+		Price:     0.134, // $120 per 1M output tokens; ~$0.134 per 1K/2K image ($0.24 at 4K)
+		MaxSize:   "2048x2048",
+		Currency:  "USD",
+		UpdatedAt: "2026-05-28",
 	},
 }
 

--- a/providers/grok/go.mod
+++ b/providers/grok/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 require (
 	github.com/deepnoodle-ai/dive v1.5.0
 	github.com/deepnoodle-ai/dive/providers/openai v1.5.0
-	github.com/deepnoodle-ai/wonton v0.0.29
+	github.com/deepnoodle-ai/wonton v0.0.34
 	github.com/openai/openai-go/v3 v3.29.0
 	golang.org/x/image v0.38.0
 )

--- a/providers/grok/go.sum
+++ b/providers/grok/go.sum
@@ -1,5 +1,5 @@
-github.com/deepnoodle-ai/wonton v0.0.29 h1:ypjEoD8gUCvQwjJ1O8d8FZRlXWsxM68BYyFoa2OxtI0=
-github.com/deepnoodle-ai/wonton v0.0.29/go.mod h1:oyogeHwAHPrVxZ7jtik55Jnj6CwC1jkF+PfHpCRlUGA=
+github.com/deepnoodle-ai/wonton v0.0.34 h1:0jE1KtbwZkKPuoxnV0CdYWrQdnYO+r3O3jWnFvZgV40=
+github.com/deepnoodle-ai/wonton v0.0.34/go.mod h1:rQ484HIdk0XfBACtcBuLDMTfn3keow1DspiXZv4IlL8=
 github.com/gobwas/glob v0.2.3 h1:A4xDbljILXROh+kObIiy5kIaPYD8e96x1tgBhUI5J+Y=
 github.com/gobwas/glob v0.2.3/go.mod h1:d3Ez4x06l9bZtSvzIay5+Yzi0fmZzPgnTbPcKjJAkT8=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=

--- a/providers/grok/grok.go
+++ b/providers/grok/grok.go
@@ -8,7 +8,7 @@ import (
 )
 
 var (
-	DefaultModel     = ModelGrok420Reasoning
+	DefaultModel     = ModelGrok43
 	DefaultEndpoint  = "https://api.x.ai/v1"
 	DefaultMaxTokens = 32768
 )

--- a/providers/grok/grok_test.go
+++ b/providers/grok/grok_test.go
@@ -25,7 +25,7 @@ func TestProvider_Name(t *testing.T) {
 }
 
 func TestProvider_DefaultModel(t *testing.T) {
-	assert.Equal(t, ModelGrok420Reasoning, DefaultModel)
+	assert.Equal(t, ModelGrok43, DefaultModel)
 }
 
 func TestProvider_GetAPIKey(t *testing.T) {

--- a/providers/grok/models.go
+++ b/providers/grok/models.go
@@ -1,10 +1,16 @@
 package grok
 
 const (
-	// Grok 4.20 models (latest, 2M context)
+	// Grok 4.3 (latest, most intelligent and fastest, 1M context)
+	ModelGrok43 = "grok-4.3"
+
+	// Grok 4.20 models (1M context)
 	ModelGrok420Reasoning    = "grok-4.20-0309-reasoning"
 	ModelGrok420NonReasoning = "grok-4.20-0309-non-reasoning"
 	ModelGrok420MultiAgent   = "grok-4.20-multi-agent-0309"
+
+	// Grok coding model (256K context)
+	ModelGrokBuild01 = "grok-build-0.1"
 
 	// Grok 4.1 models (2M context)
 	ModelGrok41FastReasoning    = "grok-4-1-fast-reasoning"
@@ -26,8 +32,9 @@ const (
 	ModelGrokCodeFast1 = "grok-code-fast-1"
 
 	// Image generation models
-	ModelImagineImagePro = "grok-imagine-image-pro"
-	ModelImagineImage    = "grok-imagine-image"
+	ModelImagineImagePro     = "grok-imagine-image-pro"
+	ModelImagineImage        = "grok-imagine-image"
+	ModelImagineImageQuality = "grok-imagine-image-quality"
 
 	// Video generation model
 	ModelImagineVideo = "grok-imagine-video"

--- a/providers/grok/pricing.go
+++ b/providers/grok/pricing.go
@@ -4,26 +4,40 @@ import "github.com/deepnoodle-ai/dive/llm"
 
 // TextModelPricing contains pricing for all text generation models
 var TextModelPricing = map[string]llm.PricingInfo{
+	ModelGrok43: {
+		Model:       ModelGrok43,
+		InputPrice:  1.25,
+		OutputPrice: 2.50,
+		Currency:    "USD",
+		UpdatedAt:   "2026-05-28",
+	},
 	ModelGrok420Reasoning: {
 		Model:       ModelGrok420Reasoning,
-		InputPrice:  2.00,
-		OutputPrice: 6.00,
+		InputPrice:  1.25,
+		OutputPrice: 2.50,
 		Currency:    "USD",
-		UpdatedAt:   "2026-03-25",
+		UpdatedAt:   "2026-05-28",
 	},
 	ModelGrok420NonReasoning: {
 		Model:       ModelGrok420NonReasoning,
-		InputPrice:  2.00,
-		OutputPrice: 6.00,
+		InputPrice:  1.25,
+		OutputPrice: 2.50,
 		Currency:    "USD",
-		UpdatedAt:   "2026-03-25",
+		UpdatedAt:   "2026-05-28",
 	},
 	ModelGrok420MultiAgent: {
 		Model:       ModelGrok420MultiAgent,
-		InputPrice:  2.00,
-		OutputPrice: 6.00,
+		InputPrice:  1.25,
+		OutputPrice: 2.50,
 		Currency:    "USD",
-		UpdatedAt:   "2026-03-25",
+		UpdatedAt:   "2026-05-28",
+	},
+	ModelGrokBuild01: {
+		Model:       ModelGrokBuild01,
+		InputPrice:  1.00,
+		OutputPrice: 2.00,
+		Currency:    "USD",
+		UpdatedAt:   "2026-05-28",
 	},
 	ModelGrok41FastReasoning: {
 		Model:       ModelGrok41FastReasoning,
@@ -80,5 +94,21 @@ var TextModelPricing = map[string]llm.PricingInfo{
 		OutputPrice: 0.50,
 		Currency:    "USD",
 		UpdatedAt:   "2026-02-09",
+	},
+}
+
+// ImageModelPricing contains pricing for Grok Imagine image generation models.
+var ImageModelPricing = map[string]llm.ImagePricingInfo{
+	ModelImagineImage: {
+		Model:     ModelImagineImage,
+		Price:     0.02,
+		Currency:  "USD",
+		UpdatedAt: "2026-05-28",
+	},
+	ModelImagineImageQuality: {
+		Model:     ModelImagineImageQuality,
+		Price:     0.05,
+		Currency:  "USD",
+		UpdatedAt: "2026-05-28",
 	},
 }

--- a/providers/openai/go.mod
+++ b/providers/openai/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/deepnoodle-ai/dive v1.5.0
-	github.com/deepnoodle-ai/wonton v0.0.29
+	github.com/deepnoodle-ai/wonton v0.0.34
 	github.com/openai/openai-go/v3 v3.29.0
 	golang.org/x/image v0.38.0
 )

--- a/providers/openai/go.sum
+++ b/providers/openai/go.sum
@@ -1,5 +1,5 @@
-github.com/deepnoodle-ai/wonton v0.0.29 h1:ypjEoD8gUCvQwjJ1O8d8FZRlXWsxM68BYyFoa2OxtI0=
-github.com/deepnoodle-ai/wonton v0.0.29/go.mod h1:oyogeHwAHPrVxZ7jtik55Jnj6CwC1jkF+PfHpCRlUGA=
+github.com/deepnoodle-ai/wonton v0.0.34 h1:0jE1KtbwZkKPuoxnV0CdYWrQdnYO+r3O3jWnFvZgV40=
+github.com/deepnoodle-ai/wonton v0.0.34/go.mod h1:rQ484HIdk0XfBACtcBuLDMTfn3keow1DspiXZv4IlL8=
 github.com/gobwas/glob v0.2.3 h1:A4xDbljILXROh+kObIiy5kIaPYD8e96x1tgBhUI5J+Y=
 github.com/gobwas/glob v0.2.3/go.mod h1:d3Ez4x06l9bZtSvzIay5+Yzi0fmZzPgnTbPcKjJAkT8=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=

--- a/providers/openrouter/models.go
+++ b/providers/openrouter/models.go
@@ -2,6 +2,8 @@ package openrouter
 
 const (
 	// Anthropic models
+	ModelClaudeOpus48   = "anthropic/claude-opus-4-8"
+	ModelClaudeOpus47   = "anthropic/claude-opus-4-7"
 	ModelClaudeOpus46   = "anthropic/claude-opus-4-6"
 	ModelClaudeSonnet46 = "anthropic/claude-sonnet-4-6"
 	ModelClaudeOpus45   = "anthropic/claude-opus-4-5"

--- a/providers/openrouter/openrouter.go
+++ b/providers/openrouter/openrouter.go
@@ -10,7 +10,7 @@ import (
 )
 
 var (
-	DefaultModel     = ModelClaudeOpus46
+	DefaultModel     = ModelClaudeOpus48
 	DefaultEndpoint  = "https://openrouter.ai/api/v1/chat/completions"
 	DefaultMaxTokens = 32768
 	DefaultClient    = &http.Client{Timeout: 300 * time.Second}


### PR DESCRIPTION
## Summary

Updates Dive's model catalog to the latest releases (verified against official docs, May 2026) and unlocks new capabilities — especially for **Claude Opus 4.8**. Dive was already current on OpenAI (GPT-5.4); the main gaps were Anthropic (stuck at Opus 4.6) plus several new Gemini/Grok models.

### Critical fix
Dive mapped `WithReasoningEffort`/`WithReasoningBudget` to `thinking: {budget_tokens: N}`, which **returns a 400 on Opus 4.7/4.8** (they reject manual thinking budgets). With the default bumped to Opus 4.8, effort/thinking was unusable. The Anthropic provider is now model-aware.

## Models + pricing

**Anthropic** — `ModelClaudeOpus48`/`47` + pricing; **default → Opus 4.8** (Anthropic + OpenRouter). Added `FastModeTextPricing`.

**Google** — `gemini-3.5-flash`, `gemini-3.1-flash-lite` (stable), `gemini-3.1-pro-image`, `gemini-3.1-flash-image`, `gemini-3.1-flash-live-preview`, `gemini-3.1-pro-preview-customtools` + pricing.

**Grok** — `grok-4.3` (new default), `grok-build-0.1`, `grok-imagine-image-quality`; corrected Grok 4.20 pricing to \$1.25/\$2.50.

## Capabilities unlocked (Opus 4.8)

Core `llm` package, mirrored on `dive.ModelSettings`:
- Native `effort` → `output_config.effort` on Opus 4.5+/Sonnet 4.6; new `ReasoningEffortXHigh`/`ReasoningEffortMax`.
- Adaptive thinking: `WithAdaptiveThinking()` / `WithThinking()`; `WithThinkingDisplay()`.
- Fast mode: `WithSpeed(llm.SpeedFast)` (adds `fast-mode-2026-02-01` beta header); `Usage.Speed` reports back.
- `Response.StopDetails` for refusal categories.
- `WithReasoningBudget` on Opus 4.7/4.8 transparently falls back to adaptive thinking (warns if a logger is set); older models keep the legacy budget mapping.

No code needed for: mid-conversation system messages (already work via `llm.System`-role messages), 1M-context-by-default on 4.7/4.8, and the lower prompt-cache minimum (server-side).

## Decisions
- **Default → Opus 4.8** (matches "latest and most capable"; same \$5/\$25 standard price as 4.6).
- **`WithReasoningBudget` on 4.7/4.8 auto-converts to adaptive** rather than erroring, so existing callers keep working.

## Tests / housekeeping
- 11 new unit tests for the reasoning/speed mapping (`providers/anthropic/reasoning_test.go`).
- LLM guide + CHANGELOG updated; design write-up in `docs/design/model-update-may-2026.md`.
- Ran `go mod tidy` across all modules (aligns `wonton` to v0.0.34, resolving a pre-existing inconsistency); all 9 modules build and tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Claude Opus 4.7 & 4.8, Gemini 3.5 Flash, and Grok 4.3 models.
  * Introduced adaptive thinking and new reasoning effort levels, plus inference speed control ("fast" mode).
  * Enhanced refusal handling with structured stop details.

* **Bug Fixes**
  * Fixed reasoning/effort request failures for Claude Opus 4.7/4.8.
  * Corrected Grok 4.20 token pricing.

* **Documentation**
  * Updated guides and changelog with May 2026 model, pricing, and behavior notes (including fast-mode pricing).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/deepnoodle-ai/dive/pull/169?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->