### PR TITLE
Agent loop correctness batch 3: hook values, partial-work errors, session lock (§4.5, §4.7, §4.8 + notes)

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -587,10 +587,6 @@ func (a *Agent) CreateResponse(ctx context.Context, opts ...CreateResponseOption
 		startHctx.SystemPrompt = systemPrompt
 		startHctx.SessionStartSource = SessionStartStartup
 		maps.Copy(startHctx.Values, options.Values)
-		// HookContext.Values is documented to persist across the whole hook
-		// chain within one CreateResponse call, so values set by SessionStart
-		// hooks must carry into the main hook context created below.
-		sessionStartValues = startHctx.Values
 
 		var persistentSeeds []*llm.Message
 		for _, hook := range a.hooks.SessionStart {
@@ -607,6 +603,13 @@ func (a *Agent) CreateResponse(ctx context.Context, opts ...CreateResponseOption
 				persistentSeeds = append(persistentSeeds, result.Messages...)
 			}
 		}
+
+		// HookContext.Values is documented to persist across the whole hook
+		// chain within one CreateResponse call, so values set by SessionStart
+		// hooks must carry into the main hook context created below. Captured
+		// after the hooks run so a hook that replaces startHctx.Values
+		// wholesale is honored too.
+		sessionStartValues = startHctx.Values
 
 		// Persist durable seeds as their own pre-turn so they remain in history
 		// on later turns and on resume, without polluting the turn delta below.

--- a/agent.go
+++ b/agent.go
@@ -23,7 +23,61 @@ const (
 var (
 	ErrLLMNoResponse = errors.New("llm did not return a response")
 	ErrNoLLM         = errors.New("no llm provided")
+
+	// ErrReentrantSession is returned when CreateResponse is invoked on a
+	// session whose lock is already held by the calling context — i.e. a
+	// tool, hook, or subagent reachable from an in-flight CreateResponse
+	// called back into the same session ID. Without this check the nested
+	// call would deadlock waiting on a lock its own caller holds. Use a
+	// separate session for nested agent calls.
+	ErrReentrantSession = errors.New("dive: reentrant CreateResponse on a session whose turn is already in progress")
 )
+
+// GenerationError wraps a failure that occurred inside the generation loop,
+// carrying the usage, output messages, and response items accumulated before
+// the failure. When iteration N of a turn fails after earlier iterations
+// succeeded — meaning tools with real side effects may have already run and
+// tokens have already been paid for — CreateResponse still returns
+// (nil, err), but err wraps a *GenerationError so callers can recover cost
+// accounting and partial work via errors.As:
+//
+//	resp, err := agent.CreateResponse(ctx, ...)
+//	if err != nil {
+//	    var genErr *dive.GenerationError
+//	    if errors.As(err, &genErr) {
+//	        recordUsage(genErr.Usage)
+//	    }
+//	}
+//
+// The partial turn is intentionally NOT persisted to the session: a turn
+// that ends mid-loop (e.g. with a trailing tool_result and no final
+// assistant message) can violate the role-alternation invariants providers
+// enforce, permanently corrupting the saved history. Callers that want to
+// keep the partial work must reconcile and persist it themselves.
+type GenerationError struct {
+	// Err is the underlying error that terminated the generation loop.
+	Err error
+
+	// Usage is the token usage accumulated across all LLM calls that
+	// completed in the failed turn. Never nil, but may be zero-valued when
+	// the very first call failed.
+	Usage *llm.Usage
+
+	// OutputMessages are the messages produced in the turn before the
+	// failure: assistant messages and tool_result messages, in order.
+	OutputMessages []*llm.Message
+
+	// Items are the response items accumulated before the failure.
+	Items []*ResponseItem
+}
+
+func (e *GenerationError) Error() string {
+	return e.Err.Error()
+}
+
+func (e *GenerationError) Unwrap() error {
+	return e.Err
+}
 
 // sessionLocks serializes CreateResponse calls that share a session ID.
 // Concurrent calls on the same session would otherwise interleave their
@@ -31,19 +85,42 @@ var (
 // — on suspended sessions — mixed pending-call sets. The lock is keyed by
 // Session.ID() so it also covers cross-agent usage of a single session.
 //
+// Each entry is a 1-buffered channel used as a semaphore so acquisition
+// can race against context cancellation instead of blocking forever.
+//
 // Entries accumulate in the map for the lifetime of the process; if you
-// create unbounded fresh session IDs, the memory cost is a small *sync.Mutex
+// create unbounded fresh session IDs, the memory cost is a small channel
 // per distinct ID. For typical workloads this is negligible.
 var sessionLocks sync.Map
 
-// acquireSessionLock blocks until the caller holds the exclusive lock for
-// the given session ID. The returned function releases the lock and must
-// be deferred by the caller.
-func acquireSessionLock(id string) func() {
-	v, _ := sessionLocks.LoadOrStore(id, &sync.Mutex{})
-	mu := v.(*sync.Mutex)
-	mu.Lock()
-	return mu.Unlock
+// sessionLockHeldKey is the context key marking that the context's call
+// chain currently holds the lock for a given session ID. Set while the lock
+// is held so a reentrant CreateResponse (from a tool/hook/subagent) fails
+// fast with ErrReentrantSession instead of deadlocking.
+type sessionLockHeldKey struct{ id string }
+
+// acquireSessionLock acquires the exclusive lock for the given session ID.
+// It returns a derived context that marks the lock as held (for reentrancy
+// detection) and a release function that must be deferred by the caller.
+//
+// It fails immediately with ErrReentrantSession when ctx already holds the
+// lock for this ID (same call chain), and with ctx.Err() if the context is
+// cancelled or times out while waiting — so a reentrant call from a
+// different goroutine that would otherwise deadlock forever instead fails
+// when the caller's deadline expires.
+func acquireSessionLock(ctx context.Context, id string) (context.Context, func(), error) {
+	if held, _ := ctx.Value(sessionLockHeldKey{id: id}).(bool); held {
+		return nil, nil, fmt.Errorf("%w (session %q)", ErrReentrantSession, id)
+	}
+	v, _ := sessionLocks.LoadOrStore(id, make(chan struct{}, 1))
+	sem := v.(chan struct{})
+	select {
+	case sem <- struct{}{}:
+	case <-ctx.Done():
+		return nil, nil, ctx.Err()
+	}
+	release := func() { <-sem }
+	return context.WithValue(ctx, sessionLockHeldKey{id: id}, true), release, nil
 }
 
 // Hooks groups all agent hook slices.
@@ -89,6 +166,25 @@ type Hooks struct {
 	// Hooks run in the main agent goroutine, never from a background goroutine.
 	// Errors are logged but do not affect the response (same as PostGeneration).
 	PostBackgroundToolUse []PostBackgroundToolUseHook
+}
+
+// cloneSlices returns a copy of h with every hook slice cloned, so appends
+// to the copy never write into the original slices' backing arrays. Used by
+// NewAgent before merging extension hooks, so a caller reusing one
+// AgentOptions value across multiple NewAgent calls doesn't get
+// cross-contaminated hook registrations.
+func (h Hooks) cloneSlices() Hooks {
+	h.SessionStart = slices.Clone(h.SessionStart)
+	h.PreGeneration = slices.Clone(h.PreGeneration)
+	h.PostGeneration = slices.Clone(h.PostGeneration)
+	h.PreToolUse = slices.Clone(h.PreToolUse)
+	h.PostToolUse = slices.Clone(h.PostToolUse)
+	h.PostToolUseFailure = slices.Clone(h.PostToolUseFailure)
+	h.Stop = slices.Clone(h.Stop)
+	h.PreIteration = slices.Clone(h.PreIteration)
+	h.OnSuspend = slices.Clone(h.OnSuspend)
+	h.PostBackgroundToolUse = slices.Clone(h.PostBackgroundToolUse)
+	return h
 }
 
 // Extension bundles tools, hooks, and system prompt rules that extend an
@@ -224,7 +320,14 @@ func NewAgent(opts AgentOptions) (*Agent, error) {
 	if opts.Logger == nil {
 		opts.Logger = &llm.NullLogger{}
 	}
-	// Merge extensions into opts before building the agent.
+	// Merge extensions into opts before building the agent. Clone the
+	// caller's slices first: appending directly may write into the caller's
+	// backing arrays, cross-contaminating a reused AgentOptions value
+	// across multiple NewAgent calls.
+	if len(opts.Extensions) > 0 {
+		opts.Tools = slices.Clone(opts.Tools)
+		opts.Hooks = opts.Hooks.cloneSlices()
+	}
 	for _, ext := range opts.Extensions {
 		if ext == nil {
 			continue
@@ -404,7 +507,11 @@ func (a *Agent) CreateResponse(ctx context.Context, opts ...CreateResponseOption
 	// Stateless callers (sess == nil) have no shared state to protect and
 	// skip the lock entirely.
 	if sess != nil {
-		release := acquireSessionLock(sess.ID())
+		lockCtx, release, lockErr := acquireSessionLock(ctx, sess.ID())
+		if lockErr != nil {
+			return nil, lockErr
+		}
+		ctx = lockCtx
 		defer release()
 	}
 
@@ -472,6 +579,7 @@ func (a *Agent) CreateResponse(ctx context.Context, opts ...CreateResponseOption
 	// is false, so seeds always flow into the non-resume history branch below.
 	// Returned messages are prepended to the conversation; those marked Persist
 	// are saved as a pre-turn so they survive later turns and resumes.
+	var sessionStartValues map[string]any
 	if !hasResumeIntent && len(sessionMsgs) == 0 && len(a.hooks.SessionStart) > 0 {
 		startHctx := NewHookContext()
 		startHctx.Agent = a
@@ -479,6 +587,10 @@ func (a *Agent) CreateResponse(ctx context.Context, opts ...CreateResponseOption
 		startHctx.SystemPrompt = systemPrompt
 		startHctx.SessionStartSource = SessionStartStartup
 		maps.Copy(startHctx.Values, options.Values)
+		// HookContext.Values is documented to persist across the whole hook
+		// chain within one CreateResponse call, so values set by SessionStart
+		// hooks must carry into the main hook context created below.
+		sessionStartValues = startHctx.Values
 
 		var persistentSeeds []*llm.Message
 		for _, hook := range a.hooks.SessionStart {
@@ -583,8 +695,11 @@ func (a *Agent) CreateResponse(ctx context.Context, opts ...CreateResponseOption
 	hctx.SystemPrompt = systemPrompt
 	hctx.Messages = messages
 
-	// Copy caller-provided values into hook context
+	// Copy caller-provided values into hook context, then layer any values
+	// set by SessionStart hooks on top (they ran later and already saw the
+	// caller's values). A nil source map is a no-op.
 	maps.Copy(hctx.Values, options.Values)
+	maps.Copy(hctx.Values, sessionStartValues)
 
 	// Run PreGeneration hooks
 	for _, hook := range a.hooks.PreGeneration {
@@ -663,7 +778,19 @@ func (a *Agent) CreateResponse(ctx context.Context, opts ...CreateResponseOption
 			}
 			batch, err := a.executeToolCalls(ctx, hctx, rs.NotStartedToolCalls, resumeToolsByName, resumeCallback)
 			if err != nil {
-				return nil, err
+				// Mirror the generate loop: expose the items accumulated
+				// during the resume phase via a *GenerationError so callers
+				// can recover partial work (no LLM calls have happened yet,
+				// so usage is zero). Snapshot under the mutex — parallel
+				// tool goroutines may still be appending as we unwind.
+				resumeItemsMu.Lock()
+				itemsSnapshot := slices.Clone(resumeItems)
+				resumeItemsMu.Unlock()
+				return nil, &GenerationError{
+					Err:   err,
+					Usage: &llm.Usage{},
+					Items: itemsSnapshot,
+				}
 			}
 			resumeExtraItems = resumeItems
 			// Merge completed outcomes into the tool_result message.
@@ -680,6 +807,20 @@ func (a *Agent) CreateResponse(ctx context.Context, opts ...CreateResponseOption
 				snap.CompletedToolCalls = append(rs.CompletedToolCalls(), snap.CompletedToolCalls...)
 				return a.finishSuspended(ctx, logger, hctx, response, inputMessages, snap, resumeExtraItems, eventCallback, sess, rs, false)
 			}
+		}
+
+		// The resume phase above mutates the merged tool_result message held
+		// in rs — a pointer that is normally shared with the model-facing
+		// `messages` slice. A PreGeneration hook that replaced hctx.Messages
+		// with copies (e.g. compaction) breaks that pointer sharing, so the
+		// post-hook result updates and re-executed not-started tool results
+		// would silently vanish from what the LLM sees, leaving orphaned
+		// tool_use blocks. Re-sync by locating the suspended turn's
+		// tool_result in the slice actually being sent and substituting the
+		// merged message.
+		if rs.ToolResultMessageIdx >= 0 {
+			messages = syncMergedToolResult(messages, rs.TurnMessages[rs.ToolResultMessageIdx], rs.AssistantToolUse)
+			hctx.Messages = messages
 		}
 	}
 
@@ -724,6 +865,25 @@ generateLoop:
 	genResult, err := a.generate(ctx, hctx, messages, systemPrompt, eventCallback, model)
 	if err != nil {
 		logger.Error("failed to generate response", "error", err)
+		// generate wraps loop failures in *GenerationError scoped to that
+		// single generate call. Fold in state accumulated before it —
+		// resume-phase items and prior Stop-hook continuation iterations —
+		// so the error reflects the whole turn's partial work. The partial
+		// turn is deliberately NOT saved to the session: a half-turn can
+		// violate provider role-alternation invariants (see GenerationError).
+		var genErr *GenerationError
+		if errors.As(err, &genErr) {
+			if genErr.Usage == nil {
+				genErr.Usage = &llm.Usage{}
+			}
+			accumulatedUsage.Add(genErr.Usage)
+			genErr.Usage = accumulatedUsage
+			genErr.OutputMessages = append(slices.Clone(accumulatedOutput), genErr.OutputMessages...)
+			turnItems := slices.Clone(resumeExtraItems)
+			turnItems = append(turnItems, accumulatedItems...)
+			turnItems = append(turnItems, genErr.Items...)
+			genErr.Items = turnItems
+		}
 		return nil, err
 	}
 
@@ -1187,7 +1347,10 @@ func (a *Agent) prepareResume(fullHistory []*llm.Message, state *SuspensionState
 		}
 	}
 	callerSupplied := make(map[string]*ToolCallResult)
-	for id, result := range toolResults {
+	// Iterate sorted IDs so the merged tool_result content blocks land in a
+	// deterministic order rather than nondeterministic map order.
+	for _, id := range slices.Sorted(maps.Keys(toolResults)) {
+		result := toolResults[id]
 		toolUse := findToolUseByID(assistant, id)
 		name := ""
 		var input json.RawMessage
@@ -1366,7 +1529,7 @@ func (a *Agent) fireResumePostHooks(ctx context.Context, hctx *HookContext, rs *
 						a.logger.Error("post-tool-use-failure hook aborted", "error", abortErr)
 						return abortErr
 					}
-					a.logger.Debug("post-tool-use-failure hook error", "error", err)
+					a.logger.Warn("post-tool-use-failure hook error", "error", err)
 				}
 			}
 		} else {
@@ -1378,7 +1541,7 @@ func (a *Agent) fireResumePostHooks(ctx context.Context, hctx *HookContext, rs *
 						a.logger.Error("post-tool-use hook aborted", "error", abortErr)
 						return abortErr
 					}
-					a.logger.Debug("post-tool-use hook error", "error", err)
+					a.logger.Warn("post-tool-use hook error", "error", err)
 				}
 			}
 		}
@@ -1405,6 +1568,86 @@ func (a *Agent) fireResumePostHooks(ctx context.Context, hctx *HookContext, rs *
 		rs.UpdateToolResultContent(toolUseID, result)
 	}
 	return nil
+}
+
+// syncMergedToolResult ensures the merged tool_result message for a resumed
+// turn is present in the model-facing message slice. Normally `merged` is
+// already in the slice by shared pointer and this is a no-op. But if a
+// PreGeneration hook replaced hctx.Messages with copies, resume-phase
+// mutations to `merged` (post-hook result updates, results of re-executed
+// not-started tools) would not be visible to the LLM. This locates the
+// copied tool_result message — or, failing that, the paired assistant
+// tool_use message — by ID and substitutes the merged message, returning a
+// new slice (the input is never mutated). If the hook removed the suspended
+// turn entirely (e.g. a full-compaction rewrite), the slice is returned
+// unchanged: the hook owns the rewrite at that point.
+func syncMergedToolResult(messages []*llm.Message, merged *llm.Message, assistant *llm.Message) []*llm.Message {
+	// Fast path: merged message already present by pointer.
+	for i := len(messages) - 1; i >= 0; i-- {
+		if messages[i] == merged {
+			return messages
+		}
+	}
+
+	// Locate a user message holding a tool_result for one of the merged IDs.
+	mergedIDs := make(map[string]bool)
+	for _, c := range merged.Content {
+		if trc, ok := c.(*llm.ToolResultContent); ok {
+			mergedIDs[trc.ToolUseID] = true
+		}
+	}
+	for i := len(messages) - 1; i >= 0; i-- {
+		msg := messages[i]
+		if msg.Role != llm.User {
+			continue
+		}
+		for _, c := range msg.Content {
+			if trc, ok := c.(*llm.ToolResultContent); ok && mergedIDs[trc.ToolUseID] {
+				out := slices.Clone(messages)
+				out[i] = merged
+				return out
+			}
+		}
+	}
+
+	// No matching tool_result found — the copy may predate the merged
+	// message gaining content (it starts as an empty placeholder when all
+	// suspended-turn tools were not-started). Fall back to the paired
+	// assistant tool_use message: substitute the message right after it if
+	// it's the (empty) tool_result copy, otherwise insert.
+	if assistant == nil {
+		return messages
+	}
+	assistantIDs := make(map[string]bool)
+	for _, c := range assistant.Content {
+		if tu, ok := c.(*llm.ToolUseContent); ok {
+			assistantIDs[tu.ID] = true
+		}
+	}
+	for i := len(messages) - 1; i >= 0; i-- {
+		msg := messages[i]
+		if msg.Role != llm.Assistant {
+			continue
+		}
+		match := false
+		for _, c := range msg.Content {
+			if tu, ok := c.(*llm.ToolUseContent); ok && assistantIDs[tu.ID] {
+				match = true
+				break
+			}
+		}
+		if !match {
+			continue
+		}
+		out := slices.Clone(messages)
+		if i+1 < len(out) && out[i+1].Role == llm.User && (len(out[i+1].Content) == 0 || hasToolResultContent(out[i+1])) {
+			out[i+1] = merged
+		} else {
+			out = slices.Insert(out, i+1, merged)
+		}
+		return out
+	}
+	return messages
 }
 
 // hasToolUseContent reports whether a message contains any tool_use blocks.
@@ -1482,7 +1725,7 @@ func (a *Agent) prepareMessages(options CreateResponseOptions) []*llm.Message {
 // generate runs the LLM generation and tool execution loop. It handles the
 // interaction between the agent and the LLM, including tool calls. Returns the
 // final LLM response, updated messages, and any error that occurred.
-func (a *Agent) generate(ctx context.Context, hctx *HookContext, messages []*llm.Message, systemPrompt string, callback EventCallback, model llm.LLM) (*generateResult, error) {
+func (a *Agent) generate(ctx context.Context, hctx *HookContext, messages []*llm.Message, systemPrompt string, callback EventCallback, model llm.LLM) (result *generateResult, err error) {
 
 	// Contains the message history we pass to the LLM
 	updatedMessages := make([]*llm.Message, len(messages))
@@ -1512,6 +1755,25 @@ func (a *Agent) generate(ctx context.Context, hctx *HookContext, messages []*llm
 	// Accumulates usage across multiple LLM calls
 	totalUsage := &llm.Usage{}
 
+	// Wrap any loop failure in a *GenerationError carrying the state
+	// accumulated before the failure, so callers can recover cost
+	// accounting and partial work via errors.As. The items snapshot is
+	// taken under the mutex because parallel tool goroutines may still be
+	// appending via collectingCallback as an error unwinds.
+	defer func() {
+		if err != nil {
+			itemsMu.Lock()
+			itemsSnapshot := slices.Clone(items)
+			itemsMu.Unlock()
+			err = &GenerationError{
+				Err:            err,
+				Usage:          totalUsage,
+				OutputMessages: outputMessages,
+				Items:          itemsSnapshot,
+			}
+		}
+	}()
+
 	newMessage := func(msg *llm.Message) {
 		updatedMessages = append(updatedMessages, msg)
 		outputMessages = append(outputMessages, msg)
@@ -1524,11 +1786,18 @@ func (a *Agent) generate(ctx context.Context, hctx *HookContext, messages []*llm
 	generationLimit := a.toolIterationLimit + 1
 	lastIteration := false
 	for i := range generationLimit {
+		// Refresh per-iteration hook context state unconditionally, so every
+		// hook that fires during this iteration (PreIteration, PreToolUse,
+		// PostToolUse, ...) observes the current message set rather than a
+		// stale snapshot from the start of the turn. This must not depend on
+		// whether PreIteration hooks happen to be registered. The refresh is
+		// a cheap slice-header assignment — no copying.
+		hctx.Iteration = i
+		hctx.SystemPrompt = systemPrompt
+		hctx.Messages = updatedMessages
+
 		// Run PreIteration hooks
 		if len(a.hooks.PreIteration) > 0 {
-			hctx.Iteration = i
-			hctx.SystemPrompt = systemPrompt
-			hctx.Messages = updatedMessages
 			for _, hook := range a.hooks.PreIteration {
 				if err := hook(ctx, hctx); err != nil {
 					return nil, fmt.Errorf("pre-iteration hook error: %w", err)
@@ -2052,7 +2321,7 @@ func (a *Agent) executeToolCallsParallel(
 						a.logger.Error("post-tool-use-failure hook aborted", "error", abortErr)
 						return nil, abortErr
 					}
-					a.logger.Debug("post-tool-use-failure hook error", "error", err)
+					a.logger.Warn("post-tool-use-failure hook error", "error", err)
 				}
 			}
 		} else {
@@ -2064,7 +2333,7 @@ func (a *Agent) executeToolCallsParallel(
 						a.logger.Error("post-tool-use hook aborted", "error", abortErr)
 						return nil, abortErr
 					}
-					a.logger.Debug("post-tool-use hook error", "error", err)
+					a.logger.Warn("post-tool-use hook error", "error", err)
 				}
 			}
 		}
@@ -2244,7 +2513,7 @@ func (a *Agent) executeOneToolCall(
 					a.logger.Error("post-tool-use-failure hook aborted", "error", abortErr)
 					return nil, abortErr
 				}
-				a.logger.Debug("post-tool-use-failure hook error", "error", err)
+				a.logger.Warn("post-tool-use-failure hook error", "error", err)
 			}
 		}
 	} else {
@@ -2256,7 +2525,7 @@ func (a *Agent) executeOneToolCall(
 					a.logger.Error("post-tool-use hook aborted", "error", abortErr)
 					return nil, abortErr
 				}
-				a.logger.Debug("post-tool-use hook error", "error", err)
+				a.logger.Warn("post-tool-use hook error", "error", err)
 			}
 		}
 	}

--- a/agent_loop_fixes_test.go
+++ b/agent_loop_fixes_test.go
@@ -86,6 +86,48 @@ func TestSessionStartValuesVisibleToLaterHooks(t *testing.T) {
 	assert.Equal(t, preToolSaw, "from-session-start")
 }
 
+// TestSessionStartValuesReplacementHonored pins that a SessionStart hook
+// replacing hctx.Values wholesale (rather than mutating the seeded map) is
+// still carried into the main hook chain — the map is captured after the
+// hooks run, not before.
+func TestSessionStartValuesReplacementHonored(t *testing.T) {
+	mock := &mockLLM{
+		generateFunc: func(ctx context.Context, opts ...llm.Option) (*llm.Response, error) {
+			return &llm.Response{
+				ID:         "resp_1",
+				Role:       llm.Assistant,
+				Content:    []llm.Content{&llm.TextContent{Text: "Done"}},
+				Type:       "message",
+				StopReason: "stop",
+			}, nil
+		},
+	}
+
+	var preGenSaw any
+	agent, err := NewAgent(AgentOptions{
+		Model: mock,
+		Hooks: Hooks{
+			SessionStart: []SessionStartHook{
+				func(ctx context.Context, hctx *HookContext) (*SessionStartResult, error) {
+					hctx.Values = map[string]any{"replaced": "yes"}
+					return nil, nil
+				},
+			},
+			PreGeneration: []PreGenerationHook{
+				func(ctx context.Context, hctx *HookContext) error {
+					preGenSaw = hctx.Values["replaced"]
+					return nil
+				},
+			},
+		},
+	})
+	assert.NoError(t, err)
+
+	_, err = agent.CreateResponse(context.Background(), WithInput("hello"))
+	assert.NoError(t, err)
+	assert.Equal(t, preGenSaw, "yes")
+}
+
 // TestGenerationErrorExposesPartialWork pins §4.7: when iteration N of a turn
 // fails after iteration N-1 succeeded (and a tool with side effects already
 // ran), CreateResponse still returns (nil, err) — but err wraps a

--- a/agent_loop_fixes_test.go
+++ b/agent_loop_fixes_test.go
@@ -1,0 +1,530 @@
+package dive
+
+// Regression tests for the agent-loop findings in
+// docs/reviews/2026-06-09-api-review.md §4 (batch 3):
+//
+//   - §4.5  SessionStart hook Values carry into the main hook chain
+//   - §4.7  Mid-turn LLM failure exposes accumulated work via GenerationError
+//   - §4.8  Hook Messages freshness no longer depends on PreIteration registration
+//   - §4 notes: deterministic resume merge order, context-aware + reentrancy-safe
+//     session lock, NewAgent not mutating caller-owned option slices, resume
+//     merge surviving a message-replacing PreGeneration hook.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/deepnoodle-ai/dive/llm"
+	"github.com/deepnoodle-ai/wonton/assert"
+)
+
+// TestSessionStartValuesVisibleToLaterHooks pins §4.5: HookContext.Values is
+// documented to persist across the hook chain within one CreateResponse call,
+// so a value stored by a SessionStart hook must be observable by PreGeneration
+// and PreToolUse hooks in the same call.
+func TestSessionStartValuesVisibleToLaterHooks(t *testing.T) {
+	callCount := 0
+	mock := &mockLLM{
+		generateFunc: func(ctx context.Context, opts ...llm.Option) (*llm.Response, error) {
+			callCount++
+			if callCount == 1 {
+				return &llm.Response{
+					ID:         "resp_1",
+					Role:       llm.Assistant,
+					Content:    []llm.Content{&llm.ToolUseContent{ID: "t1", Name: "noop", Input: []byte(`{}`)}},
+					Type:       "message",
+					StopReason: "tool_use",
+				}, nil
+			}
+			return &llm.Response{
+				ID:         "resp_2",
+				Role:       llm.Assistant,
+				Content:    []llm.Content{&llm.TextContent{Text: "Done"}},
+				Type:       "message",
+				StopReason: "stop",
+			}, nil
+		},
+	}
+	tool := &mockTool{
+		name:     "noop",
+		callFunc: func(ctx context.Context, input any) (*ToolResult, error) { return NewToolResultText("ok"), nil },
+	}
+
+	var preGenSaw, preToolSaw any
+	agent, err := NewAgent(AgentOptions{
+		Model: mock,
+		Tools: []Tool{tool},
+		Hooks: Hooks{
+			SessionStart: []SessionStartHook{
+				func(ctx context.Context, hctx *HookContext) (*SessionStartResult, error) {
+					hctx.Values["seeded"] = "from-session-start"
+					return nil, nil
+				},
+			},
+			PreGeneration: []PreGenerationHook{
+				func(ctx context.Context, hctx *HookContext) error {
+					preGenSaw = hctx.Values["seeded"]
+					return nil
+				},
+			},
+			PreToolUse: []PreToolUseHook{
+				func(ctx context.Context, hctx *HookContext) error {
+					preToolSaw = hctx.Values["seeded"]
+					return nil
+				},
+			},
+		},
+	})
+	assert.NoError(t, err)
+
+	_, err = agent.CreateResponse(context.Background(), WithInput("hello"))
+	assert.NoError(t, err)
+	assert.Equal(t, preGenSaw, "from-session-start")
+	assert.Equal(t, preToolSaw, "from-session-start")
+}
+
+// TestGenerationErrorExposesPartialWork pins §4.7: when iteration N of a turn
+// fails after iteration N-1 succeeded (and a tool with side effects already
+// ran), CreateResponse still returns (nil, err) — but err wraps a
+// *GenerationError exposing the accumulated usage, output messages, and items.
+// The partial turn must NOT be saved to the session.
+func TestGenerationErrorExposesPartialWork(t *testing.T) {
+	llmFailure := errors.New("provider exploded mid-turn")
+	callCount := 0
+	mock := &mockLLM{
+		generateFunc: func(ctx context.Context, opts ...llm.Option) (*llm.Response, error) {
+			callCount++
+			if callCount == 1 {
+				return &llm.Response{
+					ID:         "resp_1",
+					Role:       llm.Assistant,
+					Content:    []llm.Content{&llm.ToolUseContent{ID: "t1", Name: "side_effect", Input: []byte(`{}`)}},
+					Type:       "message",
+					StopReason: "tool_use",
+					Usage:      llm.Usage{InputTokens: 10, OutputTokens: 5},
+				}, nil
+			}
+			return nil, llmFailure
+		},
+	}
+	toolRan := false
+	tool := &mockTool{
+		name: "side_effect",
+		callFunc: func(ctx context.Context, input any) (*ToolResult, error) {
+			toolRan = true
+			return NewToolResultText("side effect happened"), nil
+		},
+	}
+	sess := newMemSession("partial-work")
+	agent, err := NewAgent(AgentOptions{Model: mock, Tools: []Tool{tool}, Session: sess})
+	assert.NoError(t, err)
+
+	resp, err := agent.CreateResponse(context.Background(), WithInput("do work"))
+	assert.Nil(t, resp)
+	assert.Error(t, err)
+	assert.True(t, toolRan, "the side-effecting tool ran before the failure")
+
+	// The original error remains reachable through the wrap chain.
+	assert.True(t, errors.Is(err, llmFailure))
+
+	var genErr *GenerationError
+	assert.True(t, errors.As(err, &genErr), "error must wrap *GenerationError")
+
+	// Cost accounting from the successful first iteration is recoverable.
+	assert.NotNil(t, genErr.Usage)
+	assert.Equal(t, genErr.Usage.InputTokens, 10)
+	assert.Equal(t, genErr.Usage.OutputTokens, 5)
+
+	// The turn's partial messages: assistant tool_use + tool_result.
+	assert.Len(t, genErr.OutputMessages, 2)
+	assert.Equal(t, genErr.OutputMessages[0].Role, llm.Assistant)
+	assert.True(t, hasToolUseContent(genErr.OutputMessages[0]))
+	assert.Equal(t, genErr.OutputMessages[1].Role, llm.User)
+	assert.True(t, hasToolResultContent(genErr.OutputMessages[1]))
+
+	// Items captured before the failure: assistant message, tool call, result.
+	var types []ResponseItemType
+	for _, item := range genErr.Items {
+		types = append(types, item.Type)
+	}
+	assert.Equal(t, types, []ResponseItemType{
+		ResponseItemTypeMessage,
+		ResponseItemTypeToolCall,
+		ResponseItemTypeToolCallResult,
+	})
+
+	// The half-turn must not be persisted (it could violate role alternation).
+	msgs, msgsErr := sess.Messages(context.Background())
+	assert.NoError(t, msgsErr)
+	assert.Len(t, msgs, 0, "partial turn must not be saved to the session")
+}
+
+// TestHookMessagesRefreshedWithoutPreIterationHooks pins §4.8: hctx.Messages
+// must be refreshed every iteration even when no PreIteration hooks are
+// registered, so a PreToolUse hook on iteration 2 observes iteration 1's
+// assistant and tool_result messages instead of a stale start-of-turn snapshot.
+func TestHookMessagesRefreshedWithoutPreIterationHooks(t *testing.T) {
+	callCount := 0
+	mock := &mockLLM{
+		generateFunc: func(ctx context.Context, opts ...llm.Option) (*llm.Response, error) {
+			callCount++
+			if callCount <= 2 {
+				return &llm.Response{
+					ID:   fmt.Sprintf("resp_%d", callCount),
+					Role: llm.Assistant,
+					Content: []llm.Content{
+						&llm.ToolUseContent{ID: fmt.Sprintf("t%d", callCount), Name: "noop", Input: []byte(`{}`)},
+					},
+					Type:       "message",
+					StopReason: "tool_use",
+				}, nil
+			}
+			return &llm.Response{
+				ID:         "resp_final",
+				Role:       llm.Assistant,
+				Content:    []llm.Content{&llm.TextContent{Text: "Done"}},
+				Type:       "message",
+				StopReason: "stop",
+			}, nil
+		},
+	}
+	tool := &mockTool{
+		name:     "noop",
+		callFunc: func(ctx context.Context, input any) (*ToolResult, error) { return NewToolResultText("ok"), nil },
+	}
+
+	var observedCounts []int
+	agent, err := NewAgent(AgentOptions{
+		Model: mock,
+		Tools: []Tool{tool},
+		Hooks: Hooks{
+			// Only a PreToolUse hook — deliberately NO PreIteration hooks.
+			PreToolUse: []PreToolUseHook{
+				func(ctx context.Context, hctx *HookContext) error {
+					observedCounts = append(observedCounts, len(hctx.Messages))
+					return nil
+				},
+			},
+		},
+	})
+	assert.NoError(t, err)
+
+	_, err = agent.CreateResponse(context.Background(), WithInput("go"))
+	assert.NoError(t, err)
+
+	// Iteration 1: hook sees just the user input. Iteration 2: hook sees the
+	// user input plus iteration 1's assistant tool_use and tool_result.
+	assert.Equal(t, observedCounts, []int{1, 3})
+}
+
+// TestSessionLockContextAwareAndReentrancyDetection pins the per-session lock
+// behavior: a context already holding the lock fails fast with
+// ErrReentrantSession, and a waiter honors context cancellation instead of
+// blocking forever.
+func TestSessionLockContextAwareAndReentrancyDetection(t *testing.T) {
+	lockCtx, release, err := acquireSessionLock(context.Background(), "lock-test-1")
+	assert.NoError(t, err)
+
+	// Reentrant acquisition from the same context chain fails immediately.
+	_, _, err = acquireSessionLock(lockCtx, "lock-test-1")
+	assert.True(t, errors.Is(err, ErrReentrantSession))
+
+	// A different caller waiting on the held lock honors context deadline.
+	waitCtx, cancel := context.WithTimeout(context.Background(), 25*time.Millisecond)
+	defer cancel()
+	_, _, err = acquireSessionLock(waitCtx, "lock-test-1")
+	assert.True(t, errors.Is(err, context.DeadlineExceeded))
+
+	// A different session ID is unaffected by the held lock.
+	ctx2, release2, err := acquireSessionLock(lockCtx, "lock-test-2")
+	assert.NoError(t, err)
+	assert.NotNil(t, ctx2)
+	release2()
+
+	// After release, the lock can be acquired again.
+	release()
+	_, release3, err := acquireSessionLock(context.Background(), "lock-test-1")
+	assert.NoError(t, err)
+	release3()
+}
+
+// TestReentrantCreateResponseFailsFast pins that a tool calling back into
+// CreateResponse on the same session errors promptly with ErrReentrantSession
+// instead of deadlocking on the per-session lock.
+func TestReentrantCreateResponseFailsFast(t *testing.T) {
+	callCount := 0
+	mock := &mockLLM{
+		generateFunc: func(ctx context.Context, opts ...llm.Option) (*llm.Response, error) {
+			callCount++
+			if callCount == 1 {
+				return &llm.Response{
+					ID:         "resp_1",
+					Role:       llm.Assistant,
+					Content:    []llm.Content{&llm.ToolUseContent{ID: "t1", Name: "recurse", Input: []byte(`{}`)}},
+					Type:       "message",
+					StopReason: "tool_use",
+				}, nil
+			}
+			return &llm.Response{
+				ID:         "resp_2",
+				Role:       llm.Assistant,
+				Content:    []llm.Content{&llm.TextContent{Text: "Done"}},
+				Type:       "message",
+				StopReason: "stop",
+			}, nil
+		},
+	}
+
+	sess := newMemSession("reentrant")
+	var agent *Agent
+	var nestedErr error
+	tool := &mockTool{
+		name: "recurse",
+		callFunc: func(ctx context.Context, input any) (*ToolResult, error) {
+			// Reentrant call on the same session from within a tool. Without
+			// reentrancy detection this would deadlock forever.
+			_, nestedErr = agent.CreateResponse(ctx, WithInput("nested"))
+			return NewToolResultText("recursed"), nil
+		},
+	}
+
+	var err error
+	agent, err = NewAgent(AgentOptions{Model: mock, Tools: []Tool{tool}, Session: sess})
+	assert.NoError(t, err)
+
+	done := make(chan struct{})
+	var resp *Response
+	var outerErr error
+	go func() {
+		defer close(done)
+		resp, outerErr = agent.CreateResponse(context.Background(), WithInput("start"))
+	}()
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("CreateResponse deadlocked on reentrant session lock")
+	}
+
+	assert.NoError(t, outerErr)
+	assert.Equal(t, resp.OutputText(), "Done")
+	assert.Error(t, nestedErr)
+	assert.True(t, errors.Is(nestedErr, ErrReentrantSession))
+}
+
+// TestNewAgentDoesNotContaminateReusedOptions pins that NewAgent clones the
+// caller's Tools and Hooks slices before merging extensions, so building two
+// agents from one AgentOptions value (with spare slice capacity) does not
+// leak one agent's extension hooks into the other.
+func TestNewAgentDoesNotContaminateReusedOptions(t *testing.T) {
+	newTextLLM := func() *mockLLM {
+		return &mockLLM{
+			generateFunc: func(ctx context.Context, opts ...llm.Option) (*llm.Response, error) {
+				return &llm.Response{
+					ID:         "resp",
+					Role:       llm.Assistant,
+					Content:    []llm.Content{&llm.TextContent{Text: "ok"}},
+					Type:       "message",
+					StopReason: "stop",
+				}, nil
+			},
+		}
+	}
+
+	var callerCalls, ext1Calls, ext2Calls int
+	ext1 := &mockExtension{hooks: Hooks{PreGeneration: []PreGenerationHook{
+		func(ctx context.Context, hctx *HookContext) error { ext1Calls++; return nil },
+	}}}
+	ext2 := &mockExtension{hooks: Hooks{PreGeneration: []PreGenerationHook{
+		func(ctx context.Context, hctx *HookContext) error { ext2Calls++; return nil },
+	}}}
+
+	// Caller-owned hook slice with spare capacity, so an in-place append in
+	// NewAgent would write extension hooks into the shared backing array.
+	callerHooks := make([]PreGenerationHook, 0, 4)
+	callerHooks = append(callerHooks, func(ctx context.Context, hctx *HookContext) error {
+		callerCalls++
+		return nil
+	})
+
+	opts := AgentOptions{
+		Model:      newTextLLM(),
+		Hooks:      Hooks{PreGeneration: callerHooks},
+		Extensions: []Extension{ext1},
+	}
+	agent1, err := NewAgent(opts)
+	assert.NoError(t, err)
+
+	opts.Model = newTextLLM()
+	opts.Extensions = []Extension{ext2}
+	agent2, err := NewAgent(opts)
+	assert.NoError(t, err)
+
+	// agent1 must run the caller hook + ext1's hook — and NOT ext2's, which
+	// (pre-fix) would have overwritten ext1's slot in the shared backing array.
+	_, err = agent1.CreateResponse(context.Background(), WithInput("hi"))
+	assert.NoError(t, err)
+	assert.Equal(t, callerCalls, 1)
+	assert.Equal(t, ext1Calls, 1)
+	assert.Equal(t, ext2Calls, 0)
+
+	_, err = agent2.CreateResponse(context.Background(), WithInput("hi"))
+	assert.NoError(t, err)
+	assert.Equal(t, callerCalls, 2)
+	assert.Equal(t, ext1Calls, 1)
+	assert.Equal(t, ext2Calls, 1)
+}
+
+// TestResumeCallerResultsMergeDeterministic pins that caller-supplied resume
+// results merge into the tool_result message in sorted tool_use-ID order
+// rather than nondeterministic map-iteration order.
+func TestResumeCallerResultsMergeDeterministic(t *testing.T) {
+	var received []*llm.Message
+	mock := &mockLLM{
+		generateFunc: func(ctx context.Context, opts ...llm.Option) (*llm.Response, error) {
+			cfg := &llm.Config{}
+			cfg.Apply(opts...)
+			received = cfg.Messages
+			return &llm.Response{
+				ID:         "resp",
+				Role:       llm.Assistant,
+				Content:    []llm.Content{&llm.TextContent{Text: "Done"}},
+				Type:       "message",
+				StopReason: "stop",
+			}, nil
+		},
+	}
+	agent, err := NewAgent(AgentOptions{Model: mock})
+	assert.NoError(t, err)
+
+	assistant := &llm.Message{Role: llm.Assistant, Content: []llm.Content{
+		&llm.ToolUseContent{ID: "toolu_c", Name: "ask", Input: []byte(`{}`)},
+		&llm.ToolUseContent{ID: "toolu_a", Name: "ask", Input: []byte(`{}`)},
+		&llm.ToolUseContent{ID: "toolu_b", Name: "ask", Input: []byte(`{}`)},
+	}}
+	state := &SuspensionState{
+		PendingToolCalls: []*PendingToolCall{
+			{ID: "toolu_c", Name: "ask"},
+			{ID: "toolu_a", Name: "ask"},
+			{ID: "toolu_b", Name: "ask"},
+		},
+		TurnMessages: []*llm.Message{llm.NewUserTextMessage("go"), assistant},
+	}
+
+	resp, err := agent.CreateResponse(context.Background(), WithResume(state, map[string]*ToolResult{
+		"toolu_c": NewToolResultText("c"),
+		"toolu_a": NewToolResultText("a"),
+		"toolu_b": NewToolResultText("b"),
+	}))
+	assert.NoError(t, err)
+	assert.Equal(t, resp.OutputText(), "Done")
+
+	// The merged tool_result message sent to the LLM lists results in sorted
+	// tool_use-ID order.
+	var order []string
+	for _, msg := range received {
+		if msg.Role != llm.User {
+			continue
+		}
+		for _, c := range msg.Content {
+			if trc, ok := c.(*llm.ToolResultContent); ok {
+				order = append(order, trc.ToolUseID)
+			}
+		}
+	}
+	assert.Equal(t, order, []string{"toolu_a", "toolu_b", "toolu_c"})
+}
+
+// TestResumeMergeSurvivesMessageReplacingPreGenerationHook pins the
+// shared-pointer note in §4: resume merging mutates the merged tool_result
+// message through a pointer captured in resumeState. A PreGeneration hook
+// that replaces hctx.Messages with deep copies (e.g. compaction) used to
+// break that sharing, so results from re-executed not-started tools vanished
+// from the model-facing history, orphaning their tool_use blocks.
+func TestResumeMergeSurvivesMessageReplacingPreGenerationHook(t *testing.T) {
+	var received []*llm.Message
+	mock := &mockLLM{
+		generateFunc: func(ctx context.Context, opts ...llm.Option) (*llm.Response, error) {
+			cfg := &llm.Config{}
+			cfg.Apply(opts...)
+			received = cfg.Messages
+			return &llm.Response{
+				ID:         "resp",
+				Role:       llm.Assistant,
+				Content:    []llm.Content{&llm.TextContent{Text: "Done"}},
+				Type:       "message",
+				StopReason: "stop",
+			}, nil
+		},
+	}
+	noopRan := false
+	noop := &mockTool{
+		name: "noop",
+		callFunc: func(ctx context.Context, input any) (*ToolResult, error) {
+			noopRan = true
+			return NewToolResultText("b-result"), nil
+		},
+	}
+
+	// PreGeneration hook that replaces every message with a deep copy,
+	// severing pointer sharing with the resume state.
+	copyAll := func(ctx context.Context, hctx *HookContext) error {
+		copied := make([]*llm.Message, len(hctx.Messages))
+		for i, m := range hctx.Messages {
+			copied[i] = m.Copy()
+		}
+		hctx.Messages = copied
+		return nil
+	}
+
+	agent, err := NewAgent(AgentOptions{
+		Model: mock,
+		Tools: []Tool{noop},
+		Hooks: Hooks{PreGeneration: []PreGenerationHook{copyAll}},
+	})
+	assert.NoError(t, err)
+
+	// Suspended turn: tool A ("ask") suspended (pending); tool B ("noop")
+	// never started and must be re-executed on resume.
+	assistant := &llm.Message{Role: llm.Assistant, Content: []llm.Content{
+		&llm.ToolUseContent{ID: "toolu_ask", Name: "ask", Input: []byte(`{}`)},
+		&llm.ToolUseContent{ID: "toolu_noop", Name: "noop", Input: []byte(`{}`)},
+	}}
+	state := &SuspensionState{
+		PendingToolCalls: []*PendingToolCall{{ID: "toolu_ask", Name: "ask"}},
+		TurnMessages:     []*llm.Message{llm.NewUserTextMessage("run the tools"), assistant},
+	}
+
+	resp, err := agent.CreateResponse(context.Background(), WithResume(state, map[string]*ToolResult{
+		"toolu_ask": NewToolResultText("a-result"),
+	}))
+	assert.NoError(t, err)
+	assert.Equal(t, resp.OutputText(), "Done")
+	assert.True(t, noopRan, "not-started tool must re-execute on resume")
+
+	// The LLM must see tool_results for BOTH tool_use blocks — including the
+	// not-started tool whose result was merged after the hook replaced the
+	// message slice with copies.
+	resultIDs := make(map[string]bool)
+	toolResultMessages := 0
+	for _, msg := range received {
+		if msg.Role != llm.User {
+			continue
+		}
+		found := false
+		for _, c := range msg.Content {
+			if trc, ok := c.(*llm.ToolResultContent); ok {
+				resultIDs[trc.ToolUseID] = true
+				found = true
+			}
+		}
+		if found {
+			toolResultMessages++
+		}
+	}
+	assert.Equal(t, toolResultMessages, 1, "exactly one tool_result message expected")
+	assert.True(t, resultIDs["toolu_ask"], "caller-supplied result must reach the LLM")
+	assert.True(t, resultIDs["toolu_noop"], "re-executed not-started tool result must reach the LLM")
+}

--- a/background.go
+++ b/background.go
@@ -284,7 +284,7 @@ func (a *Agent) firePostBackgroundToolUse(ctx context.Context, hctx *HookContext
 				a.logger.Error("post-background-tool-use hook aborted", "error", abortErr)
 				return abortErr
 			}
-			a.logger.Debug("post-background-tool-use hook error", "error", err)
+			a.logger.Warn("post-background-tool-use hook error", "error", err)
 		}
 	}
 	return nil


### PR DESCRIPTION
Remediates the remaining §4 findings from `docs/reviews/2026-06-09-api-review.md` (batches 1–2 landed in #181–#191). Every finding was re-verified against current `agent.go` before fixing; all of them still held.

## Fixed

**§4.5 — SessionStart hooks get a throwaway `Values` map**
SessionStart hooks ran with a separate `HookContext` whose `Values` map was discarded before the main `hctx` was created, breaking the documented "Values persist across the hook chain within one call" contract. The SessionStart context's `Values` (which already include caller-supplied `WithValue` entries) are now layered into the main `hctx.Values`. Regression: `TestSessionStartValuesVisibleToLaterHooks` (PreGeneration *and* PreToolUse observe a SessionStart-set value).

**§4.7 — Mid-turn LLM failure discards everything**
`generate()` now wraps any loop failure in a new exported `*GenerationError` carrying the accumulated `Usage`, `OutputMessages`, and `Items`; `CreateResponse` folds in state from resume-phase items and prior Stop-hook continuations so the error reflects the whole turn. Callers recover cost accounting and partial work via `errors.As`; `errors.Is/As` against the underlying error still work through `Unwrap`. The resume path's not-started tool execution failure is wrapped the same way. The partial turn is deliberately **not** persisted (half-turns can violate provider role-alternation invariants) — documented on the type. Regression: `TestGenerationErrorExposesPartialWork` (call 1 succeeds with a tool use + usage, call 2 errors; asserts usage/messages/items recovered and session left unwritten).

**§4.8 — Hook `Messages` freshness depended on PreIteration registration**
`hctx.Iteration/SystemPrompt/Messages` are now refreshed at the top of every loop iteration unconditionally. The refresh is a slice-header assignment (no copying), so there's no cost concern; honoring hook rewrites of `hctx.Messages` still only happens when PreIteration hooks ran. Regression: `TestHookMessagesRefreshedWithoutPreIterationHooks` (only a PreToolUse hook registered; iteration 2 sees iteration 1's assistant + tool_result messages).

## §4 trailing notes — all re-verified, all still held, all fixed

- **Nondeterministic resume merge order**: caller-supplied tool results now merge in sorted tool_use-ID order (`slices.Sorted(maps.Keys(...))`). Regression: `TestResumeCallerResultsMergeDeterministic`.
- **Per-session mutex deadlocks on reentrant `CreateResponse`**: the lock is now a 1-buffered channel acquired in a `select` against `ctx.Done()`, and a context value set while the lock is held detects same-call-chain reentrancy immediately, returning the new exported `ErrReentrantSession`. Regressions: `TestSessionLockContextAwareAndReentrancyDetection` (direct lock semantics incl. deadline expiry while waiting) and `TestReentrantCreateResponseFailsFast` (a tool calling back into the same session errors promptly; outer call completes). Existing `TestConcurrentCreateResponseOnSameSessionSerialized` still passes under `-race`, covering the two-agents-one-session serialization contract.
- **Post-hook errors logged at Debug**: post-tool-use, post-tool-use-failure (all three sites: sequential, parallel, resume), and post-background-tool-use hook errors now log at **Warn**. Pre-tool-use denial logging stays at Debug since denial is normal control flow.
- **`NewAgent` appends into caller-owned slices**: `opts.Tools` and all ten hook slices are cloned before the extension merge. Regression: `TestNewAgentDoesNotContaminateReusedOptions` (one `AgentOptions` with spare hook-slice capacity reused across two `NewAgent` calls with different extensions; no cross-leakage).
- **Resume merged tool_results vs message-replacing PreGeneration hook**: implemented (a clean fix existed). After the resume phase, `syncMergedToolResult` locates the suspended turn's tool_result (by tool_use ID, falling back to the paired assistant tool_use message for the empty-placeholder case) in the slice actually being sent and substitutes the merged message. If a hook removed the suspended turn entirely (full-compaction rewrite), the slice is left untouched — the hook owns the rewrite. Regression: `TestResumeMergeSurvivesMessageReplacingPreGenerationHook` (deep-copying PreGeneration hook; LLM still receives tool_results for both the caller-supplied and the re-executed not-started tool). Verified the test fails without the fix.

## Skipped

Nothing — all listed findings still held against current code.

## Testing

- `gofmt -l` clean on all touched files
- `go build ./...` (root module + `a2a`, `otel`, and CLI submodules) clean
- `go test ./...` all pass
- `go test -race .` (root package, covers the lock changes) passes
- Negative verification: the §4.5, §4.8, and resume-sync regression tests were each confirmed to fail with their fix temporarily reverted

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed session concurrency deadlocks and added reentrancy detection.
  * Improved error handling to preserve partial work during generation failures, enabling better recovery.
  * Fixed context value propagation across hook phases.
  * Ensured deterministic behavior in resume operations.
  * Fixed message refresh logic in generation loops.

* **New Features**
  * Added explicit error type for detecting concurrent session access.

* **Tests**
  * Added comprehensive regression test suite covering concurrency, error handling, and resume scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->