### PR TITLE
Fix streamed usage loss (openaicompletions) and OpenAI stream block indices

### DIFF
--- a/providers/openai/stream_iterator.go
+++ b/providers/openai/stream_iterator.go
@@ -496,12 +496,5 @@ func (s *openaiStreamIterator) processOpenAIEvent(event responses.ResponseStream
 		// For now, just ignore unhandled events
 	}
 
-	// Switch event to zero-based indexing to match Anthropic's event behavior
-	for _, event := range diveEvents {
-		if event.Index != nil {
-			*event.Index--
-		}
-	}
-
 	return diveEvents, nil
 }

--- a/providers/openai/stream_iterator_test.go
+++ b/providers/openai/stream_iterator_test.go
@@ -1,0 +1,97 @@
+package openai
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/deepnoodle-ai/dive/llm"
+	"github.com/deepnoodle-ai/wonton/assert"
+	"github.com/openai/openai-go/v3/responses"
+)
+
+// mockStreamSource replays pre-parsed SDK events through the StreamSource
+// interface used by the iterator.
+type mockStreamSource struct {
+	events []responses.ResponseStreamEventUnion
+	pos    int
+}
+
+func (m *mockStreamSource) Next() bool {
+	if m.pos < len(m.events) {
+		m.pos++
+		return true
+	}
+	return false
+}
+
+func (m *mockStreamSource) Current() responses.ResponseStreamEventUnion {
+	return m.events[m.pos-1]
+}
+
+func (m *mockStreamSource) Err() error { return nil }
+
+func (m *mockStreamSource) Close() error { return nil }
+
+// loadFixtureEvents parses an SSE fixture file into SDK stream events.
+func loadFixtureEvents(t *testing.T, path string) []responses.ResponseStreamEventUnion {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	assert.NoError(t, err)
+
+	var events []responses.ResponseStreamEventUnion
+	scanner := bufio.NewScanner(bytes.NewReader(data))
+	scanner.Buffer(make([]byte, 0, 1024*1024), 1024*1024)
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if !bytes.HasPrefix(line, []byte("data: ")) {
+			continue
+		}
+		var event responses.ResponseStreamEventUnion
+		assert.NoError(t, json.Unmarshal(bytes.TrimPrefix(line, []byte("data: ")), &event))
+		events = append(events, event)
+	}
+	assert.NoError(t, scanner.Err())
+	assert.NotEmpty(t, events)
+	return events
+}
+
+// TestStreamIteratorZeroBasedIndices verifies that content block events carry
+// the zero-based output_index from the OpenAI Responses API as-is. The fixture
+// stream has a single message item at output_index 0, so every indexed event
+// must carry index 0 (never -1).
+func TestStreamIteratorZeroBasedIndices(t *testing.T) {
+	source := &mockStreamSource{events: loadFixtureEvents(t, "fixtures/events-hello.txt")}
+	iterator := newOpenAIStreamIterator(source, &llm.Config{})
+	defer iterator.Close()
+
+	accumulator := llm.NewResponseAccumulator()
+	var indexedEventCount int
+	var firstBlockStartIndex *int
+	for iterator.Next() {
+		event := iterator.Event()
+		if event.Index != nil {
+			indexedEventCount++
+			assert.Equal(t, 0, *event.Index)
+		}
+		if event.Type == llm.EventTypeContentBlockStart && firstBlockStartIndex == nil {
+			firstBlockStartIndex = event.Index
+		}
+		assert.NoError(t, accumulator.AddEvent(event))
+	}
+	assert.NoError(t, iterator.Err())
+
+	// The first content block start must carry index 0.
+	assert.NotNil(t, firstBlockStartIndex)
+	assert.Equal(t, 0, *firstBlockStartIndex)
+	assert.NotEmpty(t, indexedEventCount)
+
+	// The accumulated response should match the fixture.
+	assert.True(t, accumulator.IsComplete())
+	response := accumulator.Response()
+	assert.Equal(t, "Hello! How can I assist you today?", response.Message().Text())
+	assert.Equal(t, 140, response.Usage.InputTokens)
+	assert.Equal(t, 11, response.Usage.OutputTokens)
+}

