### PR TITLE
Fix remaining toolkit review findings: excludes, grep pagination, SSRF dial pinning, scanner errors

### DIFF
--- a/toolkit/bash.go
+++ b/toolkit/bash.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os/exec"
 	"runtime"
 	"strings"
@@ -301,6 +302,7 @@ func (t *BashTool) execute(ctx context.Context, command, workingDir string, time
 
 	// Read stdout, streaming lines as they arrive.
 	// bufio.Scanner with ScanLines handles the final non-newline-terminated line.
+	var scanErr error
 	if stdoutPipe != nil {
 		scanner := bufio.NewScanner(stdoutPipe)
 		scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
@@ -330,6 +332,14 @@ func (t *BashTool) execute(ctx context.Context, command, workingDir string, time
 				})
 			}
 		}
+		if err := scanner.Err(); err != nil {
+			// A scan error (e.g. a line exceeding the buffer limit, or a read
+			// failure) means output was lost; record it so we don't silently
+			// truncate and report success. Drain the rest of the pipe so the
+			// child process can't block writing to a full pipe before Wait.
+			scanErr = err
+			io.Copy(io.Discard, stdoutPipe)
+		}
 	}
 
 	runErr = cmd.Wait()
@@ -342,6 +352,10 @@ func (t *BashTool) execute(ctx context.Context, command, workingDir string, time
 		} else {
 			return "", "", -1, fmt.Errorf("error: %s", runErr.Error())
 		}
+	}
+
+	if scanErr != nil {
+		return "", "", -1, fmt.Errorf("error reading command output: %s", scanErr.Error())
 	}
 
 	stdout = truncateOutput(stdoutBuf.String(), t.maxOutputLen)

--- a/toolkit/bash_test.go
+++ b/toolkit/bash_test.go
@@ -260,3 +260,22 @@ func TestBashTool_Call_ReturnsWorkspaceConfigErrorWhenValidatorMissing(t *testin
 	assert.Contains(t, result.Content[0].Text, "WorkspaceDir \"/bad/workspace\"")
 	assert.Contains(t, result.Content[0].Text, "path validator is not initialized")
 }
+
+func TestBashTool_Call_LongLineSurfacesError(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Skipping on Windows - bash not available")
+	}
+
+	tool := NewBashTool()
+	ctx := context.Background()
+
+	// Produce a single line larger than the 1 MB scanner buffer. Previously
+	// the scan error was ignored, silently truncating output while reporting
+	// success; now the error must be surfaced.
+	result, err := tool.Call(ctx, &BashInput{
+		Command: "head -c 2000000 /dev/zero | tr '\\0' 'a'",
+	})
+	assert.NoError(t, err)
+	assert.True(t, result.IsError)
+	assert.Contains(t, result.Content[0].Text, "error reading command output")
+}

--- a/toolkit/fetch.go
+++ b/toolkit/fetch.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/deepnoodle-ai/dive"
@@ -57,6 +58,10 @@ var _ dive.TypedToolPreviewer[*fetch.Request] = &FetchTool{}
 //   - Non-HTTP(S) schemes (file://, javascript://, etc.)
 //   - Localhost and private IP addresses
 //   - URLs that resolve to internal networks
