### PR TITLE
Fix A2A final-answer extraction, settings merge, and MCP tool refresh

### DIFF
--- a/a2a/a2a_test.go
+++ b/a2a/a2a_test.go
@@ -84,6 +84,18 @@ func (t *confirmTool) Call(ctx context.Context, input any) (*dive.ToolResult, er
 	return dive.NewSuspendResult("Please confirm", nil), nil
 }
 
+type lookupTool struct{}
+
+func (t *lookupTool) Name() string         { return "lookup" }
+func (t *lookupTool) Description() string  { return "Look something up" }
+func (t *lookupTool) Schema() *dive.Schema { return nil }
+func (t *lookupTool) Annotations() *dive.ToolAnnotations {
+	return &dive.ToolAnnotations{Title: "Lookup"}
+}
+func (t *lookupTool) Call(ctx context.Context, input any) (*dive.ToolResult, error) {
+	return dive.NewToolResultText("lookup result"), nil
+}
+
 type authSuspendTool struct{}
 
 func (t *authSuspendTool) Name() string         { return "auth_gate" }
@@ -196,10 +208,12 @@ func startServer(t *testing.T, agent *dive.Agent) (*httptest.Server, *a2aclient.
 	return ts, client
 }
 
-// taskText extracts the first text from a raw SDK task's artifacts, falling
-// back to the last agent message in history.
+// taskText extracts the text from a raw SDK task's artifacts (latest artifact
+// first, mirroring RemoteAgent's extraction), falling back to the last agent
+// message in history.
 func taskText(task *a2asdk.Task) string {
-	for _, art := range task.Artifacts {
+	for i := len(task.Artifacts) - 1; i >= 0; i-- {
+		art := task.Artifacts[i]
 		for _, p := range art.Parts {
 			if t := p.Text(); t != "" {
 				return t
@@ -342,6 +356,51 @@ func TestSuspendAndResume(t *testing.T) {
 	assert.Equal(t, a2asdk.TaskStateCompleted, task2.Status.State)
 	assert.True(t, len(task2.Artifacts) > 0)
 	assert.Equal(t, "Done! You approved it.", task2.Artifacts[0].Parts[0].Text())
+}
+
+// TestMultiMessageTurnReturnsFinalText is a regression test for the bug where
+// a tool-using turn emitted one artifact per assistant message and clients
+// returned the first artifact's text — i.e. the "Let me check..." preamble
+// instead of the final answer. The server must emit a single final artifact
+// (matching Response.OutputText() semantics) and RemoteAgent must surface it.
+func TestMultiMessageTurnReturnsFinalText(t *testing.T) {
+	var callNum atomic.Int32
+	model := &fakeLLM{generate: func(ctx context.Context, opts ...llm.Option) (*llm.Response, error) {
+		// Odd calls: a text preamble plus a tool call. Even calls: the answer.
+		if callNum.Add(1)%2 == 1 {
+			return &llm.Response{
+				ID:    "resp_preamble",
+				Model: "fake-model",
+				Role:  llm.Assistant,
+				Content: []llm.Content{
+					&llm.TextContent{Text: "Let me check..."},
+					&llm.ToolUseContent{ID: "call_1", Name: "lookup", Input: json.RawMessage(`{}`)},
+				},
+				Type:       "message",
+				StopReason: "tool_use",
+				Usage:      llm.Usage{InputTokens: 10, OutputTokens: 5},
+			}, nil
+		}
+		return textResponse("The answer is 42."), nil
+	}}
+	agent := buildAgent(t, model, &lookupTool{})
+	ts, client := startServer(t, agent)
+
+	// Raw SDK client: the task must carry exactly one artifact, holding the
+	// final assistant message's text, not the preamble.
+	msg := a2asdk.NewMessage(a2asdk.MessageRoleUser, a2asdk.NewTextPart("What is the answer?"))
+	task := sendAndExpectTask(t, client, msg)
+	assert.Equal(t, a2asdk.TaskStateCompleted, task.Status.State)
+	assert.Len(t, task.Artifacts, 1)
+	assert.Equal(t, "The answer is 42.", taskText(task))
+
+	// RemoteAgent: TaskResult.Text must be the final answer.
+	remote, err := a2a.NewRemoteAgentFromURL(context.Background(), ts.URL)
+	assert.NoError(t, err)
+	result, err := remote.SendText(context.Background(), "What is the answer?")
+	assert.NoError(t, err)
+	assert.True(t, result.IsCompleted())
+	assert.Equal(t, "The answer is 42.", result.Text)
 }
 
 func TestStreamMessage(t *testing.T) {

--- a/a2a/executor.go
+++ b/a2a/executor.go
@@ -270,15 +270,21 @@ func (e *Executor) yieldResponseEvents(
 		yield(event, nil)
 
 	case "", dive.ResponseStatusCompleted:
-		// Emit artifacts from assistant messages.
+		// Emit a single artifact built from the final assistant message,
+		// matching Response.OutputText() semantics. In a tool-using turn the
+		// intermediate assistant messages ("Let me check...") are streamed as
+		// working status updates but must not become the task's result —
+		// only the last assistant message with renderable content does.
+		var parts []*a2asdk.Part
 		for _, out := range resp.OutputMessages {
 			if out.Role != llm.Assistant {
 				continue
 			}
-			parts := partsFromContent(out.Content)
-			if len(parts) == 0 {
-				continue
+			if p := partsFromContent(out.Content); len(p) > 0 {
+				parts = p
 			}
+		}
+		if len(parts) > 0 {
 			artEvent := a2asdk.NewArtifactEvent(execCtx, parts...)
 			artEvent.LastChunk = true
 			if !yield(artEvent, nil) {

--- a/a2a/remoteagent.go
+++ b/a2a/remoteagent.go
@@ -258,14 +258,17 @@ func normalizeState(s a2asdk.TaskState) string {
 	return strings.ToLower(strings.TrimPrefix(string(s), "TASK_STATE_"))
 }
 
-// extractText returns the most useful text from a task: prefers artifact
-// text parts, falls back to the last agent message in history.
+// extractText returns the most useful text from a task: prefers the latest
+// artifact's text parts (Dive's A2A server emits one final artifact per turn,
+// matching Response.OutputText() semantics; other servers may emit several,
+// in which case the most recent one is the final answer), falling back to
+// the last agent message in history.
 func extractText(task *a2asdk.Task) string {
 	if task == nil {
 		return ""
 	}
-	for _, art := range task.Artifacts {
-		for _, p := range art.Parts {
+	for i := len(task.Artifacts) - 1; i >= 0; i-- {
+		for _, p := range task.Artifacts[i].Parts {
 			if t := p.Text(); t != "" {
 				return t
 			}

--- a/experimental/mcp/manager.go
+++ b/experimental/mcp/manager.go
@@ -154,7 +154,9 @@ func (m *Manager) GetToolsByServer(serverName string) []dive.Tool {
 	return nil
 }
 
-// GetTool returns a specific tool by name (with server prefix)
+// GetTool returns a specific tool by name. Tools are keyed by bare tool name
+// (no server prefix); duplicate names across servers are rejected at
+// registration time.
 func (m *Manager) GetTool(toolKey string) dive.Tool {
 	m.mutex.RLock()
 	defer m.mutex.RUnlock()
@@ -193,16 +195,26 @@ func (m *Manager) RefreshTools(ctx context.Context) error {
 			continue
 		}
 
-		// Remove old tools for this server
-		for toolKey := range m.tools {
-			if len(toolKey) > len(serverName)+1 && toolKey[:len(serverName)+1] == serverName+"." {
-				delete(m.tools, toolKey)
+		// Remove this server's old tools from the global map. Tools are
+		// keyed by bare tool name (no server prefix), so delete by identity:
+		// only remove an entry when it is one of this server's adapters, to
+		// avoid clobbering a same-named tool owned by another server.
+		for _, old := range server.Tools {
+			if existing, ok := m.tools[old.Name()]; ok && existing == old {
+				delete(m.tools, old.Name())
 			}
 		}
 
-		// Create new tool adapters
+		// Create new tool adapters, mirroring the duplicate-name guard used
+		// during initial registration: a name already registered (by another
+		// server, or twice by this one) is an error and is not overwritten.
 		var tools []dive.Tool
 		for _, mcpTool := range mcpTools {
+			if _, exists := m.tools[mcpTool.Name]; exists {
+				errors = append(errors, fmt.Errorf("mcp server %s has duplicate tool name %q",
+					serverName, mcpTool.Name))
+				continue
+			}
 			adapter := NewToolAdapter(server.Client, mcpTool, serverName)
 			tools = append(tools, adapter)
 			m.tools[mcpTool.Name] = adapter

--- a/experimental/mcp/manager_test.go
+++ b/experimental/mcp/manager_test.go
@@ -2,11 +2,13 @@ package mcp
 
 import (
 	"context"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/deepnoodle-ai/dive"
 	"github.com/deepnoodle-ai/wonton/assert"
 	"github.com/mark3labs/mcp-go/mcp"
+	mcpserver "github.com/mark3labs/mcp-go/server"
 )
 
 func TestNewManager(t *testing.T) {
@@ -159,10 +161,10 @@ func TestMCPManager_WithMockServer(t *testing.T) {
 		Tools:  diveTools,
 	}
 
-	// Add tools to the global tools map
+	// Add tools to the global tools map (keyed by bare tool name, matching
+	// what initializeServer does)
 	for _, tool := range diveTools {
-		toolKey := testConfig.Name + "." + tool.Name()
-		manager.tools[toolKey] = tool
+		manager.tools[tool.Name()] = tool
 	}
 
 	// Test GetServerNames
@@ -177,11 +179,11 @@ func TestMCPManager_WithMockServer(t *testing.T) {
 	// Test GetAllTools
 	allTools := manager.GetAllTools()
 	assert.Len(t, allTools, 2)
-	assert.Contains(t, allTools, "test-server.test-tool-1")
-	assert.Contains(t, allTools, "test-server.test-tool-2")
+	assert.Contains(t, allTools, "test-tool-1")
+	assert.Contains(t, allTools, "test-tool-2")
 
 	// Test GetTool
-	tool1 := manager.GetTool("test-server.test-tool-1")
+	tool1 := manager.GetTool("test-tool-1")
 	assert.NotNil(t, tool1)
 	assert.Equal(t, "test-tool-1", tool1.Name())
 
@@ -240,10 +242,10 @@ func TestMCPManager_RefreshTools_WithMockServer(t *testing.T) {
 		Tools:  diveTools,
 	}
 
-	// Add initial tools to global map
+	// Add initial tools to global map (keyed by bare tool name, matching
+	// what initializeServer does)
 	for _, tool := range diveTools {
-		toolKey := testConfig.Name + "." + tool.Name()
-		manager.tools[toolKey] = tool
+		manager.tools[tool.Name()] = tool
 	}
 
 	// Verify initial state
@@ -290,4 +292,120 @@ func TestMCPManager_RefreshTools_DisconnectedServer(t *testing.T) {
 	ctx := context.Background()
 	err = manager.RefreshTools(ctx)
 	assert.NoError(t, err) // Should succeed by skipping disconnected servers
+}
+
+// ---------------------------------------------------------------------------
+// RefreshTools integration tests against a real in-process MCP server
+// ---------------------------------------------------------------------------
+
+// newTestMCPServer starts an in-process streamable HTTP MCP server exposing
+// the given tools.
+func newTestMCPServer(t *testing.T, toolNames ...string) (*mcpserver.MCPServer, *httptest.Server) {
+	t.Helper()
+	srv := mcpserver.NewMCPServer("test-mcp-server", "1.0.0",
+		mcpserver.WithToolCapabilities(true))
+	for _, name := range toolNames {
+		addTestTool(srv, name)
+	}
+	ts := mcpserver.NewTestStreamableHTTPServer(srv)
+	t.Cleanup(ts.Close)
+	return srv, ts
+}
+
+func addTestTool(srv *mcpserver.MCPServer, name string) {
+	srv.AddTool(mcp.NewTool(name, mcp.WithDescription("Test tool "+name)),
+		func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			return mcp.NewToolResultText("ok"), nil
+		})
+}
+
+// TestMCPManager_RefreshTools_RemovesStaleTools is a regression test for the
+// stale-key cleanup in RefreshTools: it previously deleted keys prefixed
+// "server." even though tools are registered under bare names, so tools
+// removed server-side accumulated in the manager forever.
+func TestMCPManager_RefreshTools_RemovesStaleTools(t *testing.T) {
+	srv, ts := newTestMCPServer(t, "alpha", "beta")
+
+	manager := NewManager()
+	t.Cleanup(func() { manager.Close() })
+
+	ctx := context.Background()
+	err := manager.InitializeServers(ctx, []*ServerConfig{
+		{Type: "http", Name: "test-server", URL: ts.URL},
+	})
+	assert.NoError(t, err)
+
+	allTools := manager.GetAllTools()
+	assert.Len(t, allTools, 2)
+	assert.Contains(t, allTools, "alpha")
+	assert.Contains(t, allTools, "beta")
+
+	// Remove "beta" server-side, then refresh.
+	srv.DeleteTools("beta")
+	assert.NoError(t, manager.RefreshTools(ctx))
+
+	allTools = manager.GetAllTools()
+	assert.Len(t, allTools, 1)
+	assert.Contains(t, allTools, "alpha")
+	assert.Nil(t, manager.GetTool("beta"))
+	assert.Len(t, manager.GetToolsByServer("test-server"), 1)
+}
+
+// TestMCPManager_InitializeServers_DuplicateToolName verifies the existing
+// duplicate-name guard on initial connect: two servers exposing the same
+// tool name is an error.
+func TestMCPManager_InitializeServers_DuplicateToolName(t *testing.T) {
+	_, ts1 := newTestMCPServer(t, "shared")
+	_, ts2 := newTestMCPServer(t, "shared")
+
+	manager := NewManager()
+	t.Cleanup(func() { manager.Close() })
+
+	err := manager.InitializeServers(context.Background(), []*ServerConfig{
+		{Type: "http", Name: "server-one", URL: ts1.URL},
+		{Type: "http", Name: "server-two", URL: ts2.URL},
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "duplicate tool name")
+}
+
+// TestMCPManager_RefreshTools_DuplicateToolName verifies that a duplicate
+// tool name appearing across servers on refresh is handled the same way as
+// on initial connect: an error is reported and the original registration is
+// not clobbered.
+func TestMCPManager_RefreshTools_DuplicateToolName(t *testing.T) {
+	_, ts1 := newTestMCPServer(t, "shared")
+	srv2, ts2 := newTestMCPServer(t, "other")
+
+	manager := NewManager()
+	t.Cleanup(func() { manager.Close() })
+
+	ctx := context.Background()
+	err := manager.InitializeServers(ctx, []*ServerConfig{
+		{Type: "http", Name: "server-one", URL: ts1.URL},
+		{Type: "http", Name: "server-two", URL: ts2.URL},
+	})
+	assert.NoError(t, err)
+	assert.Len(t, manager.GetAllTools(), 2)
+
+	// server-two now also exposes "shared", colliding with server-one.
+	addTestTool(srv2, "shared")
+
+	err = manager.RefreshTools(ctx)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "duplicate tool name")
+
+	// server-one's registration of "shared" must be preserved.
+	tool := manager.GetTool("shared")
+	assert.NotNil(t, tool)
+	adapter, ok := tool.(*ToolAdapter)
+	assert.True(t, ok)
+	assert.Equal(t, "server-one", adapter.serverName)
+
+	// server-two keeps its non-conflicting tool.
+	tool = manager.GetTool("other")
+	assert.NotNil(t, tool)
+	adapter, ok = tool.(*ToolAdapter)
+	assert.True(t, ok)
+	assert.Equal(t, "server-two", adapter.serverName)
 }

--- a/experimental/settings/settings.go
+++ b/experimental/settings/settings.go
@@ -2,6 +2,7 @@ package settings
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -35,34 +36,92 @@ type SettingsPermissions struct {
 }
 
 // LoadSettings loads settings from the .dive directory in the given directory.
-// It checks for settings.local.json first (user-specific), then settings.json.
+// Both settings.json (the project base) and settings.local.json (user-specific
+// overrides) are read when present and merged, mirroring Claude Code
+// semantics: settings.local.json overrides settings.json rather than
+// replacing it wholesale.
+//
+// Merge rules, applied recursively to the raw JSON documents:
+//   - Objects/maps merge per key, with the local value winning on conflict.
+//     This applies at every nesting level (e.g. "permissions", "sandbox",
+//     "sandbox.environment").
+//   - Arrays/slices replace wholesale: a local "permissions.allow" list
+//     replaces the entire base list rather than appending to it.
+//   - Scalar keys present in the local file win, including explicit zero
+//     values such as false or "" (presence in the file is the override
+//     signal); keys absent from the local file keep the base value.
+//
 // If neither file exists, returns an empty Settings with no error.
 func LoadSettings(dir string) (*Settings, error) {
 	diveDir := filepath.Join(dir, ".dive")
 
-	// Try settings.local.json first (takes precedence, like Claude Code)
-	// Then fall back to settings.json
-	filenames := []string{"settings.local.json", "settings.json"}
-
-	for _, filename := range filenames {
-		settingsPath := filepath.Join(diveDir, filename)
-		data, err := os.ReadFile(settingsPath)
-		if os.IsNotExist(err) {
-			continue
-		}
-		if err != nil {
-			return nil, err
-		}
-
-		var settings Settings
-		if err := json.Unmarshal(data, &settings); err != nil {
-			return nil, err
-		}
-
-		return &settings, nil
+	base, err := readSettingsMap(filepath.Join(diveDir, "settings.json"))
+	if err != nil {
+		return nil, err
+	}
+	local, err := readSettingsMap(filepath.Join(diveDir, "settings.local.json"))
+	if err != nil {
+		return nil, err
 	}
 
-	return &Settings{}, nil
+	merged := mergeSettingsMaps(base, local)
+	if merged == nil {
+		return &Settings{}, nil
+	}
+
+	data, err := json.Marshal(merged)
+	if err != nil {
+		return nil, err
+	}
+	var settings Settings
+	if err := json.Unmarshal(data, &settings); err != nil {
+		return nil, err
+	}
+	return &settings, nil
+}
+
+// readSettingsMap reads a settings file into a generic JSON map. Returns
+// (nil, nil) if the file does not exist.
+func readSettingsMap(path string) (map[string]any, error) {
+	data, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	var m map[string]any
+	if err := json.Unmarshal(data, &m); err != nil {
+		return nil, fmt.Errorf("settings: parse %s: %w", path, err)
+	}
+	return m, nil
+}
+
+// mergeSettingsMaps deep-merges override into base and returns the result.
+// Objects merge per key recursively with override winning; any other value
+// type (arrays, scalars, null) present in override replaces the base value.
+// Either argument may be nil, in which case the other is returned.
+func mergeSettingsMaps(base, override map[string]any) map[string]any {
+	if base == nil {
+		return override
+	}
+	if override == nil {
+		return base
+	}
+	out := make(map[string]any, len(base)+len(override))
+	for k, v := range base {
+		out[k] = v
+	}
+	for k, v := range override {
+		if baseMap, ok := out[k].(map[string]any); ok {
+			if overrideMap, ok := v.(map[string]any); ok {
+				out[k] = mergeSettingsMaps(baseMap, overrideMap)
+				continue
+			}
+		}
+		out[k] = v
+	}
+	return out
 }
 
 // ToPermissionRules converts the settings permissions to permission.Rules.

--- a/experimental/settings/settings_test.go
+++ b/experimental/settings/settings_test.go
@@ -66,6 +66,73 @@ func TestLoadSettings(t *testing.T) {
 		assert.NotNil(t, settings)
 		assert.Len(t, settings.Permissions.Allow, 2) // local has 2, regular has 1
 	})
+
+	t.Run("settings.local.json merges with settings.json instead of shadowing it", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		diveDir := filepath.Join(tmpDir, ".dive")
+		assert.NoError(t, os.Mkdir(diveDir, 0755))
+
+		settingsJSON := `{
+  "permissions": {
+    "allow": ["WebSearch", "Bash(go build:*)"],
+    "deny": ["Bash(rm -rf:*)"]
+  },
+  "sandbox": {
+    "enabled": true,
+    "environment": {"BASE_VAR": "base", "SHARED_VAR": "from-base"},
+    "docker": {"image": "ubuntu:22.04"}
+  }
+}`
+		localJSON := `{
+  "permissions": {
+    "allow": ["Bash(go test:*)"]
+  },
+  "sandbox": {
+    "environment": {"SHARED_VAR": "from-local", "LOCAL_VAR": "local"},
+    "docker": {"command": "podman"}
+  }
+}`
+		assert.NoError(t, os.WriteFile(filepath.Join(diveDir, "settings.json"), []byte(settingsJSON), 0644))
+		assert.NoError(t, os.WriteFile(filepath.Join(diveDir, "settings.local.json"), []byte(localJSON), 0644))
+
+		settings, err := LoadSettings(tmpDir)
+		assert.NoError(t, err)
+		assert.NotNil(t, settings)
+
+		// Slice field: the local allow list replaces the base list wholesale.
+		assert.Equal(t, []string{"Bash(go test:*)"}, settings.Permissions.Allow)
+		// Slice field absent from local: the base deny list is preserved
+		// (previously the entire settings.json — deny rules included — was
+		// silently discarded when settings.local.json existed).
+		assert.Equal(t, []string{"Bash(rm -rf:*)"}, settings.Permissions.Deny)
+
+		// Map field: merged per key, local winning on conflict.
+		assert.NotNil(t, settings.Sandbox)
+		assert.Equal(t, map[string]string{
+			"BASE_VAR":   "base",
+			"SHARED_VAR": "from-local",
+			"LOCAL_VAR":  "local",
+		}, settings.Sandbox.Environment)
+
+		// Scalar fields: base values absent from local are kept; local
+		// values win where present.
+		assert.True(t, settings.Sandbox.Enabled)
+		assert.Equal(t, "ubuntu:22.04", settings.Sandbox.Docker.Image)
+		assert.Equal(t, "podman", settings.Sandbox.Docker.Command)
+	})
+
+	t.Run("only settings.local.json present", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		diveDir := filepath.Join(tmpDir, ".dive")
+		assert.NoError(t, os.Mkdir(diveDir, 0755))
+
+		localJSON := `{"permissions": {"allow": ["WebSearch"]}}`
+		assert.NoError(t, os.WriteFile(filepath.Join(diveDir, "settings.local.json"), []byte(localJSON), 0644))
+
+		settings, err := LoadSettings(tmpDir)
+		assert.NoError(t, err)
+		assert.Equal(t, []string{"WebSearch"}, settings.Permissions.Allow)
+	})
 }
 
 func TestParsePermissionPattern(t *testing.T) {


### PR DESCRIPTION
Remediates three findings from `docs/reviews/2026-06-09-api-review.md` (§7). Per the batch instructions, each finding was re-verified against current `main` (including the PR #184 mcp changes) before fixing — all three still held; #184 touched `client.go`/`token_store.go`/`transport.go` but not `manager.go`.

## ⚠️ Behavior change: `TaskResult.Text` / task artifacts for multi-message turns

The A2A server previously emitted **one artifact per assistant message**, and `RemoteAgent` returned the **first** artifact's text. For any tool-using turn this meant clients got the preamble ("Let me check…") instead of the final answer. The server now emits a **single final artifact** built from the last assistant message with renderable content (matching `Response.OutputText()` semantics), and `extractText` prefers the **latest** artifact for compatibility with non-Dive servers that emit several.

If you relied on `task.Artifacts` containing every intermediate assistant message, that data is no longer in artifacts — intermediate messages are still streamed as `working` status updates.

## Fixes

### §7.5 — A2A `RemoteAgent` returns intermediate text, not the final answer
- `a2a/executor.go`: completed responses now yield one artifact from the final assistant message instead of one per message.
- `a2a/remoteagent.go`: `extractText` iterates artifacts newest-first so server and client agree.
- Regression test `TestMultiMessageTurnReturnsFinalText`: a preamble+tool-call turn followed by a final answer yields exactly one artifact containing the final text, verified through both the raw SDK client and `RemoteAgent.SendText`. Existing suspend/resume roundtrip tests still pass unchanged (they were single-artifact already); the `taskText` test helper was updated to mirror the newest-first extraction.

### §7.7 — `settings.local.json` shadows instead of merging
- `experimental/settings/settings.go`: `LoadSettings` now reads both `settings.json` (base) and `settings.local.json` (override) and deep-merges the raw JSON documents instead of returning the first file found. Merge rules are documented on `LoadSettings`:
  - objects/maps merge per key at every nesting level, local winning on conflict;
  - arrays replace wholesale (a local `permissions.allow` replaces the base list, it does not append);
  - scalar keys **present** in the local file win — including explicit zero values like `false`, since presence in the file is the override signal; absent keys keep the base value. (This presence-based rule is a deliberate, slightly stronger interpretation of "non-zero local wins": JSON-level merging lets a local file explicitly set `"enabled": false`, which a struct-level zero-value check could not express.)
- Regression tests cover a map field (`sandbox.environment` merged per key), a slice field (`permissions.allow` replaced, base `permissions.deny` preserved — previously the whole project file including deny rules was silently discarded), and scalars (`sandbox.enabled`/`docker.image` kept from base, `docker.command` taken from local), plus the local-only case.

### §7 trailing — `Manager.RefreshTools` stale-key cleanup never matches
- `experimental/mcp/manager.go`: the cleanup deleted keys prefixed `server.`, but tools are registered under bare names — so server-side-removed tools accumulated forever. Cleanup now removes the server's previous adapters by identity (so a same-named tool owned by another server is never clobbered), and refresh now mirrors the initial-connect duplicate-name guard: a colliding name yields the same `"duplicate tool name"` error instead of silently overwriting.
- Tool key namespacing itself is unchanged (that's a §8 breaking change). The `GetTool` doc comment and two white-box tests that hand-inserted never-used `server.`-prefixed keys were corrected to the real bare-name format.
- Regression tests run against a real in-process mcp-go streamable HTTP server: (a) a tool deleted server-side disappears after `RefreshTools`; (b) duplicate names across servers error identically on refresh and on initial connect, preserving the original registration.

## Deferred / not addressed here
- **§7.6 — incremental A2A streaming**: adjacent to §7.5 but needs design discussion (token-delta events vs. whole-message status updates, and how `StreamText` surfaces chunks); deliberately not attempted.
- **§7.4 — sandbox domain allowlist is advisory, not enforcement**: out of scope for this batch.
- The review's note that `mcp.Client` lacks a mutex on `connected` was also not addressed (not part of this batch's scope).

## Testing
- `gofmt -l` clean on all touched files.
- Root module: `go build ./...` + `go test ./...` pass.
- `a2a/` module: `go build ./...` + `go test ./...` pass.
- `experimental/mcp/` module: `go build ./...` + `go test ./...` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)