### PR TITLE
Cache live sessions per ID in FileStore to fix double-Open divergence

### DIFF
--- a/session/file_store.go
+++ b/session/file_store.go
@@ -48,7 +48,12 @@ var ErrInvalidSessionID = errors.New("invalid session ID")
 //
 // Within a single process, a FileStore is safe for concurrent use across
 // distinct sessions and serializes writes to the same session via an
-// internal mutex.
+// internal mutex. Open caches live *Session instances per ID (mirroring
+// MemoryStore), so repeated Open calls for the same ID return the same
+// shared, internally-synchronized instance — two handles can never
+// diverge and clobber each other's turns on a full rewrite. Cached
+// instances are evicted by Delete and replaced by Put; they otherwise
+// live for the lifetime of the store.
 //
 // # Durability
 //
@@ -77,6 +82,11 @@ type FileStore struct {
 	mu   sync.RWMutex
 	dir  string
 	sync bool
+	// sessions caches the live *Session per ID so repeated Open calls
+	// return the same shared instance (see the concurrency model above).
+	// Guarded by mu. Never take a session's lock while holding mu — the
+	// established lock order is session first, store second.
+	sessions map[string]*Session
 }
 
 // NewFileStore creates a FileStore rooted at dir. The directory is created
@@ -105,7 +115,7 @@ func NewFileStoreWithSync(dir string, sync bool) (*FileStore, error) {
 	if err := os.MkdirAll(dir, 0755); err != nil {
 		return nil, err
 	}
-	return &FileStore{dir: dir, sync: sync}, nil
+	return &FileStore{dir: dir, sync: sync, sessions: make(map[string]*Session)}, nil
 }
 
 // validateID rejects session IDs that could escape the store directory.
@@ -152,12 +162,24 @@ type sessionHeader struct {
 	CompletedToolCalls []*dive.CompletedToolCall `json:"completed_tool_calls,omitempty"`
 }
 
