### PR TITLE
Fix flaky TestToolCallStream by forcing tool choice

### DIFF
--- a/providers/anthropic/anthropic_test.go
+++ b/providers/anthropic/anthropic_test.go
@@ -114,9 +114,16 @@ func TestToolCallStream(t *testing.T) {
 			},
 		})
 
+	// Force the calculator tool so the test deterministically exercises the
+	// tool-call streaming path. Without this, the model may answer "2+2"
+	// directly and emit no tool call (flaky).
 	iterator, err := provider.Stream(ctx,
 		llm.WithMessages(llm.NewUserTextMessage("What is 2+2?")),
 		llm.WithTools(calculatorTool),
+		llm.WithToolChoice(&llm.ToolChoice{
+			Type: llm.ToolChoiceTypeTool,
+			Name: "calculator",
+		}),
 	)
 
 	assert.NoError(t, err)


### PR DESCRIPTION
`TestToolCallStream` streams *"What is 2+2?"* with a calculator tool and asserts exactly one tool call (`len(toolCalls) == 1`). Since #169 bumped the Anthropic default to **Opus 4.8** — whose adaptive thinking answers trivial arithmetic directly more often — the model frequently emits **no** tool call, so the assertion intermittently sees `0`:

```
--- FAIL: TestToolCallStream
    anthropic_test.go:140: mismatch (-want +got): int( - 0, + 1 )
```

**Fix:** force the calculator via `tool_choice` so the test deterministically exercises the tool-call streaming/accumulation path it's meant to verify (rather than relying on the model's whim). Forced tool use is valid here because the test doesn't enable thinking.

Verified by running the test **5×** against the live API — all pass, including the `operation=add`, `a=2`, `b=2` argument assertions.

(Removing the test was an option, but forcing the tool keeps the valuable streaming-accumulation coverage at no flakiness cost.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)