### PR TITLE
Provider correctness batch 3: web-search error decode, retry layering, registry routing, Google streaming

### DIFF
--- a/llm/content.go
+++ b/llm/content.go
@@ -653,6 +653,12 @@ type WebSearchResult struct {
 }
 
 // WebSearchToolResultContent contains the results of a server-side web search tool call.
+//
+// The API returns "content" in one of two shapes: an array of web search
+// results on success, or an error object
+// ({"type": "web_search_tool_result_error", "error_code": "..."}) when the
+// server-side search failed. On error, ErrorCode is populated and Content is
+// empty.
 type WebSearchToolResultContent struct {
 	ToolUseID string             `json:"tool_use_id"`
 	Content   []*WebSearchResult `json:"content"`
@@ -663,7 +669,30 @@ func (c *WebSearchToolResultContent) Type() ContentType {
 	return ContentTypeWebSearchToolResult
 }
 
+// webSearchToolResultError is the error-object variant of the "content" field
+// in a web_search_tool_result block.
+type webSearchToolResultError struct {
+	Type      string `json:"type"`
+	ErrorCode string `json:"error_code"`
+}
+
 func (c *WebSearchToolResultContent) MarshalJSON() ([]byte, error) {
+	// Round-trip symmetry with the wire format: when the result is an error,
+	// encode the error-object content variant rather than an array.
+	if c.ErrorCode != "" && len(c.Content) == 0 {
+		return json.Marshal(struct {
+			Type      ContentType              `json:"type"`
+			ToolUseID string                   `json:"tool_use_id"`
+			Content   webSearchToolResultError `json:"content"`
+		}{
+			Type:      ContentTypeWebSearchToolResult,
+			ToolUseID: c.ToolUseID,
+			Content: webSearchToolResultError{
+				Type:      "web_search_tool_result_error",
+				ErrorCode: c.ErrorCode,
+			},
+		})
+	}
 	type Alias WebSearchToolResultContent
 	return json.Marshal(struct {
 		Type ContentType `json:"type"`
@@ -672,6 +701,42 @@ func (c *WebSearchToolResultContent) MarshalJSON() ([]byte, error) {
 		Type:  ContentTypeWebSearchToolResult,
 		Alias: (*Alias)(c),
 	})
+}
+
+// UnmarshalJSON accepts both documented variants of the "content" field: an
+// array of web search results, or an error object whose error_code is
+// surfaced via ErrorCode.
+func (c *WebSearchToolResultContent) UnmarshalJSON(data []byte) error {
+	var raw struct {
+		ToolUseID string          `json:"tool_use_id"`
+		Content   json.RawMessage `json:"content"`
+		ErrorCode string          `json:"error_code"`
+	}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	c.ToolUseID = raw.ToolUseID
+	c.ErrorCode = raw.ErrorCode
+	c.Content = nil
+	content := bytes.TrimSpace(raw.Content)
+	if len(content) == 0 || bytes.Equal(content, []byte("null")) {
+		return nil
+	}
+	switch content[0] {
+	case '[':
+		return json.Unmarshal(content, &c.Content)
+	case '{':
+		var errObj webSearchToolResultError
+		if err := json.Unmarshal(content, &errObj); err != nil {
+			return err
+		}
+		if errObj.ErrorCode != "" {
+			c.ErrorCode = errObj.ErrorCode
+		}
+		return nil
+	default:
+		return fmt.Errorf("unexpected web_search_tool_result content: %s", content)
+	}
 }
 
 //// ThinkingContent ///////////////////////////////////////////////////////////

--- a/llm/content_test.go
+++ b/llm/content_test.go
@@ -661,13 +661,14 @@ func TestWebSearchToolResultContent(t *testing.T) {
 				expected: `{"type":"web_search_tool_result","tool_use_id":"srvtool_123","content":[{"type":"web_search_result","url":"https://example.com/page1","title":"Example Page 1","encrypted_content":"encrypted123","page_age":"April 30, 2025"},{"type":"web_search_result","url":"https://example.com/page2","title":"Example Page 2","encrypted_content":"encrypted456","page_age":"May 1, 2025"}]}`,
 			},
 			{
+				// Errors encode as the API's error-object content variant
 				name: "with error code",
 				content: &WebSearchToolResultContent{
 					ToolUseID: "srvtool_123",
 					Content:   []*WebSearchResult{},
 					ErrorCode: "max_uses_exceeded",
 				},
-				expected: `{"type":"web_search_tool_result","tool_use_id":"srvtool_123","content":[],"error_code":"max_uses_exceeded"}`,
+				expected: `{"type":"web_search_tool_result","tool_use_id":"srvtool_123","content":{"type":"web_search_tool_result_error","error_code":"max_uses_exceeded"}}`,
 			},
 		}
 
@@ -1044,5 +1045,130 @@ func TestMCPContentTypes(t *testing.T) {
 			assert.Equal(t, "enhanced_tool", parsedList.Tools[0].Name)
 			assert.NotNil(t, parsedList.Tools[0].InputSchema)
 		})
+	})
+}
+
+func TestWebSearchToolResultContentUnmarshal(t *testing.T) {
+	t.Run("results array variant", func(t *testing.T) {
+		data := []byte(`{
+			"type": "web_search_tool_result",
+			"tool_use_id": "srvtoolu_01WYG3ziw53XMcoyKL4XcZmE",
+			"content": [
+				{
+					"type": "web_search_result",
+					"url": "https://en.wikipedia.org/wiki/Claude_Shannon",
+					"title": "Claude Shannon - Wikipedia",
+					"encrypted_content": "EqgfCioIARgBIiQ3YTAwMjY1Mi1mZjM5",
+					"page_age": "April 30, 2025"
+				}
+			]
+		}`)
+		content, err := UnmarshalContent(data)
+		assert.NoError(t, err)
+		result, ok := content.(*WebSearchToolResultContent)
+		assert.True(t, ok)
+		assert.Equal(t, "srvtoolu_01WYG3ziw53XMcoyKL4XcZmE", result.ToolUseID)
+		assert.Equal(t, "", result.ErrorCode)
+		assert.Len(t, result.Content, 1)
+		assert.Equal(t, "https://en.wikipedia.org/wiki/Claude_Shannon", result.Content[0].URL)
+		assert.Equal(t, "Claude Shannon - Wikipedia", result.Content[0].Title)
+	})
+
+	t.Run("error object variant", func(t *testing.T) {
+		data := []byte(`{
+			"type": "web_search_tool_result",
+			"tool_use_id": "servertoolu_a93jad",
+			"content": {
+				"type": "web_search_tool_result_error",
+				"error_code": "max_uses_exceeded"
+			}
+		}`)
+		content, err := UnmarshalContent(data)
+		assert.NoError(t, err)
+		result, ok := content.(*WebSearchToolResultContent)
+		assert.True(t, ok)
+		assert.Equal(t, "servertoolu_a93jad", result.ToolUseID)
+		assert.Equal(t, "max_uses_exceeded", result.ErrorCode)
+		assert.Len(t, result.Content, 0)
+	})
+
+	t.Run("error variant does not fail whole response decode", func(t *testing.T) {
+		data := []byte(`{
+			"id": "msg_123",
+			"type": "message",
+			"role": "assistant",
+			"model": "claude-opus-4-8",
+			"content": [
+				{"type": "text", "text": "Let me search for that."},
+				{
+					"type": "web_search_tool_result",
+					"tool_use_id": "servertoolu_a93jad",
+					"content": {
+						"type": "web_search_tool_result_error",
+						"error_code": "unavailable"
+					}
+				}
+			],
+			"stop_reason": "end_turn"
+		}`)
+		var response Response
+		err := json.Unmarshal(data, &response)
+		assert.NoError(t, err)
+		assert.Len(t, response.Content, 2)
+		result, ok := response.Content[1].(*WebSearchToolResultContent)
+		assert.True(t, ok)
+		assert.Equal(t, "unavailable", result.ErrorCode)
+	})
+}
+
+func TestWebSearchToolResultContentRoundTrip(t *testing.T) {
+	t.Run("results array variant", func(t *testing.T) {
+		original := &WebSearchToolResultContent{
+			ToolUseID: "srvtoolu_123",
+			Content: []*WebSearchResult{
+				{
+					Type:             "web_search_result",
+					URL:              "https://example.com",
+					Title:            "Example",
+					EncryptedContent: "abc123",
+					PageAge:          "May 1, 2026",
+				},
+			},
+		}
+		data, err := json.Marshal(original)
+		assert.NoError(t, err)
+		decoded, err := UnmarshalContent(data)
+		assert.NoError(t, err)
+		result, ok := decoded.(*WebSearchToolResultContent)
+		assert.True(t, ok)
+		assert.Equal(t, original.ToolUseID, result.ToolUseID)
+		assert.Equal(t, "", result.ErrorCode)
+		assert.Len(t, result.Content, 1)
+		assert.Equal(t, original.Content[0].URL, result.Content[0].URL)
+		assert.Equal(t, original.Content[0].EncryptedContent, result.Content[0].EncryptedContent)
+	})
+
+	t.Run("error variant", func(t *testing.T) {
+		original := &WebSearchToolResultContent{
+			ToolUseID: "srvtoolu_456",
+			ErrorCode: "max_uses_exceeded",
+		}
+		data, err := json.Marshal(original)
+		assert.NoError(t, err)
+		// The error encodes as the nested error-object content variant
+		var raw map[string]any
+		assert.NoError(t, json.Unmarshal(data, &raw))
+		contentObj, ok := raw["content"].(map[string]any)
+		assert.True(t, ok)
+		assert.Equal(t, "web_search_tool_result_error", contentObj["type"])
+		assert.Equal(t, "max_uses_exceeded", contentObj["error_code"])
+
+		decoded, err := UnmarshalContent(data)
+		assert.NoError(t, err)
+		result, ok := decoded.(*WebSearchToolResultContent)
+		assert.True(t, ok)
+		assert.Equal(t, original.ToolUseID, result.ToolUseID)
+		assert.Equal(t, original.ErrorCode, result.ErrorCode)
+		assert.Len(t, result.Content, 0)
 	})
 }

