### PR TITLE
Prepare v1.7.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,25 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [1.7.0] - 2026-05-29
+
 ### Added
 
-- **Latest OpenAI models** — added `gpt-5.5`, `gpt-5.4-mini`,
-  `gpt-5.4-nano`, and `gpt-image-2`; OpenAI defaults now use `gpt-5.5`
-  for text and `gpt-image-2` for image generation. Reasoning effort is now
-  normalized for known OpenAI, Grok, and Anthropic model families without
-  tightening the public `llm.ReasoningEffort` string type.
+- **Text-to-speech and transcription** — new `media.TextToSpeech` and
+  `media.Transcribe` functions backed by `TextToSpeechProvider` /
+  `TranscriptionProvider` interfaces, an `AudioFormat` type
+  (mp3/opus/aac/flac/wav/pcm), and options for voice, voice instructions,
+  speech speed, audio format, language, and transcription prompt. Supported on
+  OpenAI (`gpt-4o-mini-tts`, `gpt-4o-transcribe`, `gpt-4o-mini-transcribe`,
+  `gpt-4o-transcribe-diarize`, `whisper-1`) and Google
+  (`gemini-2.5-flash-preview-tts`, `gemini-2.5-pro-preview-tts`,
+  `gemini-3.1-flash-tts-preview`), with new text-to-speech and transcription
+  examples.
+- **Latest OpenAI models** — added `gpt-5.5`, `gpt-5.4-mini`, `gpt-5.4-nano`,
+  and `gpt-image-2`; OpenAI defaults now use `gpt-5.5` for text and
+  `gpt-image-2` for image generation. Reasoning effort is now normalized for
+  known OpenAI, Grok, and Anthropic model families without tightening the
+  public `llm.ReasoningEffort` string type.
 
 ## [1.6.0] - 2026-05-29
 

--- a/a2a/go.mod
+++ b/a2a/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/a2aproject/a2a-go/v2 v2.2.0
-	github.com/deepnoodle-ai/dive v1.6.0
+	github.com/deepnoodle-ai/dive v1.7.0
 	github.com/deepnoodle-ai/wonton v0.0.34
 )
 

