### PR TITLE
Deeper Grok/X.AI integration: server-side tools + reasoning usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
   `gemini-3.1-pro-preview-customtools`, plus pricing.
 - **Grok**: `grok-4.3` (new default), `grok-build-0.1`,
   `grok-imagine-image-quality`, plus pricing.
+- **Grok server-side tools**: `CodeExecutionTool` (sandboxed Python via the
+  xAI `code_interpreter` tool) and `CollectionsSearchTool` (search uploaded
+  collections via `file_search`). `WebSearchTool` gains `EnableImageSearch`.
+  Remote MCP servers already work for Grok via `llm.MCPServerConfig`. See the
+  new `docs/guides/grok.md` and the `grok_search_example` /
+  `grok_code_execution_example` programs.
+- **Reasoning token usage** — `llm.Usage.ReasoningTokens` now reports the output
+  tokens a provider spent on reasoning (populated for the OpenAI Responses API
+  and Grok). The streaming path also now fills `CacheReadInputTokens`.
+- **`ResponsesIncludeProvider`** interface in `providers/openai` lets a
+  server-side tool request response `include` data (e.g.
+  `code_interpreter_call.outputs`, `file_search_call.results`).
 
 ### Fixed
 
@@ -36,6 +48,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
   Claude model (no native effort parameter) now returns an error instead of
   silently re-enabling thinking via the emulated budget.
 - Corrected Grok 4.20 pricing to $1.25/$2.50 per 1M tokens.
+- Corrected the Grok X-search handle limit to 20 (was incorrectly capped at 10).
+- `file_search` / collections-search responses now decode instead of returning
+  an "unsupported" error (`openai.FileSearchCallContent`).
 
 ## [1.5.0] - 2026-05-15
 

--- a/docs/guides/grok.md
+++ b/docs/guides/grok.md
@@ -1,0 +1,151 @@
+# Grok (xAI) Guide
+
+The Grok provider (`providers/grok`) connects Dive to xAI's models through the
+xAI Responses API. It is a separate Go module
+(`github.com/deepnoodle-ai/dive/providers/grok`) built on top of the OpenAI
+Responses provider, so it inherits streaming, tool calling, prompt caching, and
+the server-side tool plumbing described below.
+
+## Setup
+
+```go
+import "github.com/deepnoodle-ai/dive/providers/grok"
+
+model := grok.New() // defaults to grok-4.3
+```
+
+**Env:** `XAI_API_KEY` (preferred) or `GROK_API_KEY`.
+**Models:** See `providers/grok/models.go`. `grok-4.3` is the current flagship
+and default; `grok-build-0.1` is the coding model.
+
+## Server-side tools
+
+Grok runs several tools on xAI's servers: you attach a tool, and the API
+executes it and folds the results into the response. Pass them with
+`llm.WithTools(...)` (or via `AgentOptions.Tools` on an agent).
+
+All of these tools return citations for the sources they used; citations are
+attached to the assistant's text content blocks (see [Citations](#citations)).
+
+### Web search
+
+```go
+webSearch, err := grok.NewWebSearchTool(grok.WebSearchToolOptions{
+    AllowedDomains:           []string{"wikipedia.org"}, // max 5; or ExcludedDomains
+    EnableImageUnderstanding: true,                      // analyze images while browsing
+    EnableImageSearch:        true,                      // find & embed relevant images
+})
+```
+
+`AllowedDomains` and `ExcludedDomains` are mutually exclusive (max 5 each).
+`EnableImageUnderstanding` lets Grok inspect images it finds while browsing;
+`EnableImageSearch` lets Grok search for images and embed them in the response
+as Markdown.
+
+### X (Twitter) search
+
+```go
+xSearch, err := grok.NewXSearchTool(grok.XSearchToolOptions{
+    AllowedXHandles:          []string{"xai", "elonmusk"}, // max 20; or ExcludedXHandles
+    FromDate:                 "2025-10-01",                // ISO-8601 YYYY-MM-DD
+    ToDate:                   "2025-10-10",
+    EnableImageUnderstanding: true,
+    EnableVideoUnderstanding: true, // X search only
+})
+```
+
+### Code execution
+
+Grok writes and runs Python in a sandbox for precise calculation and data
+analysis (the xAI API's `code_interpreter` tool).
+
+```go
+codeExec := grok.NewCodeExecutionTool(grok.CodeExecutionToolOptions{
+    IncludeOutputs: true, // return the executed code's outputs in the response
+})
+```
+
+When `IncludeOutputs` is set, the request opts into the
+`code_interpreter_call.outputs` include. The executed code and its results come
+back as a `*openai.CodeInterpreterCallContent` content block.
+
+See `examples/grok_code_execution_example`.
+
+### Collections search
+
+Grok can search your uploaded knowledge bases (collections), mapping to the
+xAI API's `file_search` tool where collection IDs are the vector store IDs.
+Create collections and upload documents with the xAI console or SDK first, then:
+
+```go
+collections, err := grok.NewCollectionsSearchTool(grok.CollectionsSearchToolOptions{
+    CollectionIDs:  []string{"collection_3be0..."}, // at least one required
+    MaxNumResults:  10,                             // optional, 1–50
+    IncludeResults: true,                           // return matched chunks
+})
+```
+
+With `IncludeResults`, matched document chunks come back as a
+`*openai.FileSearchCallContent` content block (opting into the
+`file_search_call.results` include).
+
+### Remote MCP servers
+
+Grok can connect to remote MCP servers through Dive's core MCP configuration —
+no Grok-specific code required:
+
+```go
+agent, _ := dive.NewAgent(dive.AgentOptions{
+    Model: grok.New(),
+    ModelSettings: &dive.ModelSettings{
+        MCPServers: []llm.MCPServerConfig{{
+            Type:               "url",
+            URL:                "https://mcp.deepwiki.com/mcp",
+            Name:               "deepwiki",
+            AuthorizationToken: "optional-token",
+            ToolConfiguration:  &llm.MCPToolConfiguration{AllowedTools: []string{"ask_question"}},
+        }},
+    },
+})
+```
+
+`AllowedTools` restricts which of the server's tools Grok may call. (At the
+`llm` layer, the same is available via `llm.WithMCPServers(...)`.)
+
+## Citations
+
+The sources Grok used are attached to the assistant's text content as
+`*llm.WebSearchResultLocation` citations:
+
+```go
+for _, content := range response.Content {
+    if text, ok := content.(*llm.TextContent); ok {
+        for _, citation := range text.Citations {
+            if loc, ok := citation.(*llm.WebSearchResultLocation); ok {
+                fmt.Printf("- %s (%s)\n", loc.Title, loc.URL)
+            }
+        }
+    }
+}
+```
+
+See `examples/grok_search_example`.
+
+## Reasoning token usage
+
+Grok's reasoning models report how many output tokens were spent thinking.
+Dive surfaces this on `llm.Usage.ReasoningTokens` (a subset of `OutputTokens`):
+
+```go
+fmt.Printf("reasoning tokens: %d\n", response.Usage.ReasoningTokens)
+```
+
+## Prompt caching
+
+Route requests in a conversation to the same cache with `WithPromptCacheKey`:
+
+```go
+provider := grok.New(grok.WithPromptCacheKey("conversation-uuid"))
+```
+
+Cache hits are reported on `response.Usage.CacheReadInputTokens`.