--- a/providers/google/stream_iterator.go
+++ b/providers/google/stream_iterator.go
@@ -12,29 +12,32 @@ import (
 	"google.golang.org/genai"
 )
 
+// StreamIterator adapts the genai streaming sequence to Dive's llm.Event
+// stream, mirroring the event semantics of the Anthropic and OpenAI
+// iterators: content blocks get 0-based contiguous indices, parallel function
+// calls are each surfaced as their own tool_use block, and the final
+// message_delta carries usage and the stop reason.
 type StreamIterator struct {
-	ctx          context.Context
-	model        string
-	responseID   string
-	contentIndex int
+	ctx        context.Context
+	model      string
+	responseID string
 
 	// Streaming state
 	streamSeq    iter.Seq2[*genai.GenerateContentResponse, error]
 	streamNext   func() (*genai.GenerateContentResponse, error, bool)
 	streamStop   func()
 	currentEvent *llm.Event
+	eventQueue   []*llm.Event
 	err          error
 	done         bool
 	started      bool
 
 	// Event generation state
-	messageStartSent      bool
-	contentBlockStartSent bool
-	contentBlockStopSent  bool
-	toolCallsSent         bool
-	toolInputSent         bool
-	isToolCall            bool
-	pendingToolInput      json.RawMessage
+	messageStartSent bool
+	nextBlockIndex   int
+	textBlockIndex   int // index of the open text block, or -1 if none
+	usage            *genai.GenerateContentResponseUsageMetadata
+	finishReason     genai.FinishReason
 
 	mu sync.Mutex
 }
