### PR TITLE
Parse disallowed-tools from subagent markdown frontmatter

### DIFF
--- a/docs/guides/subagents.md
+++ b/docs/guides/subagents.md
@@ -75,6 +75,7 @@ Be specific. Reference line numbers. Suggest fixes.
 | `description` | string | When the LLM should use this agent (shown in the tool description) |
 | `model` | string | Optional, provider-agnostic model identifier a custom `AgentFactory` can route on. The built-in factory ignores it. |
 | `tools` | string[] | Allowed tool names. Omit to inherit all parent tools. |
+| `disallowed-tools` | string[] | Tool names to exclude (matched case-insensitively). Applied after `tools`, or to the full inherited set when `tools` is omitted. |
 
 Use `subagent.GeneralPurpose` for a general-purpose agent that inherits the parent's tools, even without custom definitions.
 

--- a/subagent/loader.go
+++ b/subagent/loader.go
@@ -106,9 +106,10 @@ func (m *MapLoader) Load(ctx context.Context) (map[string]*Definition, error) {
 
 // frontmatter represents the YAML frontmatter in a subagent markdown file.
 type frontmatter struct {
-	Description string   `yaml:"description"`
-	Model       string   `yaml:"model,omitempty"`
-	Tools       []string `yaml:"tools,omitempty"`
+	Description     string   `yaml:"description"`
+	Model           string   `yaml:"model,omitempty"`
+	Tools           []string `yaml:"tools,omitempty"`
+	DisallowedTools []string `yaml:"disallowed-tools,omitempty"`
 }
 
 // LoadFromDirectory loads subagent definitions from a single directory.
@@ -173,10 +174,11 @@ func loadFile(path string) (*Definition, error) {
 	}
 
 	return &Definition{
-		Description: frontm.Description,
-		Prompt:      strings.TrimSpace(body),
-		Tools:       frontm.Tools,
-		Model:       frontm.Model,
+		Description:     frontm.Description,
+		Prompt:          strings.TrimSpace(body),
+		Tools:           frontm.Tools,
+		DisallowedTools: frontm.DisallowedTools,
+		Model:           frontm.Model,
 	}, nil
 }
 

--- a/subagent/subagent_test.go
+++ b/subagent/subagent_test.go
@@ -266,6 +266,37 @@ You are a code reviewer. Analyze the code and provide feedback.`
 		assert.Contains(t, def.Prompt, "code reviewer")
 	})
 
+	t.Run("Load parses disallowed-tools frontmatter", func(t *testing.T) {
+		dir := t.TempDir()
+
+		content := `---
+description: Read-only reviewer
+disallowed-tools:
+  - Edit
+  - Bash
+---
+You review code without modifying it.`
+
+		err := os.WriteFile(filepath.Join(dir, "reviewer.md"), []byte(content), 0644)
+		assert.NoError(t, err)
+
+		loader := &FileLoader{
+			Directories: []string{dir},
+		}
+
+		defs, err := loader.Load(context.Background())
+		assert.NoError(t, err)
+
+		def := defs["reviewer"]
+		assert.Equal(t, []string{"Edit", "Bash"}, def.DisallowedTools)
+
+		// And it is honored by FilterTools.
+		allTools := []dive.Tool{&mockTool{name: "Read"}, &mockTool{name: "Edit"}, &mockTool{name: "Bash"}}
+		filtered := FilterTools(def, allTools)
+		assert.Equal(t, 1, len(filtered))
+		assert.Equal(t, "Read", filtered[0].Name())
+	})
+
 	t.Run("Load skips non-markdown files", func(t *testing.T) {
 		dir := t.TempDir()
 


### PR DESCRIPTION
## Summary

Ports the one piece of #151 that wasn't already delivered by #152.

#152 added `Definition.DisallowedTools` and the denylist logic in `FilterTools` (case-insensitive, combinable with the `tools` allowlist), but the markdown loader's frontmatter parser only handled `description`/`model`/`tools`. As a result, file-defined subagents (`.dive/agents/*.md`) could **not** declare a denylist — the field existed and was enforced, but nothing populated it from frontmatter.

This adds the missing wiring:
- New `disallowed-tools` YAML key in the frontmatter struct
- Threaded into the constructed `Definition`
- `FilterTools` already enforces it — no logic change needed
- Loader test covering parsing + enforcement
- Documented the field in the sub-agents guide

```yaml
---
description: Read-only reviewer
disallowed-tools:
  - Edit
  - Bash
---
```

## Context

This supersedes the remaining unique part of #151 (which was closed as duplicated by #152). #151 targeted the old `experimental/subagent/` path that #152 relocated to `subagent/`; this change applies cleanly to the current package.

## Test plan

- `go test ./subagent/` — new `TestFileLoader/Load_parses_disallowed-tools_frontmatter` plus existing `FilterTools` denylist cases pass
- `go build ./...`, `gofmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)