### PR TITLE
Add Claude Fable 5 and Claude Mythos 5 support

### DIFF
--- a/experimental/cmd/dive/models.go
+++ b/experimental/cmd/dive/models.go
@@ -16,6 +16,8 @@ type modelInfo struct {
 // More specific patterns must appear before broader ones.
 var modelCatalog = []modelInfo{
 	// Anthropic models
+	{"claude-fable-5", "Fable 5", 1_000_000},
+	{"claude-mythos-5", "Mythos 5", 1_000_000},
 	{"claude-opus-4-8", "Opus 4.8", 1_000_000},
 	{"claude-opus-4-7", "Opus 4.7", 1_000_000},
 	{"claude-opus-4-6", "Opus 4.6", 1_000_000},
@@ -133,7 +135,8 @@ var providerCatalog = []providerInfo{
 		Name:    "Anthropic",
 		EnvVars: []string{"ANTHROPIC_API_KEY"},
 		Models: []modelChoice{
-			{"claude-opus-4-8", "Opus 4.8", "Most capable for complex work"},
+			{"claude-fable-5", "Fable 5", "Most capable for demanding reasoning and long-horizon work"},
+			{"claude-opus-4-8", "Opus 4.8", "Most capable Opus-tier model for complex work"},
 			{"claude-sonnet-4-6", "Sonnet 4.6", "Best for everyday tasks"},
 			{"claude-haiku-4-5", "Haiku 4.5", "Fastest for quick answers"},
 		},

--- a/providers/anthropic/anthropic.go
+++ b/providers/anthropic/anthropic.go
@@ -392,11 +392,12 @@ func (p *Provider) applyRequestConfig(req *Request, config *llm.Config) error {
 
 // applyReasoningConfig maps Dive's reasoning/thinking options onto the Anthropic
 // request, accounting for per-model differences:
-//   - Opus 4.5+ and Sonnet 4.6 take the native effort parameter via
-//     output_config; older models emulate effort with a thinking budget.
-//   - Opus 4.6/4.7/4.8 and Sonnet 4.6 support adaptive thinking. Opus 4.7/4.8
-//     reject manual budgets, so a budget set against them transparently falls
-//     back to adaptive thinking.
+//   - Opus 4.5+, Sonnet 4.6, and the Claude 5 models (Fable 5, Mythos 5) take
+//     the native effort parameter via output_config; older models emulate
+//     effort with a thinking budget.
+//   - Opus 4.6/4.7/4.8, Sonnet 4.6, and the Claude 5 models support adaptive
+//     thinking. Opus 4.7/4.8 and the Claude 5 models reject manual budgets, so
+//     a budget set against them transparently falls back to adaptive thinking.
 func applyReasoningConfig(req *Request, config *llm.Config) error {
 	model := req.Model
 
@@ -443,7 +444,7 @@ func applyReasoningConfig(req *Request, config *llm.Config) error {
 // resolveThinking determines the thinking configuration from the budget and
 // explicit thinking-type options, independent of the effort parameter.
 func resolveThinking(model string, config *llm.Config) (*Thinking, error) {
-	adaptiveOnly := modelRejectsManualThinking(model) // Opus 4.7/4.8
+	adaptiveOnly := modelRejectsManualThinking(model) // Opus 4.7/4.8, Fable 5, Mythos 5
 
 	switch config.Thinking {
 	case llm.ThinkingTypeDisabled:
@@ -521,14 +522,16 @@ func legacyEffortBudget(effort llm.ReasoningEffort) (int, error) {
 }
 
 // modelSupportsEffortParam reports whether the model accepts the native
-// output_config.effort parameter (Opus 4.5+ and Sonnet 4.6).
+// output_config.effort parameter (Opus 4.5+, Sonnet 4.6, Fable 5, Mythos 5).
 func modelSupportsEffortParam(model string) bool {
 	switch {
 	case strings.HasPrefix(model, "claude-opus-4-5"),
 		strings.HasPrefix(model, "claude-opus-4-6"),
 		strings.HasPrefix(model, "claude-opus-4-7"),
 		strings.HasPrefix(model, "claude-opus-4-8"),
-		strings.HasPrefix(model, "claude-sonnet-4-6"):
+		strings.HasPrefix(model, "claude-sonnet-4-6"),
+		strings.HasPrefix(model, "claude-fable-5"),
+		strings.HasPrefix(model, "claude-mythos-5"):
 		return true
 	}
 	return false
@@ -536,21 +539,31 @@ func modelSupportsEffortParam(model string) bool {
 
 func modelSupportsXHighEffort(model string) bool {
 	return strings.HasPrefix(model, "claude-opus-4-7") ||
-		strings.HasPrefix(model, "claude-opus-4-8")
+		strings.HasPrefix(model, "claude-opus-4-8") ||
+		strings.HasPrefix(model, "claude-fable-5") ||
+		strings.HasPrefix(model, "claude-mythos-5")
 }
 
 func modelSupportsMaxEffort(model string) bool {
 	return strings.HasPrefix(model, "claude-opus-4-6") ||
 		strings.HasPrefix(model, "claude-opus-4-7") ||
 		strings.HasPrefix(model, "claude-opus-4-8") ||
-		strings.HasPrefix(model, "claude-sonnet-4-6")
+		strings.HasPrefix(model, "claude-sonnet-4-6") ||
+		strings.HasPrefix(model, "claude-fable-5") ||
+		strings.HasPrefix(model, "claude-mythos-5")
 }
 
 // modelRejectsManualThinking reports whether the model rejects manual extended
-// thinking budgets and supports only adaptive thinking (Opus 4.7 and 4.8).
+// thinking budgets and supports only adaptive thinking (Opus 4.7/4.8, Fable 5,
+// Mythos 5). On the Claude 5 models adaptive thinking is always on and an
+// explicit thinking disable is also rejected by the API; Dive already omits
+// the thinking parameter entirely when thinking is disabled, so disables are
+// safe across all of these models.
 func modelRejectsManualThinking(model string) bool {
 	return strings.HasPrefix(model, "claude-opus-4-7") ||
-		strings.HasPrefix(model, "claude-opus-4-8")
+		strings.HasPrefix(model, "claude-opus-4-8") ||
+		strings.HasPrefix(model, "claude-fable-5") ||
+		strings.HasPrefix(model, "claude-mythos-5")
 }
 
 // createRequest creates an HTTP request with appropriate headers for Anthropic API calls

--- a/providers/anthropic/models.go
+++ b/providers/anthropic/models.go
@@ -28,6 +28,11 @@ const (
 	// Claude 4.7 models
 	ModelClaudeOpus47 = "claude-opus-4-7"
 
-	// Claude 4.8 models (latest)
+	// Claude 4.8 models
 	ModelClaudeOpus48 = "claude-opus-4-8"
+
+	// Claude 5 models (latest). Fable 5 is generally available; Mythos 5 is
+	// limited availability via Project Glasswing.
+	ModelClaudeFable5  = "claude-fable-5"
+	ModelClaudeMythos5 = "claude-mythos-5"
 )

--- a/providers/anthropic/pricing.go
+++ b/providers/anthropic/pricing.go
@@ -95,6 +95,20 @@ var TextModelPricing = map[string]llm.PricingInfo{
 		Currency:    "USD",
 		UpdatedAt:   "2026-05-28",
 	},
+	ModelClaudeFable5: {
+		Model:       ModelClaudeFable5,
+		InputPrice:  10.00,
+		OutputPrice: 50.00,
+		Currency:    "USD",
+		UpdatedAt:   "2026-06-09",
+	},
+	ModelClaudeMythos5: {
+		Model:       ModelClaudeMythos5,
+		InputPrice:  10.00,
+		OutputPrice: 50.00,
+		Currency:    "USD",
+		UpdatedAt:   "2026-06-09",
+	},
 }
 
 // FastModeTextPricing contains premium pricing for models when fast mode

--- a/providers/anthropic/reasoning_test.go
+++ b/providers/anthropic/reasoning_test.go
@@ -163,10 +163,43 @@ func TestModelCapabilityHelpers(t *testing.T) {
 	assert.True(t, modelSupportsEffortParam(ModelClaudeOpus48))
 	assert.True(t, modelSupportsEffortParam(ModelClaudeSonnet46))
 	assert.True(t, modelSupportsEffortParam(ModelClaudeOpus45))
+	assert.True(t, modelSupportsEffortParam(ModelClaudeFable5))
+	assert.True(t, modelSupportsEffortParam(ModelClaudeMythos5))
 	assert.False(t, modelSupportsEffortParam(ModelClaude37Sonnet20250219))
 
 	assert.True(t, modelRejectsManualThinking(ModelClaudeOpus47))
 	assert.True(t, modelRejectsManualThinking(ModelClaudeOpus48))
+	assert.True(t, modelRejectsManualThinking(ModelClaudeFable5))
+	assert.True(t, modelRejectsManualThinking(ModelClaudeMythos5))
 	assert.False(t, modelRejectsManualThinking(ModelClaudeOpus46))
 	assert.False(t, modelRejectsManualThinking(ModelClaudeSonnet46))
+
+	assert.True(t, modelSupportsXHighEffort(ModelClaudeFable5))
+	assert.True(t, modelSupportsMaxEffort(ModelClaudeFable5))
+	assert.True(t, modelSupportsXHighEffort(ModelClaudeMythos5))
+	assert.True(t, modelSupportsMaxEffort(ModelClaudeMythos5))
+}
+
+func TestReasoningEffortFable5UsesOutputConfig(t *testing.T) {
+	// Fable 5 takes the native effort parameter, including xhigh.
+	req := buildReq(t, ModelClaudeFable5, llm.WithReasoningEffort(llm.ReasoningEffortXHigh))
+	assert.NotNil(t, req.OutputConfig)
+	assert.Equal(t, "xhigh", req.OutputConfig.Effort)
+	assert.Nil(t, req.Thinking)
+}
+
+func TestReasoningBudgetFable5FallsBackToAdaptive(t *testing.T) {
+	// Fable 5 rejects manual budgets; a budget transparently becomes
+	// adaptive thinking so existing callers keep working.
+	req := buildReq(t, ModelClaudeFable5, llm.WithReasoningBudget(8000))
+	assert.NotNil(t, req.Thinking)
+	assert.Equal(t, "adaptive", req.Thinking.Type)
+	assert.Equal(t, 0, req.Thinking.BudgetTokens)
+}
+
+func TestThinkingDisabledFable5OmitsThinkingParam(t *testing.T) {
+	// Fable 5 rejects an explicit thinking disable; Dive omits the thinking
+	// parameter entirely, which is the accepted form.
+	req := buildReq(t, ModelClaudeFable5, llm.WithThinking(llm.ThinkingTypeDisabled))
+	assert.Nil(t, req.Thinking)
 }

--- a/providers/openrouter/models.go
+++ b/providers/openrouter/models.go
@@ -2,6 +2,7 @@ package openrouter
 
 const (
 	// Anthropic models
+	ModelClaudeFable5   = "anthropic/claude-fable-5"
 	ModelClaudeOpus48   = "anthropic/claude-opus-4-8"
 	ModelClaudeOpus47   = "anthropic/claude-opus-4-7"
 	ModelClaudeOpus46   = "anthropic/claude-opus-4-6"


### PR DESCRIPTION
## Summary

Adds support for Anthropic's new Claude 5 models, released June 9, 2026:

| Model | ID | Availability | Pricing | Context / Max output |
|---|---|---|---|---|
| Claude Fable 5 | `claude-fable-5` | GA | $10 / $50 per MTok | 1M / 128k |
| Claude Mythos 5 | `claude-mythos-5` | Limited (Project Glasswing) | $10 / $50 per MTok | 1M / 128k |

## Changes

- **`providers/anthropic/models.go`** — new `ModelClaudeFable5` and `ModelClaudeMythos5` constants. The provider registry already matches on the `claude-` prefix, so routing works with no registry change.
- **`providers/anthropic/pricing.go`** — pricing entries for both models.
- **`providers/anthropic/anthropic.go`** — capability helpers updated for the Claude 5 API surface (same as Opus 4.7/4.8, adaptive thinking only):
  - `modelRejectsManualThinking`: `WithReasoningBudget` transparently falls back to adaptive thinking instead of sending `thinking: {type: "enabled", budget_tokens: N}`, which returns a 400 on these models.
  - `modelSupportsEffortParam` / `modelSupportsXHighEffort` / `modelSupportsMaxEffort`: `WithReasoningEffort` maps to the native `output_config.effort` (all five levels including `xhigh`/`max`). Without this, effort would be emulated with a manual thinking budget — a guaranteed 400.
- **`providers/anthropic/reasoning_test.go`** — tests for the above, plus a test pinning that a thinking disable omits the `thinking` parameter entirely. Fable 5 newly rejects an explicit `thinking: {type: "disabled"}` (unlike Opus 4.7/4.8); Dive's existing omit-on-disable behavior is already the accepted form, so no code change was needed — the test guards against regressing that.
- **`experimental/cmd/dive/models.go`** — Fable 5 added to the model picker and context-window catalog. Mythos 5 is catalog-only (context bar works if configured) but not in the picker, since it's invitation-only.
- **`providers/openrouter/models.go`** — `ModelClaudeFable5 = "anthropic/claude-fable-5"`.

## Deliberate non-changes

- **Default model stays `claude-opus-4-8`.** Fable 5 is 2× the price; Anthropic's own guidance is to default to Opus 4.8 unless the most demanding capability is explicitly needed. Happy to flip the default if preferred.
- **No fast-mode pricing for Fable 5** — fast mode isn't offered on it.
- **Sampling params (`temperature` etc.) pass through unguarded**, consistent with existing Opus 4.7/4.8 handling — the API returns a clear 400 if set.

## Testing

- `go build ./...` and `go test ./...` pass in the root module and the `experimental/cmd/dive` module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Claude Fable 5 and Claude Mythos 5 models, each with a 1-million-token context window.
  * Extended adaptive reasoning capabilities for Claude 5 model variants.

* **Updates**
  * Refreshed Claude Opus 4.8 model description and pricing information for all new models as of June 2026.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->