@@ -42,166 +45,68 @@ type StreamIterator struct {
 // NewStreamIteratorFromSeq creates a new StreamIterator from a streaming sequence
 func NewStreamIteratorFromSeq(ctx context.Context, streamSeq iter.Seq2[*genai.GenerateContentResponse, error], model string) *StreamIterator {
 	return &StreamIterator{
-		ctx:          ctx,
-		streamSeq:    streamSeq,
-		model:        model,
-		responseID:   fmt.Sprintf("google_%s_%d", model, time.Now().UnixNano()),
-		contentIndex: 0,
+		ctx:            ctx,
+		streamSeq:      streamSeq,
+		model:          model,
+		responseID:     fmt.Sprintf("google_%s_%d", model, time.Now().UnixNano()),
+		textBlockIndex: -1,
 	}
 }
 
 func (s *StreamIterator) Next() bool {
 	s.mu.Lock()
+	defer s.mu.Unlock()
 
-	// If already done, return false
-	if s.done {
-		s.mu.Unlock()
-		return false
-	}
+	for {
+		// Drain queued events first
+		if len(s.eventQueue) > 0 {
+			s.currentEvent = s.eventQueue[0]
+			s.eventQueue = s.eventQueue[1:]
+			return true
+		}
 
-	// If not started, start the stream
-	if !s.started {
-		s.started = true
-		if err := s.startStream(); err != nil {
-			s.err = err
-			s.done = true
-			s.mu.Unlock()
+		if s.done {
 			return false
 		}
-	}
 
-	// Send message start event first
-	if !s.messageStartSent {
-		s.messageStartSent = true
-		s.currentEvent = &llm.Event{
-			Type: llm.EventTypeMessageStart,
-			Message: &llm.Response{
-				ID:      s.responseID,
-				Type:    "message",
-				Role:    llm.Assistant,
-				Model:   s.model,
-				Content: []llm.Content{},
-			},
+		// If not started, start the stream
+		if !s.started {
+			s.started = true
+			if err := s.startStream(); err != nil {
+				s.err = err
+				s.done = true
+				return false
+			}
 		}
-		s.mu.Unlock()
-		return true
-	}
 
-	// Send content block start event (only for text, tool calls are handled differently)
-	if !s.contentBlockStartSent && !s.isToolCall {
-		s.contentBlockStartSent = true
-		s.currentEvent = &llm.Event{
-			Type:  llm.EventTypeContentBlockStart,
-			Index: &s.contentIndex,
-			ContentBlock: &llm.EventContentBlock{
-				Type: llm.ContentTypeText,
-			},
+		// Check if context is cancelled
+		select {
+		case <-s.ctx.Done():
+			s.err = s.ctx.Err()
+			s.done = true
+			return false
+		default:
 		}
-		s.mu.Unlock()
-		return true
-	}
 
-	// Send tool input as delta event if we have pending tool input
-	if s.isToolCall && !s.toolInputSent && s.pendingToolInput != nil {
-		s.toolInputSent = true
-		s.currentEvent = &llm.Event{
-			Type:  llm.EventTypeContentBlockDelta,
-			Index: &s.contentIndex,
-			Delta: &llm.EventDelta{
-				Type:        llm.EventDeltaTypeInputJSON,
-				PartialJSON: string(s.pendingToolInput),
-			},
-		}
-		s.mu.Unlock()
-		return true
-	}
-
-	// Check if context is cancelled
-	select {
-	case <-s.ctx.Done():
-		s.err = s.ctx.Err()
-		s.done = true
-		s.mu.Unlock()
-		return false
-	default:
-	}
-
-	// Read from stream iterator
-	if s.streamNext != nil {
 		response, err, hasMore := s.streamNext()
 		if err != nil {
 			s.err = wrapGoogleError(err)
 			s.done = true
-			s.mu.Unlock()
 			return false
 		}
-
 		if !hasMore {
-			// Stream ended, send final events
-			result := s.sendFinalEvents()
-			s.mu.Unlock()
-			return result
+			// Stream ended: close any open block and emit the final
+			// message_delta (usage + stop reason) and message_stop events.
+			s.queueFinalEvents()
+			s.done = true
+			continue
 		}
-
-		// Process the response
-		if response != nil {
-			// Check for function calls first
-			calls := response.FunctionCalls()
-			if len(calls) > 0 && !s.toolCallsSent {
-				s.toolCallsSent = true
-				s.isToolCall = true
-
-				// Send tool use event - only handle the first call for now
-				call := calls[0]
-				args, err := json.Marshal(call.Args)
-				if err != nil {
-					s.err = fmt.Errorf("error marshaling function call args: %w", err)
-					s.done = true
-					s.mu.Unlock()
-					return false
-				}
-
-				// Store the tool input to be sent as a delta event
-				s.pendingToolInput = json.RawMessage(args)
-
-				s.currentEvent = &llm.Event{
-					Type:  llm.EventTypeContentBlockStart,
-					Index: &s.contentIndex,
-					ContentBlock: &llm.EventContentBlock{
-						Type: llm.ContentTypeToolUse,
-						ID:   generateToolCallID(call.Name),
-						Name: call.Name,
-					},
-				}
-				s.mu.Unlock()
-				return true
-			}
-
-			// Handle text content
-			text := response.Text()
-			if text != "" {
-				s.currentEvent = &llm.Event{
-					Type:  llm.EventTypeContentBlockDelta,
-					Index: &s.contentIndex,
-					Delta: &llm.EventDelta{
-						Type: llm.EventDeltaTypeText,
-						Text: text,
-					},
-				}
-				s.mu.Unlock()
-				return true
-			}
+		if err := s.processChunk(response); err != nil {
+			s.err = err
+			s.done = true
+			return false
 		}
-
-		// If no text, continue to next iteration (release lock first)
-		s.mu.Unlock()
-		return s.Next()
 	}
-
-	// Should not reach here
-	s.done = true
-	s.mu.Unlock()
-	return false
 }
 
 func (s *StreamIterator) startStream() error {
@@ -216,28 +121,179 @@ func (s *StreamIterator) startStream() error {
 	return nil
 }
 
-func (s *StreamIterator) sendFinalEvents() bool {
-	// Send content block stop event first
-	if !s.contentBlockStopSent {
-		s.contentBlockStopSent = true
-		s.currentEvent = &llm.Event{
+// processChunk converts a single streamed response chunk into events on the
+// event queue.
+func (s *StreamIterator) processChunk(response *genai.GenerateContentResponse) error {
+	if response == nil {
+		return nil
+	}
+
+	if response.ResponseID != "" {
+		s.responseID = response.ResponseID
+	}
+
+	// Send message start event first
+	if !s.messageStartSent {
+		s.messageStartSent = true
+		s.eventQueue = append(s.eventQueue, &llm.Event{
+			Type: llm.EventTypeMessageStart,
+			Message: &llm.Response{
+				ID:      s.responseID,
+				Type:    "message",
+				Role:    llm.Assistant,
+				Model:   s.model,
+				Content: []llm.Content{},
+			},
+		})
+	}
+
+	// Track the latest usage metadata; Gemini reports cumulative totals, the
+	// last chunk carrying the final values. Emitted once on message_delta.
+	if response.UsageMetadata != nil {
+		s.usage = response.UsageMetadata
+	}
+
+	if len(response.Candidates) == 0 {
+		return nil
+	}
+	candidate := response.Candidates[0]
+	if candidate.FinishReason != "" {
+		s.finishReason = candidate.FinishReason
+	}
+	if candidate.Content == nil {
+		return nil
+	}
+
+	for _, part := range candidate.Content.Parts {
+		switch {
+		case part.FunctionCall != nil:
+			if err := s.queueFunctionCall(part.FunctionCall); err != nil {
+				return err
+			}
+		case part.Text != "":
+			if part.Thought {
+				// Thought-summary parts are not surfaced (matching the
+				// previous behavior based on response.Text(), which skips
+				// them).
+				continue
+			}
+			s.queueText(part.Text)
+		}
+	}
+	return nil
+}
+
+// queueText emits a text delta, opening a new text content block if needed.
+func (s *StreamIterator) queueText(text string) {
+	if s.textBlockIndex < 0 {
+		index := s.nextBlockIndex
+		s.nextBlockIndex++
+		s.textBlockIndex = index
+		s.eventQueue = append(s.eventQueue, &llm.Event{
+			Type:  llm.EventTypeContentBlockStart,
+			Index: &index,
+			ContentBlock: &llm.EventContentBlock{
+				Type: llm.ContentTypeText,
+			},
+		})
+	}
+	index := s.textBlockIndex
+	s.eventQueue = append(s.eventQueue, &llm.Event{
+		Type:  llm.EventTypeContentBlockDelta,
+		Index: &index,
+		Delta: &llm.EventDelta{
+			Type: llm.EventDeltaTypeText,
+			Text: text,
+		},
+	})
+}
+
+// queueFunctionCall emits a complete tool_use content block for one function
+// call. Gemini delivers each function call complete in a single part (there
+// is no partial-JSON streaming), so the block starts, receives its full input
+// as one delta, and stops immediately. Parallel calls each get their own
+// sequential block index.
+func (s *StreamIterator) queueFunctionCall(call *genai.FunctionCall) error {
+	args, err := json.Marshal(call.Args)
+	if err != nil {
+		return fmt.Errorf("error marshaling function call args: %w", err)
+	}
+
+	// Close any open text block first
+	s.closeTextBlock()
+
+	// Gemini does not always populate FunctionCall.ID; synthesize a unique ID
+	// when missing (matching convertGoogleResponse).
+	toolCallID := call.ID
+	if toolCallID == "" {
+		toolCallID = generateToolCallID(call.Name)
+	}
+
+	index := s.nextBlockIndex
+	s.nextBlockIndex++
+	s.eventQueue = append(s.eventQueue,
+		&llm.Event{
+			Type:  llm.EventTypeContentBlockStart,
+			Index: &index,
+			ContentBlock: &llm.EventContentBlock{
+				Type: llm.ContentTypeToolUse,
+				ID:   toolCallID,
+				Name: call.Name,
+			},
+		},
+		&llm.Event{
+			Type:  llm.EventTypeContentBlockDelta,
+			Index: &index,
+			Delta: &llm.EventDelta{
+				Type:        llm.EventDeltaTypeInputJSON,
+				PartialJSON: string(args),
+			},
+		},
+		&llm.Event{
 			Type:  llm.EventTypeContentBlockStop,
-			Index: &s.contentIndex,
-		}
-		return true
-	}
+			Index: &index,
+		},
+	)
+	return nil
+}
 
-	// Then send message stop event
-	if !s.done {
-		s.done = true
-		s.currentEvent = &llm.Event{
-			Type: llm.EventTypeMessageStop,
-		}
-		return true
+// closeTextBlock emits a content_block_stop for the open text block, if any.
+func (s *StreamIterator) closeTextBlock() {
+	if s.textBlockIndex < 0 {
+		return
 	}
+	index := s.textBlockIndex
+	s.textBlockIndex = -1
+	s.eventQueue = append(s.eventQueue, &llm.Event{
+		Type:  llm.EventTypeContentBlockStop,
+		Index: &index,
+	})
+}
 
-	// All events sent
-	return false
+// queueFinalEvents closes any open content block and emits message_delta
+// (carrying usage and the stop reason) followed by message_stop.
+func (s *StreamIterator) queueFinalEvents() {
+	if !s.messageStartSent {
+		// Stream ended without any chunks; nothing to finalize.
+		return
+	}
+	s.closeTextBlock()
+
+	delta := &llm.EventDelta{}
+	if s.finishReason != "" {
+		delta.StopReason = convertFinishReason(s.finishReason)
+	}
+	event := &llm.Event{
+		Type:  llm.EventTypeMessageDelta,
+		Delta: delta,
+	}
+	if s.usage != nil {
+		usage := convertUsageMetadata(s.usage)
+		event.Usage = &usage
+	}
+	s.eventQueue = append(s.eventQueue, event, &llm.Event{
+		Type: llm.EventTypeMessageStop,
+	})
 }
 
 func (s *StreamIterator) Event() *llm.Event {

--- a/providers/google/stream_iterator_test.go
+++ b/providers/google/stream_iterator_test.go
@@ -1,0 +1,238 @@
+package google
+
+import (
+	"context"
+	"errors"
+	"iter"
+	"strings"
+	"testing"
+
+	"github.com/deepnoodle-ai/dive/llm"
+	"github.com/deepnoodle-ai/wonton/assert"
+	"google.golang.org/genai"
+)
+
+// chunkSeq builds a streaming sequence from fixture chunks.
+func chunkSeq(chunks ...*genai.GenerateContentResponse) iter.Seq2[*genai.GenerateContentResponse, error] {
+	return func(yield func(*genai.GenerateContentResponse, error) bool) {
+		for _, chunk := range chunks {
+			if !yield(chunk, nil) {
+				return
+			}
+		}
+	}
+}
+
+// collectStreamEvents drains the iterator and accumulates all events.
+func collectStreamEvents(t *testing.T, iterator *StreamIterator) ([]*llm.Event, *llm.ResponseAccumulator) {
+	t.Helper()
+	accumulator := llm.NewResponseAccumulator()
+	var events []*llm.Event
+	for iterator.Next() {
+		event := iterator.Event()
+		events = append(events, event)
+		assert.NoError(t, accumulator.AddEvent(event))
+	}
+	assert.NoError(t, iterator.Err())
+	return events, accumulator
+}
+
+func textChunk(text string) *genai.GenerateContentResponse {
+	return &genai.GenerateContentResponse{
+		Candidates: []*genai.Candidate{
+			{
+				Content: &genai.Content{
+					Role:  "model",
+					Parts: []*genai.Part{{Text: text}},
+				},
+			},
+		},
+	}
+}
+
+func TestStreamIteratorUsageAndStopReason(t *testing.T) {
+	final := textChunk(" world")
+	final.Candidates[0].FinishReason = genai.FinishReasonStop
+	final.UsageMetadata = &genai.GenerateContentResponseUsageMetadata{
+		PromptTokenCount:        100,
+		CandidatesTokenCount:    25,
+		CachedContentTokenCount: 60,
+		ThoughtsTokenCount:      10,
+	}
+
+	iterator := NewStreamIteratorFromSeq(context.Background(),
+		chunkSeq(textChunk("Hello"), final), "gemini-2.5-pro")
+	defer iterator.Close()
+
+	events, accumulator := collectStreamEvents(t, iterator)
+	assert.True(t, accumulator.IsComplete())
+	assert.Equal(t, llm.EventTypeMessageStop, events[len(events)-1].Type)
+
+	// The message_delta event carries usage and the stop reason
+	var messageDelta *llm.Event
+	for _, event := range events {
+		if event.Type == llm.EventTypeMessageDelta {
+			messageDelta = event
+		}
+	}
+	assert.NotNil(t, messageDelta)
+	assert.Equal(t, "stop", messageDelta.Delta.StopReason)
+	assert.NotNil(t, messageDelta.Usage)
+	assert.Equal(t, 100, messageDelta.Usage.InputTokens)
+
+	response := accumulator.Response()
+	assert.Equal(t, "Hello world", response.Message().Text())
+	assert.Equal(t, "stop", response.StopReason)
+	assert.Equal(t, 100, response.Usage.InputTokens)
+	assert.Equal(t, 25, response.Usage.OutputTokens)
+	assert.Equal(t, 60, response.Usage.CacheReadInputTokens)
+	assert.Equal(t, 10, response.Usage.ReasoningTokens)
+}
+
+func TestStreamIteratorParallelFunctionCalls(t *testing.T) {
+	chunk := &genai.GenerateContentResponse{
+		Candidates: []*genai.Candidate{
+			{
+				Content: &genai.Content{
+					Role: "model",
+					Parts: []*genai.Part{
+						{Text: "Let me check both."},
+						{FunctionCall: &genai.FunctionCall{
+							Name: "get_weather",
+							Args: map[string]any{"city": "Paris"},
+						}},
+						{FunctionCall: &genai.FunctionCall{
+							Name: "get_weather",
+							Args: map[string]any{"city": "Tokyo"},
+						}},
+					},
+				},
+				FinishReason: genai.FinishReasonStop,
+			},
+		},
+		UsageMetadata: &genai.GenerateContentResponseUsageMetadata{
+			PromptTokenCount:     50,
+			CandidatesTokenCount: 20,
+		},
+	}
+
+	iterator := NewStreamIteratorFromSeq(context.Background(),
+		chunkSeq(chunk), "gemini-2.5-pro")
+	defer iterator.Close()
+
+	events, accumulator := collectStreamEvents(t, iterator)
+	assert.True(t, accumulator.IsComplete())
+
+	// Content block indices are 0-based and contiguous
+	var startIndices []int
+	for _, event := range events {
+		if event.Type == llm.EventTypeContentBlockStart {
+			assert.NotNil(t, event.Index)
+			startIndices = append(startIndices, *event.Index)
+		}
+	}
+	assert.Equal(t, []int{0, 1, 2}, startIndices)
+
+	// All parallel function calls are surfaced
+	response := accumulator.Response()
+	assert.Len(t, response.Content, 3)
+
+	text, ok := response.Content[0].(*llm.TextContent)
+	assert.True(t, ok)
+	assert.Equal(t, "Let me check both.", text.Text)
+
+	first, ok := response.Content[1].(*llm.ToolUseContent)
+	assert.True(t, ok)
+	assert.Equal(t, "get_weather", first.Name)
+	assert.True(t, strings.Contains(string(first.Input), "Paris"))
+
+	second, ok := response.Content[2].(*llm.ToolUseContent)
+	assert.True(t, ok)
+	assert.Equal(t, "get_weather", second.Name)
+	assert.True(t, strings.Contains(string(second.Input), "Tokyo"))
+
+	// Tool call IDs are unique
+	assert.NotEqual(t, first.ID, second.ID)
+
+	// Usage and stop reason still arrive
+	assert.Equal(t, 50, response.Usage.InputTokens)
+	assert.Equal(t, 20, response.Usage.OutputTokens)
+	assert.Equal(t, "stop", response.StopReason)
+}
+
+func TestStreamIteratorFunctionCallsAcrossChunks(t *testing.T) {
+	callChunk := func(name string, args map[string]any) *genai.GenerateContentResponse {
+		return &genai.GenerateContentResponse{
+			Candidates: []*genai.Candidate{
+				{
+					Content: &genai.Content{
+						Role:  "model",
+						Parts: []*genai.Part{{FunctionCall: &genai.FunctionCall{Name: name, Args: args}}},
+					},
+				},
+			},
+		}
+	}
+	final := &genai.GenerateContentResponse{
+		Candidates: []*genai.Candidate{
+			{FinishReason: genai.FinishReasonStop},
+		},
+		UsageMetadata: &genai.GenerateContentResponseUsageMetadata{
+			PromptTokenCount:     30,
+			CandidatesTokenCount: 12,
+		},
+	}
+
+	iterator := NewStreamIteratorFromSeq(context.Background(), chunkSeq(
+		callChunk("search", map[string]any{"query": "first"}),
+		callChunk("search", map[string]any{"query": "second"}),
+		final,
+	), "gemini-2.5-pro")
+	defer iterator.Close()
+
+	_, accumulator := collectStreamEvents(t, iterator)
+	assert.True(t, accumulator.IsComplete())
+
+	response := accumulator.Response()
+	assert.Len(t, response.Content, 2)
+	first, ok := response.Content[0].(*llm.ToolUseContent)
+	assert.True(t, ok)
+	second, ok := response.Content[1].(*llm.ToolUseContent)
+	assert.True(t, ok)
+	assert.NotEqual(t, first.ID, second.ID)
+	assert.Equal(t, "stop", response.StopReason)
+	assert.Equal(t, 30, response.Usage.InputTokens)
+	assert.Equal(t, 12, response.Usage.OutputTokens)
+}
+
+func TestStreamIteratorMaxTokensStopReason(t *testing.T) {
+	final := textChunk("truncated")
+	final.Candidates[0].FinishReason = genai.FinishReasonMaxTokens
+	final.UsageMetadata = &genai.GenerateContentResponseUsageMetadata{
+		PromptTokenCount:     10,
+		CandidatesTokenCount: 5,
+	}
+
+	iterator := NewStreamIteratorFromSeq(context.Background(),
+		chunkSeq(final), "gemini-2.5-pro")
+	defer iterator.Close()
+
+	_, accumulator := collectStreamEvents(t, iterator)
+	assert.True(t, accumulator.IsComplete())
+	assert.Equal(t, "max_tokens", accumulator.Response().StopReason)
+}
+
+func TestStreamIteratorStreamError(t *testing.T) {
+	seq := func(yield func(*genai.GenerateContentResponse, error) bool) {
+		if !yield(textChunk("partial"), nil) {
+			return
+		}
+		yield(nil, errors.New("boom"))
+	}
+	iterator := NewStreamIteratorFromSeq(context.Background(), seq, "gemini-2.5-pro")
+	defer iterator.Close()
+
+	for iterator.Next() {
+	}
+	assert.Error(t, iterator.Err())
+}

--- a/providers/google/util.go
+++ b/providers/google/util.go
@@ -56,10 +56,7 @@ func convertGoogleResponse(resp *genai.GenerateContentResponse, model string) (*
 	// Convert usage information
 	var usage llm.Usage
 	if resp.UsageMetadata != nil {
-		usage = llm.Usage{
-			InputTokens:  int(resp.UsageMetadata.PromptTokenCount),
-			OutputTokens: int(resp.UsageMetadata.CandidatesTokenCount),
-		}
+		usage = convertUsageMetadata(resp.UsageMetadata)
 	}
 
 	diveResponse := &llm.Response{
@@ -72,16 +69,33 @@ func convertGoogleResponse(resp *genai.GenerateContentResponse, model string) (*
 	}
 
 	// Set stop reason
-	switch candidate.FinishReason {
-	case genai.FinishReasonStop:
-		diveResponse.StopReason = "stop"
-	case genai.FinishReasonMaxTokens:
-		diveResponse.StopReason = "max_tokens"
-	default:
-		diveResponse.StopReason = "other"
-	}
+	diveResponse.StopReason = convertFinishReason(candidate.FinishReason)
 
 	return diveResponse, nil
+}
+
+// convertUsageMetadata converts genai usage metadata to llm.Usage, carrying
+// cached-content and thoughts token counts where the API reports them.
+func convertUsageMetadata(metadata *genai.GenerateContentResponseUsageMetadata) llm.Usage {
+	return llm.Usage{
+		InputTokens:          int(metadata.PromptTokenCount),
+		OutputTokens:         int(metadata.CandidatesTokenCount),
+		CacheReadInputTokens: int(metadata.CachedContentTokenCount),
+		ReasoningTokens:      int(metadata.ThoughtsTokenCount),
+	}
+}
+
+// convertFinishReason maps a genai finish reason to Dive's stop reason
+// vocabulary for this provider (matching convertGoogleResponse).
+func convertFinishReason(reason genai.FinishReason) string {
+	switch reason {
+	case genai.FinishReasonStop:
+		return "stop"
+	case genai.FinishReasonMaxTokens:
+		return "max_tokens"
+	default:
+		return "other"
+	}
 }
 
 // toolCallCounter provides unique suffixes for synthesized tool call IDs.

--- a/providers/openai/encode.go
+++ b/providers/openai/encode.go
@@ -242,6 +242,20 @@ func encodeAssistantRefusalContent() (responses.ResponseInputItemUnionParam, err
 }
 
 func encodeAssistantToolResultContent(c *llm.ToolResultContent) (responses.ResponseInputItemUnionParam, error) {
+	output, err := toolResultOutputText(c)
+	if err != nil {
+		return responses.ResponseInputItemUnionParam{}, err
+	}
+	param := responses.ResponseInputItemParamOfFunctionCallOutput(c.ToolUseID, output)
+	return param, nil
+}
+
+// toolResultOutputText renders a tool result as the output string for a
+// Responses API function_call_output item. The Responses API has no
+// equivalent of Anthropic's is_error flag on tool results, so when IsError is
+// set the output text is prefixed with "Error: " so the model can tell the
+// call failed rather than the flag being silently dropped.
+func toolResultOutputText(c *llm.ToolResultContent) (string, error) {
 	var output string
 	switch content := c.Content.(type) {
 	case string:
@@ -251,12 +265,14 @@ func encodeAssistantToolResultContent(c *llm.ToolResultContent) (responses.Respo
 	default:
 		resultJSON, err := json.Marshal(c.Content)
 		if err != nil {
-			return responses.ResponseInputItemUnionParam{}, fmt.Errorf("failed to marshal tool result: %v", err)
+			return "", fmt.Errorf("failed to marshal tool result: %v", err)
 		}
 		output = string(resultJSON)
 	}
-	param := responses.ResponseInputItemParamOfFunctionCallOutput(c.ToolUseID, output)
-	return param, nil
+	if c.IsError && !strings.HasPrefix(output, "Error:") {
+		output = "Error: " + output
+	}
+	return output, nil
 }
 
 func encodeAssistantServerToolUseContent(c *llm.ServerToolUseContent) (responses.ResponseInputItemUnionParam, error) {
@@ -453,23 +469,10 @@ func encodeToolResultContent(c *llm.ToolResultContent) (*responses.ResponseInput
 	if c.ToolUseID == "" {
 		return nil, fmt.Errorf("tool use id is not set")
 	}
-	var output string
-
-	// Handle different content types
-	switch content := c.Content.(type) {
-	case string:
-		output = content
-	case []byte:
-		output = string(content)
-	default:
-		resultJSON, err := json.Marshal(c.Content)
-		if err != nil {
-			return nil, fmt.Errorf("failed to marshal tool result: %v", err)
-		}
-		output = string(resultJSON)
+	output, err := toolResultOutputText(c)
+	if err != nil {
+		return nil, err
 	}
-	// Note the IsError field is unused here...
-
 	param := responses.ResponseInputItemParamOfFunctionCallOutput(c.ToolUseID, output)
 	return &param, nil
 }

--- a/providers/openai/options.go
+++ b/providers/openai/options.go
@@ -46,10 +46,14 @@ func WithMaxTokens(maxTokens int) Option {
 	}
 }
 
-// WithMaxRetries sets the maximum number of retry attempts.
+// WithMaxRetries sets the maximum number of retry attempts performed by
+// Dive's retry loop (total attempts = maxRetries + 1). The underlying
+// openai-go SDK's internal retries are pinned to zero so that retries are not
+// multiplied across the two layers — this option is the single knob for
+// retry behavior.
 func WithMaxRetries(maxRetries int) Option {
 	return func(p *Provider) {
-		p.options = append(p.options, option.WithMaxRetries(maxRetries))
+		p.maxRetries = maxRetries
 	}
 }
 

--- a/providers/openai/provider.go
+++ b/providers/openai/provider.go
@@ -57,7 +57,15 @@ func New(opts ...Option) *Provider {
 	// Bake the HTTP client into the SDK client at construction time so
 	// per-request options don't have to re-specify it. WithClient only
 	// updates p.httpClient; the actual plumbing happens here.
-	p.options = append(p.options, option.WithHTTPClient(p.httpClient))
+	//
+	// Disable the SDK's internal retries (default 2): Dive owns retries via
+	// the retry loop in Generate/Stream, governed by WithMaxRetries. Without
+	// this, the two layers multiply (up to 9 HTTP requests per persistent
+	// 429/500) with compounding backoff.
+	p.options = append(p.options,
+		option.WithHTTPClient(p.httpClient),
+		option.WithMaxRetries(0),
+	)
 	p.client = openai.NewClient(p.options...)
 	return p
 }
@@ -117,7 +125,25 @@ func (p *Provider) Generate(ctx context.Context, opts ...llm.Option) (*llm.Respo
 		return nil, err
 	}
 
-	return decodeAssistantResponse(resp)
+	result, err := decodeAssistantResponse(resp)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := config.FireHooks(ctx, &llm.HookContext{
+		Type: llm.AfterGenerate,
+		Request: &llm.HookRequestContext{
+			Messages: config.Messages,
+			Config:   config,
+		},
+		Response: &llm.HookResponseContext{
+			Response: result,
+		},
+	}); err != nil {
+		return nil, err
+	}
+
+	return result, nil
 }
 
 func (p *Provider) Stream(ctx context.Context, opts ...llm.Option) (llm.StreamIterator, error) {

--- a/providers/openai/retry_test.go
+++ b/providers/openai/retry_test.go
@@ -1,0 +1,68 @@
+package openai
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/deepnoodle-ai/dive/llm"
+	"github.com/deepnoodle-ai/wonton/assert"
+)
+
+// countingTransport counts every HTTP request and always returns a 429.
+type countingTransport struct {
+	requests atomic.Int64
+}
+
+func (t *countingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	t.requests.Add(1)
+	body := `{"error": {"message": "rate limited", "type": "rate_limit_error"}}`
+	return &http.Response{
+		StatusCode: http.StatusTooManyRequests,
+		Status:     "429 Too Many Requests",
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Request:    req,
+	}, nil
+}
+
+// TestGenerateRetryCount verifies that retries are owned solely by Dive's
+// retry loop: with WithMaxRetries(2), a persistent 429 produces exactly 3
+// HTTP requests (initial + 2 retries), not multiplied by SDK-internal
+// retries.
+func TestGenerateRetryCount(t *testing.T) {
+	transport := &countingTransport{}
+	provider := New(
+		WithAPIKey("test-key"),
+		WithClient(&http.Client{Transport: transport}),
+		WithMaxRetries(2),
+	)
+	provider.retryBaseWait = time.Millisecond
+
+	_, err := provider.Generate(context.Background(),
+		llm.WithMessages(llm.NewUserTextMessage("hello")),
+	)
+	assert.Error(t, err)
+	assert.Equal(t, int64(3), transport.requests.Load())
+}
+
+// TestGenerateRetryCountDefault verifies the default retry budget (2 retries,
+// 3 total attempts) with no SDK-layer amplification.
+func TestGenerateRetryCountDefault(t *testing.T) {
+	transport := &countingTransport{}
+	provider := New(
+		WithAPIKey("test-key"),
+		WithClient(&http.Client{Transport: transport}),
+	)
+	provider.retryBaseWait = time.Millisecond
+
+	_, err := provider.Generate(context.Background(),
+		llm.WithMessages(llm.NewUserTextMessage("hello")),
+	)
+	assert.Error(t, err)
+	assert.Equal(t, int64(DefaultMaxRetries+1), transport.requests.Load())
+}

--- a/providers/openaicompletions/openai.go
+++ b/providers/openaicompletions/openai.go
@@ -202,10 +202,7 @@ func (p *Provider) Generate(ctx context.Context, opts ...llm.Option) (*llm.Respo
 		Model:   p.model,
 		Role:    llm.Assistant,
 		Content: contentBlocks,
-		Usage: llm.Usage{
-			InputTokens:  result.Usage.PromptTokens,
-			OutputTokens: result.Usage.CompletionTokens,
-		},
+		Usage:   result.Usage.toLLMUsage(),
 	}
 
 	if err := config.FireHooks(ctx, &llm.HookContext{
@@ -395,6 +392,12 @@ func convertMessages(messages []*llm.Message) ([]Message, error) {
 					})
 				case *llm.ToolUseContent:
 					// Already handled above
+				case *llm.ThinkingContent, *llm.RedactedThinkingContent:
+					// The Chat Completions API has no standard field for
+					// replaying assistant reasoning back to the server, so
+					// thinking content (which this provider's own stream
+					// iterator can produce from "reasoning" deltas) is
+					// skipped on encode rather than erroring.
 				default:
 					return nil, fmt.Errorf("unsupported content type: %s", c.Type())
 				}

--- a/providers/openaicompletions/openai_test.go
+++ b/providers/openaicompletions/openai_test.go
@@ -2,6 +2,7 @@ package openaicompletions
 
 import (
 	"context"
+	"encoding/json"
 	"os"
 	"strings"
 	"testing"
@@ -480,4 +481,50 @@ func TestConvertToolUseAndResultMessages(t *testing.T) {
 	assert.Equal(t, "2", converted[2].Content)
 	assert.Equal(t, "call_999", converted[2].ToolCallID)
 
+}
+
+// TestConvertMessagesSkipsThinkingContent verifies that ThinkingContent (which
+// this provider's stream iterator can produce from "reasoning" deltas)
+// round-trips through convertMessages without error: it is skipped on encode
+// since the Chat Completions API has no field for replaying reasoning.
+func TestConvertMessagesSkipsThinkingContent(t *testing.T) {
+	messages := []*llm.Message{
+		{
+			Role: llm.Assistant,
+			Content: []llm.Content{
+				&llm.ThinkingContent{Thinking: "Let me think about this..."},
+				&llm.TextContent{Text: "The answer is 4."},
+			},
+		},
+	}
+	result, err := convertMessages(messages)
+	assert.NoError(t, err)
+	assert.Len(t, result, 1)
+	assert.Equal(t, "assistant", result[0].Role)
+	assert.Equal(t, "The answer is 4.", result[0].Content)
+}
+
+// TestGenerateUsageDetails verifies that cached prompt tokens and reasoning
+// tokens from a non-streaming response are carried into llm.Usage.
+func TestGenerateUsageDetails(t *testing.T) {
+	var result Response
+	err := json.Unmarshal([]byte(`{
+		"id": "chatcmpl-9",
+		"object": "chat.completion",
+		"model": "gpt-5",
+		"choices": [{"index": 0, "message": {"role": "assistant", "content": "Hello"}, "finish_reason": "stop"}],
+		"usage": {
+			"prompt_tokens": 200,
+			"completion_tokens": 25,
+			"total_tokens": 225,
+			"prompt_tokens_details": {"cached_tokens": 150},
+			"completion_tokens_details": {"reasoning_tokens": 10}
+		}
+	}`), &result)
+	assert.NoError(t, err)
+	usage := result.Usage.toLLMUsage()
+	assert.Equal(t, 200, usage.InputTokens)
+	assert.Equal(t, 25, usage.OutputTokens)
+	assert.Equal(t, 150, usage.CacheReadInputTokens)
+	assert.Equal(t, 10, usage.ReasoningTokens)
 }

--- a/providers/openaicompletions/stream_iterator.go
+++ b/providers/openaicompletions/stream_iterator.go
@@ -154,10 +154,7 @@ func (s *StreamIterator) next() ([]*llm.Event, error) {
 				Role:    llm.Assistant,
 				Model:   s.responseModel,
 				Content: []llm.Content{},
-				Usage: llm.Usage{
-					InputTokens:  s.usage.PromptTokens,
-					OutputTokens: s.usage.CompletionTokens,
-				},
+				Usage:   s.usage.toLLMUsage(),
 			},
 		})
 	}
@@ -376,8 +373,7 @@ func (s *StreamIterator) flushFinalEvents() []*llm.Event {
 	s.finalEvents = nil
 	for _, event := range events {
 		if event.Type == llm.EventTypeMessageDelta && event.Usage != nil {
-			event.Usage.InputTokens = s.usage.PromptTokens
-			event.Usage.OutputTokens = s.usage.CompletionTokens
+			*event.Usage = s.usage.toLLMUsage()
 		}
 	}
 	return events

--- a/providers/openaicompletions/stream_iterator_test.go
+++ b/providers/openaicompletions/stream_iterator_test.go
@@ -157,3 +157,29 @@ func TestStreamIteratorUsageOnFinishChunk(t *testing.T) {
 	assert.Equal(t, 5, response.Usage.InputTokens)
 	assert.Equal(t, 2, response.Usage.OutputTokens)
 }
+
+// TestStreamIteratorUsageDetails verifies that cached prompt tokens and
+// reasoning tokens reported in the trailing usage chunk are carried into
+// llm.Usage.
+func TestStreamIteratorUsageDetails(t *testing.T) {
+	body := strings.Join([]string{
+		`data: {"id":"chatcmpl-5","object":"chat.completion.chunk","model":"gpt-5","choices":[{"index":0,"delta":{"role":"assistant","content":"Hi"}}]}`,
+		``,
+		`data: {"id":"chatcmpl-5","object":"chat.completion.chunk","model":"gpt-5","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}`,
+		``,
+		`data: {"id":"chatcmpl-5","object":"chat.completion.chunk","model":"gpt-5","choices":[],"usage":{"prompt_tokens":100,"completion_tokens":50,"total_tokens":150,"prompt_tokens_details":{"cached_tokens":80},"completion_tokens_details":{"reasoning_tokens":30}}}`,
+		``,
+		`data: [DONE]`,
+		``,
+	}, "\n")
+
+	iterator := newTestStreamIterator(body)
+	defer iterator.Close()
+	_, accumulator := collectEvents(t, iterator)
+
+	response := accumulator.Response()
+	assert.Equal(t, 100, response.Usage.InputTokens)
+	assert.Equal(t, 50, response.Usage.OutputTokens)
+	assert.Equal(t, 80, response.Usage.CacheReadInputTokens)
+	assert.Equal(t, 30, response.Usage.ReasoningTokens)
+}

--- a/providers/openaicompletions/types.go
+++ b/providers/openaicompletions/types.go
@@ -1,6 +1,9 @@
 package openaicompletions
 
-import "github.com/deepnoodle-ai/wonton/schema"
+import (
+	"github.com/deepnoodle-ai/dive/llm"
+	"github.com/deepnoodle-ai/wonton/schema"
+)
 
 type ReasoningEffort string
 
@@ -80,9 +83,41 @@ type Choice struct {
 }
 
 type Usage struct {
-	PromptTokens     int `json:"prompt_tokens"`
-	CompletionTokens int `json:"completion_tokens"`
-	TotalTokens      int `json:"total_tokens"`
+	PromptTokens            int                      `json:"prompt_tokens"`
+	CompletionTokens        int                      `json:"completion_tokens"`
+	TotalTokens             int                      `json:"total_tokens"`
+	PromptTokensDetails     *PromptTokensDetails     `json:"prompt_tokens_details,omitempty"`
+	CompletionTokensDetails *CompletionTokensDetails `json:"completion_tokens_details,omitempty"`
+}
+
+// PromptTokensDetails breaks down the prompt token count. CachedTokens is the
+// portion of prompt_tokens served from the prompt cache (a subset of
+// PromptTokens, not additive).
+type PromptTokensDetails struct {
+	CachedTokens int `json:"cached_tokens"`
+}
+
+// CompletionTokensDetails breaks down the completion token count.
+// ReasoningTokens is the portion of completion_tokens spent on reasoning (a
+// subset of CompletionTokens, not additive).
+type CompletionTokensDetails struct {
+	ReasoningTokens int `json:"reasoning_tokens"`
+}
+
+// toLLMUsage converts wire usage to llm.Usage, carrying cache and reasoning
+// token detail when the server reports it.
+func (u Usage) toLLMUsage() llm.Usage {
+	usage := llm.Usage{
+		InputTokens:  u.PromptTokens,
+		OutputTokens: u.CompletionTokens,
+	}
+	if u.PromptTokensDetails != nil {
+		usage.CacheReadInputTokens = u.PromptTokensDetails.CachedTokens
+	}
+	if u.CompletionTokensDetails != nil {
+		usage.ReasoningTokens = u.CompletionTokensDetails.ReasoningTokens
+	}
+	return usage
 }
 
 // {"id":"chatcmpl-123","object":"chat.completion.chunk","created":1694268190,"model":"gpt-4o-mini", "system_fingerprint": "fp_44709d6fcb", "choices":[{"index":0,"delta":{"role":"assistant","content":""},"logprobs":null,"finish_reason":null}]}

--- a/providers/registry.go
+++ b/providers/registry.go
@@ -52,11 +52,21 @@ func (r *Registry) SetFallback(factory ProviderFactory) {
 // iterates through registered entries in order and returns the first match.
 // If no entry matches and a fallback is set, the fallback is used.
 // Returns nil if no match and no fallback.
+//
+// Precedence for "/"-containing model IDs: when the text before the first "/"
+// names a registered provider, that provider wins — e.g. "openai/gpt-4"
+// routes to the native OpenAI provider (with model "gpt-4"), not to a
+// matcher-based provider like OpenRouter. When the prefix is not a registered
+// provider name (e.g. "meta-llama/llama-3-70b"), the full model ID falls
+// through to the matcher loop so matchers such as OpenRouter's
+// ContainsMatcher("/") can claim it.
 func (r *Registry) CreateModel(model, endpoint string) llm.LLM {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 
-	// Check for explicit "provider/model" syntax
+	// Check for explicit "provider/model" syntax. Only treat the text before
+	// the "/" as a provider selector when it matches a registered provider
+	// name; otherwise fall through to the matcher loop below.
 	if idx := strings.IndexByte(model, '/'); idx > 0 {
 		providerName := strings.ToLower(model[:idx])
 		modelName := model[idx+1:]
@@ -65,7 +75,6 @@ func (r *Registry) CreateModel(model, endpoint string) llm.LLM {
 				return entry.Factory(modelName, endpoint)
 			}
 		}
-		return nil
 	}
 
 	for _, entry := range r.entries {

--- a/providers/registry_test.go
+++ b/providers/registry_test.go
@@ -51,3 +51,65 @@ func TestCreateModel_ExplicitProvider(t *testing.T) {
 	result = r.CreateModel("unknown/model", "")
 	assert.Nil(t, result)
 }
+
+func TestCreateModel_SlashRouting(t *testing.T) {
+	r := &Registry{}
+	r.Register(ProviderEntry{
+		Name:  "openai",
+		Match: PrefixesMatcher("gpt-"),
+		Factory: func(model, endpoint string) llm.LLM {
+			return &stubLLM{name: "openai:" + model}
+		},
+	})
+	r.Register(ProviderEntry{
+		Name:  "openrouter",
+		Match: ContainsMatcher("/"),
+		Factory: func(model, endpoint string) llm.LLM {
+			return &stubLLM{name: "openrouter:" + model}
+		},
+	})
+
+	// A "/"-containing ID whose prefix is NOT a registered provider name falls
+	// through to the matcher loop (OpenRouter's ContainsMatcher claims it,
+	// receiving the full model ID).
+	result := r.CreateModel("meta-llama/llama-3-70b", "")
+	assert.NotNil(t, result)
+	assert.Equal(t, "openrouter:meta-llama/llama-3-70b", result.(*stubLLM).name)
+
+	// A registered provider prefix wins over matchers: "openai/gpt-4" routes
+	// to the native OpenAI provider with the prefix stripped, even though
+	// OpenRouter's matcher would also match.
+	result = r.CreateModel("openai/gpt-4", "")
+	assert.NotNil(t, result)
+	assert.Equal(t, "openai:gpt-4", result.(*stubLLM).name)
+
+	// Plain model IDs without "/" are unchanged: matched by prefix matchers.
+	result = r.CreateModel("gpt-4", "")
+	assert.NotNil(t, result)
+	assert.Equal(t, "openai:gpt-4", result.(*stubLLM).name)
+
+	// Unknown model without "/" and no fallback returns nil.
+	assert.Nil(t, r.CreateModel("totally-unknown-model", ""))
+}
+
+func TestCreateModel_SlashRoutingNoMatcher(t *testing.T) {
+	// Without any "/"-matching entry, an unknown-prefix "/" model returns nil
+	// (no fallback set).
+	r := &Registry{}
+	r.Register(ProviderEntry{
+		Name:  "openai",
+		Match: PrefixesMatcher("gpt-"),
+		Factory: func(model, endpoint string) llm.LLM {
+			return &stubLLM{name: "openai:" + model}
+		},
+	})
+	assert.Nil(t, r.CreateModel("meta-llama/llama-3-70b", ""))
+
+	// With a fallback, the fallback receives the full model ID.
+	r.SetFallback(func(model, endpoint string) llm.LLM {
+		return &stubLLM{name: "fallback:" + model}
+	})
+	result := r.CreateModel("meta-llama/llama-3-70b", "")
+	assert.NotNil(t, result)
+	assert.Equal(t, "fallback:meta-llama/llama-3-70b", result.(*stubLLM).name)
+}


### PR DESCRIPTION
Remediates the remaining findings from `docs/reviews/2026-06-09-api-review.md` §5 (batches 1–2 were #181–#191). All findings were re-verified against current code before fixing.

## Fixes

### §5.4 — Anthropic web-search error variant fails the whole response decode (`llm/content.go`)
`WebSearchToolResultContent` now has a custom `UnmarshalJSON` that accepts both documented shapes of `content`: the array-of-results variant and the error-object variant (`{"type": "web_search_tool_result_error", "error_code": "..."}`), populating `ErrorCode` for the latter. One errored server-side search no longer fails the entire turn's JSON decode. `MarshalJSON` round-trips the error variant by encoding it as the API's nested error object (the previous top-level `error_code` form did not match the wire format and could not round-trip). Regression tests decode both variants from fixture JSON (including a full `llm.Response` containing an errored block) and round-trip both.

### §5.5 — OpenAI double-retry amplification (`providers/openai/`)
The SDK client is now constructed with `option.WithMaxRetries(0)` so Dive's retry loop is the only retry layer (previously Dive's 3 attempts × the SDK's default 2 internal retries = up to 9 HTTP requests per persistent 429/500, with compounding backoff). **`WithMaxRetries` semantics changed**: it previously configured only the SDK layer; it now sets Dive-level retries (total attempts = maxRetries + 1) and is documented as the single retry knob. This also fixes Grok, which wraps this provider. `providers/openaicompletions` was checked and does **not** have the double-retry layering (it uses a raw `http.Client` with a single Dive retry loop), so no change was needed there. Regression test uses a stub `http.RoundTripper` that counts requests and always returns 429, asserting the total equals Dive's retry budget exactly (3 requests for `WithMaxRetries(2)` and for the default).

### §5.6 — Registry: `/`-containing model IDs short-circuit; OpenRouter matcher unreachable (`providers/registry.go`)
The text before `/` is treated as a provider selector only when it matches a registered provider name; otherwise the full model ID falls through to the matcher loop. `meta-llama/llama-3-70b` now reaches OpenRouter's `ContainsMatcher("/")` (previously returned nil).

**Routing precedence note (deliberate):** when the prefix *is* a registered provider name, the prefix wins — `openai/gpt-4` still routes to the **native OpenAI provider** (with model `gpt-4`), not to OpenRouter, even though OpenRouter's matcher would also match. This precedence is documented on `CreateModel`. Regression tests cover the fall-through, prefix-wins, plain-prefix, and unknown-model cases.

### §5.8 remaining — Google stream-iterator gaps (`providers/google/stream_iterator.go`)
Re-verified what #185 fixed (debug Printfs removed, tool-call ID counter); the remaining gaps are fixed by rewriting the iterator with a queue-based design mirroring the Anthropic/OpenAI event semantics:
- **Usage + stop reason**: the final `message_delta` now carries `llm.Usage` (from the last chunk's `UsageMetadata`, including cached-content and thoughts counts) and the stop reason (same mapping as the non-streaming path).
- **Indices**: content blocks get 0-based contiguous sequential indices (previously everything shared index 0).
- **Parallel function calls**: every function call in every chunk is surfaced as its own `tool_use` block (previously only the first call of the first chunk). Provided `FunctionCall.ID`s are used when present; unique IDs are synthesized otherwise.

Regression tests with fixture chunks cover: usage + stop reason on message_delta, parallel calls in one chunk, calls across chunks, sequential indices, max_tokens mapping, and mid-stream errors.

### §5.9 — non-breaking drift items
- **OpenAI Responses drops `IsError`** (`providers/openai/encode.go`): the Responses API has no equivalent of Anthropic's `is_error` flag on `function_call_output`, so the chosen mapping is to prefix the output text with `"Error: "` when `IsError` is set (skipped if the text already starts with it). Applied to both the user-side and assistant-side tool-result encoders via a shared helper; documented in code.
- **Usage detail fields**: `openaicompletions` now parses `prompt_tokens_details.cached_tokens` → `CacheReadInputTokens` and `completion_tokens_details.reasoning_tokens` → `ReasoningTokens` (Generate + streaming); Google now reads `CachedContentTokenCount` and `ThoughtsTokenCount` into the same fields (Generate + streaming).
- **OpenAI `AfterGenerate`**: the Responses provider now fires `AfterGenerate` hooks in `Generate`, consistent with Anthropic/Google/openaicompletions (which fire it only on the non-streaming path).
- **openaicompletions `ThinkingContent` round-trip**: `convertMessages` now skips `ThinkingContent`/`RedactedThinkingContent` instead of erroring on content its own stream iterator produces. Skipping (rather than mapping to assistant text) was chosen because the Chat Completions API has no standard field for replaying reasoning and OpenAI-compatible servers don't expect it back.

## Skipped / deferred (per instructions, as §8 follow-up work)
- StopReason vocabulary normalization across providers
- `llm.Usage` cache-inclusive semantics documentation/normalization (OpenAI includes cached reads in `input_tokens`; Anthropic excludes)
- Dead `WithEndpoint`/`WithAPIKey`/`WithHTTPClient` request options
- `OnError` hook wiring
- Anthropic fast-mode pricing verification (Opus 4.8 10/50 vs 4.6/4.7 30/150)

## Testing
- `gofmt -l` clean on all touched files
- `go build ./...` and `go test ./...` pass on the root module and the `providers/google`, `providers/openai`, `providers/grok`, `a2a`, `otel`, and `experimental/mcp` modules
- All new tests are unit-level: fixture JSON, fixture chunk sequences, and stub HTTP transports — no network or API keys required

🤖 Generated with [Claude Code](https://claude.com/claude-code)