--- a/examples/go.mod
+++ b/examples/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/deepnoodle-ai/dive/experimental/mcp v1.5.0
 	github.com/deepnoodle-ai/dive/otel v1.5.0
 	github.com/deepnoodle-ai/dive/providers/google v1.5.0
+	github.com/deepnoodle-ai/dive/providers/grok v1.5.0
 	github.com/deepnoodle-ai/dive/providers/openai v1.5.0
 	github.com/deepnoodle-ai/wonton v0.0.34
 	github.com/fatih/color v1.18.0
@@ -80,5 +81,6 @@ replace (
 	github.com/deepnoodle-ai/dive/experimental/mcp => ../experimental/mcp
 	github.com/deepnoodle-ai/dive/otel => ../otel
 	github.com/deepnoodle-ai/dive/providers/google => ../providers/google
+	github.com/deepnoodle-ai/dive/providers/grok => ../providers/grok
 	github.com/deepnoodle-ai/dive/providers/openai => ../providers/openai
 )

--- a/examples/grok_code_execution_example/main.go
+++ b/examples/grok_code_execution_example/main.go
@@ -1,0 +1,69 @@
+// Command grok_code_execution_example demonstrates Grok's server-side code
+// execution tool. Grok writes and runs Python in a sandbox to compute an exact
+// answer, then explains it. With IncludeOutputs enabled, the executed code and
+// its outputs come back in the response so we can show what Grok ran.
+//
+// Run with XAI_API_KEY (or GROK_API_KEY) set:
+//
+//	go run ./grok_code_execution_example -prompt "What is 2^64?"
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+
+	"github.com/deepnoodle-ai/dive/llm"
+	"github.com/deepnoodle-ai/dive/providers/grok"
+	openaiProvider "github.com/deepnoodle-ai/dive/providers/openai"
+)
+
+const defaultPrompt = "Compute the compound interest on $10,000 at 5% annually for 10 years. Use code and show the final amount."
+
+func main() {
+	var prompt string
+	flag.StringVar(&prompt, "prompt", defaultPrompt, "prompt to send to Grok")
+	flag.Parse()
+
+	// IncludeOutputs asks the server to return the code interpreter's outputs
+	// (logs/files) alongside the executed code.
+	codeExec := grok.NewCodeExecutionTool(grok.CodeExecutionToolOptions{
+		IncludeOutputs: true,
+	})
+
+	provider := grok.New() // defaults to grok-4.3
+
+	response, err := provider.Generate(context.Background(),
+		llm.WithMessages(llm.NewUserTextMessage(prompt)),
+		llm.WithTools(codeExec),
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// The code Grok wrote and executed arrives as a code_interpreter_call
+	// content block (defined in the openai provider that Grok builds on).
+	for _, content := range response.Content {
+		if call, ok := content.(*openaiProvider.CodeInterpreterCallContent); ok {
+			fmt.Println("Grok executed this code:")
+			fmt.Println("------------------------")
+			fmt.Println(call.Code)
+			fmt.Println("------------------------")
+			for _, result := range call.Results {
+				if result.Logs != "" {
+					fmt.Printf("Output: %s\n", result.Logs)
+				}
+			}
+			fmt.Println()
+		}
+	}
+
+	fmt.Println("Answer:")
+	fmt.Println(response.Message().Text())
+
+	fmt.Printf("\nUsage: input=%d output=%d reasoning=%d\n",
+		response.Usage.InputTokens,
+		response.Usage.OutputTokens,
+		response.Usage.ReasoningTokens)
+}

--- a/examples/grok_search_example/main.go
+++ b/examples/grok_search_example/main.go
@@ -1,0 +1,74 @@
+// Command grok_search_example demonstrates Grok's server-side search tools:
+// web search (with image search enabled) and X (Twitter) search. It prints the
+// answer, any citations Grok returned, and the token usage — including the
+// reasoning tokens Grok spent thinking.
+//
+// Run with XAI_API_KEY (or GROK_API_KEY) set:
+//
+//	go run ./grok_search_example -prompt "What did xAI announce recently?"
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+
+	"github.com/deepnoodle-ai/dive/llm"
+	"github.com/deepnoodle-ai/dive/providers/grok"
+)
+
+const defaultPrompt = "What are the latest announcements from Anthropic? Answer in two sentences and cite your sources."
+
+func main() {
+	var prompt string
+	flag.StringVar(&prompt, "prompt", defaultPrompt, "prompt to send to Grok")
+	flag.Parse()
+
+	// Web search with image search enabled (Grok can embed relevant images),
+	// plus X search so Grok can pull in real-time posts from X.
+	webSearch, err := grok.NewWebSearchTool(grok.WebSearchToolOptions{
+		EnableImageSearch: true,
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+	xSearch, err := grok.NewXSearchTool(grok.XSearchToolOptions{
+		AllowedXHandles: []string{"xai", "elonmusk"},
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	provider := grok.New() // defaults to grok-4.3
+
+	response, err := provider.Generate(context.Background(),
+		llm.WithMessages(llm.NewUserTextMessage(prompt)),
+		llm.WithTools(webSearch, xSearch),
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Println("Answer:")
+	fmt.Println(response.Message().Text())
+
+	// Citations are attached to the assistant's text content blocks.
+	fmt.Println("\nCitations:")
+	for _, content := range response.Content {
+		text, ok := content.(*llm.TextContent)
+		if !ok {
+			continue
+		}
+		for _, citation := range text.Citations {
+			if loc, ok := citation.(*llm.WebSearchResultLocation); ok {
+				fmt.Printf("  - %s (%s)\n", loc.Title, loc.URL)
+			}
+		}
+	}
+
+	fmt.Printf("\nUsage: input=%d output=%d reasoning=%d\n",
+		response.Usage.InputTokens,
+		response.Usage.OutputTokens,
+		response.Usage.ReasoningTokens)
+}

--- a/examples/grok_search_example/main.go
+++ b/examples/grok_search_example/main.go
@@ -34,7 +34,7 @@ func main() {
 		log.Fatal(err)
 	}
 	xSearch, err := grok.NewXSearchTool(grok.XSearchToolOptions{
-		AllowedXHandles: []string{"xai", "elonmusk"},
+		AllowedXHandles: []string{"bcherny", "claudeai", "AnthropicAI"},
 	})
 	if err != nil {
 		log.Fatal(err)

--- a/llm/usage.go
+++ b/llm/usage.go
@@ -6,6 +6,10 @@ type Usage struct {
 	OutputTokens             int `json:"output_tokens"`
 	CacheCreationInputTokens int `json:"cache_creation_input_tokens,omitempty"`
 	CacheReadInputTokens     int `json:"cache_read_input_tokens,omitempty"`
+	// ReasoningTokens is the number of output tokens spent on reasoning, when
+	// the provider reports it separately (e.g. OpenAI o-series and Grok
+	// reasoning models). It is a subset of OutputTokens, not additive.
+	ReasoningTokens int `json:"reasoning_tokens,omitempty"`
 	// Speed indicates which inference speed served the request, either "fast"
 	// or "standard". Populated by Anthropic when fast mode is requested.
 	Speed string `json:"speed,omitempty"`
@@ -18,6 +22,7 @@ func (u *Usage) Copy() *Usage {
 		OutputTokens:             u.OutputTokens,
 		CacheCreationInputTokens: u.CacheCreationInputTokens,
 		CacheReadInputTokens:     u.CacheReadInputTokens,
+		ReasoningTokens:          u.ReasoningTokens,
 		Speed:                    u.Speed,
 	}
 }
@@ -28,4 +33,5 @@ func (u *Usage) Add(other *Usage) {
 	u.OutputTokens += other.OutputTokens
 	u.CacheCreationInputTokens += other.CacheCreationInputTokens
 	u.CacheReadInputTokens += other.CacheReadInputTokens
+	u.ReasoningTokens += other.ReasoningTokens
 }

--- a/providers/grok/integration_test.go
+++ b/providers/grok/integration_test.go
@@ -438,3 +438,26 @@ func TestIntegration_Grok420Models(t *testing.T) {
 		})
 	}
 }
+
+func TestIntegration_CodeExecution(t *testing.T) {
+	skipIfNoAPIKey(t)
+
+	provider := New()
+	ctx := testContext(t, 60*time.Second)
+
+	codeExec := NewCodeExecutionTool(CodeExecutionToolOptions{IncludeOutputs: true})
+
+	response, err := provider.Generate(ctx,
+		llm.WithMessages(
+			llm.NewUserTextMessage("What is the 12th Fibonacci number? Use code to compute it."),
+		),
+		llm.WithTools(codeExec),
+	)
+	assert.NoError(t, err)
+	assert.NotNil(t, response)
+
+	text := response.Message().Text()
+	t.Logf("Code execution response: %s (reasoning tokens: %d)",
+		text, response.Usage.ReasoningTokens)
+	assert.True(t, strings.Contains(text, "144"))
+}

--- a/providers/grok/tool_code_execution.go
+++ b/providers/grok/tool_code_execution.go
@@ -1,0 +1,82 @@
+package grok
+
+import (
+	"context"
+	"errors"
+
+	"github.com/deepnoodle-ai/dive"
+	"github.com/deepnoodle-ai/dive/llm"
+	openaiProvider "github.com/deepnoodle-ai/dive/providers/openai"
+	"github.com/deepnoodle-ai/wonton/schema"
+	"github.com/openai/openai-go/v3/packages/param"
+	"github.com/openai/openai-go/v3/responses"
+)
+
+var (
+	_ llm.Tool                                = &CodeExecutionTool{}
+	_ openaiProvider.ResponsesToolProvider    = &CodeExecutionTool{}
+	_ openaiProvider.ResponsesIncludeProvider = &CodeExecutionTool{}
+)
+
+// CodeExecutionToolOptions configures the Grok code execution tool.
+type CodeExecutionToolOptions struct {
+	// IncludeOutputs requests that the server return the code execution outputs
+	// (logs and files) in the response via the "code_interpreter_call.outputs"
+	// include parameter. Outputs can be large, so they are omitted by default.
+	IncludeOutputs bool
+}
+
+// NewCodeExecutionTool creates a new Grok CodeExecutionTool. When the model uses
+// it, Grok writes and runs Python in a sandboxed environment server-side and
+// incorporates the result. This tool is only available via the xAI Responses
+// API (it maps to the API's "code_interpreter" tool).
+func NewCodeExecutionTool(opts CodeExecutionToolOptions) *CodeExecutionTool {
+	return &CodeExecutionTool{includeOutputs: opts.IncludeOutputs}
+}
+
+// CodeExecutionTool is a server-side tool that lets Grok execute Python code.
+type CodeExecutionTool struct {
+	includeOutputs bool
+}
+
+func (t *CodeExecutionTool) Name() string {
+	return "code_execution"
+}
+
+func (t *CodeExecutionTool) Description() string {
+	return "Lets Grok write and execute Python code in a sandboxed environment for precise calculations and data analysis."
+}
+
+func (t *CodeExecutionTool) Schema() *schema.Schema {
+	return nil
+}
+
+func (t *CodeExecutionTool) ResponsesToolParam() responses.ToolUnionParam {
+	// The xAI API expects a bare {"type": "code_interpreter"} with no container,
+	// unlike the OpenAI SDK's ToolCodeInterpreterParam (which requires one), so
+	// pass raw JSON via param.Override.
+	return param.Override[responses.ToolUnionParam](map[string]any{
+		"type": "code_interpreter",
+	})
+}
+
+func (t *CodeExecutionTool) ResponsesIncludes() []responses.ResponseIncludable {
+	if !t.includeOutputs {
+		return nil
+	}
+	return []responses.ResponseIncludable{"code_interpreter_call.outputs"}
+}
+
+func (t *CodeExecutionTool) Annotations() *dive.ToolAnnotations {
+	return &dive.ToolAnnotations{
+		Title:           "Code Execution",
+		ReadOnlyHint:    true,
+		DestructiveHint: false,
+		IdempotentHint:  false,
+		OpenWorldHint:   false,
+	}
+}
+
+func (t *CodeExecutionTool) Call(ctx context.Context, input any) (*dive.ToolResult, error) {
+	return nil, errors.New("server-side tool does not implement local calls")
+}

--- a/providers/grok/tool_collections_search.go
+++ b/providers/grok/tool_collections_search.go
@@ -1,0 +1,110 @@
+package grok
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/deepnoodle-ai/dive"
+	"github.com/deepnoodle-ai/dive/llm"
+	openaiProvider "github.com/deepnoodle-ai/dive/providers/openai"
+	"github.com/deepnoodle-ai/wonton/schema"
+	"github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/responses"
+)
+
+var (
+	_ llm.Tool                                = &CollectionsSearchTool{}
+	_ openaiProvider.ResponsesToolProvider    = &CollectionsSearchTool{}
+	_ openaiProvider.ResponsesIncludeProvider = &CollectionsSearchTool{}
+)
+
+// CollectionsSearchToolOptions configures the Grok collections search tool.
+type CollectionsSearchToolOptions struct {
+	// CollectionIDs are the xAI collection IDs to search (at least one required).
+	CollectionIDs []string
+
+	// MaxNumResults caps the number of results returned per search. When set it
+	// must be between 1 and 50. Zero leaves the server default in place.
+	MaxNumResults int
+
+	// IncludeResults requests that the server return the matched document chunks
+	// in the response via the "file_search_call.results" include parameter.
+	IncludeResults bool
+}
+
+func (o CollectionsSearchToolOptions) validate() error {
+	if len(o.CollectionIDs) == 0 {
+		return fmt.Errorf("at least one CollectionID is required")
+	}
+	if o.MaxNumResults < 0 || o.MaxNumResults > 50 {
+		return fmt.Errorf("MaxNumResults must be between 1 and 50 (got %d)", o.MaxNumResults)
+	}
+	return nil
+}
+
+// NewCollectionsSearchTool creates a new Grok CollectionsSearchTool, letting the
+// model search your uploaded knowledge bases (collections) for relevant
+// documents. This tool is only available via the xAI Responses API (it maps to
+// the API's "file_search" tool, where collection IDs are the vector store IDs).
+func NewCollectionsSearchTool(opts CollectionsSearchToolOptions) (*CollectionsSearchTool, error) {
+	if err := opts.validate(); err != nil {
+		return nil, fmt.Errorf("invalid CollectionsSearchToolOptions: %w", err)
+	}
+	return &CollectionsSearchTool{
+		collectionIDs:  opts.CollectionIDs,
+		maxNumResults:  opts.MaxNumResults,
+		includeResults: opts.IncludeResults,
+	}, nil
+}
+
+// CollectionsSearchTool is a server-side tool that enables Grok to search
+// uploaded collections (knowledge bases).
+type CollectionsSearchTool struct {
+	collectionIDs  []string
+	maxNumResults  int
+	includeResults bool
+}
+
+func (t *CollectionsSearchTool) Name() string {
+	return "collections_search"
+}
+
+func (t *CollectionsSearchTool) Description() string {
+	return "Searches your uploaded xAI collections (knowledge bases) for relevant documents."
+}
+
+func (t *CollectionsSearchTool) Schema() *schema.Schema {
+	return nil
+}
+
+func (t *CollectionsSearchTool) ResponsesToolParam() responses.ToolUnionParam {
+	param := &responses.FileSearchToolParam{
+		VectorStoreIDs: t.collectionIDs,
+	}
+	if t.maxNumResults > 0 {
+		param.MaxNumResults = openai.Int(int64(t.maxNumResults))
+	}
+	return responses.ToolUnionParam{OfFileSearch: param}
+}
+
+func (t *CollectionsSearchTool) ResponsesIncludes() []responses.ResponseIncludable {
+	if !t.includeResults {
+		return nil
+	}
+	return []responses.ResponseIncludable{"file_search_call.results"}
+}
+
+func (t *CollectionsSearchTool) Annotations() *dive.ToolAnnotations {
+	return &dive.ToolAnnotations{
+		Title:           "Collections Search",
+		ReadOnlyHint:    true,
+		DestructiveHint: false,
+		IdempotentHint:  false,
+		OpenWorldHint:   false,
+	}
+}
+
+func (t *CollectionsSearchTool) Call(ctx context.Context, input any) (*dive.ToolResult, error) {
+	return nil, errors.New("server-side tool does not implement local calls")
+}

--- a/providers/grok/tool_web_search.go
+++ b/providers/grok/tool_web_search.go
@@ -27,8 +27,14 @@ type WebSearchToolOptions struct {
 	// Cannot be used with AllowedDomains.
 	ExcludedDomains []string
 
-	// EnableImageUnderstanding allows analysis of images found during browsing.
+	// EnableImageUnderstanding allows analysis of images found during browsing
+	// (equips the agent with the view_image tool).
 	EnableImageUnderstanding bool
+
+	// EnableImageSearch lets Grok search for relevant images and embed them in
+	// the response as Markdown image embeds. This is distinct from
+	// EnableImageUnderstanding, which inspects images found while browsing.
+	EnableImageSearch bool
 }
 
 func (o WebSearchToolOptions) validate() error {
@@ -54,6 +60,7 @@ func NewWebSearchTool(opts WebSearchToolOptions) (*WebSearchTool, error) {
 		allowedDomains:           opts.AllowedDomains,
 		excludedDomains:          opts.ExcludedDomains,
 		enableImageUnderstanding: opts.EnableImageUnderstanding,
+		enableImageSearch:        opts.EnableImageSearch,
 	}, nil
 }
 
@@ -63,6 +70,7 @@ type WebSearchTool struct {
 	allowedDomains           []string
 	excludedDomains          []string
 	enableImageUnderstanding bool
+	enableImageSearch        bool
 }
 
 func (t *WebSearchTool) Name() string {
@@ -96,6 +104,9 @@ func (t *WebSearchTool) ResponsesToolParam() responses.ToolUnionParam {
 	}
 	if t.enableImageUnderstanding {
 		extras["enable_image_understanding"] = true
+	}
+	if t.enableImageSearch {
+		extras["enable_image_search"] = true
 	}
 	if len(extras) > 0 {
 		param.SetExtraFields(extras)

--- a/providers/grok/tool_x_search.go
+++ b/providers/grok/tool_x_search.go
@@ -21,11 +21,11 @@ var (
 
 // XSearchToolOptions configures the Grok X (Twitter) search tool.
 type XSearchToolOptions struct {
-	// AllowedXHandles restricts search to posts from these handles (max 10).
+	// AllowedXHandles restricts search to posts from these handles (max 20).
 	// Cannot be used with ExcludedXHandles.
 	AllowedXHandles []string
 
-	// ExcludedXHandles excludes posts from these handles (max 10).
+	// ExcludedXHandles excludes posts from these handles (max 20).
 	// Cannot be used with AllowedXHandles.
 	ExcludedXHandles []string
 
@@ -46,11 +46,11 @@ func (o XSearchToolOptions) validate() error {
 	if len(o.AllowedXHandles) > 0 && len(o.ExcludedXHandles) > 0 {
 		return fmt.Errorf("AllowedXHandles and ExcludedXHandles cannot both be set")
 	}
-	if len(o.AllowedXHandles) > 10 {
-		return fmt.Errorf("AllowedXHandles exceeds maximum of 10 (got %d)", len(o.AllowedXHandles))
+	if len(o.AllowedXHandles) > 20 {
+		return fmt.Errorf("AllowedXHandles exceeds maximum of 20 (got %d)", len(o.AllowedXHandles))
 	}
-	if len(o.ExcludedXHandles) > 10 {
-		return fmt.Errorf("ExcludedXHandles exceeds maximum of 10 (got %d)", len(o.ExcludedXHandles))
+	if len(o.ExcludedXHandles) > 20 {
+		return fmt.Errorf("ExcludedXHandles exceeds maximum of 20 (got %d)", len(o.ExcludedXHandles))
 	}
 	if o.FromDate != "" {
 		if _, err := time.Parse("2006-01-02", o.FromDate); err != nil {

--- a/providers/grok/tools_test.go
+++ b/providers/grok/tools_test.go
@@ -1,0 +1,144 @@
+package grok
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/deepnoodle-ai/wonton/assert"
+	"github.com/openai/openai-go/v3/responses"
+)
+
+// toolParamMap marshals a ResponsesToolParam to a generic map so tests can
+// assert on the exact JSON sent to the xAI Responses API.
+func toolParamMap(t *testing.T, p responses.ToolUnionParam) map[string]any {
+	t.Helper()
+	data, err := json.Marshal(p)
+	assert.NoError(t, err)
+	var m map[string]any
+	assert.NoError(t, json.Unmarshal(data, &m))
+	return m
+}
+
+func TestWebSearchTool_EnableImageSearch(t *testing.T) {
+	tool, err := NewWebSearchTool(WebSearchToolOptions{
+		AllowedDomains:           []string{"grokipedia.com"},
+		EnableImageUnderstanding: true,
+		EnableImageSearch:        true,
+	})
+	assert.NoError(t, err)
+
+	m := toolParamMap(t, tool.ResponsesToolParam())
+	assert.Equal(t, "web_search", m["type"])
+	assert.Equal(t, true, m["enable_image_understanding"])
+	assert.Equal(t, true, m["enable_image_search"])
+}
+
+func TestWebSearchTool_ImageSearchOmittedByDefault(t *testing.T) {
+	tool, err := NewWebSearchTool(WebSearchToolOptions{})
+	assert.NoError(t, err)
+	m := toolParamMap(t, tool.ResponsesToolParam())
+	_, hasImageSearch := m["enable_image_search"]
+	assert.False(t, hasImageSearch)
+}
+
+func TestWebSearchTool_Validation(t *testing.T) {
+	_, err := NewWebSearchTool(WebSearchToolOptions{
+		AllowedDomains:  []string{"a.com"},
+		ExcludedDomains: []string{"b.com"},
+	})
+	assert.Error(t, err)
+
+	_, err = NewWebSearchTool(WebSearchToolOptions{
+		AllowedDomains: []string{"1", "2", "3", "4", "5", "6"},
+	})
+	assert.Error(t, err)
+}
+
+func TestXSearchTool_HandleLimit(t *testing.T) {
+	handles := make([]string, 20)
+	for i := range handles {
+		handles[i] = "handle"
+	}
+	// 20 handles is allowed.
+	_, err := NewXSearchTool(XSearchToolOptions{AllowedXHandles: handles})
+	assert.NoError(t, err)
+
+	// 21 handles exceeds the maximum.
+	_, err = NewXSearchTool(XSearchToolOptions{AllowedXHandles: append(handles, "extra")})
+	assert.Error(t, err)
+}
+
+func TestXSearchTool_Param(t *testing.T) {
+	tool, err := NewXSearchTool(XSearchToolOptions{
+		AllowedXHandles:          []string{"elonmusk"},
+		FromDate:                 "2025-10-01",
+		ToDate:                   "2025-10-10",
+		EnableImageUnderstanding: true,
+		EnableVideoUnderstanding: true,
+	})
+	assert.NoError(t, err)
+
+	m := toolParamMap(t, tool.ResponsesToolParam())
+	assert.Equal(t, "x_search", m["type"])
+	assert.Equal(t, "2025-10-01", m["from_date"])
+	assert.Equal(t, "2025-10-10", m["to_date"])
+	assert.Equal(t, true, m["enable_image_understanding"])
+	assert.Equal(t, true, m["enable_video_understanding"])
+}
+
+func TestCodeExecutionTool_Param(t *testing.T) {
+	tool := NewCodeExecutionTool(CodeExecutionToolOptions{})
+	m := toolParamMap(t, tool.ResponsesToolParam())
+	assert.Equal(t, "code_interpreter", m["type"])
+	assert.Empty(t, tool.ResponsesIncludes())
+}
+
+func TestCodeExecutionTool_IncludeOutputs(t *testing.T) {
+	tool := NewCodeExecutionTool(CodeExecutionToolOptions{IncludeOutputs: true})
+	includes := tool.ResponsesIncludes()
+	assert.Len(t, includes, 1)
+	assert.Equal(t, responses.ResponseIncludable("code_interpreter_call.outputs"), includes[0])
+}
+
+func TestCollectionsSearchTool_Param(t *testing.T) {
+	tool, err := NewCollectionsSearchTool(CollectionsSearchToolOptions{
+		CollectionIDs: []string{"collection_123"},
+		MaxNumResults: 10,
+	})
+	assert.NoError(t, err)
+
+	m := toolParamMap(t, tool.ResponsesToolParam())
+	assert.Equal(t, "file_search", m["type"])
+	ids, ok := m["vector_store_ids"].([]any)
+	assert.True(t, ok)
+	assert.Len(t, ids, 1)
+	assert.Equal(t, "collection_123", ids[0])
+	assert.Equal(t, float64(10), m["max_num_results"])
+}
+
+func TestCollectionsSearchTool_Validation(t *testing.T) {
+	_, err := NewCollectionsSearchTool(CollectionsSearchToolOptions{})
+	assert.Error(t, err)
+
+	_, err = NewCollectionsSearchTool(CollectionsSearchToolOptions{
+		CollectionIDs: []string{"c1"},
+		MaxNumResults: 51,
+	})
+	assert.Error(t, err)
+}
+
+func TestCollectionsSearchTool_IncludeResults(t *testing.T) {
+	tool, err := NewCollectionsSearchTool(CollectionsSearchToolOptions{
+		CollectionIDs:  []string{"c1"},
+		IncludeResults: true,
+	})
+	assert.NoError(t, err)
+	includes := tool.ResponsesIncludes()
+	assert.Len(t, includes, 1)
+	assert.Equal(t, responses.ResponseIncludable("file_search_call.results"), includes[0])
+
+	// Default: no includes requested.
+	tool, err = NewCollectionsSearchTool(CollectionsSearchToolOptions{CollectionIDs: []string{"c1"}})
+	assert.NoError(t, err)
+	assert.Empty(t, tool.ResponsesIncludes())
+}

--- a/providers/openai/content_file_search.go
+++ b/providers/openai/content_file_search.go
@@ -1,0 +1,60 @@
+package openai
+
+import (
+	"encoding/json"
+
+	"github.com/deepnoodle-ai/dive/llm"
+)
+
+const ContentTypeFileSearchCall llm.ContentType = "file_search_call"
+
+// FileSearchCallResult mirrors openai.ResponseFileSearchToolCallResult. It
+// represents a single document chunk returned by a file/collections search.
+type FileSearchCallResult struct {
+	// FileID is the unique identifier of the matched file.
+	FileID string `json:"file_id,omitempty"`
+
+	// Filename is the name of the matched file.
+	Filename string `json:"filename,omitempty"`
+
+	// Score is the relevance score of the result (0 to 1).
+	Score float64 `json:"score,omitempty"`
+
+	// Text is the chunk of text retrieved from the file.
+	Text string `json:"text,omitempty"`
+}
+
+// FileSearchCallContent mirrors openai.ResponseFileSearchToolCall. It is emitted
+// when the model invokes a file_search (OpenAI) / collections_search (xAI/Grok)
+// server-side tool. Result text is only populated when the request opts in via
+// the "file_search_call.results" include parameter.
+type FileSearchCallContent struct {
+	// ID is the unique identifier for this tool call.
+	ID string `json:"id"`
+
+	// Queries are the search queries the model issued.
+	Queries []string `json:"queries,omitempty"`
+
+	// Status is the execution status, e.g. "in_progress", "searching",
+	// "completed", "incomplete", or "failed".
+	Status string `json:"status"`
+
+	// Results contains the matched document chunks, when requested via include.
+	Results []FileSearchCallResult `json:"results,omitempty"`
+}
+
+func (c *FileSearchCallContent) Type() llm.ContentType {
+	return ContentTypeFileSearchCall
+}
+
+// MarshalJSON ensures the content includes a top-level "type" field.
+func (c *FileSearchCallContent) MarshalJSON() ([]byte, error) {
+	type Alias FileSearchCallContent
+	return json.Marshal(struct {
+		Type llm.ContentType `json:"type"`
+		*Alias
+	}{
+		Type:  ContentTypeFileSearchCall,
+		Alias: (*Alias)(c),
+	})
+}

--- a/providers/openai/decode.go
+++ b/providers/openai/decode.go
@@ -27,6 +27,7 @@ func decodeAssistantResponse(response *responses.Response) (*llm.Response, error
 	usage.InputTokens = int(response.Usage.InputTokens)
 	usage.OutputTokens = int(response.Usage.OutputTokens)
 	usage.CacheReadInputTokens = int(response.Usage.InputTokensDetails.CachedTokens)
+	usage.ReasoningTokens = int(response.Usage.OutputTokensDetails.ReasoningTokens)
 
 	// Determine stop reason based on the response content and status
 	stopReason := determineStopReason(response)
@@ -275,7 +276,23 @@ func decodeCodeInterpreterCallContent(codeCall responses.ResponseCodeInterpreter
 }
 
 func decodeFileSearchCallContent(fileSearchCall responses.ResponseFileSearchToolCall) ([]llm.Content, error) {
-	return nil, fmt.Errorf("file search call is not yet supported")
+	var results []FileSearchCallResult
+	for _, result := range fileSearchCall.Results {
+		results = append(results, FileSearchCallResult{
+			FileID:   result.FileID,
+			Filename: result.Filename,
+			Score:    result.Score,
+			Text:     result.Text,
+		})
+	}
+	return []llm.Content{
+		&FileSearchCallContent{
+			ID:      fileSearchCall.ID,
+			Queries: fileSearchCall.Queries,
+			Status:  string(fileSearchCall.Status),
+			Results: results,
+		},
+	}, nil
 }
 
 func decodeComputerCallContent(computerCall responses.ResponseComputerToolCall) ([]llm.Content, error) {

--- a/providers/openai/provider.go
+++ b/providers/openai/provider.go
@@ -211,14 +211,6 @@ func (p *Provider) buildRequestParams(config *llm.Config) (responses.ResponseNew
 		includes[IncludeReasoningEncryptedContent] = true
 	}
 
-	// Includes are used to include additional data in the response
-	if len(includes) > 0 {
-		params.Include = make([]responses.ResponseIncludable, 0, len(includes))
-		for include := range includes {
-			params.Include = append(params.Include, responses.ResponseIncludable(include))
-		}
-	}
-
 	// Handle parallel tool calls
 	if config.ParallelToolCalls != nil {
 		params.ParallelToolCalls = openai.Bool(*config.ParallelToolCalls)
@@ -285,6 +277,13 @@ func (p *Provider) buildRequestParams(config *llm.Config) (responses.ResponseNew
 			// Check for tools that provide native Responses API params
 			if responsesTool, ok := tool.(ResponsesToolProvider); ok {
 				tools = append(tools, responsesTool.ResponsesToolParam())
+				// Tools may also request that the server return their call
+				// outputs via the response `include` parameter.
+				if includeProvider, ok := tool.(ResponsesIncludeProvider); ok {
+					for _, inc := range includeProvider.ResponsesIncludes() {
+						includes[Include(inc)] = true
+					}
+				}
 				continue
 			}
 			if toolWebSearch, ok := tool.(*WebSearchPreviewTool); ok {
@@ -367,6 +366,16 @@ func (p *Provider) buildRequestParams(config *llm.Config) (responses.ResponseNew
 			mcpParam.Headers = headers
 		}
 		params.Tools = append(params.Tools, tool)
+	}
+
+	// Includes are used to request additional data in the response. They are
+	// finalized here so tool-requested includes (set during tool conversion)
+	// are merged with any set earlier (e.g. reasoning encrypted content).
+	if len(includes) > 0 {
+		params.Include = make([]responses.ResponseIncludable, 0, len(includes))
+		for include := range includes {
+			params.Include = append(params.Include, responses.ResponseIncludable(include))
+		}
 	}
 	return params, nil
 }

--- a/providers/openai/responses_extra_test.go
+++ b/providers/openai/responses_extra_test.go
@@ -1,0 +1,103 @@
+package openai
+
+import (
+	"testing"
+
+	"github.com/deepnoodle-ai/dive/llm"
+	"github.com/deepnoodle-ai/wonton/assert"
+	"github.com/deepnoodle-ai/wonton/schema"
+	"github.com/openai/openai-go/v3/responses"
+)
+
+func TestDecodeFileSearchCallContent(t *testing.T) {
+	call := responses.ResponseFileSearchToolCall{
+		ID:      "fs_1",
+		Queries: []string{"tesla production 2024"},
+		Status:  "completed",
+		Results: []responses.ResponseFileSearchToolCallResult{
+			{FileID: "file_1", Filename: "tesla-10k.pdf", Score: 0.91, Text: "produced 1,773,443 vehicles"},
+		},
+	}
+	contents, err := decodeFileSearchCallContent(call)
+	assert.NoError(t, err)
+	assert.Len(t, contents, 1)
+
+	fsc, ok := contents[0].(*FileSearchCallContent)
+	assert.True(t, ok)
+	assert.Equal(t, "fs_1", fsc.ID)
+	assert.Equal(t, "completed", fsc.Status)
+	assert.Len(t, fsc.Queries, 1)
+	assert.Len(t, fsc.Results, 1)
+	assert.Equal(t, "file_1", fsc.Results[0].FileID)
+	assert.Equal(t, "tesla-10k.pdf", fsc.Results[0].Filename)
+	assert.Equal(t, "produced 1,773,443 vehicles", fsc.Results[0].Text)
+}
+
+func TestDecodeAssistantResponse_ReasoningTokens(t *testing.T) {
+	resp := &responses.Response{
+		ID: "resp_1",
+		Usage: responses.ResponseUsage{
+			InputTokens:         100,
+			OutputTokens:        50,
+			InputTokensDetails:  responses.ResponseUsageInputTokensDetails{CachedTokens: 10},
+			OutputTokensDetails: responses.ResponseUsageOutputTokensDetails{ReasoningTokens: 20},
+		},
+	}
+	out, err := decodeAssistantResponse(resp)
+	assert.NoError(t, err)
+	assert.Equal(t, 100, out.Usage.InputTokens)
+	assert.Equal(t, 50, out.Usage.OutputTokens)
+	assert.Equal(t, 10, out.Usage.CacheReadInputTokens)
+	assert.Equal(t, 20, out.Usage.ReasoningTokens)
+}
+
+// fakeIncludeTool implements llm.Tool, ResponsesToolProvider, and
+// ResponsesIncludeProvider for testing include wiring.
+type fakeIncludeTool struct {
+	includes []responses.ResponseIncludable
+}
+
+func (f *fakeIncludeTool) Name() string           { return "fake" }
+func (f *fakeIncludeTool) Description() string    { return "fake tool" }
+func (f *fakeIncludeTool) Schema() *schema.Schema { return nil }
+func (f *fakeIncludeTool) ResponsesToolParam() responses.ToolUnionParam {
+	return responses.ToolUnionParam{OfWebSearch: &responses.WebSearchToolParam{Type: "web_search"}}
+}
+func (f *fakeIncludeTool) ResponsesIncludes() []responses.ResponseIncludable { return f.includes }
+
+func TestBuildRequestParams_ToolIncludes(t *testing.T) {
+	provider := New(WithAPIKey("test"))
+
+	config := &llm.Config{}
+	config.Apply(
+		llm.WithMessages(llm.NewUserTextMessage("hi")),
+		llm.WithTools(&fakeIncludeTool{
+			includes: []responses.ResponseIncludable{"file_search_call.results"},
+		}),
+	)
+
+	params, err := provider.buildRequestParams(config)
+	assert.NoError(t, err)
+
+	found := false
+	for _, inc := range params.Include {
+		if inc == responses.ResponseIncludable("file_search_call.results") {
+			found = true
+		}
+	}
+	assert.True(t, found, "expected file_search_call.results in params.Include")
+}
+
+func TestBuildRequestParams_NoIncludesWhenToolOptsOut(t *testing.T) {
+	provider := New(WithAPIKey("test"))
+
+	config := &llm.Config{}
+	config.Apply(
+		llm.WithMessages(llm.NewUserTextMessage("hi")),
+		llm.WithTools(&fakeIncludeTool{includes: nil}),
+	)
+
+	params, err := provider.buildRequestParams(config)
+	assert.NoError(t, err)
+	assert.Empty(t, params.Include)
+}

--- a/providers/openai/stream_iterator.go
+++ b/providers/openai/stream_iterator.go
@@ -447,8 +447,10 @@ func (s *openaiStreamIterator) processOpenAIEvent(event responses.ResponseStream
 
 	case responses.ResponseCompletedEvent:
 		s.finalUsage = &llm.Usage{
-			InputTokens:  int(data.Response.Usage.InputTokens),
-			OutputTokens: int(data.Response.Usage.OutputTokens),
+			InputTokens:          int(data.Response.Usage.InputTokens),
+			OutputTokens:         int(data.Response.Usage.OutputTokens),
+			CacheReadInputTokens: int(data.Response.Usage.InputTokensDetails.CachedTokens),
+			ReasoningTokens:      int(data.Response.Usage.OutputTokensDetails.ReasoningTokens),
 		}
 		stopReason := determineStopReason(&data.Response)
 
@@ -468,8 +470,10 @@ func (s *openaiStreamIterator) processOpenAIEvent(event responses.ResponseStream
 
 	case responses.ResponseIncompleteEvent:
 		s.finalUsage = &llm.Usage{
-			InputTokens:  int(data.Response.Usage.InputTokens),
-			OutputTokens: int(data.Response.Usage.OutputTokens),
+			InputTokens:          int(data.Response.Usage.InputTokens),
+			OutputTokens:         int(data.Response.Usage.OutputTokens),
+			CacheReadInputTokens: int(data.Response.Usage.InputTokensDetails.CachedTokens),
+			ReasoningTokens:      int(data.Response.Usage.OutputTokensDetails.ReasoningTokens),
 		}
 		stopReason := determineStopReason(&data.Response)
 

--- a/providers/openai/tool.go
+++ b/providers/openai/tool.go
@@ -9,3 +9,12 @@ import "github.com/openai/openai-go/v3/responses"
 type ResponsesToolProvider interface {
 	ResponsesToolParam() responses.ToolUnionParam
 }
+
+// ResponsesIncludeProvider is an optional interface that a ResponsesToolProvider
+// may also implement to request additional data be returned in the response via
+// the Responses API `include` parameter (e.g. "code_interpreter_call.outputs" or
+// "file_search_call.results"). The provider merges these with any other includes
+// it sets for the request.
+type ResponsesIncludeProvider interface {
+	ResponsesIncludes() []responses.ResponseIncludable
+}


### PR DESCRIPTION
Stacked on #169 (base branch `add-opus-4.8-and-latest-models`). Deepens the Grok/X.AI integration based on the xAI Responses API tool docs.

## Grok provider
- **`CodeExecutionTool`** — sandboxed Python via the xAI `code_interpreter` tool. `IncludeOutputs` opts into returning the executed code + outputs.
- **`CollectionsSearchTool`** — search uploaded collections (knowledge bases) via `file_search`; collection IDs map to vector store IDs. Supports `MaxNumResults` (1–50) and `IncludeResults`.
- **`WebSearchTool.EnableImageSearch`** — let Grok search for and embed relevant images (distinct from the existing `EnableImageUnderstanding`).
- **Fix:** X-search handle limit corrected to **20** (per docs); was capped at 10.
- **Remote MCP** already works for Grok via core `llm.MCPServerConfig` — now documented.

## OpenAI Responses provider (shared infrastructure)
- **`ResponsesIncludeProvider`** interface — a server-side tool can request response `include` data (e.g. `code_interpreter_call.outputs`, `file_search_call.results`). Includes are finalized after tool conversion so tool-requested and reasoning includes merge.
- **`file_search` decoding** — implemented `FileSearchCallContent` instead of returning an "unsupported" error.
- **Reasoning tokens** captured from the Responses API; the streaming path also now fills `CacheReadInputTokens`.

## Core
- **`llm.Usage.ReasoningTokens`** — output tokens a provider spent reasoning (a subset of `OutputTokens`), populated for the OpenAI Responses API and Grok.

## Docs / examples / tests
- New `docs/guides/grok.md` covering every Grok server-side tool, remote MCP, citations, and reasoning-token usage.
- Two example programs: `grok_search_example` (web + X search, citations, usage) and `grok_code_execution_example` (code interpreter, executed code, usage).
- Unit tests for every new/changed tool and the new decode/include paths, plus a code-execution integration test.

All modules build; `llm`, `providers/openai`, and `providers/grok` test suites pass (the Grok code-execution integration test also passed against the live xAI API).

🤖 Generated with [Claude Code](https://claude.com/claude-code)