--- a/examples/go.mod
+++ b/examples/go.mod
@@ -3,13 +3,13 @@ module github.com/deepnoodle-ai/dive/examples
 go 1.25.0
 
 require (
-	github.com/deepnoodle-ai/dive v1.6.0
-	github.com/deepnoodle-ai/dive/a2a v1.6.0
-	github.com/deepnoodle-ai/dive/experimental/mcp v1.6.0
-	github.com/deepnoodle-ai/dive/otel v1.6.0
-	github.com/deepnoodle-ai/dive/providers/google v1.6.0
-	github.com/deepnoodle-ai/dive/providers/grok v1.6.0
-	github.com/deepnoodle-ai/dive/providers/openai v1.6.0
+	github.com/deepnoodle-ai/dive v1.7.0
+	github.com/deepnoodle-ai/dive/a2a v1.7.0
+	github.com/deepnoodle-ai/dive/experimental/mcp v1.7.0
+	github.com/deepnoodle-ai/dive/otel v1.7.0
+	github.com/deepnoodle-ai/dive/providers/google v1.7.0
+	github.com/deepnoodle-ai/dive/providers/grok v1.7.0
+	github.com/deepnoodle-ai/dive/providers/openai v1.7.0
 	github.com/deepnoodle-ai/wonton v0.0.34
 	github.com/fatih/color v1.18.0
 	github.com/mark3labs/mcp-go v0.45.0

--- a/experimental/cmd/dive/go.mod
+++ b/experimental/cmd/dive/go.mod
@@ -3,10 +3,10 @@ module github.com/deepnoodle-ai/dive/experimental/cmd/dive
 go 1.25.0
 
 require (
-	github.com/deepnoodle-ai/dive v1.6.0
-	github.com/deepnoodle-ai/dive/providers/google v1.6.0
-	github.com/deepnoodle-ai/dive/providers/grok v1.6.0
-	github.com/deepnoodle-ai/dive/providers/openai v1.6.0
+	github.com/deepnoodle-ai/dive v1.7.0
+	github.com/deepnoodle-ai/dive/providers/google v1.7.0
+	github.com/deepnoodle-ai/dive/providers/grok v1.7.0
+	github.com/deepnoodle-ai/dive/providers/openai v1.7.0
 	github.com/deepnoodle-ai/wonton v0.0.34
 	github.com/mattn/go-runewidth v0.0.21
 )

--- a/experimental/mcp/go.mod
+++ b/experimental/mcp/go.mod
@@ -3,7 +3,7 @@ module github.com/deepnoodle-ai/dive/experimental/mcp
 go 1.25.0
 
 require (
-	github.com/deepnoodle-ai/dive v1.6.0
+	github.com/deepnoodle-ai/dive v1.7.0
 	github.com/deepnoodle-ai/wonton v0.0.34
 	github.com/mark3labs/mcp-go v0.45.0
 )

--- a/otel/go.mod
+++ b/otel/go.mod
@@ -3,7 +3,7 @@ module github.com/deepnoodle-ai/dive/otel
 go 1.25.0
 
 require (
-	github.com/deepnoodle-ai/dive v1.6.0
+	github.com/deepnoodle-ai/dive v1.7.0
 	go.opentelemetry.io/otel v1.43.0
 	go.opentelemetry.io/otel/metric v1.43.0
 	go.opentelemetry.io/otel/sdk v1.43.0

--- a/providers/google/go.mod
+++ b/providers/google/go.mod
@@ -3,7 +3,7 @@ module github.com/deepnoodle-ai/dive/providers/google
 go 1.25.0
 
 require (
-	github.com/deepnoodle-ai/dive v1.6.0
+	github.com/deepnoodle-ai/dive v1.7.0
 	github.com/deepnoodle-ai/wonton v0.0.34
 	google.golang.org/genai v1.51.0
 )

--- a/providers/grok/go.mod
+++ b/providers/grok/go.mod
@@ -3,8 +3,8 @@ module github.com/deepnoodle-ai/dive/providers/grok
 go 1.25.0
 
 require (
-	github.com/deepnoodle-ai/dive v1.6.0
-	github.com/deepnoodle-ai/dive/providers/openai v1.6.0
+	github.com/deepnoodle-ai/dive v1.7.0
+	github.com/deepnoodle-ai/dive/providers/openai v1.7.0
 	github.com/deepnoodle-ai/wonton v0.0.34
 	github.com/openai/openai-go/v3 v3.29.0
 	golang.org/x/image v0.38.0

--- a/providers/openai/go.mod
+++ b/providers/openai/go.mod
@@ -3,7 +3,7 @@ module github.com/deepnoodle-ai/dive/providers/openai
 go 1.25.0
 
 require (
-	github.com/deepnoodle-ai/dive v1.6.0
+	github.com/deepnoodle-ai/dive v1.7.0
 	github.com/deepnoodle-ai/wonton v0.0.34
 	github.com/openai/openai-go/v3 v3.29.0
 	golang.org/x/image v0.38.0


### PR DESCRIPTION
Prepares the v1.7.0 release. Two PRs landed after v1.6.0 (earlier today) and are covered here:

- **#176 / #177 — Text-to-speech and transcription** — new `media.TextToSpeech` and `media.Transcribe` functions backed by `TextToSpeechProvider` / `TranscriptionProvider` interfaces, an `AudioFormat` type (mp3/opus/aac/flac/wav/pcm), and options for voice, voice instructions, speech speed, audio format, language, and transcription prompt. Supported on OpenAI (`gpt-4o-mini-tts`, `gpt-4o-transcribe`, `gpt-4o-mini-transcribe`, `gpt-4o-transcribe-diarize`, `whisper-1`) and Google (`gemini-2.5-flash-preview-tts`, `gemini-2.5-pro-preview-tts`, `gemini-3.1-flash-tts-preview`), with new examples.
- **#175 — Latest OpenAI models** — `gpt-5.5`, `gpt-5.4-mini`, `gpt-5.4-nano`, `gpt-image-2`; `gpt-5.5` / `gpt-image-2` defaults; normalized reasoning effort for known model families. (Already drafted under Unreleased.)

## Changes

- Move the `[Unreleased]` CHANGELOG content into a dated `[1.7.0] - 2026-05-29` section and add the text-to-speech / transcription entry.
- Bump intra-repo module version references from `v1.6.0` to `v1.7.0` across all 8 sub-modules and run `make tidy-all`.

## After merge

Tag the merge commit with `v1.7.0` plus the 8 sub-module tags (`make tag-modules VERSION=v1.7.0`) and `git push origin --tags`, matching the v1.6.0 process.

🤖 Generated with [Claude Code](https://claude.com/claude-code)