+// Open returns the session with the given ID, creating it (and its backing
+// file) if it does not exist.
+//
+// Open caches live sessions: all callers opening the same ID receive the
+// same shared, internally-synchronized *Session instance, so turns saved
+// through one handle are immediately visible through every other. The disk
+// file is only read on the first Open for an ID (or the first after a
+// Delete); thereafter the cached instance is the authority.
 func (s *FileStore) Open(ctx context.Context, id string) (*Session, error) {
 	if err := validateID(id); err != nil {
 		return nil, err
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
+
+	if sess, ok := s.sessions[id]; ok {
+		return sess, nil
+	}
 
 	data, torn, err := s.readSession(id)
 	if err != nil {
@@ -182,10 +204,12 @@ func (s *FileStore) Open(ctx context.Context, id string) (*Session, error) {
 			return nil, err
 		}
 	}
-	return &Session{
+	sess := &Session{
 		data:     data,
 		appender: s,
-	}, nil
+	}
+	s.sessions[id] = sess
+	return sess, nil
 }
 
 func (s *FileStore) Put(ctx context.Context, sess *Session) error {
@@ -203,6 +227,9 @@ func (s *FileStore) Put(ctx context.Context, sess *Session) error {
 		return err
 	}
 	sess.appender = s
+	// Adopt the session into the cache so subsequent Opens of this ID
+	// alias it rather than a stale prior instance (mirrors MemoryStore).
+	s.sessions[sess.data.ID] = sess
 	return nil
 }
 
@@ -276,6 +303,10 @@ func (s *FileStore) Delete(ctx context.Context, id string) error {
 	if err != nil && !os.IsNotExist(err) {
 		return err
 	}
+	// Evict the cached instance so a subsequent Open creates fresh state
+	// instead of resurrecting the deleted session. Any handle still held
+	// by a caller keeps working in memory but is orphaned from the store.
+	delete(s.sessions, id)
 	return nil
 }
 

--- a/session/session_test.go
+++ b/session/session_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/deepnoodle-ai/dive"
@@ -1216,4 +1217,162 @@ func TestSaveSuspendedTurnCopiesCallerMessages(t *testing.T) {
 	msgs, err = sess.Messages(ctx)
 	assert.NoError(t, err)
 	assert.Equal(t, msgs[len(msgs)-1].Text(), "done")
+}
+
+// ---------------------------------------------------------------------------
+// FileStore Open caching (review §3.3: double-Open divergence)
+// ---------------------------------------------------------------------------
+
+func TestFileStoreOpenReturnsSharedInstance(t *testing.T) {
+	dir := t.TempDir()
+	store, err := session.NewFileStore(dir)
+	assert.NoError(t, err)
+	ctx := context.Background()
+
+	h1, err := store.Open(ctx, "s1")
+	assert.NoError(t, err)
+	h2, err := store.Open(ctx, "s1")
+	assert.NoError(t, err)
+
+	// Both handles must be the same shared instance, mirroring MemoryStore.
+	assert.True(t, h1 == h2)
+
+	// A turn saved through one handle is visible through the other.
+	assert.NoError(t, h1.SaveTurn(ctx, []*llm.Message{llm.NewUserTextMessage("one")}, nil))
+	msgs, err := h2.Messages(ctx)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(msgs))
+	assert.Equal(t, "one", msgs[0].Text())
+
+	// Distinct IDs still get distinct sessions.
+	other, err := store.Open(ctx, "s2")
+	assert.NoError(t, err)
+	assert.True(t, h1 != other)
+}
+
+func TestFileStoreDoubleOpenFullRewriteNoDataLoss(t *testing.T) {
+	// The original §3.3 data-loss scenario: open the same ID twice, append
+	// a turn through each handle, then trigger a full file rewrite through
+	// one of them. Before Open caching, each Open returned a divergent
+	// in-memory copy and the rewrite silently deleted the other handle's
+	// turn from disk.
+	dir := t.TempDir()
+	store, err := session.NewFileStore(dir)
+	assert.NoError(t, err)
+	ctx := context.Background()
+
+	h1, err := store.Open(ctx, "s1")
+	assert.NoError(t, err)
+	h2, err := store.Open(ctx, "s1")
+	assert.NoError(t, err)
+
+	assert.NoError(t, h1.SaveTurn(ctx, []*llm.Message{llm.NewUserTextMessage("from-h1")}, nil))
+	assert.NoError(t, h2.SaveTurn(ctx, []*llm.Message{llm.NewUserTextMessage("from-h2")}, nil))
+
+	// SaveSuspendedTurn performs a full rewrite of the JSONL file from h1's
+	// in-memory state.
+	assert.NoError(t, h1.SaveSuspendedTurn(ctx, []*llm.Message{
+		llm.NewUserTextMessage("suspend-turn"),
+	}, nil, singleSuspensionState()))
+
+	// Re-read from disk with a fresh store: every turn must have survived.
+	store2, err := session.NewFileStore(dir)
+	assert.NoError(t, err)
+	got, err := store2.Open(ctx, "s1")
+	assert.NoError(t, err)
+	msgs, err := got.Messages(ctx)
+	assert.NoError(t, err)
+	assert.Equal(t, 3, len(msgs))
+	assert.Equal(t, "from-h1", msgs[0].Text())
+	assert.Equal(t, "from-h2", msgs[1].Text())
+	assert.Equal(t, "suspend-turn", msgs[2].Text())
+	assert.True(t, got.IsSuspended())
+
+	// store.Put is the other full-rewrite path; it must also rewrite from
+	// the single shared state.
+	assert.NoError(t, h2.CancelSuspension(ctx))
+	assert.NoError(t, store.Put(ctx, h1))
+	store3, err := session.NewFileStore(dir)
+	assert.NoError(t, err)
+	got, err = store3.Open(ctx, "s1")
+	assert.NoError(t, err)
+	msgs, err = got.Messages(ctx)
+	assert.NoError(t, err)
+	assert.Equal(t, 2, len(msgs))
+	assert.Equal(t, "from-h1", msgs[0].Text())
+	assert.Equal(t, "from-h2", msgs[1].Text())
+}
+
+func TestFileStoreDeleteEvictsCachedSession(t *testing.T) {
+	dir := t.TempDir()
+	store, err := session.NewFileStore(dir)
+	assert.NoError(t, err)
+	ctx := context.Background()
+
+	h1, err := store.Open(ctx, "s1")
+	assert.NoError(t, err)
+	assert.NoError(t, h1.SaveTurn(ctx, []*llm.Message{llm.NewUserTextMessage("old")}, nil))
+
+	assert.NoError(t, store.Delete(ctx, "s1"))
+
+	// A subsequent Open must create fresh state, not resurrect the deleted
+	// session from the cache.
+	h2, err := store.Open(ctx, "s1")
+	assert.NoError(t, err)
+	assert.True(t, h1 != h2)
+	msgs, err := h2.Messages(ctx)
+	assert.NoError(t, err)
+	assert.Equal(t, 0, len(msgs))
+}
+
+func TestFileStorePutAdoptsSessionIntoCache(t *testing.T) {
+	dir := t.TempDir()
+	store, err := session.NewFileStore(dir)
+	assert.NoError(t, err)
+	ctx := context.Background()
+
+	orig, err := store.Open(ctx, "orig")
+	assert.NoError(t, err)
+	assert.NoError(t, orig.SaveTurn(ctx, []*llm.Message{llm.NewUserTextMessage("hello")}, nil))
+
+	// Fork creates a detached session; Put must both persist it and adopt
+	// it into the cache so Open aliases the same instance (as MemoryStore
+	// does).
+	forked := orig.Fork("forked")
+	assert.NoError(t, store.Put(ctx, forked))
+
+	got, err := store.Open(ctx, "forked")
+	assert.NoError(t, err)
+	assert.True(t, got == forked)
+}
+
+func TestFileStoreConcurrentOpenSingleInstance(t *testing.T) {
+	dir := t.TempDir()
+	store, err := session.NewFileStore(dir)
+	assert.NoError(t, err)
+	ctx := context.Background()
+
+	// Concurrent Opens of the same ID must all resolve to one instance and
+	// concurrent SaveTurns through them must not race (run under -race).
+	const n = 8
+	handles := make([]*session.Session, n)
+	var wg sync.WaitGroup
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			h, err := store.Open(ctx, "s1")
+			assert.NoError(t, err)
+			assert.NoError(t, h.SaveTurn(ctx, []*llm.Message{llm.NewUserTextMessage("hi")}, nil))
+			handles[i] = h
+		}(i)
+	}
+	wg.Wait()
+
+	for i := 1; i < n; i++ {
+		assert.True(t, handles[0] == handles[i])
+	}
+	msgs, err := handles[0].Messages(ctx)
+	assert.NoError(t, err)
+	assert.Equal(t, n, len(msgs))
 }