+//
+// With the default fetcher, IP validation is also enforced at connect time
+// on every connection (see [SafeHTTPClient]), so DNS rebinding between the
+// pre-flight check and the actual dial cannot bypass the policy.
 type FetchTool struct {
 	fetcher         fetch.Fetcher
 	maxSize         int
@@ -89,13 +94,54 @@ type FetchToolOptions struct {
 	Fetcher fetch.Fetcher `json:"-"`
 }
 
-// SafeHTTPClient returns an *http.Client that validates redirect targets
-// against SSRF rules. Each redirect URL is checked for blocked schemes,
-// localhost, and private IP addresses using the same rules as the initial
-// URL validation.
+// validateConnAddress is a [net.Dialer] Control function that validates the
+// IP address actually being connected to, after DNS resolution. Pre-connect
+// hostname validation alone is bypassable via DNS rebinding (the transport
+// re-resolves at connect time); pinning validation to the connection closes
+// that window and naturally covers redirects, since every connection the
+// client opens passes through here.
+func validateConnAddress(network, address string, _ syscall.RawConn) error {
+	host, _, err := net.SplitHostPort(address)
+	if err != nil {
+		return fmt.Errorf("invalid dial address %q: %w", address, err)
+	}
+	ip := net.ParseIP(host)
+	if ip == nil {
+		return fmt.Errorf("dial address %q is not an IP address", host)
+	}
+	if isPrivateIP(ip) {
+		return fmt.Errorf("access to private/internal IP address %s is not allowed", ip.String())
+	}
+	return nil
+}
+
+// SafeHTTPClient returns an *http.Client that enforces SSRF rules at two
+// layers:
+//
+//   - Connect time: a custom dialer validates the resolved IP for every
+//     connection (including redirect targets), preventing DNS-rebinding
+//     bypasses of hostname-based checks.
+//   - Redirects: each redirect URL is additionally checked for blocked
+//     schemes, localhost, and private IP addresses using the same rules
+//     as the initial URL validation.
 func SafeHTTPClient(timeout time.Duration) *http.Client {
+	dialer := &net.Dialer{
+		Timeout:   30 * time.Second,
+		KeepAlive: 30 * time.Second,
+		Control:   validateConnAddress,
+	}
+	transport := &http.Transport{
+		Proxy:                 http.ProxyFromEnvironment,
+		DialContext:           dialer.DialContext,
+		ForceAttemptHTTP2:     true,
+		MaxIdleConns:          100,
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+	}
 	return &http.Client{
-		Timeout: timeout,
+		Timeout:   timeout,
+		Transport: transport,
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {
 			if len(via) >= 10 {
 				return fmt.Errorf("stopped after 10 redirects")
@@ -290,7 +336,10 @@ func isPrivateIP(ip net.IP) bool {
 	return false
 }
 
-// validateFetchURL validates a URL for safe fetching, preventing SSRF attacks
+// validateFetchURL validates a URL for safe fetching, preventing SSRF attacks.
+// This is a pre-flight check (scheme, hostname, and a DNS lookup); the
+// connect-time enforcement that closes the DNS-rebinding window lives in
+// validateConnAddress.
 func validateFetchURL(rawURL string) error {
 	parsedURL, err := url.Parse(rawURL)
 	if err != nil {

--- a/toolkit/fetch_test.go
+++ b/toolkit/fetch_test.go
@@ -2,7 +2,10 @@ package toolkit
 
 import (
 	"net"
+	"net/http"
+	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/deepnoodle-ai/wonton/assert"
 )
@@ -195,4 +198,57 @@ func TestValidateFetchURL_IPv6(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestValidateConnAddress(t *testing.T) {
+	blocked := []string{
+		"127.0.0.1:80",
+		"10.0.0.5:443",
+		"172.16.0.1:8080",
+		"192.168.1.1:8080",
+		"169.254.169.254:80",
+		"0.0.0.0:80",
+		"[::1]:443",
+		"[fe80::1]:80",
+	}
+	for _, addr := range blocked {
+		err := validateConnAddress("tcp", addr, nil)
+		assert.Error(t, err, "Expected error for address: %s", addr)
+		assert.Contains(t, err.Error(), "not allowed")
+	}
+
+	allowed := []string{
+		"93.184.216.34:80",
+		"8.8.8.8:443",
+		"[2606:4700:4700::1111]:443",
+	}
+	for _, addr := range allowed {
+		err := validateConnAddress("tcp", addr, nil)
+		assert.NoError(t, err, "Expected no error for address: %s", addr)
+	}
+
+	// Non-IP hosts and malformed addresses fail closed
+	assert.Error(t, validateConnAddress("tcp", "example.com:80", nil))
+	assert.Error(t, validateConnAddress("tcp", "missing-port", nil))
+}
+
+func TestSafeHTTPClient_BlocksLoopbackAtDial(t *testing.T) {
+	// Regression test for DNS rebinding: even if a URL passes pre-flight
+	// validation, the connection itself must be refused when it resolves to
+	// a blocked IP. The httptest server listens on 127.0.0.1, so the dial
+	// must fail before the request reaches the handler.
+	handlerReached := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		handlerReached = true
+	}))
+	defer server.Close()
+
+	client := SafeHTTPClient(5 * time.Second)
+	resp, err := client.Get(server.URL)
+	if resp != nil {
+		resp.Body.Close()
+	}
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "not allowed")
+	assert.False(t, handlerReached)
 }

--- a/toolkit/file_tools_test.go
+++ b/toolkit/file_tools_test.go
@@ -601,3 +601,29 @@ func TestWriteFileTool_EmptyContent(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "", string(content))
 }
+
+func TestReadFileTool_OffsetLimitWithLongLine(t *testing.T) {
+	// Regression test: the offset/limit path used a default 64 KB
+	// bufio.Scanner buffer, so a single long line failed the read even though
+	// whole-file reads handled it fine. The buffer now matches bash.go (1 MB).
+	tempDir := t.TempDir()
+
+	longLine := strings.Repeat("a", 100*1024) // 100 KB, > 64 KB scanner default
+	content := longLine + "\nshort line\n"
+	testFile := filepath.Join(tempDir, "longline.txt")
+	assert.NoError(t, os.WriteFile(testFile, []byte(content), 0644))
+
+	tool := NewReadFileTool(ReadFileToolOptions{WorkspaceDir: tempDir})
+
+	result, err := tool.Call(context.Background(), &ReadFileInput{
+		FilePath: testFile,
+		Offset:   1,
+		Limit:    2,
+	})
+	assert.NoError(t, err)
+	assert.False(t, result.IsError)
+
+	output := result.Content[0].Text
+	assert.Contains(t, output, longLine)
+	assert.Contains(t, output, "short line")
+}

--- a/toolkit/glob.go
+++ b/toolkit/glob.go
@@ -114,6 +114,17 @@ func NewGlobTool(opts ...GlobToolOptions) *dive.TypedToolAdapter[*GlobInput] {
 	})
 }
 
+// matchesExclude reports whether relPath matches the exclude pattern.
+// Patterns are tested against both the bare relative path and a "./"-prefixed
+// variant: under gobwas/glob, "**/" requires a literal separator, so a pattern
+// like "**/node_modules/**" would otherwise never match entries at the search
+// root (e.g. "node_modules/foo.js"). Testing the "./" form makes the pure-Go
+// matching agree with ripgrep's gitignore-style globs, where "**/" also
+// matches zero directories.
+func matchesExclude(eg glob.Glob, relPath string) bool {
+	return eg.Match(relPath) || eg.Match("./"+relPath)
+}
+
 // Name returns "Glob" as the tool identifier.
 func (t *GlobTool) Name() string {
 	return "Glob"
@@ -266,7 +277,7 @@ func (t *GlobTool) Call(ctx context.Context, input *GlobInput) (*dive.ToolResult
 		if info.IsDir() {
 			// Check if directory should be excluded
 			for _, eg := range excludeGlobs {
-				if eg.Match(relPath) || eg.Match(relPath+"/") {
+				if matchesExclude(eg, relPath) || matchesExclude(eg, relPath+"/") {
 					return filepath.SkipDir
 				}
 			}
@@ -275,7 +286,7 @@ func (t *GlobTool) Call(ctx context.Context, input *GlobInput) (*dive.ToolResult
 
 		// Check excludes
 		for _, eg := range excludeGlobs {
-			if eg.Match(relPath) {
+			if matchesExclude(eg, relPath) {
 				return nil
 			}
 		}

--- a/toolkit/glob_test.go
+++ b/toolkit/glob_test.go
@@ -363,3 +363,32 @@ func TestGlobTool_Call_ReturnsWorkspaceConfigErrorWhenValidatorMissing(t *testin
 	assert.Contains(t, result.Content[0].Text, "WorkspaceDir \"/bad/workspace\"")
 	assert.Contains(t, result.Content[0].Text, "path validator is not initialized")
 }
+
+func TestGlobTool_DefaultExcludesTopLevelDirs(t *testing.T) {
+	// Regression test: gobwas/glob requires a literal separator after "**/",
+	// so "**/node_modules/**" did not match entries directly under the search
+	// root (e.g. "node_modules/dep.js"). Default excludes must also apply to
+	// top-level directories.
+	tempDir := t.TempDir()
+
+	nodeModules := filepath.Join(tempDir, "node_modules")
+	assert.NoError(t, os.MkdirAll(nodeModules, 0755))
+	assert.NoError(t, os.MkdirAll(filepath.Join(tempDir, "src"), 0755))
+
+	assert.NoError(t, os.WriteFile(filepath.Join(nodeModules, "dep.js"), []byte("dep"), 0644))
+	assert.NoError(t, os.WriteFile(filepath.Join(tempDir, "src", "app.js"), []byte("code"), 0644))
+
+	tool := NewGlobTool(GlobToolOptions{WorkspaceDir: tempDir})
+
+	result, err := tool.Call(context.Background(), &GlobInput{
+		Pattern: "**/*.js",
+		Path:    tempDir,
+	})
+
+	assert.NoError(t, err)
+	assert.False(t, result.IsError)
+
+	output := result.Content[0].Text
+	assert.Contains(t, output, "src/app.js")
+	assert.NotContains(t, output, "node_modules")
+}

--- a/toolkit/grep.go
+++ b/toolkit/grep.go
@@ -63,7 +63,8 @@ type GrepInput struct {
 
 	// ShowLines includes line numbers in output (default true).
 	// Only applies when OutputMode is GrepOutputContent.
-	ShowLines bool `json:"-n,omitempty"`
+	// A nil value means true.
+	ShowLines *bool `json:"-n,omitempty"`
 
 	// Context shows N lines before and after each match.
 	// Only applies when OutputMode is GrepOutputContent.
@@ -446,11 +447,9 @@ func (t *GrepTool) parseRipgrepOutput(output, basePath string, input *GrepInput)
 			line:       strings.TrimRight(m.Data.Lines.Text, "\n\r"),
 		})
 
-		limit := input.HeadLimit
-		if limit == 0 {
-			limit = t.maxResults
-		}
-		if len(matches) >= limit {
+		// Collect up to maxResults; offset/head_limit pagination is applied
+		// in formatResults so both search paths paginate identically.
+		if len(matches) >= t.maxResults {
 			break
 		}
 	}
@@ -542,11 +541,6 @@ func (t *GrepTool) callPureGo(ctx context.Context, input *GrepInput) (*dive.Tool
 
 	var matches []grepMatch
 
-	limit := input.HeadLimit
-	if limit == 0 {
-		limit = t.maxResults
-	}
-
 	err = filepath.Walk(searchPath, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return nil
@@ -558,7 +552,7 @@ func (t *GrepTool) callPureGo(ctx context.Context, input *GrepInput) (*dive.Tool
 		// Skip directories but check excludes
 		if info.IsDir() {
 			for _, eg := range excludeGlobs {
-				if eg.Match(relPath) || eg.Match(relPath+"/") {
+				if matchesExclude(eg, relPath) || matchesExclude(eg, relPath+"/") {
 					return filepath.SkipDir
 				}
 			}
@@ -567,7 +561,7 @@ func (t *GrepTool) callPureGo(ctx context.Context, input *GrepInput) (*dive.Tool
 
 		// Check excludes
 		for _, eg := range excludeGlobs {
-			if eg.Match(relPath) {
+			if matchesExclude(eg, relPath) {
 				return nil
 			}
 		}
@@ -614,7 +608,10 @@ func (t *GrepTool) callPureGo(ctx context.Context, input *GrepInput) (*dive.Tool
 					lineNumber: i + 1,
 					line:       strings.TrimRight(line, "\r"),
 				})
-				if len(matches) >= limit {
+				// Collect up to maxResults; offset/head_limit pagination is
+				// applied in formatResults so both search paths paginate
+				// identically.
+				if len(matches) >= t.maxResults {
 					return filepath.SkipAll
 				}
 			}
@@ -637,7 +634,26 @@ type grepMatch struct {
 	line       string // Content of the matching line
 }
 
+// paginate applies offset and limit to a slice of entries.
+// A limit of 0 means no limit.
+func paginate[T any](entries []T, offset, limit int) []T {
+	if offset < 0 {
+		offset = 0
+	}
+	if offset >= len(entries) {
+		return nil
+	}
+	entries = entries[offset:]
+	if limit > 0 && len(entries) > limit {
+		entries = entries[:limit]
+	}
+	return entries
+}
+
 // formatResults converts matches into the output format specified by OutputMode.
+// Pagination (offset + head_limit) is applied here, after the full result set
+// is grouped into entries, so both the ripgrep and pure-Go paths paginate
+// identically.
 func (t *GrepTool) formatResults(matches []grepMatch, input *GrepInput) (*dive.ToolResult, error) {
 	if len(matches) == 0 {
 		return t.formatNoMatches(input), nil
@@ -648,6 +664,18 @@ func (t *GrepTool) formatResults(matches []grepMatch, input *GrepInput) (*dive.T
 		outputMode = GrepOutputFilesWithMatches
 	}
 
+	offset := input.Offset
+	if offset < 0 {
+		offset = 0
+	}
+	limit := input.HeadLimit
+
+	showLines := true
+	if input.ShowLines != nil {
+		showLines = *input.ShowLines
+	}
+
+	var shown int
 	var result strings.Builder
 
 	switch outputMode {
@@ -662,6 +690,8 @@ func (t *GrepTool) formatResults(matches []grepMatch, input *GrepInput) (*dive.T
 			}
 		}
 		sort.Strings(files)
+		files = paginate(files, offset, limit)
+		shown = len(files)
 		for _, f := range files {
 			result.WriteString(f)
 			result.WriteString("\n")
@@ -678,15 +708,19 @@ func (t *GrepTool) formatResults(matches []grepMatch, input *GrepInput) (*dive.T
 			files = append(files, f)
 		}
 		sort.Strings(files)
+		files = paginate(files, offset, limit)
+		shown = len(files)
 		for _, f := range files {
 			result.WriteString(fmt.Sprintf("%s:%d\n", f, counts[f]))
 		}
 
 	case GrepOutputContent:
-		// Group by file
+		// Paginate matches, then group by file
+		paged := paginate(matches, offset, limit)
+		shown = len(paged)
 		byFile := make(map[string][]grepMatch)
 		var files []string
-		for _, m := range matches {
+		for _, m := range paged {
 			if _, ok := byFile[m.file]; !ok {
 				files = append(files, m.file)
 			}
@@ -697,19 +731,29 @@ func (t *GrepTool) formatResults(matches []grepMatch, input *GrepInput) (*dive.T
 		for _, f := range files {
 			result.WriteString(fmt.Sprintf("## %s\n", f))
 			for _, m := range byFile[f] {
-				result.WriteString(fmt.Sprintf("%d: %s\n", m.lineNumber, m.line))
+				if showLines {
+					result.WriteString(fmt.Sprintf("%d: %s\n", m.lineNumber, m.line))
+				} else {
+					result.WriteString(m.line)
+					result.WriteString("\n")
+				}
 			}
 			result.WriteString("\n")
 		}
 	}
 
-	display := fmt.Sprintf("Found %d match(es) for %q", len(matches), input.Pattern)
-	limit := input.HeadLimit
-	if limit == 0 {
-		limit = t.maxResults
+	if shown == 0 {
+		text := fmt.Sprintf("No results at offset %d (%d total match(es))", offset, len(matches))
+		display := fmt.Sprintf("No results for %q at offset %d", input.Pattern, offset)
+		return dive.NewToolResultText(text).WithDisplay(display), nil
 	}
-	if len(matches) >= limit {
-		display += fmt.Sprintf(" (limited to %d)", limit)
+
+	display := fmt.Sprintf("Found %d match(es) for %q", len(matches), input.Pattern)
+	if len(matches) >= t.maxResults {
+		display += fmt.Sprintf(" (limited to %d)", t.maxResults)
+	}
+	if offset > 0 || limit > 0 {
+		display += fmt.Sprintf(" (showing %d)", shown)
 	}
 
 	return dive.NewToolResultText(strings.TrimSpace(result.String())).WithDisplay(display), nil

--- a/toolkit/grep_test.go
+++ b/toolkit/grep_test.go
@@ -3,6 +3,7 @@ package toolkit
 import (
 	"context"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -291,7 +292,8 @@ func TestGrepTool_HeadLimit(t *testing.T) {
 
 	assert.NoError(t, err)
 	assert.False(t, result.IsError)
-	assert.Contains(t, result.Display, "limited to 3")
+	assert.Contains(t, result.Display, "showing 3")
+	assert.Equal(t, 3, strings.Count(result.Content[0].Text, "match"))
 }
 
 func TestGrepTool_DefaultExcludes(t *testing.T) {
@@ -408,4 +410,180 @@ func TestGrepTool_RecursiveSearch(t *testing.T) {
 	output := result.Content[0].Text
 	assert.Contains(t, output, "root.txt")
 	assert.Contains(t, output, "deep.txt")
+}
+
+func requireRipgrep(t *testing.T) {
+	t.Helper()
+	if _, err := exec.LookPath("rg"); err != nil {
+		t.Skip("ripgrep not available")
+	}
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}
+
+func TestGrepTool_DefaultExcludesTopLevelDirs(t *testing.T) {
+	// Regression test: gobwas/glob requires a literal separator after "**/",
+	// so "**/node_modules/**" did not match entries directly under the search
+	// root on the pure-Go path. Default excludes must also apply to top-level
+	// directories, matching ripgrep's behavior.
+	tempDir := t.TempDir()
+
+	nodeModules := filepath.Join(tempDir, "node_modules")
+	assert.NoError(t, os.MkdirAll(nodeModules, 0755))
+	assert.NoError(t, os.MkdirAll(filepath.Join(tempDir, "src"), 0755))
+
+	assert.NoError(t, os.WriteFile(filepath.Join(nodeModules, "dep.js"), []byte("World"), 0644))
+	assert.NoError(t, os.WriteFile(filepath.Join(tempDir, "src", "app.js"), []byte("World"), 0644))
+
+	tool := NewGrepTool(GrepToolOptions{WorkspaceDir: tempDir}) // pure-Go path
+
+	result, err := tool.Call(context.Background(), &GrepInput{
+		Pattern: "World",
+		Path:    tempDir,
+	})
+
+	assert.NoError(t, err)
+	assert.False(t, result.IsError)
+
+	output := result.Content[0].Text
+	assert.Contains(t, output, "src/app.js")
+	assert.NotContains(t, output, "node_modules")
+}
+
+func TestGrepTool_PaginationContent(t *testing.T) {
+	tempDir := t.TempDir()
+
+	content := "match a\nmatch b\nmatch c\nmatch d\nmatch e"
+	assert.NoError(t, os.WriteFile(filepath.Join(tempDir, "file.txt"), []byte(content), 0644))
+
+	tool := NewGrepTool(GrepToolOptions{WorkspaceDir: tempDir}) // pure-Go path
+
+	result, err := tool.Call(context.Background(), &GrepInput{
+		Pattern:    "match",
+		Path:       tempDir,
+		OutputMode: GrepOutputContent,
+		Offset:     2,
+		HeadLimit:  2,
+	})
+
+	assert.NoError(t, err)
+	assert.False(t, result.IsError)
+
+	output := result.Content[0].Text
+	assert.Contains(t, output, "match c")
+	assert.Contains(t, output, "match d")
+	assert.NotContains(t, output, "match a")
+	assert.NotContains(t, output, "match b")
+	assert.NotContains(t, output, "match e")
+
+	// Offset beyond the result set
+	result, err = tool.Call(context.Background(), &GrepInput{
+		Pattern:    "match",
+		Path:       tempDir,
+		OutputMode: GrepOutputContent,
+		Offset:     10,
+	})
+	assert.NoError(t, err)
+	assert.False(t, result.IsError)
+	assert.Contains(t, result.Content[0].Text, "No results at offset 10")
+}
+
+func TestGrepTool_PaginationFilesWithMatches(t *testing.T) {
+	tempDir := t.TempDir()
+
+	for _, name := range []string{"a.txt", "b.txt", "c.txt", "d.txt", "e.txt"} {
+		assert.NoError(t, os.WriteFile(filepath.Join(tempDir, name), []byte("pattern"), 0644))
+	}
+
+	tool := NewGrepTool(GrepToolOptions{WorkspaceDir: tempDir}) // pure-Go path
+
+	result, err := tool.Call(context.Background(), &GrepInput{
+		Pattern:    "pattern",
+		Path:       tempDir,
+		OutputMode: GrepOutputFilesWithMatches,
+		Offset:     2,
+		HeadLimit:  2,
+	})
+
+	assert.NoError(t, err)
+	assert.False(t, result.IsError)
+
+	output := result.Content[0].Text
+	assert.Contains(t, output, "c.txt")
+	assert.Contains(t, output, "d.txt")
+	assert.NotContains(t, output, "a.txt")
+	assert.NotContains(t, output, "b.txt")
+	assert.NotContains(t, output, "e.txt")
+}
+
+func TestGrepTool_ShowLines(t *testing.T) {
+	tempDir := t.TempDir()
+
+	assert.NoError(t, os.WriteFile(filepath.Join(tempDir, "file.txt"), []byte("alpha\nbeta match"), 0644))
+
+	tool := NewGrepTool(GrepToolOptions{WorkspaceDir: tempDir}) // pure-Go path
+
+	// Defaults to showing line numbers
+	result, err := tool.Call(context.Background(), &GrepInput{
+		Pattern:    "match",
+		Path:       tempDir,
+		OutputMode: GrepOutputContent,
+	})
+	assert.NoError(t, err)
+	assert.False(t, result.IsError)
+	assert.Contains(t, result.Content[0].Text, "2: beta match")
+
+	// Explicitly disabled
+	result, err = tool.Call(context.Background(), &GrepInput{
+		Pattern:    "match",
+		Path:       tempDir,
+		OutputMode: GrepOutputContent,
+		ShowLines:  boolPtr(false),
+	})
+	assert.NoError(t, err)
+	assert.False(t, result.IsError)
+	assert.Contains(t, result.Content[0].Text, "beta match")
+	assert.NotContains(t, result.Content[0].Text, "2: beta match")
+}
+
+func TestGrepTool_Ripgrep_PaginationAndShowLines(t *testing.T) {
+	requireRipgrep(t)
+
+	tempDir := t.TempDir()
+	content := "match a\nmatch b\nmatch c\nmatch d\nmatch e"
+	assert.NoError(t, os.WriteFile(filepath.Join(tempDir, "file.txt"), []byte(content), 0644))
+
+	tool := NewGrepTool(GrepToolOptions{WorkspaceDir: tempDir, UseRipgrep: true})
+
+	// Pagination
+	result, err := tool.Call(context.Background(), &GrepInput{
+		Pattern:    "match",
+		Path:       tempDir,
+		OutputMode: GrepOutputContent,
+		Offset:     2,
+		HeadLimit:  2,
+	})
+	assert.NoError(t, err)
+	assert.False(t, result.IsError)
+
+	output := result.Content[0].Text
+	assert.Contains(t, output, "3: match c")
+	assert.Contains(t, output, "4: match d")
+	assert.NotContains(t, output, "match a")
+	assert.NotContains(t, output, "match b")
+	assert.NotContains(t, output, "match e")
+
+	// Line numbers disabled
+	result, err = tool.Call(context.Background(), &GrepInput{
+		Pattern:    "match c",
+		Path:       tempDir,
+		OutputMode: GrepOutputContent,
+		ShowLines:  boolPtr(false),
+	})
+	assert.NoError(t, err)
+	assert.False(t, result.IsError)
+	assert.Contains(t, result.Content[0].Text, "match c")
+	assert.NotContains(t, result.Content[0].Text, "3: match c")
 }

--- a/toolkit/read_file.go
+++ b/toolkit/read_file.go
@@ -217,8 +217,11 @@ func (t *ReadFileTool) Call(ctx context.Context, input *ReadFileInput) (*dive.To
 			WithDisplay(fmt.Sprintf("Read %s (%d bytes)", filePath, len(content))), nil
 	}
 
-	// Read with offset/limit (line-based)
+	// Read with offset/limit (line-based). Raise the scanner buffer above the
+	// 64 KB default (mirroring bash.go) so a single long line doesn't fail
+	// the read and diverge from whole-file reads.
 	scanner := bufio.NewScanner(file)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
 	var lines []string
 	lineNum := 0
 	startLine := input.Offset


### PR DESCRIPTION
Remediates the remaining toolkit findings from `docs/reviews/2026-06-09-api-review.md` §2. All findings were re-verified against current `main` before fixing; all four still held (none skipped).

## §2.5 — Default exclude patterns miss top-level dirs (Glob + Grep, pure-Go path)

Verified empirically against `gobwas/glob`: `**/node_modules/**` does **not** match `node_modules/foo.js` (or the dir-skip form `node_modules/`), because `**/` requires a literal leading separator — while `./node_modules/foo.js` matches. Fix: a shared `matchesExclude` helper tests each exclude pattern against both the bare relative path and a `"./"`-prefixed variant, in both the file check and the directory-skip check. This makes the pure-Go path agree with ripgrep's gitignore-style globs (where `**/` matches zero directories). Regression tests cover a file under top-level `node_modules/` for both Glob and Grep.

## §2.6 — Grep `offset` and `-n` accepted but ignored

Implemented both (rather than removing from the schema):

- **Pagination**: `offset` + `head_limit` are now applied in `formatResults`, after the full result set is grouped into entries (matches for `content` mode, files for `files_with_matches`/`count`), so they compose into working pagination. Both search paths now collect up to `MaxResults` and paginate identically at format time.
- **Line numbers**: `ShowLines` changed to `*bool` (nil = true, per the documented default) and is honored in `content`-mode output on both paths. No ripgrep flag was needed — the `--json` output always carries `line_number`; rendering is shared in `formatResults`.
- Behavior note: the `head_limit` display text changed from `(limited to N)` to `(showing N)`; `(limited to N)` now refers only to the `MaxResults` cap. One existing test was updated accordingly.

Regression tests cover content/files pagination, offset-past-end, default-on line numbers, and explicit `-n: false` on the pure-Go path, plus a ripgrep-path test (guarded by an `rg` availability check) asserting identical pagination/line-number behavior.

## §2.4 — Fetch SSRF DNS-rebinding gap

`SafeHTTPClient` now installs a custom transport whose dialer has a `Control` function (`validateConnAddress`) that validates the IP actually being connected to, after DNS resolution — for every connection, including redirect targets and each Happy-Eyeballs attempt. This closes the window where a host could pass the pre-flight `net.LookupIP` check and then re-resolve to an internal IP at connect time. The pre-flight `validateFetchURL` check and the redirect `CheckRedirect` validation are kept as backstops; policy semantics (blocked ranges via `isPrivateIP`, localhost names, scheme restrictions) are unchanged. Regression tests exercise `validateConnAddress` directly (blocked/allowed/malformed addresses fail closed) and an end-to-end test asserting `SafeHTTPClient` refuses to connect to an `httptest` server on 127.0.0.1 before the handler is reached.

## §2 trailing notes — Bash/ReadFile scanner issues

- `toolkit/bash.go`: `scanner.Err()` is no longer ignored — a scan failure (e.g. a line exceeding the 1 MB buffer) now returns an error instead of silently truncating output and reporting success. The remaining pipe is drained so the child process can't deadlock writing to a full pipe before `Wait`. Regression test: a >1 MB single-line output yields an error result mentioning the read failure.
- `toolkit/read_file.go`: the offset/limit path raises its `bufio.Scanner` buffer from the 64 KB default to 1 MB (mirroring bash.go), so a long line no longer fails the read and diverges from whole-file reads. Regression test: offset/limit read of a file with a 100 KB line succeeds.

## Skipped

Nothing skipped — all four findings reproduced against current code.

## Testing

- `go build ./...`, `go vet ./toolkit/`, `gofmt -l .` clean
- `go test ./...` passes (including the new regression tests; the ripgrep-path tests ran rather than skipped since `rg` is installed locally)
- `experimental/cmd/dive` CLI module builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)