### PR TITLE
Fail closed on workspace validator errors; fix toolkit docs and TextEditor map race

### DIFF
--- a/toolkit/edit.go
+++ b/toolkit/edit.go
@@ -43,8 +43,8 @@ type EditToolOptions struct {
 	MaxFileSize int64
 
 	// WorkspaceDir restricts file edits to paths within this directory.
-	// Defaults to the current working directory if empty.
-	// Ignored when Validator is set.
+	// If empty, no workspace restriction is applied (access to the entire
+	// filesystem). Ignored when Validator is set.
 	WorkspaceDir string
 
 	// Validator is an optional shared PathValidator. When set, it is used
@@ -70,6 +70,8 @@ type EditToolOptions struct {
 type EditTool struct {
 	maxFileSize   int64
 	pathValidator *PathValidator
+	workspaceDir  string
+	configErr     error
 }
 
 // NewEditTool creates a new EditTool with the given options.
@@ -83,14 +85,20 @@ func NewEditTool(opts ...EditToolOptions) *dive.TypedToolAdapter[*EditInput] {
 		resolvedOpts.MaxFileSize = 10 * 1024 * 1024 // 10MB
 	}
 	var pathValidator *PathValidator
+	var configErr error
 	if resolvedOpts.Validator != nil {
 		pathValidator = resolvedOpts.Validator
 	} else if resolvedOpts.WorkspaceDir != "" {
-		pathValidator, _ = NewPathValidator(resolvedOpts.WorkspaceDir)
+		pathValidator, configErr = NewPathValidator(resolvedOpts.WorkspaceDir)
+		if configErr != nil {
+			configErr = fmt.Errorf("invalid workspace configuration for WorkspaceDir %q: %w", resolvedOpts.WorkspaceDir, configErr)
+		}
 	}
 	return dive.ToolAdapter(&EditTool{
 		maxFileSize:   resolvedOpts.MaxFileSize,
 		pathValidator: pathValidator,
+		workspaceDir:  resolvedOpts.WorkspaceDir,
+		configErr:     configErr,
 	})
 }
 
@@ -191,6 +199,13 @@ func (t *EditTool) PreviewCall(ctx context.Context, input *EditInput) *dive.Tool
 // On success, returns the replacement count and a diff showing context
 // around the changes.
 func (t *EditTool) Call(ctx context.Context, input *EditInput) (*dive.ToolResult, error) {
+	if t.configErr != nil {
+		return dive.NewToolResultError(fmt.Sprintf("error: %s", t.configErr.Error())), nil
+	}
+	if t.workspaceDir != "" && t.pathValidator == nil {
+		return dive.NewToolResultError(fmt.Sprintf("error: invalid workspace configuration for WorkspaceDir %q: path validator is not initialized", t.workspaceDir)), nil
+	}
+
 	// Validate inputs
 	if input.OldString == input.NewString {
 		return dive.NewToolResultError("old_string and new_string must be different"), nil

--- a/toolkit/glob.go
+++ b/toolkit/glob.go
@@ -42,8 +42,8 @@ type GlobToolOptions struct {
 	MaxResults int
 
 	// WorkspaceDir restricts searches to paths within this directory.
-	// Defaults to the current working directory if empty.
-	// Ignored when Validator is set.
+	// If empty, no workspace restriction is applied (access to the entire
+	// filesystem). Ignored when Validator is set.
 	WorkspaceDir string
 
 	// Validator is an optional shared PathValidator. When set, it is used

--- a/toolkit/grep.go
+++ b/toolkit/grep.go
@@ -103,8 +103,8 @@ type GrepToolOptions struct {
 	UseRipgrep bool
 
 	// WorkspaceDir restricts searches to paths within this directory.
-	// Defaults to the current working directory if empty.
-	// Ignored when Validator is set.
+	// If empty, no workspace restriction is applied (access to the entire
+	// filesystem). Ignored when Validator is set.
 	WorkspaceDir string
 
 	// Validator is an optional shared PathValidator. When set, it is used
@@ -133,6 +133,8 @@ type GrepTool struct {
 	useRipgrep      bool
 	ripgrepPath     string
 	pathValidator   *PathValidator
+	workspaceDir    string
+	configErr       error
 }
 
 // NewGrepTool creates a new GrepTool with the given options.
@@ -166,10 +168,14 @@ func NewGrepTool(opts ...GrepToolOptions) *dive.TypedToolAdapter[*GrepInput] {
 	}
 
 	var pathValidator *PathValidator
+	var configErr error
 	if resolvedOpts.Validator != nil {
 		pathValidator = resolvedOpts.Validator
 	} else if resolvedOpts.WorkspaceDir != "" {
-		pathValidator, _ = NewPathValidator(resolvedOpts.WorkspaceDir)
+		pathValidator, configErr = NewPathValidator(resolvedOpts.WorkspaceDir)
+		if configErr != nil {
+			configErr = fmt.Errorf("invalid workspace configuration for WorkspaceDir %q: %w", resolvedOpts.WorkspaceDir, configErr)
+		}
 	}
 
 	return dive.ToolAdapter(&GrepTool{
@@ -178,6 +184,8 @@ func NewGrepTool(opts ...GrepToolOptions) *dive.TypedToolAdapter[*GrepInput] {
 		useRipgrep:      resolvedOpts.UseRipgrep,
 		ripgrepPath:     ripgrepPath,
 		pathValidator:   pathValidator,
+		workspaceDir:    resolvedOpts.WorkspaceDir,
+		configErr:       configErr,
 	})
 }
 
@@ -311,6 +319,13 @@ func (t *GrepTool) PreviewCall(ctx context.Context, input *GrepInput) *dive.Tool
 // using Go's built-in regexp package. Results are formatted according to
 // the OutputMode setting.
 func (t *GrepTool) Call(ctx context.Context, input *GrepInput) (*dive.ToolResult, error) {
+	if t.configErr != nil {
+		return dive.NewToolResultError(fmt.Sprintf("error: %s", t.configErr.Error())), nil
+	}
+	if t.workspaceDir != "" && t.pathValidator == nil {
+		return dive.NewToolResultError(fmt.Sprintf("error: invalid workspace configuration for WorkspaceDir %q: path validator is not initialized", t.workspaceDir)), nil
+	}
+
 	// Use ripgrep if available
 	if t.ripgrepPath != "" {
 		return t.callRipgrep(ctx, input)

--- a/toolkit/list_directory.go
+++ b/toolkit/list_directory.go
@@ -59,8 +59,8 @@ type ListDirectoryToolOptions struct {
 	MaxEntries int
 
 	// WorkspaceDir restricts listings to paths within this directory.
-	// Defaults to the current working directory if empty.
-	// Ignored when Validator is set.
+	// If empty, no workspace restriction is applied (access to the entire
+	// filesystem). Ignored when Validator is set.
 	WorkspaceDir string
 
 	// Validator is an optional shared PathValidator. When set, it is used
@@ -83,6 +83,8 @@ type ListDirectoryTool struct {
 	defaultPath   string
 	maxEntries    int
 	pathValidator *PathValidator
+	workspaceDir  string
+	configErr     error
 }
 
 // NewListDirectoryTool creates a new ListDirectoryTool with the given options.
@@ -95,15 +97,21 @@ func NewListDirectoryTool(opts ...ListDirectoryToolOptions) *dive.TypedToolAdapt
 		options.MaxEntries = DefaultListDirectoryMaxEntries
 	}
 	var pathValidator *PathValidator
+	var configErr error
 	if options.Validator != nil {
 		pathValidator = options.Validator
 	} else if options.WorkspaceDir != "" {
-		pathValidator, _ = NewPathValidator(options.WorkspaceDir)
+		pathValidator, configErr = NewPathValidator(options.WorkspaceDir)
+		if configErr != nil {
+			configErr = fmt.Errorf("invalid workspace configuration for WorkspaceDir %q: %w", options.WorkspaceDir, configErr)
+		}
 	}
 	return dive.ToolAdapter(&ListDirectoryTool{
 		defaultPath:   options.DefaultPath,
 		maxEntries:    options.MaxEntries,
 		pathValidator: pathValidator,
+		workspaceDir:  options.WorkspaceDir,
+		configErr:     configErr,
 	})
 }
 
@@ -160,6 +168,13 @@ func (t *ListDirectoryTool) PreviewCall(ctx context.Context, input *ListDirector
 // array of [DirectoryEntry] objects. If the entry count exceeds MaxEntries,
 // only the first MaxEntries items are returned with a note about the limit.
 func (t *ListDirectoryTool) Call(ctx context.Context, input *ListDirectoryInput) (*dive.ToolResult, error) {
+	if t.configErr != nil {
+		return dive.NewToolResultError(fmt.Sprintf("error: %s", t.configErr.Error())), nil
+	}
+	if t.workspaceDir != "" && t.pathValidator == nil {
+		return dive.NewToolResultError(fmt.Sprintf("error: invalid workspace configuration for WorkspaceDir %q: path validator is not initialized", t.workspaceDir)), nil
+	}
+
 	dirPath := input.Path
 	if dirPath == "" {
 		dirPath = t.defaultPath

--- a/toolkit/read_file.go
+++ b/toolkit/read_file.go
@@ -43,8 +43,8 @@ type ReadFileToolOptions struct {
 	MaxSize int `json:"max_size,omitempty"`
 
 	// WorkspaceDir restricts file reads to paths within this directory.
-	// Defaults to the current working directory if empty.
-	// Ignored when Validator is set.
+	// If empty, no workspace restriction is applied (access to the entire
+	// filesystem). Ignored when Validator is set.
 	WorkspaceDir string
 
 	// Validator is an optional shared PathValidator. When set, it is used
@@ -67,6 +67,8 @@ type ReadFileToolOptions struct {
 type ReadFileTool struct {
 	maxSize       int
 	pathValidator *PathValidator
+	workspaceDir  string
+	configErr     error
 }
 
 // NewReadFileTool creates a new ReadFileTool with the given options.
@@ -79,14 +81,20 @@ func NewReadFileTool(opts ...ReadFileToolOptions) *dive.TypedToolAdapter[*ReadFi
 		options.MaxSize = DefaultReadFileMaxSize
 	}
 	var pathValidator *PathValidator
+	var configErr error
 	if options.Validator != nil {
 		pathValidator = options.Validator
 	} else if options.WorkspaceDir != "" {
-		pathValidator, _ = NewPathValidator(options.WorkspaceDir)
+		pathValidator, configErr = NewPathValidator(options.WorkspaceDir)
+		if configErr != nil {
+			configErr = fmt.Errorf("invalid workspace configuration for WorkspaceDir %q: %w", options.WorkspaceDir, configErr)
+		}
 	}
 	return dive.ToolAdapter(&ReadFileTool{
 		maxSize:       options.MaxSize,
 		pathValidator: pathValidator,
+		workspaceDir:  options.WorkspaceDir,
+		configErr:     configErr,
 	})
 }
 
@@ -143,6 +151,13 @@ func (t *ReadFileTool) PreviewCall(ctx context.Context, input *ReadFileInput) *d
 // Binary files are detected by checking for null bytes and control characters.
 // If detected, an error is returned instead of garbled content.
 func (t *ReadFileTool) Call(ctx context.Context, input *ReadFileInput) (*dive.ToolResult, error) {
+	if t.configErr != nil {
+		return dive.NewToolResultError(fmt.Sprintf("error: %s", t.configErr.Error())), nil
+	}
+	if t.workspaceDir != "" && t.pathValidator == nil {
+		return dive.NewToolResultError(fmt.Sprintf("error: invalid workspace configuration for WorkspaceDir %q: path validator is not initialized", t.workspaceDir)), nil
+	}
+
 	filePath := input.FilePath
 	if filePath == "" {
 		return NewToolResultError("Error: No file path provided."), nil

--- a/toolkit/text_editor.go
+++ b/toolkit/text_editor.go
@@ -99,8 +99,8 @@ type TextEditorToolOptions struct {
 	FileSystem FileSystem
 
 	// WorkspaceDir restricts operations to paths within this directory.
-	// Defaults to the current working directory if empty.
-	// Ignored when Validator is set.
+	// If empty, no workspace restriction is applied (access to the entire
+	// filesystem). Ignored when Validator is set.
 	WorkspaceDir string
 
 	// Validator is an optional shared PathValidator. When set, it is used
@@ -133,17 +133,22 @@ func NewTextEditorTool(opts ...TextEditorToolOptions) *dive.TypedToolAdapter[*Te
 		resolvedOpts.MaxFileSize = MaxFileSize // Default 1MB
 	}
 	var pathValidator *PathValidator
+	var configErr error
 	if resolvedOpts.Validator != nil {
 		pathValidator = resolvedOpts.Validator
 	} else if resolvedOpts.WorkspaceDir != "" {
-		pathValidator, _ = NewPathValidator(resolvedOpts.WorkspaceDir)
+		pathValidator, configErr = NewPathValidator(resolvedOpts.WorkspaceDir)
+		if configErr != nil {
+			configErr = fmt.Errorf("invalid workspace configuration for WorkspaceDir %q: %w", resolvedOpts.WorkspaceDir, configErr)
+		}
 	}
 	return dive.ToolAdapter(&TextEditorTool{
 		typeString:    resolvedOpts.Type,
 		name:          resolvedOpts.Name,
 		fs:            resolvedOpts.FileSystem,
 		pathValidator: pathValidator,
-		fileHistory:   make(map[string][]string),
+		workspaceDir:  resolvedOpts.WorkspaceDir,
+		configErr:     configErr,
 		maxFileSize:   resolvedOpts.MaxFileSize,
 	})
 }
@@ -155,8 +160,8 @@ func NewTextEditorTool(opts ...TextEditorToolOptions) *dive.TypedToolAdapter[*Te
 // files with commands that Claude models are specifically trained to use
 // effectively.
 //
-// The tool maintains edit history per file and provides detailed feedback
-// with code snippets showing the context around each change.
+// The tool provides detailed feedback with code snippets showing the
+// context around each change.
 //
 // Compatibility: This tool is designed for use with Anthropic Claude models.
 // The Type field in options should match the model version being used:
@@ -168,7 +173,8 @@ type TextEditorTool struct {
 	name          string
 	fs            FileSystem
 	pathValidator *PathValidator
-	fileHistory   map[string][]string // Edit history for potential undo
+	workspaceDir  string
+	configErr     error
 	maxFileSize   int
 }
 
@@ -283,6 +289,13 @@ func (t *TextEditorTool) Annotations() *dive.ToolAnnotations {
 // All paths must be absolute. Returns detailed feedback including
 // code snippets showing context around changes.
 func (t *TextEditorTool) Call(ctx context.Context, input *TextEditorToolInput) (*dive.ToolResult, error) {
+	if t.configErr != nil {
+		return dive.NewToolResultError(fmt.Sprintf("error: %s", t.configErr.Error())), nil
+	}
+	if t.workspaceDir != "" && t.pathValidator == nil {
+		return dive.NewToolResultError(fmt.Sprintf("error: invalid workspace configuration for WorkspaceDir %q: path validator is not initialized", t.workspaceDir)), nil
+	}
+
 	if err := t.validatePath(input.Command, input.Path); err != nil {
 		return dive.NewToolResultError(err.Error()), nil
 	}
@@ -447,9 +460,6 @@ func (t *TextEditorTool) handleStrReplace(path string, oldStr, newStr *string) (
 		return dive.NewToolResultError(fmt.Sprintf("No replacement was performed. Multiple occurrences of old_str `%s` in lines %v. Please ensure it is unique", *oldStr, lineNumbers)), nil
 	}
 
-	// Save original content to history
-	t.fileHistory[path] = append(t.fileHistory[path], content)
-
 	// Perform replacement
 	newContent := strings.Replace(content, *oldStr, newStrValue, 1)
 
@@ -489,9 +499,6 @@ func (t *TextEditorTool) handleInsert(path string, insertLine *int, newStr *stri
 	if *insertLine < 0 || *insertLine > nLines {
 		return dive.NewToolResultError(fmt.Sprintf("invalid `insert_line` parameter: %d. It should be within the range [0, %d]", *insertLine, nLines)), nil
 	}
-
-	// Save original content to history
-	t.fileHistory[path] = append(t.fileHistory[path], content)
 
 	// Insert new content
 	newStrLines := strings.Split(*newStr, "\n")

--- a/toolkit/text_editor_test.go
+++ b/toolkit/text_editor_test.go
@@ -22,7 +22,6 @@ func TestTextEditorTool_View_File(t *testing.T) {
 		fs:            fs,
 		pathValidator: testPathValidator("/"),
 		maxFileSize:   MaxFileSize,
-		fileHistory:   make(map[string][]string),
 	}
 
 	input := &TextEditorToolInput{
@@ -52,7 +51,6 @@ func TestTextEditorTool_View_FileWithRange(t *testing.T) {
 		fs:            fs,
 		pathValidator: testPathValidator("/"),
 		maxFileSize:   MaxFileSize,
-		fileHistory:   make(map[string][]string),
 	}
 
 	input := &TextEditorToolInput{
@@ -88,7 +86,6 @@ func TestTextEditorTool_View_Directory(t *testing.T) {
 		fs:            fs,
 		pathValidator: testPathValidator("/"),
 		maxFileSize:   MaxFileSize,
-		fileHistory:   make(map[string][]string),
 	}
 
 	input := &TextEditorToolInput{
@@ -113,7 +110,6 @@ func TestTextEditorTool_Create(t *testing.T) {
 		fs:            fs,
 		pathValidator: testPathValidator("/"),
 		maxFileSize:   MaxFileSize,
-		fileHistory:   make(map[string][]string),
 	}
 
 	content := "Hello, World!\nThis is a test file."
@@ -134,9 +130,6 @@ func TestTextEditorTool_Create(t *testing.T) {
 	// Verify content
 	actualContent, _ := fs.ReadFile("/test/new_file.txt")
 	assert.Equal(t, content, actualContent, "Expected content to match")
-
-	// Verify no history for create operation
-	assert.Len(t, tool.fileHistory["/test/new_file.txt"], 0, "Expected 0 history entries for create operation")
 }
 
 func TestTextEditorTool_StrReplace(t *testing.T) {
@@ -148,7 +141,6 @@ func TestTextEditorTool_StrReplace(t *testing.T) {
 		fs:            fs,
 		pathValidator: testPathValidator("/"),
 		maxFileSize:   MaxFileSize,
-		fileHistory:   make(map[string][]string),
 	}
 
 	oldStr := "This is a test."
@@ -169,10 +161,6 @@ func TestTextEditorTool_StrReplace(t *testing.T) {
 	newContent, _ := fs.ReadFile("/test/file.txt")
 	expectedContent := "Hello, World!\nThis is a successful test.\nHello, Universe!"
 	assert.Equal(t, expectedContent, newContent, "Expected content to match")
-
-	// Verify history contains original content
-	assert.Len(t, tool.fileHistory["/test/file.txt"], 1, "Expected 1 history entry")
-	assert.Equal(t, originalContent, tool.fileHistory["/test/file.txt"][0], "Expected history to contain original content")
 }
 
 func TestTextEditorTool_StrReplace_MultipleOccurrences(t *testing.T) {
@@ -183,7 +171,6 @@ func TestTextEditorTool_StrReplace_MultipleOccurrences(t *testing.T) {
 		fs:            fs,
 		pathValidator: testPathValidator("/"),
 		maxFileSize:   MaxFileSize,
-		fileHistory:   make(map[string][]string),
 	}
 
 	oldStr := "Hello, World!"
@@ -211,7 +198,6 @@ func TestTextEditorTool_Insert(t *testing.T) {
 		fs:            fs,
 		pathValidator: testPathValidator("/"),
 		maxFileSize:   MaxFileSize,
-		fileHistory:   make(map[string][]string),
 	}
 
 	insertLine := 2
@@ -232,9 +218,6 @@ func TestTextEditorTool_Insert(t *testing.T) {
 	newContent, _ := fs.ReadFile("/test/file.txt")
 	expectedContent := "line 1\nline 2\nline 3\nline 4"
 	assert.Equal(t, expectedContent, newContent, "Expected content to match")
-
-	// Verify history
-	assert.Len(t, tool.fileHistory["/test/file.txt"], 1, "Expected 1 history entry")
 }
 
 func TestTextEditorTool_ValidationErrors(t *testing.T) {
@@ -243,7 +226,6 @@ func TestTextEditorTool_ValidationErrors(t *testing.T) {
 		fs:            fs,
 		pathValidator: testPathValidator("/"),
 		maxFileSize:   MaxFileSize,
-		fileHistory:   make(map[string][]string),
 	}
 
 	tests := []struct {
@@ -364,7 +346,6 @@ func TestTextEditorTool_Integration(t *testing.T) {
 		fs:            fs,
 		pathValidator: testPathValidator("/"),
 		maxFileSize:   MaxFileSize,
-		fileHistory:   make(map[string][]string),
 	}
 
 	// 1. Create a file
@@ -422,9 +403,6 @@ func TestTextEditorTool_Integration(t *testing.T) {
 	expectedFinal := "# README\n\nThis is a comprehensive documentation file.\n\n## Features\n- Feature 1\n- Feature 3\n- Feature 2"
 
 	assert.Equal(t, expectedFinal, finalContent, "Final content should match expected content")
-
-	// 6. Verify history tracking
-	assert.Len(t, tool.fileHistory["/project/README.md"], 2, "Expected 2 history entries")
 }
 
 func TestNewTextEditorTool(t *testing.T) {
@@ -459,7 +437,6 @@ func TestTextEditorTool_PathValidation(t *testing.T) {
 		fs:            fs,
 		pathValidator: pathValidator,
 		maxFileSize:   MaxFileSize,
-		fileHistory:   make(map[string][]string),
 	}
 
 	tests := []struct {
@@ -557,7 +534,6 @@ func TestTextEditorTool_TabPreservation(t *testing.T) {
 		fs:            fs,
 		pathValidator: testPathValidator("/"),
 		maxFileSize:   MaxFileSize,
-		fileHistory:   make(map[string][]string),
 	}
 
 	// Test str_replace preserves tabs
@@ -591,7 +567,6 @@ func TestTextEditorTool_InsertTabPreservation(t *testing.T) {
 		fs:            fs,
 		pathValidator: testPathValidator("/"),
 		maxFileSize:   MaxFileSize,
-		fileHistory:   make(map[string][]string),
 	}
 
 	// Insert a new line with a tab

--- a/toolkit/toolkit.go
+++ b/toolkit/toolkit.go
@@ -28,8 +28,11 @@
 // # Path Validation
 //
 // Tools that access the filesystem use [PathValidator] to enforce workspace
-// boundaries and prevent path traversal attacks. By default, operations are
-// restricted to the configured workspace directory.
+// boundaries and prevent path traversal attacks. The file tools only apply
+// this restriction when a WorkspaceDir (or shared Validator) is configured;
+// if left empty, no workspace restriction is applied and the tool has access
+// to the entire filesystem. [BashTool] is the exception: it defaults to the
+// current working directory when WorkspaceDir is empty.
 //
 // # Creating Tools
 //

--- a/toolkit/workspace_config_test.go
+++ b/toolkit/workspace_config_test.go
@@ -1,0 +1,119 @@
+package toolkit
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/deepnoodle-ai/wonton/assert"
+)
+
+// invalidWorkspaceDir returns a workspace path that causes NewPathValidator
+// to fail: the NUL byte makes symlink resolution return an error that is not
+// os.IsNotExist.
+func invalidWorkspaceDir() string {
+	return "/tmp/bad\x00workspace"
+}
+
+func TestReadFileTool_InvalidWorkspaceFailsClosed(t *testing.T) {
+	// Create a real file that the tool must NOT read
+	tempDir := t.TempDir()
+	secretPath := filepath.Join(tempDir, "secret.txt")
+	assert.NoError(t, os.WriteFile(secretPath, []byte("secret content"), 0644))
+
+	tool := NewReadFileTool(ReadFileToolOptions{WorkspaceDir: invalidWorkspaceDir()})
+
+	result, err := tool.Call(context.Background(), &ReadFileInput{FilePath: secretPath})
+	assert.NoError(t, err)
+	assert.True(t, result.IsError, "expected config error, got success")
+	assert.Contains(t, result.Content[0].Text, "invalid workspace configuration")
+	assert.NotContains(t, result.Content[0].Text, "secret content")
+}
+
+func TestWriteFileTool_InvalidWorkspaceFailsClosed(t *testing.T) {
+	tempDir := t.TempDir()
+	targetPath := filepath.Join(tempDir, "out.txt")
+
+	tool := NewWriteFileTool(WriteFileToolOptions{WorkspaceDir: invalidWorkspaceDir()})
+
+	result, err := tool.Call(context.Background(), &WriteFileInput{
+		FilePath: targetPath,
+		Content:  "data",
+	})
+	assert.NoError(t, err)
+	assert.True(t, result.IsError, "expected config error, got success")
+	assert.Contains(t, result.Content[0].Text, "invalid workspace configuration")
+
+	// Verify the file was not written
+	_, statErr := os.Stat(targetPath)
+	assert.True(t, os.IsNotExist(statErr), "expected file to not be written")
+}
+
+func TestEditTool_InvalidWorkspaceFailsClosed(t *testing.T) {
+	tempDir := t.TempDir()
+	targetPath := filepath.Join(tempDir, "file.txt")
+	assert.NoError(t, os.WriteFile(targetPath, []byte("hello world"), 0644))
+
+	tool := NewEditTool(EditToolOptions{WorkspaceDir: invalidWorkspaceDir()})
+
+	result, err := tool.Call(context.Background(), &EditInput{
+		FilePath:  targetPath,
+		OldString: "hello",
+		NewString: "goodbye",
+	})
+	assert.NoError(t, err)
+	assert.True(t, result.IsError, "expected config error, got success")
+	assert.Contains(t, result.Content[0].Text, "invalid workspace configuration")
+
+	// Verify the file was not modified
+	content, readErr := os.ReadFile(targetPath)
+	assert.NoError(t, readErr)
+	assert.Equal(t, "hello world", string(content))
+}
+
+func TestGrepTool_InvalidWorkspaceFailsClosed(t *testing.T) {
+	tempDir := t.TempDir()
+	assert.NoError(t, os.WriteFile(filepath.Join(tempDir, "file.txt"), []byte("needle"), 0644))
+
+	tool := NewGrepTool(GrepToolOptions{WorkspaceDir: invalidWorkspaceDir()})
+
+	result, err := tool.Call(context.Background(), &GrepInput{
+		Pattern: "needle",
+		Path:    tempDir,
+	})
+	assert.NoError(t, err)
+	assert.True(t, result.IsError, "expected config error, got success")
+	assert.Contains(t, result.Content[0].Text, "invalid workspace configuration")
+}
+
+func TestListDirectoryTool_InvalidWorkspaceFailsClosed(t *testing.T) {
+	tempDir := t.TempDir()
+	assert.NoError(t, os.WriteFile(filepath.Join(tempDir, "file.txt"), []byte("x"), 0644))
+
+	tool := NewListDirectoryTool(ListDirectoryToolOptions{WorkspaceDir: invalidWorkspaceDir()})
+
+	result, err := tool.Call(context.Background(), &ListDirectoryInput{Path: tempDir})
+	assert.NoError(t, err)
+	assert.True(t, result.IsError, "expected config error, got success")
+	assert.Contains(t, result.Content[0].Text, "invalid workspace configuration")
+}
+
+func TestTextEditorTool_InvalidWorkspaceFailsClosed(t *testing.T) {
+	fs := newMockFileSystem()
+	fs.AddFile("/test/file.txt", "secret content")
+
+	tool := NewTextEditorTool(TextEditorToolOptions{
+		FileSystem:   fs,
+		WorkspaceDir: invalidWorkspaceDir(),
+	})
+
+	result, err := tool.Call(context.Background(), &TextEditorToolInput{
+		Command: CommandView,
+		Path:    "/test/file.txt",
+	})
+	assert.NoError(t, err)
+	assert.True(t, result.IsError, "expected config error, got success")
+	assert.Contains(t, result.Content[0].Text, "invalid workspace configuration")
+	assert.NotContains(t, result.Content[0].Text, "secret content")
+}

--- a/toolkit/write_file.go
+++ b/toolkit/write_file.go
@@ -25,8 +25,8 @@ type WriteFileInput struct {
 // WriteFileToolOptions configures the behavior of [WriteFileTool].
 type WriteFileToolOptions struct {
 	// WorkspaceDir restricts file writes to paths within this directory.
-	// Defaults to the current working directory if empty.
-	// Ignored when Validator is set.
+	// If empty, no workspace restriction is applied (access to the entire
+	// filesystem). Ignored when Validator is set.
 	WorkspaceDir string
 
 	// Validator is an optional shared PathValidator. When set, it is used
@@ -48,6 +48,8 @@ type WriteFileToolOptions struct {
 // permission system should be used to control which files can be written.
 type WriteFileTool struct {
 	pathValidator *PathValidator
+	workspaceDir  string
+	configErr     error
 }
 
 // NewWriteFileTool creates a new WriteFileTool with the given options.
@@ -57,13 +59,19 @@ func NewWriteFileTool(opts ...WriteFileToolOptions) *dive.TypedToolAdapter[*Writ
 		options = opts[0]
 	}
 	var pathValidator *PathValidator
+	var configErr error
 	if options.Validator != nil {
 		pathValidator = options.Validator
 	} else if options.WorkspaceDir != "" {
-		pathValidator, _ = NewPathValidator(options.WorkspaceDir)
+		pathValidator, configErr = NewPathValidator(options.WorkspaceDir)
+		if configErr != nil {
+			configErr = fmt.Errorf("invalid workspace configuration for WorkspaceDir %q: %w", options.WorkspaceDir, configErr)
+		}
 	}
 	return dive.ToolAdapter(&WriteFileTool{
 		pathValidator: pathValidator,
+		workspaceDir:  options.WorkspaceDir,
+		configErr:     configErr,
 	})
 }
 
@@ -108,6 +116,13 @@ func (t *WriteFileTool) PreviewCall(ctx context.Context, input *WriteFileInput) 
 // Creates parent directories as needed. Overwrites existing files.
 // Returns the number of bytes written on success.
 func (t *WriteFileTool) Call(ctx context.Context, input *WriteFileInput) (*dive.ToolResult, error) {
+	if t.configErr != nil {
+		return dive.NewToolResultError(fmt.Sprintf("error: %s", t.configErr.Error())), nil
+	}
+	if t.workspaceDir != "" && t.pathValidator == nil {
+		return dive.NewToolResultError(fmt.Sprintf("error: invalid workspace configuration for WorkspaceDir %q: path validator is not initialized", t.workspaceDir)), nil
+	}
+
 	filePath := input.FilePath
 	if filePath == "" {
 		return dive.NewToolResultError("Error: No file path provided. Please provide a file path either in the constructor or as an argument."), nil


### PR DESCRIPTION
## Fixes

- **Workspace validation fails open (HIGH):** `NewReadFileTool`, `NewWriteFileTool`, `NewEditTool`, `NewGrepTool`, `NewListDirectoryTool`, and `NewTextEditorTool` all discarded the `NewPathValidator` error (`pathValidator, _ = ...`) and later treated a nil validator as "allow everything" — so a misconfigured workspace silently granted unrestricted filesystem access. All six now adopt the exact `configErr` pattern already used by `BashTool` and `GlobTool`: the construction error is stored and returned from `Call` before any work is done, plus the same defensive nil-validator check.
- **Inaccurate docs (HIGH, docs-only):** The options structs claimed `WorkspaceDir` "defaults to the current working directory if empty," and the package doc claimed operations are workspace-restricted by default. In reality only Bash defaults to cwd; the file tools apply no restriction when `WorkspaceDir` is empty. Doc comments now state the truth: "If empty, no workspace restriction is applied (access to the entire filesystem)." The `toolkit` package doc notes Bash as the exception. **Note:** changing the empty-`WorkspaceDir` default to cwd is deliberately deferred — it's a breaking behavior change and will be a follow-up.
- **TextEditorTool unsynchronized map (MEDIUM-HIGH):** `fileHistory` was written from `handleStrReplace`/`handleInsert` with no mutex; the agent runs tools in parallel goroutines, and concurrent map writes are an unrecoverable runtime throw. Verified the history is never read by any production code (only test assertions; there's no undo command), so the field and both append sites were **removed** entirely — it was also an unbounded memory leak. Stale doc text about edit history was updated.

## Tests

- New `toolkit/workspace_config_test.go`: each of the six tools constructed with an invalid `WorkspaceDir` (NUL byte makes `NewPathValidator` fail) returns the config error from `Call` and performs no filesystem work (e.g. Read does not leak file contents, Write creates no file, Edit leaves the file unmodified).
- `gofmt`, `go build ./...`, and `go test ./...` all pass on the root module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Filesystem tools now fail safely when workspace configuration is invalid, returning explicit errors instead of proceeding with misconfigured settings.

* **Documentation**
  * Clarified that an empty workspace directory enables full filesystem access, and workspace restrictions are ignored when a shared validator is set.

* **Refactor**
  * Removed file history tracking from the text editor tool.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->