### PR DESCRIPTION
## Summary

Fixes **§3.3 (HIGH)** of `docs/reviews/2026-06-09-api-review.md`: FileStore double-`Open` divergence. This was deliberately deferred from #181 (which covered §3.1, §3.2, parts of §3.4, and §3.6) and builds on that PR's healed-read path and lock-order discipline.

### The bug

Unlike `MemoryStore`, every `FileStore.Open` for the same session ID returned a fresh in-memory `*Session`. Two handles appended to the same JSONL file but never saw each other's events, and any full-rewrite operation (`SaveSuspendedTurn`, `Compact`, `Put`) from one handle rewrote the file from that handle's stale in-memory state — silently deleting the other handle's turns from disk.

### The fix

`FileStore` now caches the live `*Session` per ID, mirroring `MemoryStore`:

- **`Open`** returns the cached instance on a hit; disk is only read on the first `Open` for an ID (or the first after `Delete`). The torn-line healing path from #181 is unchanged — it runs on the cache-miss read, after which the cached instance is the authority.
- **`Delete`** evicts the cache entry, so a subsequent `Open` creates fresh state rather than resurrecting the deleted session.
- **`Put`** adopts the given session into the cache (as `MemoryStore` does), so later `Open`s alias it rather than a stale prior instance.

### New aliasing semantics

All callers opening the same ID through one `FileStore` now receive the **same shared, internally-synchronized `*Session` instance** — turns saved through one handle are immediately visible through every other, and full rewrites always reflect the single shared state. Documented on `Open` and in the `FileStore` concurrency-model doc block. Cached instances live for the lifetime of the store (same as `MemoryStore`). Cross-process behavior is unchanged: single-writer-per-session with sequential handoff, as before.

Lock-order note: the cache is guarded by the existing store mutex and is never touched while acquiring a session lock, preserving the session-lock → store-lock order established in #181.

### Tests

New regression tests (all run under `-race`):

- `TestFileStoreOpenReturnsSharedInstance` — two `Open`s of one ID return the same instance and see each other's turns
- `TestFileStoreDoubleOpenFullRewriteNoDataLoss` — the original data-loss scenario (append from two handles, full rewrite via `SaveSuspendedTurn` and via `Put`) no longer loses turns on disk
- `TestFileStoreDeleteEvictsCachedSession` — `Open` after `Delete` yields fresh state
- `TestFileStorePutAdoptsSessionIntoCache` — `Put` of a forked session makes `Open` alias it
- `TestFileStoreConcurrentOpenSingleInstance` — 8 concurrent `Open`+`SaveTurn` resolve to one instance with no races

`gofmt` clean, `go build ./...`, `go test ./...`, and `go test -race ./session/...` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session persistence to prevent data loss during file rewrite operations
  * Fixed session cache invalidation on deletion to prevent stale session resurrection

* **Performance Improvements**
  * Sessions are now cached in memory to reduce file I/O on repeated access
  * Concurrent session operations are now handled safely with single-writer-per-session semantics

<!-- end of auto-generated comment: release notes by coderabbit.ai -->