### PR TITLE
Fix FileStore durability and session store races

### DIFF
--- a/session/file_store.go
+++ b/session/file_store.go
@@ -2,10 +2,12 @@ package session
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"maps"
 	"os"
 	"path/filepath"
@@ -58,6 +60,12 @@ var ErrInvalidSessionID = errors.New("invalid session ID")
 // loss between commit and the kernel flush can lose the most recent
 // completed turn. For most workloads this trade-off is correct — fsync
 // on every append costs a disk round-trip per message.
+//
+// Because appends are not atomic, a crash mid-append can also leave a
+// torn partial line at the end of the file. Open tolerates this: the
+// corrupt trailing line is dropped (consistent with the contract above
+// that the most recent turn may be lost) and the file is rewritten to
+// heal it. Corruption anywhere else in the file is treated as fatal.
 //
 // Callers who need power-loss durability for every turn can opt in by
 // constructing the store with NewFileStoreWithSync(dir, true). When
@@ -151,7 +159,7 @@ func (s *FileStore) Open(ctx context.Context, id string) (*Session, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	data, err := s.readSession(id)
+	data, torn, err := s.readSession(id)
 	if err != nil {
 		if err != ErrNotFound {
 			return nil, err
@@ -166,6 +174,13 @@ func (s *FileStore) Open(ctx context.Context, id string) (*Session, error) {
 		if err := s.writeSession(data); err != nil {
 			return nil, err
 		}
+	} else if torn {
+		// A torn trailing line (crash mid-append) was dropped during the
+		// read. Heal the file now so a future append cannot concatenate
+		// onto the garbage and turn it into fatal mid-file corruption.
+		if err := s.writeSession(data); err != nil {
+			return nil, err
+		}
 	}
 	return &Session{
 		data:     data,
@@ -174,6 +189,11 @@ func (s *FileStore) Open(ctx context.Context, id string) (*Session, error) {
 }
 
 func (s *FileStore) Put(ctx context.Context, sess *Session) error {
+	// Lock order: session first, store second. This matches SaveTurn and
+	// the suspend/resume paths, which hold the session lock while
+	// appendEvent/putSession take the store lock. Do NOT invert.
+	sess.mu.Lock()
+	defer sess.mu.Unlock()
 	if err := validateID(sess.data.ID); err != nil {
 		return err
 	}
@@ -204,7 +224,7 @@ func (s *FileStore) List(ctx context.Context, opts *ListOptions) (*ListResult, e
 			continue
 		}
 		id := strings.TrimSuffix(entry.Name(), ".jsonl")
-		data, err := s.readSession(id)
+		data, _, err := s.readSession(id)
 		if err != nil {
 			continue
 		}
@@ -304,55 +324,97 @@ func (s *FileStore) putSession(ctx context.Context, data *sessionData) error {
 
 // readSession parses a JSONL file into sessionData. Must be called with at
 // least a read lock held.
-func (s *FileStore) readSession(id string) (*sessionData, error) {
+//
+// The torn return value reports that a corrupt trailing line — the signature
+// of a crash mid-append — was dropped; callers holding the write lock should
+// rewrite the file to heal it.
+func (s *FileStore) readSession(id string) (data *sessionData, torn bool, err error) {
 	p, err := s.path(id)
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 	f, err := os.Open(p)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return nil, ErrNotFound
+			return nil, false, ErrNotFound
 		}
-		return nil, err
+		return nil, false, err
 	}
 	defer f.Close()
 
-	scanner := bufio.NewScanner(f)
-	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	// Read line-by-line with bufio.Reader rather than bufio.Scanner so
+	// there is no cap on line length — appendEvent places no limit on
+	// event size, so an oversized event must remain readable.
+	r := bufio.NewReader(f)
 
 	var header sessionHeader
 	var events []*event
 	first := true
 
-	for scanner.Scan() {
+	parseLine := func(b []byte) error {
 		var line jsonlLine
-		if err := json.Unmarshal(scanner.Bytes(), &line); err != nil {
-			return nil, err
+		if err := json.Unmarshal(b, &line); err != nil {
+			return err
 		}
 		switch line.LineType {
 		case "header":
 			if err := json.Unmarshal(line.Data, &header); err != nil {
-				return nil, err
+				return err
 			}
-			first = false
 		case "event":
 			var evt event
 			if err := json.Unmarshal(line.Data, &evt); err != nil {
-				return nil, err
+				return err
 			}
 			events = append(events, &evt)
 		default:
 			if first {
-				return nil, ErrNotFound
+				// Deliberately NOT ErrNotFound: Open treats ErrNotFound as
+				// "create a fresh session", which would overwrite the
+				// existing (unrecognized) file.
+				return fmt.Errorf("session file %s: unrecognized first line type %q", p, line.LineType)
 			}
+			// Unknown line types after the header are skipped for forward
+			// compatibility.
 		}
-	}
-	if err := scanner.Err(); err != nil {
-		return nil, err
+		first = false
+		return nil
 	}
 
-	data := &sessionData{
+	// parseFailure defers a parse error until we know whether more content
+	// follows. appendEvent is not atomic, so a crash mid-append can leave a
+	// torn partial line at the end of the file. A corrupt final line (other
+	// than the header) is dropped — the documented append durability
+	// contract already allows losing the most recent turn. Corruption
+	// anywhere else in the file is fatal.
+	var parseFailure error
+
+	for {
+		raw, readErr := r.ReadBytes('\n')
+		if line := bytes.TrimSuffix(raw, []byte{'\n'}); len(line) > 0 {
+			if parseFailure != nil {
+				// The bad line was followed by more content, so it is not
+				// a torn final append — treat it as real corruption.
+				return nil, false, parseFailure
+			}
+			if err := parseLine(line); err != nil {
+				if first {
+					// A corrupt header line is never a torn append: the
+					// header is always written atomically by writeSession.
+					return nil, false, err
+				}
+				parseFailure = err
+			}
+		}
+		if readErr == io.EOF {
+			break
+		}
+		if readErr != nil {
+			return nil, false, readErr
+		}
+	}
+
+	data = &sessionData{
 		ID:                 header.ID,
 		Title:              header.Title,
 		CreatedAt:          header.CreatedAt,
@@ -376,7 +438,7 @@ func (s *FileStore) readSession(id string) (*sessionData, error) {
 		}
 	}
 
-	return data, nil
+	return data, parseFailure != nil, nil
 }
 
 // writeSession writes a complete session as a JSONL file (header + events).

--- a/session/memory_store.go
+++ b/session/memory_store.go
@@ -2,6 +2,7 @@ package session
 
 import (
 	"context"
+	"maps"
 	"sort"
 	"sync"
 	"time"
@@ -71,13 +72,20 @@ func (s *MemoryStore) List(ctx context.Context, opts *ListOptions) (*ListResult,
 			sess.mu.RUnlock()
 			continue
 		}
+		// Copy metadata so the returned info neither races with
+		// SetMetadata nor lets callers mutate the live session map.
+		var metadata map[string]any
+		if sess.data.Metadata != nil {
+			metadata = make(map[string]any, len(sess.data.Metadata))
+			maps.Copy(metadata, sess.data.Metadata)
+		}
 		info := &SessionInfo{
 			ID:         sess.data.ID,
 			Title:      sess.data.Title,
 			CreatedAt:  sess.data.CreatedAt,
 			UpdatedAt:  sess.data.UpdatedAt,
 			EventCount: len(sess.data.Events),
-			Metadata:   sess.data.Metadata,
+			Metadata:   metadata,
 			Suspended:  suspended,
 		}
 		sess.mu.RUnlock()

--- a/session/session_test.go
+++ b/session/session_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/deepnoodle-ai/dive"
@@ -933,4 +934,165 @@ func TestSuspendReasonRoundTrip(t *testing.T) {
 	loaded := sess2.LoadSuspension()
 	assert.NotNil(t, loaded)
 	assert.Equal(t, loaded.PendingToolCalls[0].Reason, dive.SuspendReasonAuth)
+}
+
+// ---------------------------------------------------------------------------
+// FileStore durability
+// ---------------------------------------------------------------------------
+
+func TestFileStoreTornAppendRecovery(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("corrupt final line is dropped and healed", func(t *testing.T) {
+		dir := t.TempDir()
+		store, _ := session.NewFileStore(dir)
+
+		sess, _ := store.Open(ctx, "s1")
+		assert.NoError(t, sess.SaveTurn(ctx, []*llm.Message{llm.NewUserTextMessage("one")}, nil))
+		assert.NoError(t, sess.SaveTurn(ctx, []*llm.Message{llm.NewUserTextMessage("two")}, nil))
+
+		// Simulate a crash mid-append: a partial JSONL line with no
+		// trailing newline.
+		p := filepath.Join(dir, "s1.jsonl")
+		f, err := os.OpenFile(p, os.O_APPEND|os.O_WRONLY, 0644)
+		assert.NoError(t, err)
+		_, err = f.Write([]byte(`{"line_type":"event","data":{"trunc`))
+		assert.NoError(t, err)
+		assert.NoError(t, f.Close())
+
+		// Open succeeds with the prior events intact.
+		store2, _ := session.NewFileStore(dir)
+		got, err := store2.Open(ctx, "s1")
+		assert.NoError(t, err)
+		msgs, err := got.Messages(ctx)
+		assert.NoError(t, err)
+		assert.Equal(t, 2, len(msgs))
+		assert.Equal(t, "one", msgs[0].Text())
+		assert.Equal(t, "two", msgs[1].Text())
+
+		// Open healed the file, so subsequent appends must not concatenate
+		// onto the torn garbage and corrupt the session.
+		assert.NoError(t, got.SaveTurn(ctx, []*llm.Message{llm.NewUserTextMessage("three")}, nil))
+		store3, _ := session.NewFileStore(dir)
+		again, err := store3.Open(ctx, "s1")
+		assert.NoError(t, err)
+		msgs, err = again.Messages(ctx)
+		assert.NoError(t, err)
+		assert.Equal(t, 3, len(msgs))
+		assert.Equal(t, "three", msgs[2].Text())
+	})
+
+	t.Run("mid-file corruption still errors", func(t *testing.T) {
+		dir := t.TempDir()
+		store, _ := session.NewFileStore(dir)
+
+		sess, _ := store.Open(ctx, "s1")
+		assert.NoError(t, sess.SaveTurn(ctx, []*llm.Message{llm.NewUserTextMessage("one")}, nil))
+		assert.NoError(t, sess.SaveTurn(ctx, []*llm.Message{llm.NewUserTextMessage("two")}, nil))
+
+		// Corrupt a line in the middle of the file (a bad line followed by
+		// valid lines is real corruption, not a torn append).
+		p := filepath.Join(dir, "s1.jsonl")
+		b, err := os.ReadFile(p)
+		assert.NoError(t, err)
+		lines := strings.Split(strings.TrimSuffix(string(b), "\n"), "\n")
+		assert.Equal(t, 3, len(lines)) // header + 2 events
+		lines[1] = `{"line_type":"event","data":{"trunc`
+		assert.NoError(t, os.WriteFile(p, []byte(strings.Join(lines, "\n")+"\n"), 0644))
+
+		store2, _ := session.NewFileStore(dir)
+		_, err = store2.Open(ctx, "s1")
+		assert.Error(t, err)
+	})
+}
+
+func TestFileStoreLargeEvent(t *testing.T) {
+	dir := t.TempDir()
+	store, _ := session.NewFileStore(dir)
+	ctx := context.Background()
+
+	// 2MB message — beyond the 1MB line cap the old scanner-based reader
+	// imposed, which made oversized sessions unreadable after a save.
+	large := strings.Repeat("x", 2*1024*1024)
+	sess, _ := store.Open(ctx, "big")
+	assert.NoError(t, sess.SaveTurn(ctx, []*llm.Message{llm.NewUserTextMessage(large)}, nil))
+
+	store2, _ := session.NewFileStore(dir)
+	got, err := store2.Open(ctx, "big")
+	assert.NoError(t, err)
+	msgs, err := got.Messages(ctx)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(msgs))
+	assert.Equal(t, large, msgs[0].Text())
+
+	// List must also tolerate the oversized line.
+	result, err := store2.List(ctx, nil)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(result.Sessions))
+}
+
+func TestFileStoreUnrecognizedHeaderNotOverwritten(t *testing.T) {
+	dir := t.TempDir()
+	store, _ := session.NewFileStore(dir)
+	ctx := context.Background()
+
+	// A file with an unrecognized first line type (e.g. written by a future
+	// version) must cause Open to fail, NOT to treat the session as missing
+	// and destructively overwrite the file with a fresh empty session.
+	content := `{"line_type":"header_v2","data":{"id":"s1"}}` + "\n"
+	p := filepath.Join(dir, "s1.jsonl")
+	assert.NoError(t, os.WriteFile(p, []byte(content), 0644))
+
+	_, err := store.Open(ctx, "s1")
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "unrecognized first line type")
+
+	// The file must be untouched.
+	b, err := os.ReadFile(p)
+	assert.NoError(t, err)
+	assert.Equal(t, content, string(b))
+}
+
+func TestFileStorePutConcurrentWithSessionMutation(t *testing.T) {
+	dir := t.TempDir()
+	store, _ := session.NewFileStore(dir)
+	ctx := context.Background()
+
+	sess, _ := store.Open(ctx, "s1")
+
+	// Put reads sess.data (events + metadata) while other goroutines mutate
+	// the session. Put must take the session lock; run under -race to catch
+	// regressions.
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for i := 0; i < 50; i++ {
+			sess.SetMetadata("k", i)
+			_ = sess.SaveTurn(ctx, []*llm.Message{llm.NewUserTextMessage("hi")}, nil)
+		}
+	}()
+	for i := 0; i < 50; i++ {
+		assert.NoError(t, store.Put(ctx, sess))
+	}
+	<-done
+}
+
+// ---------------------------------------------------------------------------
+// MemoryStore metadata isolation
+// ---------------------------------------------------------------------------
+
+func TestMemoryStoreListMetadataIsCopy(t *testing.T) {
+	store := session.NewMemoryStore()
+	ctx := context.Background()
+
+	sess, _ := store.Open(ctx, "s1")
+	sess.SetMetadata("key", "original")
+
+	result, err := store.List(ctx, nil)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(result.Sessions))
+
+	// Mutating the returned metadata must not affect the live session.
+	result.Sessions[0].Metadata["key"] = "mutated"
+	assert.Equal(t, "original", sess.Metadata()["key"])
 }


### PR DESCRIPTION
A batch of durability and concurrency fixes in `session/`, each with a regression test.

## Fixes

- **Torn append no longer bricks a session (HIGH).** `appendEvent` is non-atomic by design, so a crash mid-append leaves a partial trailing JSONL line — and `readSession` hard-failed on any unparsable line, making the whole session permanently unreadable. `Open` now drops a corrupt *final* line (the documented append durability contract already allows losing the most recent turn) and rewrites the file to heal it, so the next append can't concatenate onto the garbage. Corruption mid-file (a bad line followed by valid lines) is still a fatal error.

- **No more 1MB read cap (HIGH).** Writes had no size limit, but `readSession` used a `bufio.Scanner` capped at 1MB lines — so a large event (big tool result, base64 image) saved fine and then every subsequent `Open`/`List` failed with "token too long". Reading now uses `bufio.Reader` with no line-size cap.

- **`FileStore.Put` data race (MEDIUM).** `Put` read `sess.data` (iterating events in `writeSession`) and assigned `sess.appender` without holding the session lock, racing with concurrent `SaveTurn`/`SetMetadata`. It now locks session-then-store, matching the lock order `SaveTurn` establishes (session lock held while `appendEvent` takes the store lock).

- **`MemoryStore.List` metadata aliasing (MEDIUM).** `SessionInfo.Metadata` aliased the live session metadata map — a data race with `SetMetadata`, and callers could mutate session internals through the returned map. The map is now copied under the session lock, mirroring `Session.Metadata()`.

- **Unrecognized header line no longer triggers a destructive overwrite (LOW but nasty).** An unrecognized `line_type` on the first line returned `ErrNotFound`, which sent `Open` down its get-or-create path and overwrote the existing file with a fresh empty session. It now returns a descriptive error and leaves the file untouched.

## Known related issue (deliberately deferred)

`FileStore.Open` returns a new `*Session` on every call, so two concurrent `Open`s of the same ID in one process yield divergent in-memory copies that can clobber each other's writes. Fixing that properly means caching live sessions per ID — out of scope for this PR.

## Testing

- `gofmt`, `go build ./...` clean
- `go test ./...` passes (root module)
- `go test -race ./session/` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session durability by correctly recovering data after unexpected shutdowns.
  * Fixed race condition where concurrent session access could corrupt metadata.
  * Enhanced error handling for malformed session files to prevent silent failures.
  * Added support for large session events (2MB+).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->