### PR TITLE
Harden skill package: expansion injection, hidden-command invocation, catalog hook race

### DIFF
--- a/docs/guides/skills.md
+++ b/docs/guides/skills.md
@@ -49,7 +49,7 @@ Target: $ARGUMENTS
 | --------------- | -------- | ---------------------------------------------------- |
 | `name`          | No       | Unique identifier (defaults to filename/directory)   |
 | `description`   | No       | Brief explanation for the LLM; presence makes it agent-invocable |
-| `allowed-tools` | No       | Metadata only — parsed but not enforced at runtime   |
+| `allowed-tools` | No       | Parsed for compatibility; informational only — NOT enforced at runtime, so it provides no security guarantee. Use the `permission` package to restrict tool access. |
 | `model`         | No       | Model override for this skill (reserved for future use) |
 | `argument-hint` | No       | Describes expected arguments (shown in CLI help) |
 | `triggers`      | No       | Keyword/regex patterns for automatic skill suggestion |
@@ -81,6 +81,8 @@ Skills support three kinds of variable substitution in their instructions:
 Shell expansion (`!{...}`) is **disabled by default** for security. Enable it with `skill.LoaderOptions{ShellExpansion: true}`, or `skill.WithShellExpansion(true)` when calling `Expand()` directly.
 
 **Security:** Shell expansion is only allowed for local skills (`file://` or empty SourceURI). Skills loaded from remote providers (e.g., custom HTTP providers) never get shell expansion regardless of configuration. This is enforced by `Skill.IsLocal()`.
+
+**Expansion order:** `!{...}` blocks are executed against the raw template *before* `$ARGUMENTS`/`$N` substitution. Arguments may be model-controlled, so a `!{...}` sequence carried in arguments is never executed — it appears as literal text. Shell command output is also inserted verbatim and never re-scanned for placeholders. To reference arguments inside a `!{command}` block, use `$1`-`$9` (passed as shell positional parameters) or `$ARGUMENTS` (exported as an environment variable); the shell receives the values as data, so argument text is never interpreted as shell syntax.
 
 ## Skill Discovery
 

--- a/skill/agent.go
+++ b/skill/agent.go
@@ -3,6 +3,7 @@ package skill
 import (
 	"context"
 	"strings"
+	"sync"
 
 	"github.com/deepnoodle-ai/dive"
 )