--- a/providers/openaicompletions/stream_iterator.go
+++ b/providers/openaicompletions/stream_iterator.go
@@ -27,6 +27,11 @@ type StreamIterator struct {
 	nextBlockIndex    int
 	closeOnce         sync.Once
 	eventQueue        []*llm.Event
+	// finalEvents holds the message_delta and message_stop events generated
+	// when a finish_reason is seen. They are deferred until the trailing
+	// usage chunk (stream_options.include_usage) has been consumed, so the
+	// message_delta carries the real token usage.
+	finalEvents []*llm.Event
 	// thinkingIndex and textIndex track the sequential content block index
 	// assigned to each block type, or -1 if not yet started.
 	thinkingIndex int
@@ -91,6 +96,14 @@ func (s *StreamIterator) Event() *llm.Event {
 func (s *StreamIterator) next() ([]*llm.Event, error) {
 	line, err := s.reader.ReadBytes('\n')
 	if err != nil {
+		// If the stream ends before a trailing usage chunk or [DONE] marker
+		// arrives, flush any deferred final events so the message still
+		// terminates with message_delta and message_stop.
+		if err == io.EOF {
+			if events := s.flushFinalEvents(); len(events) > 0 {
+				return events, nil
+			}
+		}
 		return nil, err
 	}
 	// Skip empty lines
@@ -105,7 +118,7 @@ func (s *StreamIterator) next() ([]*llm.Event, error) {
 	line = bytes.TrimPrefix(line, []byte("data: "))
 	// Check for stream end
 	if bytes.Equal(bytes.TrimSpace(line), []byte("[DONE]")) {
-		return nil, nil
+		return s.flushFinalEvents(), nil
 	}
 	// Unmarshal the event
 	var event StreamResponse
@@ -122,7 +135,10 @@ func (s *StreamIterator) next() ([]*llm.Event, error) {
 		s.usage = event.Usage
 	}
 	if len(event.Choices) == 0 {
-		return nil, nil
+		// With stream_options.include_usage set, the API sends a final chunk
+		// with empty choices that carries the usage, after the finish_reason
+		// chunk. Now that usage is known, flush the deferred final events.
+		return s.flushFinalEvents(), nil
 	}
 	choice := event.Choices[0]
 	var events []*llm.Event
@@ -327,25 +343,44 @@ func (s *StreamIterator) next() ([]*llm.Event, error) {
 				toolCall.IsComplete = true
 			}
 		}
-		// Add message_delta event with stop reason
+		// Build the message_delta event with the stop reason, but defer it
+		// (along with message_stop) until the trailing usage chunk, [DONE]
+		// marker, or EOF, so the message_delta carries the real token usage.
 		stopReason := choice.FinishReason
 		if stopReason == "tool_calls" {
 			stopReason = "tool_use" // Match Anthropic
 		}
-		events = append(events, &llm.Event{
-			Type:  llm.EventTypeMessageDelta,
-			Delta: &llm.EventDelta{StopReason: stopReason},
-			Usage: &llm.Usage{
-				InputTokens:  s.usage.PromptTokens,
-				OutputTokens: s.usage.CompletionTokens,
+		s.finalEvents = []*llm.Event{
+			{
+				Type:  llm.EventTypeMessageDelta,
+				Delta: &llm.EventDelta{StopReason: stopReason},
+				Usage: &llm.Usage{},
 			},
-		})
-		events = append(events, &llm.Event{
-			Type: llm.EventTypeMessageStop,
-		})
+			{
+				Type: llm.EventTypeMessageStop,
+			},
+		}
 	}
 
 	return events, nil
+}
+
+// flushFinalEvents returns the deferred message_delta and message_stop events,
+// stamping the message_delta with the most recent usage. Returns nil if there
+// are no deferred events (or they were already flushed).
+func (s *StreamIterator) flushFinalEvents() []*llm.Event {
+	if len(s.finalEvents) == 0 {
+		return nil
+	}
+	events := s.finalEvents
+	s.finalEvents = nil
+	for _, event := range events {
+		if event.Type == llm.EventTypeMessageDelta && event.Usage != nil {
+			event.Usage.InputTokens = s.usage.PromptTokens
+			event.Usage.OutputTokens = s.usage.CompletionTokens
+		}
+	}
+	return events
 }
 
 func (s *StreamIterator) Close() error {

--- a/providers/openaicompletions/stream_iterator_test.go
+++ b/providers/openaicompletions/stream_iterator_test.go
@@ -1,0 +1,159 @@
+package openaicompletions
+
+import (
+	"bufio"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/deepnoodle-ai/dive/llm"
+	"github.com/deepnoodle-ai/wonton/assert"
+)
+
+// newTestStreamIterator creates a StreamIterator that reads from a synthetic
+// SSE stream body, mirroring how Provider.Stream constructs the iterator.
+func newTestStreamIterator(body string) *StreamIterator {
+	reader := io.NopCloser(strings.NewReader(body))
+	return &StreamIterator{
+		body:            reader,
+		reader:          bufio.NewReader(reader),
+		contentBlocks:   map[int]*ContentBlockAccumulator{},
+		toolCalls:       map[int]*ToolCallAccumulator{},
+		toolCallIndices: map[int]int{},
+		thinkingIndex:   -1,
+		textIndex:       -1,
+	}
+}
+
+// collectEvents drains the iterator and accumulates all events.
+func collectEvents(t *testing.T, iterator *StreamIterator) ([]*llm.Event, *llm.ResponseAccumulator) {
+	t.Helper()
+	accumulator := llm.NewResponseAccumulator()
+	var events []*llm.Event
+	for iterator.Next() {
+		event := iterator.Event()
+		events = append(events, event)
+		assert.NoError(t, accumulator.AddEvent(event))
+	}
+	assert.NoError(t, iterator.Err())
+	return events, accumulator
+}
+
+// TestStreamIteratorUsageFromTrailingChunk verifies that the token usage
+// delivered in the final empty-choices chunk (stream_options.include_usage)
+// is reflected in the accumulated response, and that message_stop is still
+// the last event.
+func TestStreamIteratorUsageFromTrailingChunk(t *testing.T) {
+	body := strings.Join([]string{
+		`data: {"id":"chatcmpl-1","object":"chat.completion.chunk","model":"mistral-large","choices":[{"index":0,"delta":{"role":"assistant","content":"Hello"}}]}`,
+		``,
+		`data: {"id":"chatcmpl-1","object":"chat.completion.chunk","model":"mistral-large","choices":[{"index":0,"delta":{"content":" world"}}]}`,
+		``,
+		`data: {"id":"chatcmpl-1","object":"chat.completion.chunk","model":"mistral-large","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}`,
+		``,
+		`data: {"id":"chatcmpl-1","object":"chat.completion.chunk","model":"mistral-large","choices":[],"usage":{"prompt_tokens":12,"completion_tokens":7,"total_tokens":19}}`,
+		``,
+		`data: [DONE]`,
+		``,
+	}, "\n")
+
+	iterator := newTestStreamIterator(body)
+	defer iterator.Close()
+	events, accumulator := collectEvents(t, iterator)
+
+	assert.NotEmpty(t, events)
+	assert.Equal(t, llm.EventTypeMessageStop, events[len(events)-1].Type)
+	assert.True(t, accumulator.IsComplete())
+
+	response := accumulator.Response()
+	assert.Equal(t, "Hello world", response.Message().Text())
+	assert.Equal(t, "stop", response.StopReason)
+	assert.Equal(t, 12, response.Usage.InputTokens)
+	assert.Equal(t, 7, response.Usage.OutputTokens)
+}
+
+// TestStreamIteratorToolUseWithTrailingUsage verifies that tool-use streams
+// still terminate correctly and report usage from the trailing usage chunk.
+func TestStreamIteratorToolUseWithTrailingUsage(t *testing.T) {
+	body := strings.Join([]string{
+		`data: {"id":"chatcmpl-2","object":"chat.completion.chunk","model":"mistral-large","choices":[{"index":0,"delta":{"role":"assistant","tool_calls":[{"index":0,"id":"call_123","type":"function","function":{"name":"calculator","arguments":""}}]}}]}`,
+		``,
+		`data: {"id":"chatcmpl-2","object":"chat.completion.chunk","model":"mistral-large","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\"a\":15,"}}]}}]}`,
+		``,
+		`data: {"id":"chatcmpl-2","object":"chat.completion.chunk","model":"mistral-large","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\"b\":27}"}}]}}]}`,
+		``,
+		`data: {"id":"chatcmpl-2","object":"chat.completion.chunk","model":"mistral-large","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}`,
+		``,
+		`data: {"id":"chatcmpl-2","object":"chat.completion.chunk","model":"mistral-large","choices":[],"usage":{"prompt_tokens":30,"completion_tokens":9,"total_tokens":39}}`,
+		``,
+		`data: [DONE]`,
+		``,
+	}, "\n")
+
+	iterator := newTestStreamIterator(body)
+	defer iterator.Close()
+	events, accumulator := collectEvents(t, iterator)
+
+	assert.NotEmpty(t, events)
+	assert.Equal(t, llm.EventTypeMessageStop, events[len(events)-1].Type)
+	assert.True(t, accumulator.IsComplete())
+
+	response := accumulator.Response()
+	assert.Equal(t, "tool_use", response.StopReason)
+	toolCalls := response.ToolCalls()
+	assert.Len(t, toolCalls, 1)
+	assert.Equal(t, "call_123", toolCalls[0].ID)
+	assert.Equal(t, "calculator", toolCalls[0].Name)
+	assert.Equal(t, `{"a":15,"b":27}`, string(toolCalls[0].Input))
+	assert.Equal(t, 30, response.Usage.InputTokens)
+	assert.Equal(t, 9, response.Usage.OutputTokens)
+}
+
+// TestStreamIteratorTerminatesWithoutTrailingUsage verifies that streams
+// without a trailing usage chunk (or [DONE] marker) still emit the final
+// message_delta and message_stop events when the stream ends.
+func TestStreamIteratorTerminatesWithoutTrailingUsage(t *testing.T) {
+	body := strings.Join([]string{
+		`data: {"id":"chatcmpl-3","object":"chat.completion.chunk","model":"mistral-large","choices":[{"index":0,"delta":{"role":"assistant","content":"Hi"}}]}`,
+		``,
+		`data: {"id":"chatcmpl-3","object":"chat.completion.chunk","model":"mistral-large","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}`,
+		``,
+	}, "\n")
+
+	iterator := newTestStreamIterator(body)
+	defer iterator.Close()
+	events, accumulator := collectEvents(t, iterator)
+
+	assert.NotEmpty(t, events)
+	assert.Equal(t, llm.EventTypeMessageStop, events[len(events)-1].Type)
+	assert.True(t, accumulator.IsComplete())
+
+	response := accumulator.Response()
+	assert.Equal(t, "Hi", response.Message().Text())
+	assert.Equal(t, "stop", response.StopReason)
+}
+
+// TestStreamIteratorUsageOnFinishChunk verifies that providers which include
+// usage directly on the finish_reason chunk still report it correctly.
+func TestStreamIteratorUsageOnFinishChunk(t *testing.T) {
+	body := strings.Join([]string{
+		`data: {"id":"chatcmpl-4","object":"chat.completion.chunk","model":"mistral-large","choices":[{"index":0,"delta":{"role":"assistant","content":"Hey"}}]}`,
+		``,
+		`data: {"id":"chatcmpl-4","object":"chat.completion.chunk","model":"mistral-large","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":5,"completion_tokens":2,"total_tokens":7}}`,
+		``,
+		`data: [DONE]`,
+		``,
+	}, "\n")
+
+	iterator := newTestStreamIterator(body)
+	defer iterator.Close()
+	events, accumulator := collectEvents(t, iterator)
+
+	assert.NotEmpty(t, events)
+	assert.Equal(t, llm.EventTypeMessageStop, events[len(events)-1].Type)
+	assert.True(t, accumulator.IsComplete())
+
+	response := accumulator.Response()
+	assert.Equal(t, 5, response.Usage.InputTokens)
+	assert.Equal(t, 2, response.Usage.OutputTokens)
+}


### PR DESCRIPTION
Two verified streaming bugs in the OpenAI-family providers:

- **openaicompletions streaming lost token usage (Mistral, OpenRouter)** — requests set `stream_options.include_usage`, which delivers usage in a final empty-choices chunk *after* the `finish_reason` chunk. The iterator stored that usage but had already emitted the `message_delta` with zero usage, so every streamed response reported **0 input / 0 output tokens**, silently breaking cost tracking. The final `message_delta`/`message_stop` events are now deferred until the trailing usage chunk, `[DONE]`, or EOF, and stamped with the real usage at flush time — `message_stop` remains the last event and no usage is double-counted.
- **OpenAI (Responses API) stream emitted negative/off-by-one content-block indices** — the iterator decremented every event index to "match Anthropic's zero-based indexing", but `output_index` is already 0-based (see `providers/openai/fixtures/events-hello.txt`), so event-callback consumers saw the first content block at **index -1** and all indices inconsistent with every other provider. Removed the decrement; verified there is no paired `+1` adjustment anywhere in the iterator.

Tests:

- New unit test replays the `events-hello.txt` fixture through the openai iterator and asserts the first content block start carries index 0 and the accumulated response matches the fixture text and usage (140 in / 11 out).
- New openaicompletions unit tests drive the iterator with synthetic SSE streams: trailing usage chunk (12/7 tokens), tool-use stream with trailing usage (terminates correctly, `tool_use` stop reason, correct args), usage carried on the finish chunk, and a stream ending without any usage chunk (still terminates with `message_stop`).
- `gofmt`, `go build ./...`, and `go test ./...` pass in both the root module and the `providers/openai` module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected event index handling in OpenAI streaming responses to preserve original source values.
  * Improved ordering of final events and usage information in OpenAI Completions streaming to ensure proper sequencing.

* **Tests**
  * Added comprehensive test coverage for stream iterator behavior, including index validation and finalization event handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->