### PR TITLE
Fix agent loop races and background-results persistence

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -240,6 +240,7 @@ func NewAgent(opts AgentOptions) (*Agent, error) {
 		opts.Hooks.Stop = append(opts.Hooks.Stop, extHooks.Stop...)
 		opts.Hooks.PreIteration = append(opts.Hooks.PreIteration, extHooks.PreIteration...)
 		opts.Hooks.OnSuspend = append(opts.Hooks.OnSuspend, extHooks.OnSuspend...)
+		opts.Hooks.PostBackgroundToolUse = append(opts.Hooks.PostBackgroundToolUse, extHooks.PostBackgroundToolUse...)
 		if rules := ext.Rules(); rules != "" {
 			opts.SystemPrompt = strings.TrimRight(opts.SystemPrompt, "\n") + "\n\n" + rules
 		}
@@ -622,9 +623,15 @@ func (a *Agent) CreateResponse(ctx context.Context, opts ...CreateResponseOption
 		}
 		// Execute not-started tool calls, if any.
 		if len(rs.NotStartedToolCalls) > 0 {
+			// The mutex guards the append: during parallel tool execution,
+			// tool goroutines invoke this callback for stream/progress
+			// events concurrently with the drain loop in the main goroutine.
 			var resumeItems []*ResponseItem
+			var resumeItemsMu sync.Mutex
 			resumeCallback := func(ctx context.Context, item *ResponseItem) error {
+				resumeItemsMu.Lock()
 				resumeItems = append(resumeItems, item)
+				resumeItemsMu.Unlock()
 				return eventCallback(ctx, item)
 			}
 			batch, err := a.executeToolCalls(ctx, hctx, rs.NotStartedToolCalls, resumeToolsByName, resumeCallback)
@@ -668,12 +675,22 @@ func (a *Agent) CreateResponse(ctx context.Context, opts ...CreateResponseOption
 	// LLM sees the results in its next turn. Happens once before the first
 	// generate() call; Stop-hook re-entries skip this block.
 	if len(options.BackgroundHandles) > 0 && options.BackgroundResults != nil {
+		preInjectLen := len(messages)
 		var injErr error
 		messages, injErr = a.injectBackgroundResults(ctx, hctx, messages, options.BackgroundHandles, options.BackgroundResults)
 		if injErr != nil {
 			return nil, injErr
 		}
 		hctx.Messages = messages
+		// The injected synthetic user message must also be part of the
+		// persisted turn: the session save below builds the turn from
+		// inputMessages + response.OutputMessages, so without this the
+		// saved history would pair two consecutive assistant messages and
+		// permanently lose the background results. Clone before appending
+		// so the caller's options.Messages backing array is not mutated.
+		if injected := messages[preInjectLen:]; len(injected) > 0 {
+			inputMessages = append(slices.Clone(inputMessages), injected...)
+		}
 	}
 
 generateLoop:
@@ -1342,7 +1359,13 @@ func (a *Agent) fireResumePostHooks(ctx context.Context, hctx *HookContext, rs *
 		// Propagate hook mutations back into the caller-supplied result and
 		// the merged tool_result message, mirroring the normal execution path
 		// in executeOneToolCall which reads postHctx.Result and
-		// postHctx.AdditionalContext after hooks fire.
+		// postHctx.AdditionalContext after hooks fire. Hooks may modify or
+		// replace results but may not delete them — a missing result would
+		// orphan the tool_use block (no paired tool_result) — so restore the
+		// original if a hook set Result to nil.
+		if postHctx.Result == nil {
+			postHctx.Result = result
+		}
 		result = postHctx.Result
 		rs.CallerSupplied[toolUseID] = result
 
@@ -1447,9 +1470,15 @@ func (a *Agent) generate(ctx context.Context, hctx *HookContext, messages []*llm
 	// Background task handles collected across all tool batches
 	var backgroundTasks []*BackgroundTaskHandle
 
-	// Wrap callback to collect all items
+	// Wrap callback to collect all items. The mutex guards the append:
+	// during parallel tool execution, tool goroutines invoke this callback
+	// for stream/progress events concurrently with the drain loop in the
+	// main goroutine.
+	var itemsMu sync.Mutex
 	collectingCallback := func(ctx context.Context, item *ResponseItem) error {
+		itemsMu.Lock()
 		items = append(items, item)
+		itemsMu.Unlock()
 		return callback(ctx, item)
 	}
 
@@ -1995,6 +2024,13 @@ func (a *Agent) executeToolCallsParallel(
 			}
 		}
 
+		// Use potentially modified result from hooks. Hooks may modify or
+		// replace results but may not delete them — a missing result would
+		// orphan the tool_use block (no paired tool_result) and break the
+		// next LLM call — so restore the original if a hook set Result to nil.
+		if postHctx.Result == nil {
+			postHctx.Result = result
+		}
 		result = postHctx.Result
 
 		// Re-attach background handle after hooks.
@@ -2180,7 +2216,13 @@ func (a *Agent) executeOneToolCall(
 		}
 	}
 
-	// Use potentially modified result from hooks
+	// Use potentially modified result from hooks. Hooks may modify or
+	// replace results but may not delete them — a missing result would
+	// orphan the tool_use block (no paired tool_result) and break the next
+	// LLM call — so restore the original if a hook set Result to nil.
+	if postHctx.Result == nil {
+		postHctx.Result = result
+	}
 	result = postHctx.Result
 
 	// Re-attach the background handle after hooks (hooks may have replaced

--- a/agent_suspend_test.go
+++ b/agent_suspend_test.go
@@ -734,6 +734,64 @@ func TestResumePostHooksFireInToolUseOrder(t *testing.T) {
 	}
 }
 
+func TestResumePostHookNilResultRestored(t *testing.T) {
+	// A PostToolUse hook that nils hctx.Result during resume must not panic
+	// or drop the caller-supplied tool result: hooks may modify or replace
+	// results but may not delete them, so the original is restored.
+	mock := &scriptedLLM{
+		script: []scriptedTurn{
+			toolUseAssistantTurn(newScriptedToolUse("toolu_a", "approve", `{}`)),
+			finalTextTurn("done"),
+		},
+	}
+	tool := &scriptedTool{
+		name:     "approve",
+		outcomes: []toolOutcome{{result: NewSuspendResult("waiting", nil)}},
+	}
+	sess := session.New("nil-result-resume")
+	agent, err := NewAgent(AgentOptions{
+		Model:   mock,
+		Tools:   []Tool{tool},
+		Session: sess,
+		Hooks: Hooks{
+			PostToolUse: []PostToolUseHook{
+				func(ctx context.Context, hctx *HookContext) error {
+					hctx.Result = nil
+					hctx.AdditionalContext = "post-hook context"
+					return nil
+				},
+			},
+		},
+	})
+	assert.NoError(t, err)
+
+	_, err = agent.CreateResponse(context.Background(), WithInput("hi"))
+	assert.NoError(t, err)
+	assert.True(t, sessIsSuspended(sess))
+
+	resp, err := agent.CreateResponse(context.Background(),
+		WithToolResults(map[string]*ToolResult{
+			"toolu_a": NewToolResultText("approved"),
+		}),
+	)
+	assert.NoError(t, err)
+	assert.Equal(t, resp.Status, ResponseStatusCompleted)
+	assert.Equal(t, resp.OutputText(), "done")
+
+	// The second LLM call must still see the caller-supplied tool_result —
+	// the hook nilling Result must not orphan the tool_use block.
+	lastCallMsgs := mock.received[1]
+	lastMsg := lastCallMsgs[len(lastCallMsgs)-1]
+	assert.Equal(t, lastMsg.Role, llm.User)
+	foundResult := false
+	for _, c := range lastMsg.Content {
+		if trc, ok := c.(*llm.ToolResultContent); ok && trc.ToolUseID == "toolu_a" {
+			foundResult = true
+		}
+	}
+	assert.True(t, foundResult, "resumed tool_result should reference toolu_a despite hook nilling Result")
+}
+
 func TestResumeNotStartedRunsInParallel(t *testing.T) {
 	// A sequential agent lets tool A suspend and leaves B, C not-started.
 	// On resume with a parallel-enabled agent, the not-started tools should

--- a/agent_test.go
+++ b/agent_test.go
@@ -1035,4 +1035,135 @@ func TestExtensionMerge(t *testing.T) {
 		assert.Error(t, err)
 		assert.ErrorContains(t, err, `duplicate tool name: "same_name"`)
 	})
+
+	t.Run("merges every hook type from extensions", func(t *testing.T) {
+		// One hook of each type — if a new hook slice is added to Hooks
+		// without a matching line in the NewAgent extension merge, this
+		// test catches the omission.
+		extHooks := Hooks{
+			SessionStart: []SessionStartHook{
+				func(ctx context.Context, hctx *HookContext) (*SessionStartResult, error) { return nil, nil },
+			},
+			PreGeneration: []PreGenerationHook{
+				func(ctx context.Context, hctx *HookContext) error { return nil },
+			},
+			PostGeneration: []PostGenerationHook{
+				func(ctx context.Context, hctx *HookContext) error { return nil },
+			},
+			PreToolUse: []PreToolUseHook{
+				func(ctx context.Context, hctx *HookContext) error { return nil },
+			},
+			PostToolUse: []PostToolUseHook{
+				func(ctx context.Context, hctx *HookContext) error { return nil },
+			},
+			PostToolUseFailure: []PostToolUseFailureHook{
+				func(ctx context.Context, hctx *HookContext) error { return nil },
+			},
+			Stop: []StopHook{
+				func(ctx context.Context, hctx *HookContext) (*StopDecision, error) { return nil, nil },
+			},
+			PreIteration: []PreIterationHook{
+				func(ctx context.Context, hctx *HookContext) error { return nil },
+			},
+			OnSuspend: []OnSuspendHook{
+				func(ctx context.Context, hctx *HookContext) error { return nil },
+			},
+			PostBackgroundToolUse: []PostBackgroundToolUseHook{
+				func(ctx context.Context, hctx *HookContext) error { return nil },
+			},
+		}
+
+		agent, err := NewAgent(AgentOptions{
+			Model:      mock,
+			Extensions: []Extension{&mockExtension{hooks: extHooks}},
+		})
+		assert.NoError(t, err)
+		assert.Len(t, agent.hooks.SessionStart, 1)
+		assert.Len(t, agent.hooks.PreGeneration, 1)
+		assert.Len(t, agent.hooks.PostGeneration, 1)
+		assert.Len(t, agent.hooks.PreToolUse, 1)
+		assert.Len(t, agent.hooks.PostToolUse, 1)
+		assert.Len(t, agent.hooks.PostToolUseFailure, 1)
+		assert.Len(t, agent.hooks.Stop, 1)
+		assert.Len(t, agent.hooks.PreIteration, 1)
+		assert.Len(t, agent.hooks.OnSuspend, 1)
+		assert.Len(t, agent.hooks.PostBackgroundToolUse, 1)
+	})
+}
+
+// TestParallelToolStreaming_NoDataRace verifies that the response item
+// accumulator is synchronized when parallel tools stream output from their
+// own goroutines while the drain loop processes completions on the main
+// goroutine. Run with -race to catch regressions.
+func TestParallelToolStreaming_NoDataRace(t *testing.T) {
+	const chunksPerTool = 50
+
+	// Both tools rendezvous before streaming so their StreamOutput calls
+	// are guaranteed to overlap.
+	var ready sync.WaitGroup
+	ready.Add(2)
+	makeStreamTool := func(name string) Tool {
+		return &mockTool{
+			name: name,
+			callFunc: func(ctx context.Context, input any) (*ToolResult, error) {
+				ready.Done()
+				ready.Wait()
+				for i := 0; i < chunksPerTool; i++ {
+					StreamOutput(ctx, "chunk")
+				}
+				return NewToolResultText(name + " done"), nil
+			},
+		}
+	}
+
+	callCount := 0
+	mock := &mockLLM{
+		nameFunc: func() string { return "test-model" },
+		generateFunc: func(ctx context.Context, opts ...llm.Option) (*llm.Response, error) {
+			callCount++
+			if callCount == 1 {
+				return &llm.Response{
+					ID:    "resp_1",
+					Model: "test-model",
+					Role:  llm.Assistant,
+					Content: []llm.Content{
+						&llm.ToolUseContent{ID: "t1", Name: "stream_a", Input: []byte(`{}`)},
+						&llm.ToolUseContent{ID: "t2", Name: "stream_b", Input: []byte(`{}`)},
+					},
+					Type:       "message",
+					StopReason: "tool_use",
+					Usage:      llm.Usage{InputTokens: 10, OutputTokens: 5},
+				}, nil
+			}
+			return &llm.Response{
+				ID:         "resp_2",
+				Model:      "test-model",
+				Role:       llm.Assistant,
+				Content:    []llm.Content{&llm.TextContent{Text: "Done"}},
+				Type:       "message",
+				StopReason: "stop",
+				Usage:      llm.Usage{InputTokens: 15, OutputTokens: 3},
+			}, nil
+		},
+	}
+
+	agent, err := NewAgent(AgentOptions{
+		Model:                 mock,
+		Tools:                 []Tool{makeStreamTool("stream_a"), makeStreamTool("stream_b")},
+		ParallelToolExecution: true,
+	})
+	assert.NoError(t, err)
+
+	resp, err := agent.CreateResponse(context.Background(), WithInput("stream both"))
+	assert.NoError(t, err)
+	assert.Equal(t, resp.OutputText(), "Done")
+
+	// All stream events from both tool goroutines must be collected.
+	streamItems := 0
+	for _, item := range resp.Items {
+		if item.Type == ResponseItemTypeToolStream {
+			streamItems++
+		}
+	}
+	assert.Equal(t, streamItems, 2*chunksPerTool)
 }

--- a/background_integration_test.go
+++ b/background_integration_test.go
@@ -649,6 +649,108 @@ func TestAgent_BackgroundTool_SessionBacked(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, finalResp.OutputText(), "Found 42 items.")
 	assert.Equal(t, int(callCount.Load()), 3)
+
+	// The synthetic background-results user message must be persisted to the
+	// session as part of the continuation turn. Without it, the saved history
+	// would pair two consecutive assistant messages and the model would
+	// permanently lose the background results on later turns.
+	msgs, err := sess.Messages(ctx)
+	assert.NoError(t, err)
+
+	ackIdx, resultsIdx, finalIdx := -1, -1, -1
+	for i, msg := range msgs {
+		text := msg.Text()
+		switch {
+		case msg.Role == llm.Assistant && strings.Contains(text, "Analyzing in background."):
+			ackIdx = i
+		case msg.Role == llm.User && strings.Contains(text, "Background task completed: analyzing data") &&
+			strings.Contains(text, "analysis complete: 42 items found"):
+			resultsIdx = i
+		case msg.Role == llm.Assistant && strings.Contains(text, "Found 42 items."):
+			finalIdx = i
+		}
+	}
+	assert.True(t, resultsIdx >= 0, "synthetic background-results user message should be persisted")
+	assert.True(t, ackIdx >= 0 && finalIdx >= 0, "both assistant turns should be persisted")
+	assert.True(t, ackIdx < resultsIdx && resultsIdx < finalIdx,
+		"background-results message should sit between the two assistant messages")
+
+	// No two consecutive assistant messages in the persisted history.
+	for i := 1; i < len(msgs); i++ {
+		if msgs[i].Role == llm.Assistant && msgs[i-1].Role == llm.Assistant {
+			t.Errorf("persisted history has consecutive assistant messages at %d and %d", i-1, i)
+		}
+	}
+}
+
+// TestAgent_PostBackgroundToolUseHook_FromExtension verifies that a
+// PostBackgroundToolUse hook registered via an Extension is merged into the
+// agent's hooks and fires when background results are delivered.
+func TestAgent_PostBackgroundToolUseHook_FromExtension(t *testing.T) {
+	var callCount atomic.Int32
+	var hookFired atomic.Bool
+
+	bgTool := &mockTool{
+		name: "bg_task",
+		callFunc: func(ctx context.Context, input any) (*ToolResult, error) {
+			return NewBackgroundResult(ctx, "ext hook test", func(ctx context.Context) (string, error) {
+				return "ext hook result", nil
+			}), nil
+		},
+	}
+
+	mock := &mockLLM{
+		nameFunc: func() string { return "test-model" },
+		generateFunc: func(ctx context.Context, opts ...llm.Option) (*llm.Response, error) {
+			n := int(callCount.Add(1))
+			switch n {
+			case 1:
+				return &llm.Response{
+					Role: llm.Assistant,
+					Content: []llm.Content{
+						&llm.ToolUseContent{ID: "t1", Name: "bg_task", Input: []byte(`{}`)},
+					},
+					StopReason: "tool_use",
+					Usage:      llm.Usage{},
+				}, nil
+			default:
+				return &llm.Response{
+					Role:       llm.Assistant,
+					Content:    []llm.Content{&llm.TextContent{Text: "done"}},
+					StopReason: "stop",
+					Usage:      llm.Usage{},
+				}, nil
+			}
+		},
+	}
+
+	ext := &mockExtension{hooks: Hooks{
+		PostBackgroundToolUse: []PostBackgroundToolUseHook{
+			func(ctx context.Context, hctx *HookContext) error {
+				hookFired.Store(true)
+				return nil
+			},
+		},
+	}}
+
+	agent, err := NewAgent(AgentOptions{
+		Name:       "TestAgent",
+		Model:      mock,
+		Tools:      []Tool{bgTool},
+		Extensions: []Extension{ext},
+	})
+	assert.NoError(t, err)
+
+	ctx := context.Background()
+	resp, err := agent.CreateResponse(ctx, WithInput("run it"))
+	assert.NoError(t, err)
+	assert.Equal(t, len(resp.BackgroundTasks), 1)
+
+	_, err = ContinueWithBackground(ctx, agent, resp,
+		WithMessages(resp.OutputMessages...),
+	)
+	assert.NoError(t, err)
+	assert.True(t, hookFired.Load(), "extension-provided PostBackgroundToolUse hook should fire")
 }
 
 // ---------------------------------------------------------------------------

