### PR TITLE
Fix MCP client lifecycle: real Close, HTTP auth headers, OAuth callback and token store

### DIFF
--- a/experimental/mcp/client.go
+++ b/experimental/mcp/client.go
@@ -3,6 +3,7 @@ package mcp
 import (
 	"context"
 	"fmt"
+	"html"
 	"log"
 	"net/http"
 	"os"
@@ -11,6 +12,7 @@ import (
 	"time"
 
 	"github.com/mark3labs/mcp-go/client"
+	"github.com/mark3labs/mcp-go/client/transport"
 	"github.com/mark3labs/mcp-go/mcp"
 )
 
@@ -79,7 +81,11 @@ func (c *Client) Connect(ctx context.Context) error {
 			if c.config.URL == "" {
 				return fmt.Errorf("url is required for http mcp server")
 			}
-			c.client, err = client.NewStreamableHttpClient(c.config.URL)
+			var opts []transport.StreamableHTTPCOption
+			if headers := buildRequestHeaders(c.config.AuthorizationToken, c.config.Headers); len(headers) > 0 {
+				opts = append(opts, transport.WithHTTPHeaders(headers))
+			}
+			c.client, err = client.NewStreamableHttpClient(c.config.URL, opts...)
 		case "stdio":
 			if c.config.Command == "" {
 				return fmt.Errorf("command is required for stdio mcp server")
@@ -137,7 +143,17 @@ func (c *Client) connectWithOAuth() error {
 		return fmt.Errorf("OAuth configuration is nil")
 	}
 	if c.tokenStore == nil {
-		c.tokenStore = client.NewMemoryTokenStore()
+		store, err := newClientTokenStore(c.oauthConfig.TokenStore)
+		if err != nil {
+			return fmt.Errorf("failed to create token store: %w", err)
+		}
+		c.tokenStore = store
+	}
+	// Custom headers are still sent on OAuth requests; the OAuth handler sets
+	// the Authorization header after custom headers, so it remains authoritative.
+	var opts []transport.StreamableHTTPCOption
+	if len(c.config.Headers) > 0 {
+		opts = append(opts, transport.WithHTTPHeaders(c.config.Headers))
 	}
 	var err error
 	c.client, err = client.NewOAuthStreamableHttpClient(c.config.URL, client.OAuthConfig{
@@ -147,7 +163,7 @@ func (c *Client) connectWithOAuth() error {
 		Scopes:       c.oauthConfig.Scopes,
 		TokenStore:   c.tokenStore,
 		PKCEEnabled:  c.oauthConfig.PKCEEnabled,
-	})
+	}, opts...)
 	return err
 }
 
@@ -211,6 +227,14 @@ func (c *Client) handleOAuthAuthorization(ctx context.Context, err error) error 
 	// Wait for authorization callback
 	params := <-callbackChan
 
+	// Surface authorization errors reported by the authorization server
+	if errCode := params["error"]; errCode != "" {
+		if desc := params["error_description"]; desc != "" {
+			return fmt.Errorf("authorization failed: %s: %s", errCode, desc)
+		}
+		return fmt.Errorf("authorization failed: %s", errCode)
+	}
+
 	if params["state"] != state {
 		return fmt.Errorf("state mismatch: expected %s, got %s", state, params["state"])
 	}
@@ -225,13 +249,34 @@ func (c *Client) handleOAuthAuthorization(ctx context.Context, err error) error 
 	return nil
 }
 