@@ -135,9 +136,16 @@ const skillReminderName = "skills"
 // The hook uses dive.SetSystemReminder, which is idempotent: it inserts the
 // block on first call and replaces it in place if the catalog changes.
 func catalogHook(loader *Loader) dive.PreGenerationHook {
+	// lastHash is shared across invocations of the returned hook, which may
+	// run concurrently when multiple CreateResponse calls execute on one
+	// agent. The mutex guards it; per-call HookContext state needs no guard.
+	var mu sync.Mutex
 	var lastHash string
 
 	return func(_ context.Context, hctx *dive.HookContext) error {
+		mu.Lock()
+		defer mu.Unlock()
+
 		hash := CatalogHash(loader)
 		if hash == "" {
 			// No skills — remove stale catalog block if present.

--- a/skill/agent_test.go
+++ b/skill/agent_test.go
@@ -2,6 +2,8 @@ package skill
 
 import (
 	"context"
+	"fmt"
+	"sync"
 	"testing"
 
 	"github.com/deepnoodle-ai/dive"
@@ -460,4 +462,68 @@ func TestCatalogHook_RemovesOnReloadToEmpty(t *testing.T) {
 	hctx2 := &dive.HookContext{Messages: []*llm.Message{firstMsg}}
 	assert.NoError(t, hook(context.Background(), hctx2))
 	assert.False(t, dive.HasSystemReminder(hctx2.Messages, "skills"))
+}
+
+// staticLLM is a minimal llm.LLM for exercising the agent loop in tests.
+type staticLLM struct{}
+
+func (s *staticLLM) Name() string { return "test-model" }
+
+func (s *staticLLM) Generate(_ context.Context, _ ...llm.Option) (*llm.Response, error) {
+	return &llm.Response{
+		ID:         "resp_1",
+		Model:      "test-model",
+		Role:       llm.Assistant,
+		Content:    []llm.Content{&llm.TextContent{Text: "ok"}},
+		Type:       "message",
+		StopReason: "stop",
+		Usage:      llm.Usage{InputTokens: 1, OutputTokens: 1},
+	}, nil
+}
+
+// TestCatalogHook_ConcurrentCreateResponse exercises the catalog hook's
+// shared lastHash state under concurrent CreateResponse calls on a single
+// agent. Run with -race to detect unsynchronized access.
+func TestCatalogHook_ConcurrentCreateResponse(t *testing.T) {
+	loader := &Loader{
+		skills: map[string]*Skill{
+			"reviewer": {
+				Name:        "reviewer",
+				Description: "Review code.",
+				Config:      SkillConfig{Description: "Review code."},
+			},
+		},
+		pendingInstructions: make(map[string]string),
+	}
+
+	agent, err := dive.NewAgent(dive.AgentOptions{
+		Name:       "TestAgent",
+		Model:      &staticLLM{},
+		Extensions: []dive.Extension{loader},
+	})
+	assert.NoError(t, err)
+
+	const goroutines = 16
+	var wg sync.WaitGroup
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			// Mutate the catalog from some goroutines so CatalogHash
+			// changes and the hook takes the lastHash write path.
+			if i%4 == 0 {
+				loader.mu.Lock()
+				name := fmt.Sprintf("skill-%d", i)
+				loader.skills[name] = &Skill{
+					Name:        name,
+					Description: "Generated.",
+					Config:      SkillConfig{Description: "Generated."},
+				}
+				loader.mu.Unlock()
+			}
+			_, err := agent.CreateResponse(context.Background(), dive.WithInput("hello"))
+			assert.NoError(t, err)
+		}(i)
+	}
+	wg.Wait()
 }

--- a/skill/expand.go
+++ b/skill/expand.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"os"
 	"os/exec"
 	"regexp"
 	"strings"
@@ -53,6 +54,17 @@ var shellPattern = regexp.MustCompile(`!\{([^}]+)\}`)
 //   - $1, $2, ..., $9 — positional arguments
 //   - !{command} — shell command substitution (requires WithShellExpansion(true))
 //
+// Security: shell expansion runs against the raw template only, before any
+// argument substitution. Arguments are model-controlled, so a !{...} sequence
+// carried in args is never executed — it appears as literal text in the
+// output. Shell command output is likewise inserted verbatim and never
+// re-scanned for !{...} or $N placeholders.
+//
+// Template authors can still reference arguments inside a !{command} block:
+// $1-$9 are passed to the shell as positional parameters and the full
+// argument string is exported as $ARGUMENTS in the environment, so the shell
+// receives argument values as data rather than as spliced command text.
+//
 // Returns the expanded instructions text.
 func (s *Skill) Expand(ctx context.Context, args string, opts ...ExpandOption) (string, error) {
 	cfg := defaultExpandConfig()
@@ -60,32 +72,41 @@ func (s *Skill) Expand(ctx context.Context, args string, opts ...ExpandOption) (
 		opt(cfg)
 	}
 
-	result := s.expandVariables(args)
-
-	if cfg.allowShellExpansion {
-		var expandErr error
-		result = shellPattern.ReplaceAllStringFunc(result, func(match string) string {
-			if expandErr != nil {
-				return match
-			}
-			submatch := shellPattern.FindStringSubmatch(match)
-			if len(submatch) < 2 {
-				return match
-			}
-			cmd := submatch[1]
-			output, err := runShellCommand(ctx, cmd, cfg.shellTimeout)
-			if err != nil {
-				expandErr = fmt.Errorf("shell expansion !{%s}: %w", cmd, err)
-				return match
-			}
-			return strings.TrimSpace(output)
-		})
-		if expandErr != nil {
-			return result, expandErr
-		}
+	if !cfg.allowShellExpansion {
+		return s.expandVariables(args), nil
 	}
 
-	return result, nil
+	positionalArgs := strings.Fields(args)
+	var sb strings.Builder
+	var expandErr error
+	last := 0
+	for _, loc := range shellPattern.FindAllStringSubmatchIndex(s.Instructions, -1) {
+		// Literal template text before the !{...} block: substitute args.
+		sb.WriteString(substituteArgs(s.Instructions[last:loc[0]], args, positionalArgs))
+		match := s.Instructions[loc[0]:loc[1]]
+		command := s.Instructions[loc[2]:loc[3]]
+		last = loc[1]
+		if expandErr != nil {
+			sb.WriteString(match)
+			continue
+		}
+		output, err := runShellCommand(ctx, command, args, positionalArgs, cfg.shellTimeout)
+		if err != nil {
+			expandErr = fmt.Errorf("shell expansion !{%s}: %w", command, err)
+			sb.WriteString(match)
+			continue
+		}
+		// Insert command output verbatim — never re-scanned for
+		// placeholders, so output cannot trigger further expansion.
+		sb.WriteString(strings.TrimSpace(output))
+	}
+	// Remaining literal template text after the last !{...} block.
+	sb.WriteString(substituteArgs(s.Instructions[last:], args, positionalArgs))
+
+	if expandErr != nil {
+		return sb.String(), expandErr
+	}
+	return sb.String(), nil
 }
 
 // ExpandArguments replaces $ARGUMENTS and $1-$9 placeholders only (no shell).
@@ -96,11 +117,15 @@ func (s *Skill) ExpandArguments(args string) string {
 
 // expandVariables handles $ARGUMENTS and positional $N substitution.
 func (s *Skill) expandVariables(argsString string) string {
-	positionalArgs := strings.Fields(argsString)
-	result := s.Instructions
+	return substituteArgs(s.Instructions, argsString, strings.Fields(argsString))
+}
 
+// substituteArgs replaces $1-$9 positional placeholders and $ARGUMENTS in the
+// given text. It performs plain text substitution and must never be applied
+// to text that will subsequently be shell-expanded.
+func substituteArgs(text, argsString string, positionalArgs []string) string {
 	// Replace positional arguments $1, $2, etc.
-	result = positionalArgPattern.ReplaceAllStringFunc(result, func(match string) string {
+	result := positionalArgPattern.ReplaceAllStringFunc(text, func(match string) string {
 		var num int
 		fmt.Sscanf(match, "$%d", &num)
 		if num > 0 && num <= len(positionalArgs) {
@@ -116,11 +141,18 @@ func (s *Skill) expandVariables(argsString string) string {
 }
 
 // runShellCommand executes a command with the user's shell and returns stdout.
-func runShellCommand(ctx context.Context, command string, timeout time.Duration) (string, error) {
+// Skill arguments are passed as data, not code: positional args become shell
+// positional parameters ($1, $2, ...) and the full argument string is
+// exported as $ARGUMENTS, so the command can reference them without the
+// argument text ever being interpreted as shell syntax.
+func runShellCommand(ctx context.Context, command, argsString string, positionalArgs []string, timeout time.Duration) (string, error) {
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
-	cmd := exec.CommandContext(ctx, "sh", "-c", command)
+	// "skill" is $0; positional args follow as $1, $2, ...
+	shellArgs := append([]string{"-c", command, "skill"}, positionalArgs...)
+	cmd := exec.CommandContext(ctx, "sh", shellArgs...)
+	cmd.Env = append(os.Environ(), "ARGUMENTS="+argsString)
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr

--- a/skill/expand_test.go
+++ b/skill/expand_test.go
@@ -2,6 +2,9 @@ package skill
 
 import (
 	"context"
+	"fmt"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -121,6 +124,74 @@ func TestExpand_ShellWithEmptyArgs(t *testing.T) {
 	result, err := s.Expand(context.Background(), "", WithShellExpansion(true))
 	assert.NoError(t, err)
 	assert.Equal(t, "Branch: main. Args: ", result)
+}
+
+func TestExpand_ArgInjectionNotExecuted(t *testing.T) {
+	// Regression test for shell-expansion injection: model-controlled args
+	// containing !{...} must never be executed, even with shell expansion
+	// enabled. The injected sequence must appear as literal text.
+	marker := filepath.Join(t.TempDir(), "pwned")
+	hostileArgs := fmt.Sprintf("Bob !{touch %s}", marker)
+
+	s := &Skill{Instructions: "Hello $ARGUMENTS. Branch: !{echo main}"}
+	result, err := s.Expand(context.Background(), hostileArgs, WithShellExpansion(true))
+	assert.NoError(t, err)
+
+	// The template's own shell block ran.
+	assert.Contains(t, result, "Branch: main")
+	// The injected !{...} appears literally in the output.
+	assert.Contains(t, result, fmt.Sprintf("!{touch %s}", marker))
+	// The injected command did NOT run.
+	_, statErr := os.Stat(marker)
+	assert.True(t, os.IsNotExist(statErr), "injected command must not execute")
+}
+
+func TestExpand_ArgInjectionViaPositional(t *testing.T) {
+	marker := filepath.Join(t.TempDir(), "pwned")
+	// A whitespace-free injection so it survives positional splitting intact:
+	// `>file` would create the file if the shell executed it.
+	hostileArg := fmt.Sprintf("!{>%s}", marker)
+	s := &Skill{Instructions: "First: $1. Branch: !{echo main}"}
+	result, err := s.Expand(context.Background(), hostileArg, WithShellExpansion(true))
+	assert.NoError(t, err)
+	assert.Contains(t, result, "Branch: main")
+	assert.Contains(t, result, "First: "+hostileArg)
+	_, statErr := os.Stat(marker)
+	assert.True(t, os.IsNotExist(statErr), "injected command must not execute")
+}
+
+func TestExpand_ArgsInsideShellBlock(t *testing.T) {
+	// Template authors can reference arguments inside !{...}: positional
+	// args are shell positional parameters and $ARGUMENTS is exported in
+	// the environment. The shell receives them as data, not code.
+	s := &Skill{Instructions: `Result: !{echo "first=$1 all=$ARGUMENTS"}`}
+	result, err := s.Expand(context.Background(), "foo bar", WithShellExpansion(true))
+	assert.NoError(t, err)
+	assert.Equal(t, "Result: first=foo all=foo bar", result)
+}
+
+func TestExpand_ArgsInsideShellBlockAreData(t *testing.T) {
+	// Hostile args referenced inside a shell block must be expanded as data
+	// by the shell — command substitution syntax in args must not execute.
+	marker := filepath.Join(t.TempDir(), "pwned")
+	s := &Skill{Instructions: `Result: !{echo "$ARGUMENTS"}`}
+	hostileArgs := fmt.Sprintf("$(touch %s)", marker)
+	result, err := s.Expand(context.Background(), hostileArgs, WithShellExpansion(true))
+	assert.NoError(t, err)
+	assert.Contains(t, result, hostileArgs)
+	_, statErr := os.Stat(marker)
+	assert.True(t, os.IsNotExist(statErr), "command substitution in args must not execute")
+}
+
+func TestExpand_ShellOutputNotReexpanded(t *testing.T) {
+	// Shell output is inserted verbatim: placeholders or !{...} sequences
+	// in command output must not be substituted or executed. The command
+	// emits "!{echo nested}" via printf escapes (\041 = "!", \175 = "}")
+	// because a !{command} block cannot itself contain a literal "}".
+	s := &Skill{Instructions: `Result: !{printf '$1 $ARGUMENTS \041{echo nested\175'}`}
+	result, err := s.Expand(context.Background(), "foo", WithShellExpansion(true))
+	assert.NoError(t, err)
+	assert.Equal(t, "Result: $1 $ARGUMENTS !{echo nested}", result)
 }
 
 func TestExpand_NoPlaceholders(t *testing.T) {

--- a/skill/loader.go
+++ b/skill/loader.go
@@ -172,12 +172,26 @@ func (l *Loader) Load(ctx context.Context) error {
 	return nil
 }
 
-// Get retrieves a skill by exact name.
+// Get retrieves a skill or command by exact name.
 func (l *Loader) Get(name string) (*Skill, bool) {
 	l.mu.RLock()
 	defer l.mu.RUnlock()
 	s, ok := l.skills[name]
 	return s, ok
+}
+
+// GetSkill retrieves an agent-invocable skill by exact name. Commands
+// (user-invocable only) are not returned, even if a command with the given
+// name exists. This is the lookup the Skill tool uses, so the model cannot
+// trigger commands that are hidden from its catalog.
+func (l *Loader) GetSkill(name string) (*Skill, bool) {
+	l.mu.RLock()
+	defer l.mu.RUnlock()
+	s, ok := l.skills[name]
+	if !ok || s.IsCommand() {
+		return nil, false
+	}
+	return s, true
 }
 
 // List returns all loaded skills and commands, sorted alphabetically.

--- a/skill/loader_test.go
+++ b/skill/loader_test.go
@@ -565,3 +565,33 @@ Review the code.`), 0644))
 	assert.True(t, ok)
 	assert.Equal(t, "Review code.", s.Description)
 }
+
+func TestLoader_GetSkill(t *testing.T) {
+	loader := &Loader{
+		skills: map[string]*Skill{
+			"reviewer": {
+				Name:        "reviewer",
+				Description: "Review code.",
+				Config:      SkillConfig{Description: "Review code."},
+			},
+			"commit": {
+				Name: "commit", // no description: user-invocable-only command
+			},
+		},
+	}
+
+	// Agent-invocable skill is returned.
+	s, ok := loader.GetSkill("reviewer")
+	assert.True(t, ok)
+	assert.Equal(t, "reviewer", s.Name)
+
+	// Command exists via Get but is hidden from GetSkill.
+	_, ok = loader.Get("commit")
+	assert.True(t, ok)
+	_, ok = loader.GetSkill("commit")
+	assert.False(t, ok)
+
+	// Unknown name.
+	_, ok = loader.GetSkill("nonexistent")
+	assert.False(t, ok)
+}

--- a/skill/skill.go
+++ b/skill/skill.go
@@ -91,8 +91,12 @@ type SkillConfig struct {
 	// Description explains what the skill does and when to use it.
 	Description string `yaml:"description,omitempty"`
 
-	// AllowedTools restricts which tools are available while this skill is active.
-	// An empty list means all tools are available.
+	// AllowedTools lists tools the skill author intends to be available while
+	// this skill is active. Parsed for compatibility with the skill file
+	// format, but NOT currently enforced by Dive — it is informational
+	// metadata only and provides no security guarantee. Runtime enforcement
+	// is planned as follow-up work; until then, use the permission package
+	// to restrict tool access.
 	AllowedTools []string `yaml:"allowed-tools,omitempty"`
 
 	// Model is an optional model override for this skill.

--- a/skill/tool.go
+++ b/skill/tool.go
@@ -96,7 +96,9 @@ func (t *toolImpl) Call(ctx context.Context, input *ToolInput) (*dive.ToolResult
 		return dive.NewToolResultError("skill name is required"), nil
 	}
 
-	s, ok := t.loader.Get(input.Skill)
+	// Resolve through the skills-only lookup: commands (user-invocable only)
+	// are hidden from the model's catalog and must not be invocable here.
+	s, ok := t.loader.GetSkill(input.Skill)
 	if !ok {
 		// Only list agent-invocable skills (not commands) in error
 		skillNames := make([]string, 0)

--- a/skill/tool_test.go
+++ b/skill/tool_test.go
@@ -169,6 +169,25 @@ func TestTool_Call(t *testing.T) {
 		assert.Contains(t, result.Content[0].Text, "Available skills:")
 	})
 
+	t.Run("command is not invocable via tool", func(t *testing.T) {
+		loader := setupTestLoader(t)
+		tool := NewTool(loader)
+
+		// "commit" is loaded as a user-invocable-only command. It is hidden
+		// from the model's catalog, so the Skill tool must reject it with
+		// the same not-found error shape as an unknown name.
+		s, ok := loader.Get("commit")
+		assert.True(t, ok)
+		assert.True(t, s.IsCommand())
+
+		result, err := tool.Call(ctx, &ToolInput{Skill: "commit"})
+		assert.NoError(t, err)
+		assert.True(t, result.IsError)
+		assert.Contains(t, result.Content[0].Text, "skill \"commit\" not found")
+		// The available list contains only agent-invocable skills.
+		assert.Contains(t, result.Content[0].Text, "Available skills: code-reviewer, deploy, helper")
+	})
+
 	t.Run("empty skill name", func(t *testing.T) {
 		loader := setupTestLoader(t)
 		tool := NewTool(loader)


### PR DESCRIPTION
Remediates the `skill/` package findings from `docs/reviews/2026-06-09-api-review.md` §6. All findings were re-verified against current code before fixing; all four still held. The `permission/` package is explicitly out of scope for this batch (deferred).

## Fixes

### §6.1 HIGH — Shell-expansion injection via skill arguments (`skill/expand.go`)
Verified still present: `$ARGUMENTS`/`$N` substitution ran before `!{...}` expansion, so model-controlled args containing `!{...}` were executed when `WithShellExpansion(true)` was set.

Fix: `!{...}` expansion now runs against the **raw template first**, then `$ARGUMENTS`/`$N` are substituted into the literal text around the command output. Consequences:
- `!{...}` sequences carried in args are never executed — they appear as literal text.
- Shell command output is inserted verbatim and never re-scanned for `!{...}` or `$N`.
- Author-intended argument references **inside** a `!{command}` block are preserved, but safely: `$1`-`$9` are passed as shell positional parameters and the full argument string is exported as `$ARGUMENTS` in the environment, so the shell expands them as data rather than spliced command text. For benign args this produces the same results as before (e.g. `!{git log $1}`); injection syntax (`$(...)`, `;`, `!{...}`) in args is inert. This semantic change is documented in `Expand`'s doc comment and `docs/guides/skills.md`.

Regression tests: hostile args with `!{touch <marker>}` (via `$ARGUMENTS` and via `$1`) assert the marker file is never created and the injected text appears literally; plus tests for args-as-data inside `!{...}` blocks and verbatim (non-re-expanded) command output.

### §6.2 MEDIUM — `allowed-tools` parsed but unenforced (`skill/skill.go`)
Verified still present: nothing reads `SkillConfig.AllowedTools`. Per the batch decision, this is a **re-documentation, not enforcement**: the field's doc comment and the `docs/guides/skills.md` frontmatter table now state it is parsed for compatibility, informational only, provides no security guarantee, and point to the `permission` package for actual tool restriction. **Runtime enforcement is filed as follow-up work.**

### §6.3 MEDIUM — Skill tool executes catalog-hidden commands (`skill/tool.go`)
Verified still present: `Call` resolved via `loader.Get`, which includes user-invocable-only commands hidden from the model's catalog. Fix: added `Loader.GetSkill` (skills-only lookup, excludes commands) and the tool now resolves through it, returning the identical not-found error shape (including the agent-invocable-only available list). Regression test: a loaded command (`commit`) is rejected when invoked via the tool.

### §6 trailing — `catalogHook` `lastHash` race (`skill/agent.go`)
Verified still present: the closure-captured `lastHash` was read/written unsynchronized across concurrent `CreateResponse` calls. Fix: guarded with a `sync.Mutex`. Test: realistic concurrent `CreateResponse` on one agent with a mock LLM (16 goroutines, with catalog mutation to force the write path), run under `-race`. The test was verified to detect the race against the pre-fix code.

## Not addressed (out of scope)
- `permission/` package findings — explicitly deferred per batch instructions.
- §6 trailing `SetSystemReminder` `</system-reminder>` content guard (`system_reminder.go`) — core package, not part of the four fixes in this batch.

## Verification
- `gofmt -l` clean on touched files
- `go build ./...` passes
- `go test ./...` passes
- `go test -race ./skill/...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)