--- a/background_test.go
+++ b/background_test.go
@@ -274,9 +274,15 @@ func TestAwaitBackgroundTasks_PartialResultsOnCancellation(t *testing.T) {
 		Done:   fastR.Background.done,
 	}
 
-	// slow task — blocks until context cancelled
+	// slow task — blocks until the test ends, so it can never deliver a
+	// result before AwaitBackgroundTasks observes the cancellation. (If the
+	// task returned on ctx.Done() instead, its error result could land on
+	// the Done channel first and Await's select would non-deterministically
+	// return it with a nil error, making the test flaky.)
+	release := make(chan struct{})
+	defer close(release)
 	slowR := NewBackgroundResult(ctx, "slow", func(ctx context.Context) (string, error) {
-		<-ctx.Done()
+		<-release
 		return "", ctx.Err()
 	})
 	slowHandle := &BackgroundTaskHandle{

--- a/hooks_test.go
+++ b/hooks_test.go
@@ -1148,6 +1148,128 @@ func TestPostToolUseHookIntegration(t *testing.T) {
 		}
 		t.Fatal("expected to find a tool call result item")
 	})
+
+	t.Run("hook setting Result to nil restores original result", func(t *testing.T) {
+		// Hooks may modify or replace results but may not delete them. A
+		// hook that nils hctx.Result must not panic the agent or orphan the
+		// tool_use block — the original result is restored.
+		tool := &mockTool{
+			name: "test_tool",
+			callFunc: func(ctx context.Context, input any) (*ToolResult, error) {
+				return NewToolResultText("tool output"), nil
+			},
+		}
+
+		agent, err := NewAgent(AgentOptions{
+			Model: newToolCallingMockLLM("test_tool"),
+			Tools: []Tool{tool},
+			Hooks: Hooks{
+				PostToolUse: []PostToolUseHook{
+					func(ctx context.Context, hctx *HookContext) error {
+						hctx.Result = nil
+						hctx.AdditionalContext = "post-hook context"
+						return nil
+					},
+				},
+			},
+		})
+		assert.NoError(t, err)
+
+		resp, err := agent.CreateResponse(context.Background(), WithInput("Use the tool"))
+		assert.NoError(t, err)
+		assert.Equal(t, resp.OutputText(), "Done")
+		assertToolResultPaired(t, resp, "tool_1", "tool output")
+	})
+
+	t.Run("hook setting Result to nil restores original result (parallel)", func(t *testing.T) {
+		makeTool := func(name string) Tool {
+			return &mockTool{
+				name: name,
+				callFunc: func(ctx context.Context, input any) (*ToolResult, error) {
+					return NewToolResultText(name + " output"), nil
+				},
+			}
+		}
+
+		callCount := 0
+		mock := &mockLLM{
+			nameFunc: func() string { return "test-model" },
+			generateFunc: func(ctx context.Context, opts ...llm.Option) (*llm.Response, error) {
+				callCount++
+				if callCount == 1 {
+					return &llm.Response{
+						ID:    "resp_1",
+						Model: "test-model",
+						Role:  llm.Assistant,
+						Content: []llm.Content{
+							&llm.ToolUseContent{ID: "tool_1", Name: "tool_a", Input: []byte(`{}`)},
+							&llm.ToolUseContent{ID: "tool_2", Name: "tool_b", Input: []byte(`{}`)},
+						},
+						Type:       "message",
+						StopReason: "tool_use",
+						Usage:      llm.Usage{InputTokens: 10, OutputTokens: 5},
+					}, nil
+				}
+				return &llm.Response{
+					ID:         "resp_2",
+					Model:      "test-model",
+					Role:       llm.Assistant,
+					Content:    []llm.Content{&llm.TextContent{Text: "Done"}},
+					Type:       "message",
+					StopReason: "stop",
+					Usage:      llm.Usage{InputTokens: 15, OutputTokens: 3},
+				}, nil
+			},
+		}
+
+		agent, err := NewAgent(AgentOptions{
+			Model:                 mock,
+			Tools:                 []Tool{makeTool("tool_a"), makeTool("tool_b")},
+			ParallelToolExecution: true,
+			Hooks: Hooks{
+				PostToolUse: []PostToolUseHook{
+					func(ctx context.Context, hctx *HookContext) error {
+						hctx.Result = nil
+						hctx.AdditionalContext = "post-hook context"
+						return nil
+					},
+				},
+			},
+		})
+		assert.NoError(t, err)
+
+		resp, err := agent.CreateResponse(context.Background(), WithInput("Use both tools"))
+		assert.NoError(t, err)
+		assert.Equal(t, resp.OutputText(), "Done")
+		assertToolResultPaired(t, resp, "tool_1", "tool_a output")
+		assertToolResultPaired(t, resp, "tool_2", "tool_b output")
+	})
+}
+
+// assertToolResultPaired asserts that the response's output messages contain
+// a tool_result block for the given tool_use ID carrying the expected text,
+// i.e. the tool_use block was not orphaned.
+func assertToolResultPaired(t *testing.T, resp *Response, toolUseID, expectedText string) {
+	t.Helper()
+	for _, msg := range resp.OutputMessages {
+		for _, c := range msg.Content {
+			trc, ok := c.(*llm.ToolResultContent)
+			if !ok || trc.ToolUseID != toolUseID {
+				continue
+			}
+			blocks, ok := trc.Content.([]*ToolResultContent)
+			assert.True(t, ok, "tool_result content should be []*ToolResultContent")
+			found := false
+			for _, b := range blocks {
+				if b.Text == expectedText {
+					found = true
+				}
+			}
+			assert.True(t, found, "tool_result for %q should carry text %q", toolUseID, expectedText)
+			return
+		}
+	}
+	t.Fatalf("no tool_result block found for tool_use %q", toolUseID)
 }
 
 func TestPostToolUseFailureHookIntegration(t *testing.T) {


### PR DESCRIPTION
Four verified correctness fixes in the core agent loop (`agent.go`), each with a regression test confirmed to fail against the previous code.

- **Extension `PostBackgroundToolUse` hooks were dropped.** The extension hook merge in `NewAgent` appended every other hook slice but omitted `PostBackgroundToolUse`, so an extension's background-completion hooks silently never fired (e.g. OTel spans opened at tool-call time would never close). Cross-checked the full `Hooks` struct against the merge block — this was the only omission; a new test asserts all ten hook types merge so future additions can't regress silently.

- **Data race on the response-item accumulator.** During parallel tool execution, tool goroutines invoke the collecting callback for stream/progress events concurrently with the drain loop on the main goroutine, producing unsynchronized appends to the shared `items` slice — corrupting or dropping response items under load. Both the `generate` accumulator and the resume path's `resumeItems` accumulator are now mutex-guarded. Regression test runs two concurrently-streaming tools with `ParallelToolExecution` and fails under `-race` pre-fix.

- **A PostToolUse hook setting `hctx.Result = nil` panicked or orphaned the tool_use block.** Three sites (sequential, parallel, resume) trusted `postHctx.Result` unconditionally: a nil result caused a nil-pointer panic when a background handle or `AdditionalContext` was attached, and otherwise omitted the `tool_result` block so the next LLM call failed provider validation. Hooks may modify or replace results but may not delete them — the original result is now restored at all three sites.

- **Injected background-results message was never persisted.** `WithBackgroundResults` appended the synthetic user message only to the in-memory LLM context; the session turn was built from `inputMessages + OutputMessages`, so the saved history paired two consecutive assistant messages and the model permanently lost the background results on every later turn. The injected message is now part of the persisted turn (cloned so the caller's slice is never mutated, and never double-added to the LLM context).

Also deflakes the pre-existing `TestAwaitBackgroundTasks_PartialResultsOnCancellation` (reproducible on `main` under `-race`): the slow task returned on `ctx.Done()` and could deliver its error result before `AwaitBackgroundTasks` observed the cancellation, non-deterministically yielding a nil error.

**Testing:** `gofmt`, `go build ./...`, `go test ./...`, and `go test -race ./...` all pass (plus the `a2a` and `otel` submodules, which `replace`-depend on core).

🤖 Generated with [Claude Code](https://claude.com/claude-code)