### PR TITLE
Fix resume/session semantics: history drop, usage loss, aliasing, precondition

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -426,9 +426,13 @@ func (a *Agent) CreateResponse(ctx context.Context, opts ...CreateResponseOption
 	// fresher one. When the option is absent and the session is
 	// suspendable, the session's stored state is used.
 	suspendable, _ := sess.(SuspendableSession)
+	var storedSuspension *SuspensionState
+	if suspendable != nil {
+		storedSuspension = suspendable.LoadSuspension()
+	}
 	suspState := options.Suspension
-	if suspState == nil && suspendable != nil {
-		suspState = suspendable.LoadSuspension()
+	if suspState == nil {
+		suspState = storedSuspension
 	}
 
 	hasToolResults := len(options.ToolResults) > 0
@@ -437,6 +441,14 @@ func (a *Agent) CreateResponse(ctx context.Context, opts ...CreateResponseOption
 
 	if hasResumeIntent && suspState == nil {
 		return nil, ErrNoSuspendedTurn
+	}
+	// An explicit WithResume against a SuspendableSession requires the
+	// session to actually hold a suspended turn: the resume completion is
+	// persisted via SaveResumedTurn, which fails when the session is not
+	// suspended. Detect the mismatch before calling the LLM so no tokens
+	// are spent on a turn that could never be saved.
+	if hasExplicitSuspension && suspendable != nil && storedSuspension == nil {
+		return nil, ErrSessionNotSuspended
 	}
 	// A session-backed resume cannot accept new user input — the new
 	// input belongs in a fresh turn after the suspended one resolves.
@@ -506,7 +518,22 @@ func (a *Agent) CreateResponse(ctx context.Context, opts ...CreateResponseOption
 	var fullHistory []*llm.Message
 	switch {
 	case suspState != nil && hasExplicitSuspension:
-		fullHistory = append(fullHistory, inputMessages...)
+		// Pre-turn history: explicit WithMessages wins (stateless flow).
+		// Otherwise fall back to the loaded session history — the
+		// documented cross-process handoff resumes with a session attached
+		// and no explicit messages, and generating against only the
+		// suspended turn would silently drop all prior context. When the
+		// session itself persisted the suspended turn (SuspendableSession),
+		// strip that stored turn from the tail so the explicit snapshot's
+		// TurnMessages replace it rather than duplicate it.
+		preTurn := inputMessages
+		if len(preTurn) == 0 && len(sessionMsgs) > 0 {
+			preTurn = sessionMsgs
+			if storedSuspension != nil && len(storedSuspension.TurnMessages) <= len(preTurn) {
+				preTurn = preTurn[:len(preTurn)-len(storedSuspension.TurnMessages)]
+			}
+		}
+		fullHistory = append(fullHistory, preTurn...)
 		fullHistory = append(fullHistory, suspState.TurnMessages...)
 	case suspState != nil:
 		fullHistory = append(fullHistory, sessionMsgs...)

--- a/agent_suspend_test.go
+++ b/agent_suspend_test.go
@@ -3415,3 +3415,132 @@ func TestCompletedToolCallsPreservedAcrossPartialResume(t *testing.T) {
 	}
 	assert.True(t, foundFast, "fast_tool should appear in CompletedToolCalls after partial resume")
 }
+
+// TestResumeWithSessionNoMessagesIncludesHistory pins the cross-process
+// handoff flow from review finding §4.3: resuming with WithResume against a
+// session-backed agent WITHOUT WithMessages must use the loaded session
+// history as the pre-turn context. Before the fix, the LLM saw only
+// suspState.TurnMessages — all prior turns were silently dropped.
+func TestResumeWithSessionNoMessagesIncludesHistory(t *testing.T) {
+	dir := t.TempDir()
+
+	mock := &scriptedLLM{
+		script: []scriptedTurn{
+			finalTextTurn("hi there"), // turn 1: plain history
+			toolUseAssistantTurn(newScriptedToolUse("toolu_a", "tool_a", `{}`)), // turn 2: suspends
+			finalTextTurn("resumed done"),                                       // resume completion
+		},
+	}
+	suspendTool := &scriptedTool{name: "tool_a", outcomes: []toolOutcome{{result: NewSuspendResult("wait", nil)}}}
+
+	// Process A: build history, then suspend.
+	var savedState *SuspensionState
+	{
+		store, err := session.NewFileStore(dir)
+		assert.NoError(t, err)
+		sess, err := store.Open(context.Background(), "handoff")
+		assert.NoError(t, err)
+		agent, err := NewAgent(AgentOptions{Model: mock, Tools: []Tool{suspendTool}, Session: sess})
+		assert.NoError(t, err)
+
+		_, err = agent.CreateResponse(context.Background(), WithInput("hello"))
+		assert.NoError(t, err)
+
+		resp, err := agent.CreateResponse(context.Background(), WithInput("start work"))
+		assert.NoError(t, err)
+		assert.Equal(t, resp.Status, ResponseStatusSuspended)
+		savedState = resp.Suspension
+		assert.NotNil(t, savedState)
+	}
+
+	// Process B: fresh store + session, resume via WithResume with NO
+	// WithMessages — the session must supply the pre-turn history.
+	{
+		store, err := session.NewFileStore(dir)
+		assert.NoError(t, err)
+		sess, err := store.Open(context.Background(), "handoff")
+		assert.NoError(t, err)
+		agent, err := NewAgent(AgentOptions{Model: mock, Tools: []Tool{suspendTool}, Session: sess})
+		assert.NoError(t, err)
+
+		resp, err := agent.CreateResponse(context.Background(),
+			WithResume(savedState, map[string]*ToolResult{
+				"toolu_a": NewToolResultText("approved"),
+			}),
+		)
+		assert.NoError(t, err)
+		assert.Equal(t, resp.Status, ResponseStatusCompleted)
+		assert.Equal(t, resp.OutputText(), "resumed done")
+
+		// The resumed LLM call must see the FULL history: turn 1 (user
+		// "hello" + assistant "hi there") followed by the suspended turn
+		// and its merged tool_result.
+		mock.mu.Lock()
+		resumeCallMsgs := mock.received[len(mock.received)-1]
+		mock.mu.Unlock()
+		assert.True(t, len(resumeCallMsgs) >= 5,
+			"resume call should include prior session history, got %d messages", len(resumeCallMsgs))
+		assert.Equal(t, resumeCallMsgs[0].Role, llm.User)
+		assert.Equal(t, resumeCallMsgs[0].Text(), "hello")
+		assert.Equal(t, resumeCallMsgs[1].Text(), "hi there")
+
+		// The suspended turn must not be duplicated: exactly one assistant
+		// tool_use message in the context.
+		toolUseCount := 0
+		for _, msg := range resumeCallMsgs {
+			for _, c := range msg.Content {
+				if _, ok := c.(*llm.ToolUseContent); ok {
+					toolUseCount++
+				}
+			}
+		}
+		assert.Equal(t, toolUseCount, 1, "suspended turn must not be duplicated in the LLM context")
+
+		// And the persisted history must be intact: turn 1 + completed turn 2.
+		msgs, err := sess.Messages(context.Background())
+		assert.NoError(t, err)
+		assert.Equal(t, msgs[0].Text(), "hello")
+		assert.Equal(t, msgs[len(msgs)-1].Text(), "resumed done")
+		assert.False(t, sessIsSuspended(sess))
+	}
+}
+
+// TestResumeNonSuspendedSessionFailsBeforeGeneration pins the up-front
+// precondition check (review §3 / core C3): WithResume against a
+// SuspendableSession that is NOT currently suspended must fail before the
+// LLM is called — previously the mismatch surfaced only after generation,
+// when SaveResumedTurn rejected the save (tokens spent, turn discarded).
+func TestResumeNonSuspendedSessionFailsBeforeGeneration(t *testing.T) {
+	mock := &scriptedLLM{
+		script: []scriptedTurn{
+			toolUseAssistantTurn(newScriptedToolUse("toolu_a", "tool_a", `{}`)),
+			finalTextTurn("should never be generated"),
+		},
+	}
+	suspendTool := &scriptedTool{name: "tool_a", outcomes: []toolOutcome{{result: NewSuspendResult("wait", nil)}}}
+
+	// Obtain a genuine SuspensionState from a stateless suspend.
+	statelessAgent, err := NewAgent(AgentOptions{Model: mock, Tools: []Tool{suspendTool}})
+	assert.NoError(t, err)
+	resp, err := statelessAgent.CreateResponse(context.Background(), WithInput("start"))
+	assert.NoError(t, err)
+	assert.Equal(t, resp.Status, ResponseStatusSuspended)
+	state := resp.Suspension
+	assert.NotNil(t, state)
+	callsAfterSuspend := mock.Calls()
+
+	// Attach a SuspendableSession that has never been suspended.
+	sess := session.New("not-suspended")
+	agent, err := NewAgent(AgentOptions{Model: mock, Tools: []Tool{suspendTool}, Session: sess})
+	assert.NoError(t, err)
+
+	_, err = agent.CreateResponse(context.Background(),
+		WithResume(state, map[string]*ToolResult{
+			"toolu_a": NewToolResultText("approved"),
+		}),
+	)
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, ErrSessionNotSuspended)
+	assert.Equal(t, mock.Calls(), callsAfterSuspend, "LLM must not be called when the precondition fails")
+	assert.Equal(t, sess.EventCount(), 0, "session must be untouched")
+}

--- a/dive.go
+++ b/dive.go
@@ -90,6 +90,13 @@ var ErrInputOnSuspendedSession = errors.New("dive: session is suspended; resume 
 // an idle suspended turn.
 var ErrResumeRequired = errors.New("dive: session is suspended; pass WithResume or WithToolResults to continue the turn")
 
+// ErrSessionNotSuspended is returned when WithResume supplies an explicit
+// SuspensionState but the attached SuspendableSession is not currently
+// suspended. The completed resume would be persisted via SaveResumedTurn,
+// which fails on a non-suspended session — so the mismatch is detected
+// before generation rather than after tokens have been spent.
+var ErrSessionNotSuspended = errors.New("dive: WithResume supplied but the attached session has no suspended turn to resume")
+
 // CreateResponseOptions contains configuration for LLM generations.
 //
 // This struct holds all the options that can be passed to Agent.CreateResponse.

--- a/docs/guides/suspend-resume.md
+++ b/docs/guides/suspend-resume.md
@@ -220,7 +220,10 @@ resp, err := agent.CreateResponse(ctx,
 
 `WithResume` overrides any session-stored state, which is also what you
 want when doing a cross-process handoff where the resumer holds a newer
-snapshot than what is on disk.
+snapshot than what is on disk. When a session is attached and no
+`WithMessages` is given, the loaded session history supplies the
+pre-turn context (with any session-stored suspended turn replaced by the
+explicit snapshot's `TurnMessages`).
 
 On completion, the agent populates `resp.Suspension` a second time —
 this time with `PendingToolCalls == nil` and `TurnMessages` holding the
@@ -371,6 +374,7 @@ observe `Response.Status` and `Response.Suspension` on the final return.
 | `ErrResumeRequired`             | `CreateResponse` was called on a suspended session without `WithResume`, `WithToolResults`, or new input. Resume is explicit — no silent no-op polling. |
 | `ErrInputOnSuspendedSession`    | New user input was supplied while the session is suspended. Resume the current turn first. |
 | `ErrNoSuspendedTurn`            | `WithResume` or `WithToolResults` was supplied but there is no suspended turn to resume. |
+| `ErrSessionNotSuspended`        | `WithResume` supplied an explicit state but the attached `SuspendableSession` is not suspended. Detected before any LLM call — the completed resume could never be saved (`SaveResumedTurn` requires a suspended session). |
 | `ErrUnknownPendingToolCall`     | A key in `WithToolResults` is not in the pending set. No state changes. |
 
 ## Concurrency

--- a/session/session.go
+++ b/session/session.go
@@ -213,6 +213,9 @@ func (e *event) copy() *event {
 
 // copyMessages returns a deep copy of a message slice, or nil when empty, so
 // callers cannot mutate the session's internal messages through the result.
+// It is also used on ingestion (SaveTurn and friends) so caller mutations
+// after a save cannot rewrite stored history. llm.Message.Copy is a JSON
+// round-trip; a structural copy is a possible future optimization.
 func copyMessages(msgs []*llm.Message) []*llm.Message {
 	if len(msgs) == 0 {
 		return nil
@@ -222,6 +225,33 @@ func copyMessages(msgs []*llm.Message) []*llm.Message {
 		out[i] = msg.Copy()
 	}
 	return out
+}
+
+// copyUsage returns a deep copy of usage, or nil when usage is nil.
+func copyUsage(usage *llm.Usage) *llm.Usage {
+	if usage == nil {
+		return nil
+	}
+	return usage.Copy()
+}
+
+// sumUsage returns a new Usage holding the sum of a and b without mutating
+// either, or nil when both are nil. Used when a resumed (or re-suspended)
+// turn replaces a suspended event: the replaced event's usage covers tokens
+// already paid before suspension and must be carried forward so TotalUsage
+// does not undercount.
+func sumUsage(a, b *llm.Usage) *llm.Usage {
+	if a == nil && b == nil {
+		return nil
+	}
+	total := &llm.Usage{}
+	if a != nil {
+		total.Add(a)
+	}
+	if b != nil {
+		total.Add(b)
+	}
+	return total
 }
 
 // eventAppender is the internal interface used by Session to persist events.
@@ -358,8 +388,11 @@ func (s *Session) SaveTurn(ctx context.Context, messages []*llm.Message, usage *
 		ID:        newEventID(),
 		Type:      eventTypeTurn,
 		Timestamp: time.Now(),
-		Messages:  messages,
-		Usage:     usage,
+		// Deep-copy on ingestion: reads already deep-copy, so without this
+		// a caller mutating e.g. response.OutputMessages after SaveTurn
+		// would silently rewrite stored history.
+		Messages: copyMessages(messages),
+		Usage:    copyUsage(usage),
 	}
 	prevLen := len(s.data.Events)
 	prevUpdatedAt := s.data.UpdatedAt
@@ -472,8 +505,14 @@ func (s *Session) SaveSuspendedTurn(ctx context.Context, messages []*llm.Message
 			s.data.Events[len(s.data.Events)-1].Type == eventTypeTurn
 
 		var evtID string
+		var priorUsage *llm.Usage
 		if replaceLast {
-			evtID = s.data.Events[len(s.data.Events)-1].ID
+			prev := s.data.Events[len(s.data.Events)-1]
+			evtID = prev.ID
+			// The replaced suspended event's usage covers tokens already
+			// paid before this partial resume; carry it forward so
+			// TotalUsage does not undercount.
+			priorUsage = prev.Usage
 		} else {
 			evtID = newEventID()
 		}
@@ -481,8 +520,8 @@ func (s *Session) SaveSuspendedTurn(ctx context.Context, messages []*llm.Message
 			ID:        evtID,
 			Type:      eventTypeTurn,
 			Timestamp: now,
-			Messages:  messages,
-			Usage:     usage,
+			Messages:  copyMessages(messages),
+			Usage:     sumUsage(priorUsage, usage),
 			Metadata: map[string]any{
 				"suspended": true,
 			},
@@ -524,13 +563,16 @@ func (s *Session) SaveResumedTurn(ctx context.Context, messages []*llm.Message, 
 
 	return s.withRollback(ctx, func() {
 		now := time.Now()
-		evtID := s.data.Events[len(s.data.Events)-1].ID
+		prev := s.data.Events[len(s.data.Events)-1]
 		evt := &event{
-			ID:        evtID,
+			ID:        prev.ID,
 			Type:      eventTypeTurn,
 			Timestamp: now,
-			Messages:  messages,
-			Usage:     usage,
+			Messages:  copyMessages(messages),
+			// The replaced suspended event's usage covers tokens already
+			// paid before suspension; the agent passes only the resume
+			// call's own usage. Sum so TotalUsage reflects both phases.
+			Usage: sumUsage(prev.Usage, usage),
 		}
 		s.data.Events[len(s.data.Events)-1] = evt
 		s.data.Suspended = false

--- a/session/session_test.go
+++ b/session/session_test.go
@@ -1096,3 +1096,124 @@ func TestMemoryStoreListMetadataIsCopy(t *testing.T) {
 	result.Sessions[0].Metadata["key"] = "mutated"
 	assert.Equal(t, "original", sess.Metadata()["key"])
 }
+
+// TestSuspendResumeUsageAccumulates pins that the usage paid before a
+// suspension is carried into the completed turn when SaveResumedTurn
+// replaces the suspended event, so TotalUsage reflects both phases
+// (review finding §3.5).
+func TestSuspendResumeUsageAccumulates(t *testing.T) {
+	ctx := context.Background()
+	sess := session.New("usage-sum")
+
+	// Suspend with usage A.
+	err := sess.SaveSuspendedTurn(ctx, suspendedTurnMessages(),
+		&llm.Usage{InputTokens: 10, OutputTokens: 5}, singleSuspensionState())
+	assert.NoError(t, err)
+
+	// Resume with usage B.
+	complete := append(suspendedTurnMessages(), llm.NewAssistantTextMessage("done"))
+	err = sess.SaveResumedTurn(ctx, complete, &llm.Usage{InputTokens: 20, OutputTokens: 7})
+	assert.NoError(t, err)
+
+	total := sess.TotalUsage()
+	assert.Equal(t, total.InputTokens, 30)
+	assert.Equal(t, total.OutputTokens, 12)
+}
+
+// TestPartialResumeUsageAccumulates pins the replace-last branch of
+// SaveSuspendedTurn: a partial resume that re-suspends must also carry the
+// already-paid usage forward, and a final SaveResumedTurn adds its own on
+// top (review finding §3.5).
+func TestPartialResumeUsageAccumulates(t *testing.T) {
+	ctx := context.Background()
+	sess := session.New("usage-partial")
+
+	// Initial suspend with usage A.
+	err := sess.SaveSuspendedTurn(ctx, suspendedTurnMessages(),
+		&llm.Usage{InputTokens: 10, OutputTokens: 1}, singleSuspensionState())
+	assert.NoError(t, err)
+
+	// Partial resume re-suspends, replacing the suspended event with usage B.
+	err = sess.SaveSuspendedTurn(ctx, suspendedTurnMessages(),
+		&llm.Usage{InputTokens: 20, OutputTokens: 2}, singleSuspensionState())
+	assert.NoError(t, err)
+	assert.Equal(t, sess.EventCount(), 1, "replace-last must not append a second event")
+
+	// Final resume completes the turn with usage C.
+	complete := append(suspendedTurnMessages(), llm.NewAssistantTextMessage("done"))
+	err = sess.SaveResumedTurn(ctx, complete, &llm.Usage{InputTokens: 40, OutputTokens: 4})
+	assert.NoError(t, err)
+
+	total := sess.TotalUsage()
+	assert.Equal(t, total.InputTokens, 70)
+	assert.Equal(t, total.OutputTokens, 7)
+}
+
+// TestSuspendResumeNilUsage pins that summation tolerates nil usage on
+// either side of a suspend/resume pair.
+func TestSuspendResumeNilUsage(t *testing.T) {
+	ctx := context.Background()
+	sess := session.New("usage-nil")
+
+	err := sess.SaveSuspendedTurn(ctx, suspendedTurnMessages(),
+		&llm.Usage{InputTokens: 10}, singleSuspensionState())
+	assert.NoError(t, err)
+	err = sess.SaveResumedTurn(ctx,
+		append(suspendedTurnMessages(), llm.NewAssistantTextMessage("done")), nil)
+	assert.NoError(t, err)
+	assert.Equal(t, sess.TotalUsage().InputTokens, 10)
+}
+
+// TestSaveTurnCopiesCallerMessages pins that SaveTurn deep-copies messages
+// and usage on ingestion: mutating the caller's message (or usage) after
+// the call must not rewrite stored history (review finding §3.4).
+func TestSaveTurnCopiesCallerMessages(t *testing.T) {
+	ctx := context.Background()
+	sess := session.New("no-alias")
+
+	userMsg := llm.NewUserTextMessage("original input")
+	assistantMsg := llm.NewAssistantTextMessage("original output")
+	usage := &llm.Usage{InputTokens: 10}
+	err := sess.SaveTurn(ctx, []*llm.Message{userMsg, assistantMsg}, usage)
+	assert.NoError(t, err)
+
+	// Mutate the caller-owned messages and usage after the save.
+	userMsg.Content[0].(*llm.TextContent).Text = "mutated input"
+	assistantMsg.Content[0].(*llm.TextContent).Text = "mutated output"
+	usage.InputTokens = 999
+
+	msgs, err := sess.Messages(ctx)
+	assert.NoError(t, err)
+	assert.Len(t, msgs, 2)
+	assert.Equal(t, msgs[0].Text(), "original input")
+	assert.Equal(t, msgs[1].Text(), "original output")
+	assert.Equal(t, sess.TotalUsage().InputTokens, 10)
+}
+
+// TestSaveSuspendedTurnCopiesCallerMessages extends the §3.4 aliasing fix to
+// the suspend/resume ingestion paths.
+func TestSaveSuspendedTurnCopiesCallerMessages(t *testing.T) {
+	ctx := context.Background()
+	sess := session.New("no-alias-suspend")
+
+	turn := suspendedTurnMessages()
+	err := sess.SaveSuspendedTurn(ctx, turn, nil, singleSuspensionState())
+	assert.NoError(t, err)
+
+	// Mutate the caller's copy of the user message after the save.
+	turn[0].Content[0].(*llm.TextContent).Text = "mutated"
+
+	msgs, err := sess.Messages(ctx)
+	assert.NoError(t, err)
+	assert.Equal(t, msgs[0].Text(), "start")
+
+	// Same for the resume completion path.
+	complete := append(suspendedTurnMessages(), llm.NewAssistantTextMessage("done"))
+	err = sess.SaveResumedTurn(ctx, complete, nil)
+	assert.NoError(t, err)
+	complete[len(complete)-1].Content[0].(*llm.TextContent).Text = "mutated done"
+
+	msgs, err = sess.Messages(ctx)
+	assert.NoError(t, err)
+	assert.Equal(t, msgs[len(msgs)-1].Text(), "done")
+}


### PR DESCRIPTION
Remediates four findings from `docs/reviews/2026-06-09-api-review.md` (batch 2 follow-up to #181–#186). All four findings were re-verified against current `main` before fixing — none had been resolved by batch 1.

## §4.3 — `WithResume` on a session-backed agent drops prior history
The explicit-suspension branch in `CreateResponse` built the LLM context from `inputMessages + suspState.TurnMessages` only, ignoring the already-loaded session messages. The documented cross-process handoff (resume in a new process with a session attached, no `WithMessages`) silently generated against only the suspended turn — this is exactly how the a2a executor resumes (`WithSession` + `WithResume`, no messages).

**Fix:** when no explicit messages are given, fall back to the loaded session history as the pre-turn context. If the session itself persisted the suspended turn (`SuspendableSession`), that stored turn is stripped from the tail so the explicit snapshot's `TurnMessages` replace it rather than duplicate it.
**Test:** `TestResumeWithSessionNoMessagesIncludesHistory` — FileStore-backed two-"process" handoff; asserts the resumed LLM call sees the full prior history, the suspended turn appears exactly once, and the persisted session ends up intact.

## §3.5 — Suspend-phase usage dropped
`SaveResumedTurn` and the replace-last branch of `SaveSuspendedTurn` replaced the suspended event wholesale, including `Usage`, so tokens paid before suspension vanished from `TotalUsage()`.

**Fix:** the replaced event's usage is summed into the new event (new `sumUsage` helper; allocates a fresh `Usage`, never mutates caller or stored values). `Response.Usage` semantics are unchanged (still per-call).
**Tests:** `TestSuspendResumeUsageAccumulates` (A then B → A+B), `TestPartialResumeUsageAccumulates` (replace-last chain A, B, C → A+B+C with stable event count), `TestSuspendResumeNilUsage`.

## §3.4 (remaining item) — `SaveTurn` aliases caller-owned message pointers
`SaveTurn` stored the caller's `[]*llm.Message` and `*llm.Usage` pointers directly while reads deep-copy, so mutating `response.OutputMessages` after the call silently rewrote stored history. Applied the same fix to the other ingestion paths (`SaveSuspendedTurn`, `SaveResumedTurn`) since they alias identically.

**Fix:** deep-copy messages and usage on ingestion, reusing `llm.Message.Copy` (a JSON round-trip; a structural copy is noted in a comment as a possible future optimization).
**Tests:** `TestSaveTurnCopiesCallerMessages`, `TestSaveSuspendedTurnCopiesCallerMessages`.

## Review §3 / core C3 — late failure on `WithResume` against a non-suspended session
Calling `CreateResponse` with `WithResume` against a `SuspendableSession` that is not currently suspended failed only after generation completed, when `SaveResumedTurn` returned `ErrNotSuspended` — tokens spent, turn discarded.

**Fix:** the mismatch is detected before the LLM call (`hasExplicitSuspension && suspendable != nil && LoadSuspension() == nil`) and returns a new sentinel, `ErrSessionNotSuspended`.
**Test:** `TestResumeNonSuspendedSessionFailsBeforeGeneration` — asserts the error, zero LLM calls, and an untouched session.

## Docs
`docs/guides/suspend-resume.md`: added `ErrSessionNotSuspended` to the error table and documented the session-history fallback for `WithResume`.

## Skipped / deferred
- Nothing in scope was skipped — all four findings still held against current code.
- Adjacent items deliberately not done per batch plan: §4.5 (SessionStart `Values`), §4.7 (partial-result-on-error), §4.8 (hook `Messages` freshness). §4.7/§4.8 touch the same `CreateResponse` body as the §4.3 fix but are independent behaviors.

## Verification
- `gofmt -l .` clean; `go build ./...`, `go vet . ./session` clean.
- `go test ./...` — all packages pass.
- `go test -race . ./session` — pass.
- `a2a` module (separate go.mod with `replace => ..`): `go test ./...` — pass, exercising the fixed resume path.
- All five new regression tests were verified to FAIL against the pre-fix code (production changes temporarily reverted) and pass with the fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)