### PR TITLE
Remove unreachable arg-count guard in CLI getInput

### DIFF
--- a/experimental/cmd/dive/main.go
+++ b/experimental/cmd/dive/main.go
@@ -524,9 +524,9 @@ func appendAttachedContent(input, attachment string) string {
 }
 
 func getInput(args []string) (string, error) {
-	if len(args) > 1 {
-		return "", fmt.Errorf("expected at most 1 argument, got %d", len(args))
-	}
+	// The main command declares a single optional positional ("prompt?"), so the
+	// parser caps args at one element (extras are rejected as "unexpected
+	// argument" before we get here).
 	if len(args) == 1 {
 		return strings.TrimSpace(args[0]), nil
 	}


### PR DESCRIPTION
## Summary

Follow-up tidy-up to the `-p` positional-prompt fix that shipped with #152.

The main `dive` command now declares a single optional positional argument (`Args("prompt?")`). The parser therefore caps positionals at one and rejects extras as `unexpected argument` *before* `runPrint` calls `getInput`. Since `getInput`'s only caller passes `ctx.Args()` from that command, its `len(args) > 1` branch is unreachable dead code.

This removes the guard and documents the invariant. No behavior change.

## Verification

```
echo x | dive -p      -> reads stdin
dive -p               -> "no input provided" (no arg, no stdin)
dive -p one two       -> "unexpected argument: one" (rejected by parser)
```

`gofmt` clean, `go build` + `go vet` pass on the CLI module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)