-// startCallbackServer starts a local HTTP server to handle the OAuth callback
+// startCallbackServer starts a local HTTP server to handle the OAuth callback.
+// A per-server ServeMux is used (rather than the package-global default mux)
+// so that multiple OAuth flows in the same process don't panic on duplicate
+// route registration.
 func (c *Client) startCallbackServer(callbackChan chan<- map[string]string) *http.Server {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/oauth/callback", oauthCallbackHandler(callbackChan))
+
 	server := &http.Server{
-		Addr: ":8085", // Use fixed port 8085
+		Addr:    ":8085", // Use fixed port 8085
+		Handler: mux,
 	}
 
-	http.HandleFunc("/oauth/callback", func(w http.ResponseWriter, r *http.Request) {
+	go func() {
+		if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			log.Printf("HTTP server error: %v", err)
+		}
+	}()
+
+	return server
+}
+
+// oauthCallbackHandler returns the HTTP handler for the OAuth callback
+// endpoint. It forwards the callback query parameters to callbackChan and
+// renders a success page, or an error page when the authorization server
+// reported an error via the error/error_description parameters.
+func oauthCallbackHandler(callbackChan chan<- map[string]string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
 		// Extract query parameters
 		params := make(map[string]string)
 		for key, values := range r.URL.Query() {
@@ -247,8 +292,30 @@ func (c *Client) startCallbackServer(callbackChan chan<- map[string]string) *htt
 			// Channel is full, ignore
 		}
 
-		// Respond to the user
 		w.Header().Set("Content-Type", "text/html")
+
+		// Render an error page if the authorization server reported an error
+		if errCode := params["error"]; errCode != "" {
+			message := html.EscapeString(errCode)
+			if desc := params["error_description"]; desc != "" {
+				message += ": " + html.EscapeString(desc)
+			}
+			w.WriteHeader(http.StatusBadRequest)
+			if _, err := fmt.Fprintf(w, `
+			<html>
+				<body>
+					<h1>Authorization Failed</h1>
+					<p>%s</p>
+					<p>You can close this window and return to the application.</p>
+				</body>
+			</html>
+		`, message); err != nil {
+				log.Printf("Error writing response: %v", err)
+			}
+			return
+		}
+
+		// Respond to the user
 		_, err := w.Write([]byte(`
 			<html>
 				<body>
@@ -261,15 +328,7 @@ func (c *Client) startCallbackServer(callbackChan chan<- map[string]string) *htt
 		if err != nil {
 			log.Printf("Error writing response: %v", err)
 		}
-	})
-
-	go func() {
-		if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-			log.Printf("HTTP server error: %v", err)
-		}
-	}()
-
-	return server
+	}
 }
 
 // openBrowser opens the default browser to the specified URL
@@ -446,12 +505,12 @@ func (c *Client) IsConnected() bool {
 	return c.connected
 }
 
-// Close closes the MCP client connection
+// Close closes the MCP client connection, shutting down the underlying
+// transport (and terminating the child process for stdio servers).
 func (c *Client) Close() error {
-	if c.client != nil && c.connected {
-		c.connected = false
-		// Note: The mcp-go client doesn't seem to have a Close method
-		// This might need to be updated based on the actual API
+	c.connected = false
+	if c.client != nil {
+		return c.client.Close()
 	}
 	return nil
 }

--- a/experimental/mcp/client_test.go
+++ b/experimental/mcp/client_test.go
@@ -2,6 +2,9 @@ package mcp
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync"
 	"testing"
 
 	"github.com/deepnoodle-ai/wonton/assert"
@@ -304,4 +307,69 @@ func TestClient_Connect_StdioWithEnvAndArgs(t *testing.T) {
 	// Note: We don't actually call Connect() here because it would try to start
 	// a real subprocess, which would fail in the test environment.
 	// The important part is that the configuration is properly stored and accessible.
+}
+
+func TestClient_Connect_HTTPSendsAuthHeaders(t *testing.T) {
+	var mu sync.Mutex
+	var gotAuth, gotCustom, gotAccept string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		gotAuth = r.Header.Get("Authorization")
+		gotCustom = r.Header.Get("X-Custom-Header")
+		gotAccept = r.Header.Get("Accept")
+		mu.Unlock()
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer ts.Close()
+
+	client, err := NewClient(&ServerConfig{
+		Type:               "http",
+		Name:               "header-test",
+		URL:                ts.URL,
+		AuthorizationToken: "secret-token",
+		Headers:            map[string]string{"X-Custom-Header": "custom-value"},
+	})
+	assert.NoError(t, err)
+
+	// The server always returns 500 so Connect fails, but the request it
+	// received proves which headers the transport sent.
+	err = client.Connect(context.Background())
+	assert.Error(t, err)
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Equal(t, "Bearer secret-token", gotAuth)
+	assert.Equal(t, "custom-value", gotCustom)
+	// The transport's own Accept header must not be clobbered
+	assert.Contains(t, gotAccept, "text/event-stream")
+}
+
+func TestClient_Close(t *testing.T) {
+	// Close with no underlying client is a no-op
+	client, err := NewClient(&ServerConfig{
+		Type: "http",
+		Name: "close-test",
+		URL:  "https://example.com",
+	})
+	assert.NoError(t, err)
+	client.connected = true
+	assert.NoError(t, client.Close())
+	assert.False(t, client.IsConnected())
+
+	// Close after a failed Connect closes the underlying mcp-go client
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer ts.Close()
+
+	client2, err := NewClient(&ServerConfig{
+		Type: "http",
+		Name: "close-test-2",
+		URL:  ts.URL,
+	})
+	assert.NoError(t, err)
+	assert.Error(t, client2.Connect(context.Background()))
+	assert.NotNil(t, client2.client)
+	assert.NoError(t, client2.Close())
+	assert.False(t, client2.IsConnected())
 }

--- a/experimental/mcp/oauth_test.go
+++ b/experimental/mcp/oauth_test.go
@@ -2,6 +2,8 @@ package mcp
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/deepnoodle-ai/wonton/assert"
@@ -189,4 +191,71 @@ func TestMCPClient_OAuthConfiguration_Validation(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestOAuthCallbackHandler_Success(t *testing.T) {
+	callbackChan := make(chan map[string]string, 1)
+	handler := oauthCallbackHandler(callbackChan)
+
+	req := httptest.NewRequest(http.MethodGet, "/oauth/callback?code=abc123&state=xyz", nil)
+	rec := httptest.NewRecorder()
+	handler(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Contains(t, rec.Body.String(), "Authorization Successful")
+
+	params := <-callbackChan
+	assert.Equal(t, "abc123", params["code"])
+	assert.Equal(t, "xyz", params["state"])
+}
+
+func TestOAuthCallbackHandler_Error(t *testing.T) {
+	callbackChan := make(chan map[string]string, 1)
+	handler := oauthCallbackHandler(callbackChan)
+
+	req := httptest.NewRequest(http.MethodGet,
+		"/oauth/callback?error=access_denied&error_description=User+denied+access&state=xyz", nil)
+	rec := httptest.NewRecorder()
+	handler(rec, req)
+
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	body := rec.Body.String()
+	assert.Contains(t, body, "Authorization Failed")
+	assert.Contains(t, body, "access_denied")
+	assert.Contains(t, body, "User denied access")
+
+	// The error parameters are still forwarded so the flow can surface them
+	params := <-callbackChan
+	assert.Equal(t, "access_denied", params["error"])
+	assert.Equal(t, "User denied access", params["error_description"])
+}
+
+func TestOAuthCallbackHandler_ErrorEscapesHTML(t *testing.T) {
+	callbackChan := make(chan map[string]string, 1)
+	handler := oauthCallbackHandler(callbackChan)
+
+	req := httptest.NewRequest(http.MethodGet,
+		"/oauth/callback?error=%3Cscript%3Ealert(1)%3C%2Fscript%3E", nil)
+	rec := httptest.NewRecorder()
+	handler(rec, req)
+
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	body := rec.Body.String()
+	assert.NotContains(t, body, "<script>alert(1)</script>")
+	assert.Contains(t, body, "&lt;script&gt;")
+}
+
+func TestStartCallbackServer_MultipleFlows(t *testing.T) {
+	// Previously the callback route was registered on the package-global
+	// http.DefaultServeMux, so a second OAuth flow in the same process
+	// panicked with a duplicate registration. Each server now gets its own mux.
+	config := &ServerConfig{Type: "http", Name: "test-server", URL: "https://example.com"}
+	client, err := NewClient(config)
+	assert.NoError(t, err)
+
+	server1 := client.startCallbackServer(make(chan map[string]string, 1))
+	assert.NoError(t, server1.Shutdown(context.Background()))
+
+	server2 := client.startCallbackServer(make(chan map[string]string, 1))
+	assert.NoError(t, server2.Shutdown(context.Background()))
 }

--- a/experimental/mcp/token_store.go
+++ b/experimental/mcp/token_store.go
@@ -1,13 +1,21 @@
 package mcp
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"sync"
 	"time"
+
+	"github.com/mark3labs/mcp-go/client"
+	"github.com/mark3labs/mcp-go/client/transport"
 )
+
+// ErrNoToken is returned by token stores when no token has been saved yet.
+var ErrNoToken = errors.New("no token found")
 
 // Token represents an OAuth 2.0 token with all relevant fields
 type Token struct {
@@ -64,7 +72,7 @@ func (fs *FileOAuthTokenStore) GetToken() (*Token, error) {
 
 	// Check if file exists
 	if _, err := os.Stat(fs.filePath); os.IsNotExist(err) {
-		return nil, fmt.Errorf("no token found")
+		return nil, ErrNoToken
 	}
 
 	// Read file content
@@ -131,4 +139,78 @@ func (fs *FileOAuthTokenStore) HasToken() bool {
 
 	_, err := os.Stat(fs.filePath)
 	return err == nil
+}
+
+// newClientTokenStore builds the mcp-go token store described by the given
+// configuration. A nil configuration or a "memory" type yields an in-memory
+// store. A "file" type yields a file-backed store at the configured path.
+// Other types (including "keychain", which has no implementation yet) return
+// an error.
+func newClientTokenStore(cfg *TokenStore) (client.TokenStore, error) {
+	if cfg == nil {
+		return client.NewMemoryTokenStore(), nil
+	}
+	switch cfg.Type {
+	case "", "memory":
+		return client.NewMemoryTokenStore(), nil
+	case "file":
+		fileStore, err := NewFileOAuthTokenStore(cfg.Path)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create file token store: %w", err)
+		}
+		return &clientTokenStoreAdapter{store: fileStore}, nil
+	case "keychain":
+		return nil, fmt.Errorf("keychain token store is not supported yet (supported types: memory, file)")
+	default:
+		return nil, fmt.Errorf("unsupported token store type %q (supported types: memory, file)", cfg.Type)
+	}
+}
+
+// clientTokenStoreAdapter adapts an OAuthTokenStore to the mcp-go
+// client.TokenStore interface.
+type clientTokenStoreAdapter struct {
+	store OAuthTokenStore
+}
+
+// GetToken returns the current token, translating the store's ErrNoToken
+// into the sentinel error expected by the mcp-go transport.
+func (a *clientTokenStoreAdapter) GetToken(ctx context.Context) (*transport.Token, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	token, err := a.store.GetToken()
+	if err != nil {
+		if errors.Is(err, ErrNoToken) {
+			return nil, transport.ErrNoToken
+		}
+		return nil, err
+	}
+	return &transport.Token{
+		AccessToken:  token.AccessToken,
+		RefreshToken: token.RefreshToken,
+		TokenType:    token.TokenType,
+		Scope:        token.Scope,
+		ExpiresAt:    token.ExpiresAt,
+	}, nil
+}
+
+// SaveToken persists the token to the underlying store.
+func (a *clientTokenStoreAdapter) SaveToken(ctx context.Context, token *transport.Token) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if token == nil {
+		return fmt.Errorf("token cannot be nil")
+	}
+	expiresAt := token.ExpiresAt
+	if expiresAt.IsZero() && token.ExpiresIn > 0 {
+		expiresAt = time.Now().Add(time.Duration(token.ExpiresIn) * time.Second)
+	}
+	return a.store.SaveToken(&Token{
+		AccessToken:  token.AccessToken,
+		RefreshToken: token.RefreshToken,
+		TokenType:    token.TokenType,
+		Scope:        token.Scope,
+		ExpiresAt:    expiresAt,
+	})
 }

--- a/experimental/mcp/token_store_test.go
+++ b/experimental/mcp/token_store_test.go
@@ -1,12 +1,15 @@
 package mcp
 
 import (
+	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/deepnoodle-ai/wonton/assert"
+	"github.com/mark3labs/mcp-go/client/transport"
 )
 
 func TestNewFileOAuthTokenStore(t *testing.T) {
@@ -291,4 +294,122 @@ func TestFileOAuthTokenStore_AtomicWrites(t *testing.T) {
 		}
 	}
 	assert.Empty(t, tmpFiles, "Should not leave temporary files behind")
+}
+
+func TestNewClientTokenStore(t *testing.T) {
+	t.Run("nil config returns memory store", func(t *testing.T) {
+		store, err := newClientTokenStore(nil)
+		assert.NoError(t, err)
+		assert.NotNil(t, store)
+	})
+
+	t.Run("memory type", func(t *testing.T) {
+		store, err := newClientTokenStore(&TokenStore{Type: "memory"})
+		assert.NoError(t, err)
+		assert.NotNil(t, store)
+	})
+
+	t.Run("empty type defaults to memory", func(t *testing.T) {
+		store, err := newClientTokenStore(&TokenStore{})
+		assert.NoError(t, err)
+		assert.NotNil(t, store)
+	})
+
+	t.Run("file type", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "token.json")
+		store, err := newClientTokenStore(&TokenStore{Type: "file", Path: path})
+		assert.NoError(t, err)
+		assert.NotNil(t, store)
+	})
+
+	t.Run("file type without path", func(t *testing.T) {
+		store, err := newClientTokenStore(&TokenStore{Type: "file"})
+		assert.Error(t, err)
+		assert.Nil(t, store)
+	})
+
+	t.Run("keychain type unsupported", func(t *testing.T) {
+		store, err := newClientTokenStore(&TokenStore{Type: "keychain"})
+		assert.Error(t, err)
+		assert.Nil(t, store)
+		assert.Contains(t, err.Error(), "keychain")
+	})
+
+	t.Run("unknown type", func(t *testing.T) {
+		store, err := newClientTokenStore(&TokenStore{Type: "bogus"})
+		assert.Error(t, err)
+		assert.Nil(t, store)
+		assert.Contains(t, err.Error(), "bogus")
+	})
+}
+
+func TestClientTokenStoreAdapter_RoundTrip(t *testing.T) {
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "token.json")
+	store, err := newClientTokenStore(&TokenStore{Type: "file", Path: path})
+	assert.NoError(t, err)
+
+	// Empty store reports the mcp-go sentinel error
+	_, err = store.GetToken(ctx)
+	assert.True(t, errors.Is(err, transport.ErrNoToken))
+
+	expiresAt := time.Now().Add(time.Hour)
+	err = store.SaveToken(ctx, &transport.Token{
+		AccessToken:  "access-123",
+		RefreshToken: "refresh-456",
+		TokenType:    "Bearer",
+		Scope:        "mcp.read",
+		ExpiresAt:    expiresAt,
+	})
+	assert.NoError(t, err)
+
+	token, err := store.GetToken(ctx)
+	assert.NoError(t, err)
+	assert.Equal(t, "access-123", token.AccessToken)
+	assert.Equal(t, "refresh-456", token.RefreshToken)
+	assert.Equal(t, "Bearer", token.TokenType)
+	assert.Equal(t, "mcp.read", token.Scope)
+	assert.True(t, token.ExpiresAt.Equal(expiresAt))
+
+	// Tokens survive process restarts: a fresh store reads the same file
+	store2, err := newClientTokenStore(&TokenStore{Type: "file", Path: path})
+	assert.NoError(t, err)
+	token2, err := store2.GetToken(ctx)
+	assert.NoError(t, err)
+	assert.Equal(t, "access-123", token2.AccessToken)
+}
+
+func TestClientTokenStoreAdapter_ExpiresInFallback(t *testing.T) {
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "token.json")
+	store, err := newClientTokenStore(&TokenStore{Type: "file", Path: path})
+	assert.NoError(t, err)
+
+	before := time.Now()
+	err = store.SaveToken(ctx, &transport.Token{
+		AccessToken: "access-123",
+		TokenType:   "Bearer",
+		ExpiresIn:   3600,
+	})
+	assert.NoError(t, err)
+
+	token, err := store.GetToken(ctx)
+	assert.NoError(t, err)
+	assert.False(t, token.ExpiresAt.IsZero())
+	assert.True(t, token.ExpiresAt.After(before.Add(59*time.Minute)))
+}
+
+func TestClientTokenStoreAdapter_ContextCancelled(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "token.json")
+	store, err := newClientTokenStore(&TokenStore{Type: "file", Path: path})
+	assert.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err = store.GetToken(ctx)
+	assert.True(t, errors.Is(err, context.Canceled))
+
+	err = store.SaveToken(ctx, &transport.Token{AccessToken: "x"})
+	assert.True(t, errors.Is(err, context.Canceled))
 }

--- a/experimental/mcp/transport.go
+++ b/experimental/mcp/transport.go
@@ -84,6 +84,22 @@ func BuildHTTPHeaders(authToken string, additionalHeaders map[string]string) map
 	return headers
 }
 
+// buildRequestHeaders builds the extra HTTP headers passed to the mcp-go
+// streamable HTTP transport. Unlike BuildHTTPHeaders, it deliberately omits
+// Content-Type and Accept: the transport manages those itself and requires
+// Accept values that include text/event-stream, which a blanket
+// "application/json" override would break.
+func buildRequestHeaders(authToken string, additionalHeaders map[string]string) map[string]string {
+	headers := make(map[string]string, len(additionalHeaders)+1)
+	if authToken != "" {
+		headers["Authorization"] = "Bearer " + authToken
+	}
+	for key, value := range additionalHeaders {
+		headers[key] = value
+	}
+	return headers
+}
+
 // TransportConfig holds configuration for different transport types
 type TransportConfig struct {
 	Type      TransportType

--- a/experimental/mcp/transport_test.go
+++ b/experimental/mcp/transport_test.go
@@ -1,0 +1,38 @@
+package mcp
+
+import (
+	"testing"
+
+	"github.com/deepnoodle-ai/wonton/assert"
+)
+
+func TestBuildRequestHeaders(t *testing.T) {
+	t.Run("auth token and custom headers", func(t *testing.T) {
+		headers := buildRequestHeaders("secret", map[string]string{"X-Custom": "value"})
+		assert.Equal(t, "Bearer secret", headers["Authorization"])
+		assert.Equal(t, "value", headers["X-Custom"])
+	})
+
+	t.Run("no auth token", func(t *testing.T) {
+		headers := buildRequestHeaders("", map[string]string{"X-Custom": "value"})
+		_, hasAuth := headers["Authorization"]
+		assert.False(t, hasAuth)
+		assert.Equal(t, "value", headers["X-Custom"])
+	})
+
+	t.Run("does not set Content-Type or Accept", func(t *testing.T) {
+		// The mcp-go streamable HTTP transport manages Content-Type and
+		// Accept itself, and custom headers override the transport's values.
+		// Setting Accept here would break SSE streaming.
+		headers := buildRequestHeaders("secret", nil)
+		_, hasContentType := headers["Content-Type"]
+		_, hasAccept := headers["Accept"]
+		assert.False(t, hasContentType)
+		assert.False(t, hasAccept)
+	})
+
+	t.Run("custom headers can override authorization", func(t *testing.T) {
+		headers := buildRequestHeaders("secret", map[string]string{"Authorization": "Custom xyz"})
+		assert.Equal(t, "Custom xyz", headers["Authorization"])
+	})
+}


### PR DESCRIPTION
Fixes four verified bugs in `experimental/mcp` (mcp-go pinned at v0.45.0; all SDK API usage verified against the module cache):

- **`Client.Close()` was a no-op (subprocess/transport leak).** The comment claimed the mcp-go client has no `Close` method — it does (`client/client.go:123` in v0.45.0). Every stdio MCP server leaked its child process and `Manager.Close()` looped over no-ops. `Close` now calls the underlying client's `Close` and propagates the error.
- **HTTP transport dropped `AuthorizationToken` and `Headers`.** The non-OAuth `"http"` case created the client with no options, so configured bearer tokens were silently never sent. Headers are now passed via `transport.WithHTTPHeaders`. Note: a new `buildRequestHeaders` helper is used instead of the existing `BuildHTTPHeaders`, because the transport applies custom headers *after* its own `Accept`/`Content-Type` — `BuildHTTPHeaders`'s `Accept: application/json` would clobber the required `text/event-stream` accept value and break streaming. Custom `Headers` are also forwarded on the OAuth client (the OAuth handler sets `Authorization` last, so it stays authoritative). No `"sse"` transport case exists, so there was nothing to fix there.
- **OAuth callback used the package-global ServeMux.** A second OAuth flow in the same process panicked on duplicate `http.HandleFunc` registration. The callback server now gets a per-call `http.NewServeMux`. The handler also renders an HTML-escaped error page (HTTP 400) when the callback carries `error`/`error_description`, and `handleOAuthAuthorization` surfaces that error instead of failing on a missing code.
- **Configured OAuth `TokenStore` was ignored.** `connectWithOAuth` always fell back to `client.NewMemoryTokenStore()`, so the `"memory"`/`"file"` config in `token_store.go` was dead code and every restart re-ran the browser flow. `newClientTokenStore` now builds the configured store; a `clientTokenStoreAdapter` bridges `FileOAuthTokenStore` to mcp-go's context-aware `client.TokenStore` interface (mapping `ErrNoToken` to `transport.ErrNoToken`, with an `ExpiresIn` fallback). `"keychain"` has no implementation, so it returns a clear unsupported-type error.

Tests added (no live MCP server needed):
- End-to-end header verification via `httptest`: `Connect` against a recording server proves `Authorization`/custom headers are sent and the transport's `Accept: text/event-stream` is not clobbered.
- OAuth callback handler success, error, and HTML-escaping paths via `httptest`; regression test that two callback servers can be started without panicking.
- Token store selection (`nil`/memory/file/keychain/unknown), file-store round-trip across "restarts", `ExpiresIn` fallback, and context cancellation.
- `buildRequestHeaders` unit tests.

Untestable without a live server: that the OAuth handler actually consults the store during a full browser flow (the seam is inside mcp-go), and stdio child-process termination on `Close` (would require a long-lived fake MCP stdio server; the fix is a direct delegation to the SDK's `Close`).

`gofmt`, `go build ./...`, `go vet ./...`, `go test ./...` (and `-race`) all pass in the `experimental/mcp` module; root module build/tests also pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced OAuth flow with improved error handling and explicit error parameter support in authorization callbacks
  * Added support for custom HTTP headers in MCP client requests
  * Extended token store flexibility with configurable storage options (memory, file-backed, or custom implementations)
  * Improved OAuth callback server implementation with HTML response rendering

* **Tests**
  * Added comprehensive test coverage for OAuth callback handling, HTTP header transmission, and token store operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->