### PR TITLE
Permission hardening: deny-first precedence, scoped session grants, type-aware specifier matching (§1)

### DIFF
--- a/docs/guides/permissions.md
+++ b/docs/guides/permissions.md
@@ -83,6 +83,17 @@ Default specifier fields:
 
 Override with `Config.SpecifierFields` for custom tools.
 
+**Deny rules fail closed:** if a deny rule has a specifier but no specifier can be extracted from the tool input (unknown tool shape, missing field, unparsable JSON), the rule matches and the call is denied. Allow and ask rules fail open (they simply don't match).
+
+### How Specifiers Are Matched
+
+Matching is type-aware per tool (`DefaultSpecifierMatchers`, overridable via `Config.SpecifierMatchers`):
+
+- **Bash (command-aware).** The command is split on unquoted shell control operators (`;`, `&&`, `||`, `|`, `&`, newlines). An *allow* rule matches only if **every** segment matches the pattern, and never matches commands containing command/process substitution (`$(...)`, backticks, `<(...)`) — so `Bash(go test *)` does not authorize `go test ./...; rm -rf /` or `go test $(...)`. A *deny* rule matches if the full command **or any** segment matches, so `Bash(*rm*)` catches `ls\nrm -rf /`. Note: a compound command only matches an allow rule if all of its segments match that one rule; segments covered by different allow rules fall through to ask.
+- **Read/Write/Edit (path-aware).** Paths are cleaned before matching (`/safe/dir/../../etc/shadow` becomes `/etc/shadow`), `*` stays within one path segment, and `**` crosses segments — so `Read(/safe/dir/*)` covers files directly in that directory and `Read(/safe/dir/**)` covers the whole tree. Deny rules additionally match the absolutized form of relative paths. Symlinks are **not** resolved — pair path rules with the toolkit's workspace validation for filesystem-level enforcement.
+- **WebFetch (domain-aware).** `domain:example.com` (or a bare domain like `example.com`) matches the URL's host exactly or as a subdomain, case-insensitively — `*example.com*`-style globs are discouraged because they also match `https://example.com.attacker.net`. Patterns containing wildcards, a scheme, or a path are glob-matched against the full URL.
+- **Other tools** fall back to plain glob matching (`MatchGlob`).
+
 ### Parsing Rules from Strings
 
 ```go
@@ -115,21 +126,29 @@ agent, _ := dive.NewAgent(dive.AgentOptions{
 When using the full `Manager`:
 
 ```text
-Session Allowlist -> Deny Rules -> Allow Rules -> Ask Rules -> Mode Check -> Default (confirm)
+Deny Rules -> Session Allowlist -> Allow Rules -> Ask Rules -> Mode Check -> Default (confirm)
 ```
+
+Deny rules are absolute: they are evaluated first and cannot be bypassed by session grants or by any mode, including `BypassPermissions`.
 
 ### Session Allowlists
 
-Users can approve "allow all X this session" for a tool category:
+When a user approves a dialog with "allow for session", the grant is scoped to the tool **and the approved value**: the exact command for Bash, the exact path for file tools, the URL's domain for WebFetch, or the whole tool when no specifier can be extracted. Approving `ls` does not approve `rm -rf /`, and approving one Bash command does not approve other command-like tools.
+
+Hosts can also grant scopes programmatically, with an optional specifier pattern:
 
 ```go
 manager := permission.NewManager(config, dialog)
 hook := permission.HookFromManager(manager)
 
-// Later, allow a category for the session
-manager.AllowForSession("bash")
-manager.AllowForSession(permission.CategoryEdit.Key)
+// Grant a specific command prefix for the session
+manager.AllowToolForSession("Bash", "git status*")
+
+// Grant an entire tool for the session
+manager.AllowToolForSession("Glob", "")
 ```
+
+`AllowForSession(categoryKey)` (category-wide grants like `"bash"`) is deprecated: categories are very broad, collapsing every command-like tool into one bucket. It is still honored for backward compatibility, but dialog approvals no longer create category grants.
 
 ### DontAsk Mode
 

--- a/experimental/cmd/dive/main.go
+++ b/experimental/cmd/dive/main.go
@@ -295,6 +295,7 @@ func runInteractive(ctx *cli.Context) error {
 		Rules: defaultPermissionRules(tools),
 	}
 	permManager := permission.NewManager(permConfig, tuiDialog)
+	tuiDialog.perm = permManager
 	permissionHook := permission.HookFromManager(permManager)
 
 	// Set up compaction config
@@ -639,9 +640,11 @@ func (n *monitorNotifier) notify(description string, lines []string) {
 }
 
 // tuiDialog implements dive.Dialog by routing to the App's TUI dialog system.
-// The app field is set after App creation (same pattern as the confirmer closure).
+// The app and perm fields are set after App and Manager creation (same
+// pattern as the confirmer closure).
 type tuiDialog struct {
-	app *App
+	app  *App
+	perm *permission.Manager
 }
 
 func (d *tuiDialog) Show(ctx context.Context, in *dive.DialogInput) (*dive.DialogOutput, error) {
@@ -676,11 +679,12 @@ func (d *tuiDialog) showConfirm(ctx context.Context, in *dive.DialogInput) (*div
 	}
 	question := tp.question
 
-	// Get tool category for "allow all X this session" option
+	// Describe what an "allow all X this session" approval would grant
 	categoryLabel := "this action"
-	if in.Tool != nil {
-		category := permission.GetToolCategory(in.Tool.Name())
-		categoryLabel = category.Label
+	if d.perm != nil {
+		categoryLabel = d.perm.SessionGrantLabel(in.Tool, in.Call)
+	} else if in.Tool != nil {
+		categoryLabel = in.Tool.Name() + " operations"
 	}
 
 	confirmChan := make(chan ConfirmResult, 1)

--- a/permission/command.go
+++ b/permission/command.go
@@ -1,0 +1,121 @@
+package permission
+
+import (
+	"strings"
+)
+
+// SplitCommand splits a shell command into segments separated by unquoted
+// control operators: ;, &&, ||, |, &, and newlines. Quoting is respected:
+// operators inside single or double quotes (or escaped with a backslash) do
+// not split. The returned hasSubstitution is true when the command contains
+// command or process substitution outside single quotes ($(...), backticks,
+// <(...), >(...)), which means parts of the command cannot be validated by
+// pattern matching.
+func SplitCommand(command string) (segments []string, hasSubstitution bool) {
+	var cur strings.Builder
+	inSingle := false
+	inDouble := false
+	flush := func() {
+		s := strings.TrimSpace(cur.String())
+		if s != "" {
+			segments = append(segments, s)
+		}
+		cur.Reset()
+	}
+	for i := 0; i < len(command); i++ {
+		c := command[i]
+		if inSingle {
+			if c == '\'' {
+				inSingle = false
+			}
+			cur.WriteByte(c)
+			continue
+		}
+		if c == '\\' && i+1 < len(command) {
+			cur.WriteByte(c)
+			i++
+			cur.WriteByte(command[i])
+			continue
+		}
+		switch c {
+		case '\'':
+			if !inDouble {
+				inSingle = true
+			}
+			cur.WriteByte(c)
+		case '"':
+			inDouble = !inDouble
+			cur.WriteByte(c)
+		case '`':
+			// Backticks substitute even inside double quotes.
+			hasSubstitution = true
+			cur.WriteByte(c)
+		case '$':
+			// $(...) substitutes even inside double quotes.
+			if i+1 < len(command) && command[i+1] == '(' {
+				hasSubstitution = true
+			}
+			cur.WriteByte(c)
+		case '<', '>':
+			if !inDouble && i+1 < len(command) && command[i+1] == '(' {
+				hasSubstitution = true
+			}
+			cur.WriteByte(c)
+		case ';', '\n':
+			if inDouble {
+				cur.WriteByte(c)
+				continue
+			}
+			flush()
+		case '&', '|':
+			if inDouble {
+				cur.WriteByte(c)
+				continue
+			}
+			flush()
+			if i+1 < len(command) && command[i+1] == c {
+				i++ // skip the second char of && or ||
+			}
+		default:
+			cur.WriteByte(c)
+		}
+	}
+	flush()
+	return segments, hasSubstitution
+}
+
+// MatchCommandAllow reports whether a shell command is authorized by an
+// allow-side specifier pattern. The command is split on unquoted shell
+// control operators and EVERY segment must match the pattern; a compound
+// command like "go test ./...; rm -rf /" therefore does not match
+// "go test *". Commands containing command or process substitution never
+// match, since the substituted command cannot be validated.
+func MatchCommandAllow(pattern, command string) bool {
+	segments, hasSubstitution := SplitCommand(command)
+	if hasSubstitution || len(segments) == 0 {
+		return false
+	}
+	for _, segment := range segments {
+		if !MatchGlob(pattern, segment) {
+			return false
+		}
+	}
+	return true
+}
+
+// MatchCommandDeny reports whether a shell command is blocked by a deny-side
+// specifier pattern. The pattern is matched against the full command and
+// against each segment after splitting on unquoted shell control operators,
+// so "ls\nrm -rf /" is still caught by "rm -rf*".
+func MatchCommandDeny(pattern, command string) bool {
+	if MatchGlob(pattern, command) {
+		return true
+	}
+	segments, _ := SplitCommand(command)
+	for _, segment := range segments {
+		if MatchGlob(pattern, segment) {
+			return true
+		}
+	}
+	return false
+}

--- a/permission/match.go
+++ b/permission/match.go
@@ -32,7 +32,9 @@ func MatchGlob(pattern, value string) bool {
 	return matched
 }
 
-// MatchDomain checks if a URL's host matches or is a subdomain of the given domain.
+// MatchDomain checks if a URL's host matches or is a subdomain of the given
+// domain. Matching is case-insensitive and tolerates a trailing dot on either
+// side (https://EXAMPLE.COM. matches example.com).
 func MatchDomain(urlStr, domain string) bool {
 	// Ensure the string has a scheme so url.Parse treats it as absolute.
 	if !strings.Contains(urlStr, "://") {
@@ -50,10 +52,37 @@ func MatchDomain(urlStr, domain string) bool {
 		host = strings.Trim(h, "[]")
 	}
 
+	host = strings.ToLower(strings.TrimSuffix(host, "."))
+	domain = strings.ToLower(strings.TrimSuffix(domain, "."))
+	if host == "" || domain == "" {
+		return false
+	}
+
 	if host == domain {
 		return true
 	}
 	return strings.HasSuffix(host, "."+domain)
+}
+
+// MatchURLSpecifier matches a URL specifier pattern against a URL. Three
+// pattern forms are supported:
+//   - "domain:example.com" matches the URL's host (exact or subdomain)
+//   - a bare domain with no wildcards, scheme, or path (e.g. "example.com")
+//     is treated the same as "domain:example.com"
+//   - anything else is glob-matched against the full URL string
+//
+// Domain-based forms are preferred: a glob like "*example.com*" also matches
+// "https://example.com.attacker.net".
+func MatchURLSpecifier(pattern, urlStr string) bool {
+	if domain, ok := strings.CutPrefix(pattern, "domain:"); ok {
+		return MatchDomain(urlStr, domain)
+	}
+	if !strings.ContainsAny(pattern, "*?{") &&
+		!strings.Contains(pattern, "://") &&
+		!strings.Contains(pattern, "/") {
+		return MatchDomain(urlStr, pattern)
+	}
+	return MatchGlob(pattern, urlStr)
 }
 
 // MatchPath performs glob-style matching on file paths.
@@ -75,9 +104,11 @@ func MatchPath(pattern, path string) bool {
 // If pathMode is true, * matches [^/]* (single segment); otherwise * matches .*.
 // ** always matches .* (any path).
 // Handles {a,b,c} alternatives.
+// The (?s) flag makes . match newlines so wildcards cannot be escaped by
+// embedding a newline in the value (relevant for deny rules on commands).
 func globToRegex(glob string, pathMode bool) string {
 	var result strings.Builder
-	result.WriteString("^")
+	result.WriteString("(?s)^")
 
 	i := 0
 	for i < len(glob) {

--- a/permission/permission.go
+++ b/permission/permission.go
@@ -3,6 +3,11 @@
 // This package implements permission checking as a PreToolUse hook,
 // including rule-based evaluation, session allowlists, and user confirmation.
 //
+// Evaluation order: deny rules, session allowlist, allow rules, ask rules,
+// permission mode, then the default confirmation dialog. Deny rules are
+// absolute: they cannot be bypassed by session grants or by any mode,
+// including ModeBypassPermissions.
+//
 // Example:
 //
 //	config := &permission.Config{
@@ -26,6 +31,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/url"
+	"path/filepath"
+	"strings"
 	"sync"
 
 	"github.com/deepnoodle-ai/dive"
@@ -89,6 +97,12 @@ type Rules []Rule
 // The input is the raw JSON input from the tool call.
 type SpecifierFieldFunc func(input json.RawMessage) string
 
+// SpecifierMatcherFunc matches a rule's specifier pattern against the value
+// extracted from a tool call. The rule type is provided because safe matching
+// is direction-dependent: deny matching should be generous (catch evasions)
+// while allow matching should be strict (reject anything not clearly covered).
+type SpecifierMatcherFunc func(ruleType RuleType, pattern, value string) bool
+
 // Config contains all permission-related configuration.
 type Config struct {
 	Mode  Mode
@@ -97,6 +111,24 @@ type Config struct {
 	// SpecifierFields maps tool names to functions that extract the specifier
 	// value from tool call input. If not set, DefaultSpecifierFields is used.
 	SpecifierFields map[string]SpecifierFieldFunc
+
+	// SpecifierMatchers maps tool names to functions that match a rule's
+	// specifier pattern against the extracted value. If not set,
+	// DefaultSpecifierMatchers is used (command-aware matching for Bash,
+	// segment-aware path matching for Read/Write/Edit, domain-aware matching
+	// for WebFetch). Tools with no matcher fall back to MatchGlob.
+	SpecifierMatchers map[string]SpecifierMatcherFunc
+}
+
+// sessionGrant is a session-scoped approval for a specific tool, optionally
+// narrowed to a specifier. Grants created from dialog approvals are exact
+// (the literal specifier value, compared by equality so glob characters in
+// the approved input cannot widen the grant); grants created via
+// AllowToolForSession are patterns matched with the tool's specifier matcher.
+type sessionGrant struct {
+	tool      string
+	specifier string // empty means the entire tool
+	exact     bool
 }
 
 // Manager orchestrates the permission evaluation flow.
@@ -105,6 +137,7 @@ type Manager struct {
 	config         *Config
 	dialog         dive.Dialog
 	sessionAllowed map[string]bool
+	sessionGrants  []sessionGrant
 }
 
 // NewManager creates a new permission manager.
@@ -119,47 +152,68 @@ func NewManager(config *Config, dialog dive.Dialog) *Manager {
 	}
 }
 
-// Internal decision type used between evaluateRules/evaluateMode and EvaluateToolUse.
+// Internal decision type used between evaluateMode and EvaluateToolUse.
 type decision int
 
 const (
 	noDecision decision = iota
 	allow
 	deny
-	askUser
 )
 
 // EvaluateToolUse runs the full permission evaluation flow.
 // Returns nil if the tool is allowed, or an error if denied.
+//
+// Evaluation order: deny rules, session allowlist, allow rules, ask rules,
+// permission mode, then the default confirmation dialog. Deny rules are
+// absolute — they beat session grants and every mode, including
+// ModeBypassPermissions.
 func (pm *Manager) EvaluateToolUse(
 	ctx context.Context,
 	tool dive.Tool,
 	call *llm.ToolUseContent,
 ) error {
-	// Check session allowlist
+	denyRules, allowRules, askRules := pm.partitionRules()
+
+	var toolName string
 	if tool != nil {
-		category := GetToolCategory(tool.Name())
-		pm.mu.RLock()
-		allowed := pm.sessionAllowed[category.Key]
-		pm.mu.RUnlock()
-		if allowed {
-			return nil
+		toolName = tool.Name()
+	}
+
+	// Deny rules are evaluated first and are absolute.
+	if tool != nil && call != nil {
+		for _, rule := range denyRules {
+			if pm.matchRule(rule, toolName, call) {
+				msg := rule.Message
+				if msg == "" {
+					msg = "denied by rule " + rule.String()
+				}
+				return fmt.Errorf("%s", msg)
+			}
 		}
 	}
 
-	// Evaluate rules
-	d, msg := pm.evaluateRules(tool, call)
-	switch d {
-	case deny:
-		return fmt.Errorf("%s", msg)
-	case allow:
+	// Check session allowlist
+	if tool != nil && pm.isSessionAllowed(toolName, call) {
 		return nil
-	case askUser:
-		return pm.confirm(ctx, tool, call, msg)
+	}
+
+	// Check allow and ask rules
+	if tool != nil && call != nil {
+		for _, rule := range allowRules {
+			if pm.matchRule(rule, toolName, call) {
+				return nil
+			}
+		}
+		for _, rule := range askRules {
+			if pm.matchRule(rule, toolName, call) {
+				return pm.confirm(ctx, tool, call, rule.Message)
+			}
+		}
 	}
 
 	// Check permission mode
-	d, msg = pm.evaluateMode(tool, call)
+	d, msg := pm.evaluateMode(tool, call)
 	switch d {
 	case deny:
 		return fmt.Errorf("%s", msg)
@@ -171,13 +225,9 @@ func (pm *Manager) EvaluateToolUse(
 	return pm.confirm(ctx, tool, call, "")
 }
 
-func (pm *Manager) evaluateRules(tool dive.Tool, call *llm.ToolUseContent) (decision, string) {
-	if tool == nil || call == nil {
-		return noDecision, ""
-	}
-
+func (pm *Manager) partitionRules() (denyRules, allowRules, askRules Rules) {
 	pm.mu.RLock()
-	var denyRules, allowRules, askRules Rules
+	defer pm.mu.RUnlock()
 	for _, rule := range pm.config.Rules {
 		switch rule.Type {
 		case RuleDeny:
@@ -188,32 +238,7 @@ func (pm *Manager) evaluateRules(tool dive.Tool, call *llm.ToolUseContent) (deci
 			askRules = append(askRules, rule)
 		}
 	}
-	pm.mu.RUnlock()
-
-	toolName := tool.Name()
-
-	// Check deny rules first
-	for _, rule := range denyRules {
-		if pm.matchRule(rule, toolName, call) {
-			return deny, rule.Message
-		}
-	}
-
-	// Check allow rules
-	for _, rule := range allowRules {
-		if pm.matchRule(rule, toolName, call) {
-			return allow, ""
-		}
-	}
-
-	// Check ask rules
-	for _, rule := range askRules {
-		if pm.matchRule(rule, toolName, call) {
-			return askUser, rule.Message
-		}
-	}
-
-	return noDecision, ""
+	return denyRules, allowRules, askRules
 }
 
 func (pm *Manager) matchRule(rule Rule, toolName string, call *llm.ToolUseContent) bool {
@@ -225,7 +250,13 @@ func (pm *Manager) matchRule(rule Rule, toolName string, call *llm.ToolUseConten
 	// Match specifier pattern if specified
 	if rule.Specifier != "" {
 		specifier := pm.extractSpecifier(toolName, call.Input)
-		if specifier == "" || !MatchGlob(rule.Specifier, specifier) {
+		if specifier == "" {
+			// No specifier could be extracted. Deny rules fail closed: a
+			// rule meant to block "rm -rf*" must not be evaded by an input
+			// shape the extractor doesn't understand.
+			return rule.Type == RuleDeny
+		}
+		if !pm.matchSpecifier(rule.Type, toolName, rule.Specifier, specifier) {
 			return false
 		}
 	}
@@ -234,7 +265,8 @@ func (pm *Manager) matchRule(rule Rule, toolName string, call *llm.ToolUseConten
 	if rule.InputMatch != nil {
 		var input any
 		if err := json.Unmarshal(call.Input, &input); err != nil {
-			return false
+			// Unparsable input fails closed for deny rules.
+			return rule.Type == RuleDeny
 		}
 		if !rule.InputMatch(input) {
 			return false
@@ -242,6 +274,24 @@ func (pm *Manager) matchRule(rule Rule, toolName string, call *llm.ToolUseConten
 	}
 
 	return true
+}
+
+// matchSpecifier matches a specifier pattern against an extracted value using
+// the tool's configured matcher (custom, then default, then MatchGlob).
+func (pm *Manager) matchSpecifier(ruleType RuleType, toolName, pattern, value string) bool {
+	pm.mu.RLock()
+	custom := pm.config.SpecifierMatchers
+	pm.mu.RUnlock()
+
+	if custom != nil {
+		if fn, ok := custom[toolName]; ok {
+			return fn(ruleType, pattern, value)
+		}
+	}
+	if fn, ok := DefaultSpecifierMatchers[toolName]; ok {
+		return fn(ruleType, pattern, value)
+	}
+	return MatchGlob(pattern, value)
 }
 
 func (pm *Manager) extractSpecifier(toolName string, input json.RawMessage) string {
@@ -337,8 +387,7 @@ func (pm *Manager) confirm(
 		return err
 	}
 	if output.AllowSession {
-		category := GetToolCategory(tool.Name())
-		pm.AllowForSession(category.Key)
+		pm.grantSessionFromCall(tool, call)
 		return nil
 	}
 	if output.Feedback != "" {
@@ -365,24 +414,143 @@ func (pm *Manager) SetMode(mode Mode) {
 }
 
 // AllowForSession marks a tool category as allowed for this session.
+//
+// Deprecated: category grants are very broad (one approval covers every
+// command-like tool, for example). Use AllowToolForSession to grant a
+// specific tool, optionally narrowed to a specifier pattern. Category grants
+// are still honored for backward compatibility, but dialog approvals no
+// longer create them, and deny rules beat them.
 func (pm *Manager) AllowForSession(categoryKey string) {
 	pm.mu.Lock()
 	defer pm.mu.Unlock()
 	pm.sessionAllowed[categoryKey] = true
 }
 
+// AllowToolForSession marks a specific tool as allowed for this session.
+// If specifierPattern is non-empty, the grant only covers calls whose
+// extracted specifier matches the pattern (using the tool's specifier
+// matcher with allow-side semantics, e.g. "git status*" for Bash). An empty
+// specifierPattern grants every call to the tool. Deny rules always beat
+// session grants.
+func (pm *Manager) AllowToolForSession(toolName, specifierPattern string) {
+	pm.mu.Lock()
+	defer pm.mu.Unlock()
+	pm.sessionGrants = append(pm.sessionGrants, sessionGrant{
+		tool:      toolName,
+		specifier: specifierPattern,
+	})
+}
+
 // IsSessionAllowed checks if a tool category is allowed for this session.
+//
+// Deprecated: this reflects only legacy category grants created via
+// AllowForSession, not the scoped grants created by dialog approvals or
+// AllowToolForSession.
 func (pm *Manager) IsSessionAllowed(categoryKey string) bool {
 	pm.mu.RLock()
 	defer pm.mu.RUnlock()
 	return pm.sessionAllowed[categoryKey]
 }
 
-// ClearSessionAllowlist removes all session-scoped allowlist entries.
+// ClearSessionAllowlist removes all session-scoped allowlist entries,
+// including both scoped tool grants and legacy category grants.
 func (pm *Manager) ClearSessionAllowlist() {
 	pm.mu.Lock()
 	defer pm.mu.Unlock()
 	pm.sessionAllowed = make(map[string]bool)
+	pm.sessionGrants = nil
+}
+
+// isSessionAllowed reports whether a tool call is covered by a session grant.
+func (pm *Manager) isSessionAllowed(toolName string, call *llm.ToolUseContent) bool {
+	pm.mu.RLock()
+	legacyAllowed := pm.sessionAllowed[GetToolCategory(toolName).Key]
+	grants := make([]sessionGrant, len(pm.sessionGrants))
+	copy(grants, pm.sessionGrants)
+	pm.mu.RUnlock()
+
+	if legacyAllowed {
+		return true
+	}
+	if len(grants) == 0 {
+		return false
+	}
+
+	var specifier string
+	if call != nil {
+		specifier = pm.extractSpecifier(toolName, call.Input)
+	}
+	for _, grant := range grants {
+		if grant.tool != toolName {
+			continue
+		}
+		if grant.specifier == "" {
+			return true
+		}
+		if specifier == "" {
+			continue
+		}
+		if grant.exact {
+			if specifier == grant.specifier {
+				return true
+			}
+			continue
+		}
+		if pm.matchSpecifier(RuleAllow, toolName, grant.specifier, specifier) {
+			return true
+		}
+	}
+	return false
+}
+
+// SessionGrantLabel returns a short human-readable description of the
+// session grant that approving the given call with "allow for session" would
+// create: the exact command or path, the URL's domain, or the tool name when
+// no specifier can be extracted. Intended for dialog option labels like
+// "Yes, allow all <label> during this session".
+func (pm *Manager) SessionGrantLabel(tool dive.Tool, call *llm.ToolUseContent) string {
+	if tool == nil {
+		return "this action"
+	}
+	toolName := tool.Name()
+	var specifier string
+	if call != nil {
+		specifier = pm.extractSpecifier(toolName, call.Input)
+	}
+	if specifier == "" {
+		return toolName + " operations"
+	}
+	if host := urlHost(specifier); host != "" {
+		return "fetches from " + host
+	}
+	return fmt.Sprintf("%q", specifier)
+}
+
+// grantSessionFromCall records a session grant scoped to the approved call.
+// The grant covers the exact specifier value (command, file path) rather
+// than a category, so approving "ls" does not approve "rm -rf /". URL
+// specifiers are granted at domain scope, matching how users think about
+// approving a fetch ("allow example.com this session").
+func (pm *Manager) grantSessionFromCall(tool dive.Tool, call *llm.ToolUseContent) {
+	toolName := tool.Name()
+	var specifier string
+	if call != nil {
+		specifier = pm.extractSpecifier(toolName, call.Input)
+	}
+
+	grant := sessionGrant{tool: toolName}
+	if specifier != "" {
+		if host := urlHost(specifier); host != "" {
+			grant.specifier = "domain:" + host
+		} else {
+			grant.specifier = specifier
+			grant.exact = true
+		}
+	}
+
+	pm.mu.Lock()
+	defer pm.mu.Unlock()
+	pm.sessionGrants = append(pm.sessionGrants, grant)
 }
 
 // Category represents a tool's category for session allowlist purposes.
@@ -435,6 +603,68 @@ var DefaultSpecifierFields = map[string]SpecifierFieldFunc{
 	"WebFetch": func(input json.RawMessage) string {
 		return jsonStringField(input, "url")
 	},
+}
+
+// DefaultSpecifierMatchers maps tool names to specifier matching functions.
+// These are used when Config.SpecifierMatchers does not have an entry for the
+// tool. Tools with no entry in either map fall back to MatchGlob.
+//
+//   - Bash: command-aware matching. Allow rules require every shell segment
+//     to match and reject command substitution; deny rules match if the full
+//     command or any segment matches. See MatchCommandAllow/MatchCommandDeny.
+//   - Read/Write/Edit: paths are cleaned (so "/safe/../etc" cannot evade a
+//     rule) and matched with MatchPath, where * stays within one path segment
+//     and ** crosses segments. Deny rules also match the absolutized form of
+//     relative paths.
+//   - WebFetch: domain-aware matching via MatchURLSpecifier ("domain:x.com"
+//     or a bare domain matches the host; other patterns glob the full URL).
+var DefaultSpecifierMatchers = map[string]SpecifierMatcherFunc{
+	"Bash":     matchCommandSpecifier,
+	"Read":     matchPathSpecifier,
+	"Write":    matchPathSpecifier,
+	"Edit":     matchPathSpecifier,
+	"WebFetch": matchURLSpecifier,
+}
+
+func matchCommandSpecifier(ruleType RuleType, pattern, command string) bool {
+	if ruleType == RuleDeny {
+		return MatchCommandDeny(pattern, command)
+	}
+	return MatchCommandAllow(pattern, command)
+}
+
+func matchPathSpecifier(ruleType RuleType, pattern, path string) bool {
+	cleaned := filepath.Clean(path)
+	if MatchPath(pattern, cleaned) {
+		return true
+	}
+	// Deny rules also consider the absolute form of a relative path, so
+	// "../../etc/shadow" is still caught by a deny on "/etc/**". (Allow rules
+	// must not do this: relative paths may be resolved against a tool's
+	// workspace dir, not the process working directory.)
+	if ruleType == RuleDeny && !filepath.IsAbs(cleaned) {
+		if abs, err := filepath.Abs(cleaned); err == nil && MatchPath(pattern, abs) {
+			return true
+		}
+	}
+	return false
+}
+
+func matchURLSpecifier(_ RuleType, pattern, urlStr string) bool {
+	return MatchURLSpecifier(pattern, urlStr)
+}
+
+// urlHost returns the lowercased host of a specifier that is unambiguously a
+// URL (http or https scheme), or "" otherwise.
+func urlHost(specifier string) string {
+	u, err := url.Parse(specifier)
+	if err != nil {
+		return ""
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return ""
+	}
+	return strings.ToLower(strings.TrimSuffix(u.Hostname(), "."))
 }
 
 // jsonStringField extracts the first non-empty string value from the given

--- a/permission/permission_test.go
+++ b/permission/permission_test.go
@@ -40,7 +40,7 @@ func TestManager(t *testing.T) {
 		manager := NewManager(config, nil)
 
 		tool := &mockTool{name: "Bash"}
-		call := &llm.ToolUseContent{Name: "Bash", Input: []byte(`{"command": "rm -rf /"}`)}
+		call := &llm.ToolUseContent{Name: "Bash", Input: []byte(`{"command": "rm -rf /tmp/dive-test-no-such-dir"}`)}
 
 		err := manager.EvaluateToolUse(context.Background(), tool, call)
 		assert.NoError(t, err)
@@ -228,7 +228,7 @@ func TestManager(t *testing.T) {
 		manager := NewManager(config, nil)
 
 		tool := &mockTool{name: "Bash"}
-		call := &llm.ToolUseContent{Name: "Bash", Input: []byte(`{"command": "rm -rf /"}`)}
+		call := &llm.ToolUseContent{Name: "Bash", Input: []byte(`{"command": "rm -rf /tmp/dive-test-no-such-dir"}`)}
 
 		err := manager.EvaluateToolUse(context.Background(), tool, call)
 		assert.Error(t, err)
@@ -433,7 +433,7 @@ func TestMatchGlob(t *testing.T) {
 		// Specifier patterns
 		{"go test*", "go test ./...", true},
 		{"go test*", "go build", false},
-		{"rm -rf*", "rm -rf /", true},
+		{"rm -rf*", "rm -rf /tmp/dive-test-no-such-dir", true},
 		{"rm -rf*", "rm foo", false},
 	}
 
@@ -774,7 +774,7 @@ func TestConfirmDialogInput(t *testing.T) {
 }
 
 func TestConfirmAllowSession(t *testing.T) {
-	t.Run("AllowSession adds category to session allowlist", func(t *testing.T) {
+	t.Run("AllowSession grants the exact approved command", func(t *testing.T) {
 		config := &Config{Mode: ModeDefault}
 
 		dialog := &testDialog{showFunc: func(ctx context.Context, in *dive.DialogInput) (*dive.DialogOutput, error) {
@@ -790,10 +790,10 @@ func TestConfirmAllowSession(t *testing.T) {
 		err := manager.EvaluateToolUse(context.Background(), tool, call)
 		assert.NoError(t, err)
 
-		// Category should now be in session allowlist
-		assert.True(t, manager.IsSessionAllowed("bash"))
+		// The grant is scoped, not a broad category grant
+		assert.False(t, manager.IsSessionAllowed("bash"))
 
-		// Second call should skip dialog entirely (session allowed)
+		// Second identical call should skip dialog entirely
 		dialogCalled := false
 		dialog.showFunc = func(ctx context.Context, in *dive.DialogInput) (*dive.DialogOutput, error) {
 			dialogCalled = true
@@ -803,9 +803,15 @@ func TestConfirmAllowSession(t *testing.T) {
 		err = manager.EvaluateToolUse(context.Background(), tool, call)
 		assert.NoError(t, err)
 		assert.False(t, dialogCalled)
+
+		// A different command on the same tool must prompt again
+		otherCall := &llm.ToolUseContent{Name: "Bash", Input: []byte(`{"command": "rm -rf /tmp/dive-test-no-such-dir"}`)}
+		err = manager.EvaluateToolUse(context.Background(), tool, otherCall)
+		assert.NoError(t, err)
+		assert.True(t, dialogCalled)
 	})
 
-	t.Run("AllowSession uses correct category for edit tools", func(t *testing.T) {
+	t.Run("AllowSession grant does not extend to other tools in the category", func(t *testing.T) {
 		config := &Config{Mode: ModeDefault}
 
 		dialog := &testDialog{showFunc: func(ctx context.Context, in *dive.DialogInput) (*dive.DialogOutput, error) {
@@ -814,15 +820,142 @@ func TestConfirmAllowSession(t *testing.T) {
 
 		manager := NewManager(config, dialog)
 
-		tool := &mockTool{name: "Write"}
-		call := &llm.ToolUseContent{Name: "Write", Input: []byte(`{}`)}
+		// Approve a Write call with no extractable specifier (whole-tool grant)
+		writeTool := &mockTool{name: "Write"}
+		writeCall := &llm.ToolUseContent{Name: "Write", Input: []byte(`{}`)}
+		err := manager.EvaluateToolUse(context.Background(), writeTool, writeCall)
+		assert.NoError(t, err)
 
+		// No category grants were created
+		assert.False(t, manager.IsSessionAllowed("edit"))
+
+		// Another tool in the same "edit" category still prompts
+		dialogCalled := false
+		dialog.showFunc = func(ctx context.Context, in *dive.DialogInput) (*dive.DialogOutput, error) {
+			dialogCalled = true
+			return &dive.DialogOutput{Confirmed: true}, nil
+		}
+		editTool := &mockTool{name: "Edit"}
+		editCall := &llm.ToolUseContent{Name: "Edit", Input: []byte(`{}`)}
+		err = manager.EvaluateToolUse(context.Background(), editTool, editCall)
+		assert.NoError(t, err)
+		assert.True(t, dialogCalled)
+
+		// But the approved tool itself is covered
+		dialogCalled = false
+		err = manager.EvaluateToolUse(context.Background(), writeTool, writeCall)
+		assert.NoError(t, err)
+		assert.False(t, dialogCalled)
+	})
+
+	t.Run("AllowSession grants domain scope for WebFetch", func(t *testing.T) {
+		config := &Config{Mode: ModeDefault}
+
+		dialog := &testDialog{showFunc: func(ctx context.Context, in *dive.DialogInput) (*dive.DialogOutput, error) {
+			return &dive.DialogOutput{Confirmed: true, AllowSession: true}, nil
+		}}
+
+		manager := NewManager(config, dialog)
+
+		tool := &mockTool{name: "WebFetch"}
+		call := &llm.ToolUseContent{Name: "WebFetch", Input: []byte(`{"url": "https://example.com/page"}`)}
 		err := manager.EvaluateToolUse(context.Background(), tool, call)
 		assert.NoError(t, err)
 
-		// Write is in the "edit" category
-		assert.True(t, manager.IsSessionAllowed("edit"))
-		assert.False(t, manager.IsSessionAllowed("bash"))
+		// Other URLs on the same domain are covered
+		dialogCalled := false
+		dialog.showFunc = func(ctx context.Context, in *dive.DialogInput) (*dive.DialogOutput, error) {
+			dialogCalled = true
+			return &dive.DialogOutput{Confirmed: true}, nil
+		}
+		sameDomain := &llm.ToolUseContent{Name: "WebFetch", Input: []byte(`{"url": "https://example.com/other"}`)}
+		err = manager.EvaluateToolUse(context.Background(), tool, sameDomain)
+		assert.NoError(t, err)
+		assert.False(t, dialogCalled)
+
+		// A lookalike domain still prompts
+		lookalike := &llm.ToolUseContent{Name: "WebFetch", Input: []byte(`{"url": "https://example.com.attacker.net/"}`)}
+		err = manager.EvaluateToolUse(context.Background(), tool, lookalike)
+		assert.NoError(t, err)
+		assert.True(t, dialogCalled)
+	})
+
+	t.Run("glob characters in an approved command do not widen the grant", func(t *testing.T) {
+		config := &Config{Mode: ModeDefault}
+
+		dialog := &testDialog{showFunc: func(ctx context.Context, in *dive.DialogInput) (*dive.DialogOutput, error) {
+			return &dive.DialogOutput{Confirmed: true, AllowSession: true}, nil
+		}}
+
+		manager := NewManager(config, dialog)
+
+		tool := &mockTool{name: "Bash"}
+		call := &llm.ToolUseContent{Name: "Bash", Input: []byte(`{"command": "rm /tmp/dive-test-no-such-dir/*"}`)}
+		err := manager.EvaluateToolUse(context.Background(), tool, call)
+		assert.NoError(t, err)
+
+		// The * in the approved command was granted literally, not as a
+		// wildcard; a different rm command must still prompt.
+		dialogCalled := false
+		dialog.showFunc = func(ctx context.Context, in *dive.DialogInput) (*dive.DialogOutput, error) {
+			dialogCalled = true
+			return &dive.DialogOutput{Confirmed: true}, nil
+		}
+		other := &llm.ToolUseContent{Name: "Bash", Input: []byte(`{"command": "rm /tmp/dive-test-no-such-dir/other"}`)}
+		err = manager.EvaluateToolUse(context.Background(), tool, other)
+		assert.NoError(t, err)
+		assert.True(t, dialogCalled)
+	})
+}
+
+func TestAllowToolForSession(t *testing.T) {
+	t.Run("pattern grant covers matching commands only", func(t *testing.T) {
+		config := &Config{Mode: ModeDontAsk}
+		manager := NewManager(config, nil)
+		ctx := context.Background()
+
+		tool := &mockTool{name: "Bash"}
+		manager.AllowToolForSession("Bash", "git status*")
+
+		ok := &llm.ToolUseContent{Name: "Bash", Input: []byte(`{"command": "git status --short"}`)}
+		assert.NoError(t, manager.EvaluateToolUse(ctx, tool, ok))
+
+		other := &llm.ToolUseContent{Name: "Bash", Input: []byte(`{"command": "git push"}`)}
+		assert.Error(t, manager.EvaluateToolUse(ctx, tool, other))
+
+		// Compound commands are not covered by an allow-side grant
+		compound := &llm.ToolUseContent{Name: "Bash", Input: []byte(`{"command": "git status; rm -rf /tmp/dive-test-no-such-dir"}`)}
+		assert.Error(t, manager.EvaluateToolUse(ctx, tool, compound))
+	})
+
+	t.Run("empty specifier grants the whole tool", func(t *testing.T) {
+		config := &Config{Mode: ModeDontAsk}
+		manager := NewManager(config, nil)
+		ctx := context.Background()
+
+		manager.AllowToolForSession("Glob", "")
+		tool := &mockTool{name: "Glob"}
+		call := &llm.ToolUseContent{Name: "Glob", Input: []byte(`{"pattern": "*.go"}`)}
+		assert.NoError(t, manager.EvaluateToolUse(ctx, tool, call))
+
+		// Other tools are unaffected
+		readTool := &mockTool{name: "Read"}
+		readCall := &llm.ToolUseContent{Name: "Read", Input: []byte(`{"file_path": "x"}`)}
+		assert.Error(t, manager.EvaluateToolUse(ctx, readTool, readCall))
+	})
+
+	t.Run("ClearSessionAllowlist removes scoped grants", func(t *testing.T) {
+		config := &Config{Mode: ModeDontAsk}
+		manager := NewManager(config, nil)
+		ctx := context.Background()
+
+		manager.AllowToolForSession("Glob", "")
+		tool := &mockTool{name: "Glob"}
+		call := &llm.ToolUseContent{Name: "Glob", Input: []byte(`{}`)}
+		assert.NoError(t, manager.EvaluateToolUse(ctx, tool, call))
+
+		manager.ClearSessionAllowlist()
+		assert.Error(t, manager.EvaluateToolUse(ctx, tool, call))
 	})
 }
 
@@ -999,7 +1132,7 @@ func TestInputMatchRule(t *testing.T) {
 							return false
 						}
 						cmd, _ := m["command"].(string)
-						return cmd == "rm -rf /"
+						return cmd == "rm -rf /tmp/dive-test-no-such-dir"
 					},
 					Message: "dangerous",
 				},
@@ -1010,7 +1143,7 @@ func TestInputMatchRule(t *testing.T) {
 		tool := &mockTool{name: "Bash"}
 
 		// Matching input - should deny
-		call := &llm.ToolUseContent{Name: "Bash", Input: []byte(`{"command": "rm -rf /"}`)}
+		call := &llm.ToolUseContent{Name: "Bash", Input: []byte(`{"command": "rm -rf /tmp/dive-test-no-such-dir"}`)}
 		err := manager.EvaluateToolUse(context.Background(), tool, call)
 		assert.Error(t, err)
 		assert.Equal(t, "dangerous", err.Error())
@@ -1224,7 +1357,7 @@ func TestIntegrationFlow(t *testing.T) {
 		// rm command should be denied by specifier rule
 		err = manager.EvaluateToolUse(ctx,
 			&mockTool{name: "Bash"},
-			&llm.ToolUseContent{Name: "Bash", Input: []byte(`{"command": "rm -rf /"}`)})
+			&llm.ToolUseContent{Name: "Bash", Input: []byte(`{"command": "rm -rf /tmp/dive-test-no-such-dir"}`)})
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "rm commands are not allowed")
 		assert.Equal(t, 0, dialogCalls) // deny rules don't trigger dialog

--- a/permission/security_test.go
+++ b/permission/security_test.go
@@ -1,0 +1,411 @@
+package permission
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/deepnoodle-ai/dive"
+	"github.com/deepnoodle-ai/dive/llm"
+	"github.com/deepnoodle-ai/wonton/assert"
+)
+
+// Regression tests for the 2026-06-09 API review, §1 (permission).
+
+// §1.1: deny rules must be absolute — a session grant must not bypass them.
+func TestDenyBeatsSessionAllowlist(t *testing.T) {
+	t.Run("legacy category grant does not bypass deny", func(t *testing.T) {
+		config := &Config{
+			Mode: ModeDefault,
+			Rules: Rules{
+				DenySpecifierRule("Bash", "*rm -rf*", "Recursive deletion blocked"),
+			},
+		}
+		manager := NewManager(config, nil)
+		manager.AllowForSession("bash")
+
+		tool := &mockTool{name: "Bash"}
+		call := &llm.ToolUseContent{Name: "Bash", Input: []byte(`{"command": "rm -rf /tmp/dive-test-no-such-dir"}`)}
+
+		err := manager.EvaluateToolUse(context.Background(), tool, call)
+		assert.Error(t, err)
+		assert.Equal(t, "Recursive deletion blocked", err.Error())
+
+		// The grant still covers non-denied commands
+		ok := &llm.ToolUseContent{Name: "Bash", Input: []byte(`{"command": "ls"}`)}
+		assert.NoError(t, manager.EvaluateToolUse(context.Background(), tool, ok))
+	})
+
+	t.Run("scoped grant does not bypass deny", func(t *testing.T) {
+		config := &Config{
+			Mode: ModeDefault,
+			Rules: Rules{
+				DenySpecifierRule("Bash", "*rm -rf*", "blocked"),
+			},
+		}
+		manager := NewManager(config, nil)
+		manager.AllowToolForSession("Bash", "")
+
+		tool := &mockTool{name: "Bash"}
+		call := &llm.ToolUseContent{Name: "Bash", Input: []byte(`{"command": "rm -rf /tmp/dive-test-no-such-dir"}`)}
+		err := manager.EvaluateToolUse(context.Background(), tool, call)
+		assert.Error(t, err)
+	})
+
+	t.Run("dialog session approval does not disarm deny rules", func(t *testing.T) {
+		config := &Config{
+			Mode: ModeDefault,
+			Rules: Rules{
+				DenySpecifierRule("Bash", "*rm -rf*", "blocked"),
+			},
+		}
+		dialog := &testDialog{showFunc: func(ctx context.Context, in *dive.DialogInput) (*dive.DialogOutput, error) {
+			return &dive.DialogOutput{Confirmed: true, AllowSession: true}, nil
+		}}
+		manager := NewManager(config, dialog)
+
+		tool := &mockTool{name: "Bash"}
+		benign := &llm.ToolUseContent{Name: "Bash", Input: []byte(`{"command": "ls"}`)}
+		assert.NoError(t, manager.EvaluateToolUse(context.Background(), tool, benign))
+
+		evil := &llm.ToolUseContent{Name: "Bash", Input: []byte(`{"command": "rm -rf /tmp/dive-test-no-such-dir"}`)}
+		err := manager.EvaluateToolUse(context.Background(), tool, evil)
+		assert.Error(t, err)
+		assert.Equal(t, "blocked", err.Error())
+	})
+}
+
+// §1.3: specifier-bearing deny rules fail closed when no specifier can be
+// extracted from the tool input.
+func TestDenyFailsClosed(t *testing.T) {
+	t.Run("unknown tool shape matches deny", func(t *testing.T) {
+		config := &Config{
+			Mode: ModeDefault,
+			Rules: Rules{
+				DenySpecifierRule("CustomExec", "*rm*", "blocked"),
+			},
+		}
+		manager := NewManager(config, nil)
+
+		// CustomExec has no specifier extractor, so the specifier is "".
+		tool := &mockTool{name: "CustomExec"}
+		call := &llm.ToolUseContent{Name: "CustomExec", Input: []byte(`{"program": "rm -rf /tmp/dive-test-no-such-dir"}`)}
+		err := manager.EvaluateToolUse(context.Background(), tool, call)
+		assert.Error(t, err)
+		assert.Equal(t, "blocked", err.Error())
+	})
+
+	t.Run("missing field matches deny", func(t *testing.T) {
+		config := &Config{
+			Mode: ModeDefault,
+			Rules: Rules{
+				DenySpecifierRule("Bash", "rm *", "blocked"),
+			},
+		}
+		manager := NewManager(config, nil)
+
+		tool := &mockTool{name: "Bash"}
+		call := &llm.ToolUseContent{Name: "Bash", Input: []byte(`{"unexpected": "rm -rf /tmp/dive-test-no-such-dir"}`)}
+		err := manager.EvaluateToolUse(context.Background(), tool, call)
+		assert.Error(t, err)
+	})
+
+	t.Run("allow rules still fail open on missing specifier", func(t *testing.T) {
+		config := &Config{
+			Mode: ModeDontAsk,
+			Rules: Rules{
+				AllowSpecifierRule("Bash", "go test*"),
+			},
+		}
+		manager := NewManager(config, nil)
+
+		tool := &mockTool{name: "Bash"}
+		call := &llm.ToolUseContent{Name: "Bash", Input: []byte(`{"unexpected": "go test"}`)}
+		// No specifier extracted: allow rule does not match, dontAsk denies.
+		err := manager.EvaluateToolUse(context.Background(), tool, call)
+		assert.Error(t, err)
+	})
+}
+
+// §1.4: command-aware matching for Bash specifiers.
+func TestCommandAwareMatching(t *testing.T) {
+	t.Run("allow rule does not authorize chained commands", func(t *testing.T) {
+		config := &Config{
+			Mode: ModeDontAsk,
+			Rules: Rules{
+				AllowSpecifierRule("Bash", "go test *"),
+			},
+		}
+		manager := NewManager(config, nil)
+		ctx := context.Background()
+		tool := &mockTool{name: "Bash"}
+
+		allowed := []string{
+			"go test ./...",
+			"go test -v ./permission/",
+		}
+		for _, cmd := range allowed {
+			call := &llm.ToolUseContent{Name: "Bash", Input: []byte(`{"command": "` + cmd + `"}`)}
+			assert.NoError(t, manager.EvaluateToolUse(ctx, tool, call), "expected allow: %s", cmd)
+		}
+
+		denied := []string{
+			"go test ./...; rm -rf /tmp/dive-test-no-such-dir",
+			"go test ./... && rm -rf /tmp/dive-test-no-such-dir",
+			"go test ./... || rm -rf /tmp/dive-test-no-such-dir",
+			"go test ./... | cat",
+			"go test ./... & rm -rf /tmp/dive-test-no-such-dir",
+			"go test $(rm -rf /tmp/dive-test-no-such-dir)",
+			"go test `rm -rf /tmp/dive-test-no-such-dir`",
+			"rm -rf /tmp/dive-test-no-such-dir # go test",
+		}
+		for _, cmd := range denied {
+			call := &llm.ToolUseContent{Name: "Bash", Input: []byte(`{"command": "` + cmd + `"}`)}
+			assert.Error(t, manager.EvaluateToolUse(ctx, tool, call), "expected deny: %s", cmd)
+		}
+
+		// Newline-chained command (JSON-escaped newline)
+		call := &llm.ToolUseContent{Name: "Bash", Input: []byte(`{"command": "go test ./...\nrm -rf /tmp/dive-test-no-such-dir"}`)}
+		assert.Error(t, manager.EvaluateToolUse(ctx, tool, call))
+	})
+
+	t.Run("deny rule is not escaped by newlines or chaining", func(t *testing.T) {
+		config := &Config{
+			Mode: ModeDefault,
+			Rules: Rules{
+				DenySpecifierRule("Bash", "*rm*", "blocked"),
+			},
+		}
+		manager := NewManager(config, nil)
+		ctx := context.Background()
+		tool := &mockTool{name: "Bash"}
+
+		for _, cmd := range []string{
+			"rm -rf /tmp/dive-test-no-such-dir",
+			"ls\nrm -rf /tmp/dive-test-no-such-dir",
+			"ls; rm -rf /tmp/dive-test-no-such-dir",
+			"ls && rm -rf /tmp/dive-test-no-such-dir",
+		} {
+			call := &llm.ToolUseContent{Name: "Bash", Input: []byte(`{"command": ` + jsonQuote(cmd) + `}`)}
+			err := manager.EvaluateToolUse(ctx, tool, call)
+			assert.Error(t, err, "expected deny: %q", cmd)
+		}
+	})
+
+	t.Run("quoted operators do not split", func(t *testing.T) {
+		config := &Config{
+			Mode: ModeDontAsk,
+			Rules: Rules{
+				AllowSpecifierRule("Bash", "echo *"),
+			},
+		}
+		manager := NewManager(config, nil)
+		tool := &mockTool{name: "Bash"}
+		call := &llm.ToolUseContent{Name: "Bash", Input: []byte(`{"command": "echo 'a; b'"}`)}
+		assert.NoError(t, manager.EvaluateToolUse(context.Background(), tool, call))
+	})
+}
+
+// §1.5: path specifiers are cleaned and segment-aware.
+func TestPathSpecifierMatching(t *testing.T) {
+	t.Run("traversal does not escape an allow rule", func(t *testing.T) {
+		config := &Config{
+			Mode: ModeDontAsk,
+			Rules: Rules{
+				AllowSpecifierRule("Read", "/safe/dir/*"),
+			},
+		}
+		manager := NewManager(config, nil)
+		ctx := context.Background()
+		tool := &mockTool{name: "Read"}
+
+		ok := &llm.ToolUseContent{Name: "Read", Input: []byte(`{"file_path": "/safe/dir/file.txt"}`)}
+		assert.NoError(t, manager.EvaluateToolUse(ctx, tool, ok))
+
+		traversal := &llm.ToolUseContent{Name: "Read", Input: []byte(`{"file_path": "/safe/dir/../../etc/shadow"}`)}
+		assert.Error(t, manager.EvaluateToolUse(ctx, tool, traversal))
+
+		// * does not cross directory boundaries; ** is required for that
+		nested := &llm.ToolUseContent{Name: "Read", Input: []byte(`{"file_path": "/safe/dir/sub/file.txt"}`)}
+		assert.Error(t, manager.EvaluateToolUse(ctx, tool, nested))
+	})
+
+	t.Run("double star allows nested paths", func(t *testing.T) {
+		config := &Config{
+			Mode: ModeDontAsk,
+			Rules: Rules{
+				AllowSpecifierRule("Read", "/safe/dir/**"),
+			},
+		}
+		manager := NewManager(config, nil)
+		tool := &mockTool{name: "Read"}
+		call := &llm.ToolUseContent{Name: "Read", Input: []byte(`{"file_path": "/safe/dir/sub/deep/file.txt"}`)}
+		assert.NoError(t, manager.EvaluateToolUse(context.Background(), tool, call))
+	})
+
+	t.Run("deny rule catches relative traversal to an absolute target", func(t *testing.T) {
+		config := &Config{
+			Mode: ModeDefault,
+			Rules: Rules{
+				DenySpecifierRule("Read", "/etc/**", "no reading /etc"),
+			},
+		}
+		manager := NewManager(config, nil)
+		tool := &mockTool{name: "Read"}
+
+		// Enough ../ to reach the root from any cwd, then into /etc.
+		rel := strings.Repeat("../", 64) + "etc/shadow"
+		call := &llm.ToolUseContent{Name: "Read", Input: []byte(`{"file_path": ` + jsonQuote(rel) + `}`)}
+		err := manager.EvaluateToolUse(context.Background(), tool, call)
+		assert.Error(t, err)
+		assert.Equal(t, "no reading /etc", err.Error())
+	})
+}
+
+// §1.6: domain matching is case/trailing-dot tolerant and wired into
+// WebFetch rules.
+func TestURLSpecifierMatching(t *testing.T) {
+	t.Run("domain pattern is not fooled by lookalike hosts", func(t *testing.T) {
+		config := &Config{
+			Mode: ModeDontAsk,
+			Rules: Rules{
+				AllowSpecifierRule("WebFetch", "domain:example.com"),
+			},
+		}
+		manager := NewManager(config, nil)
+		ctx := context.Background()
+		tool := &mockTool{name: "WebFetch"}
+
+		for _, url := range []string{
+			"https://example.com/page",
+			"https://sub.example.com/page",
+			"HTTPS://EXAMPLE.COM/page",
+			"https://example.com./page",
+		} {
+			call := &llm.ToolUseContent{Name: "WebFetch", Input: []byte(`{"url": ` + jsonQuote(url) + `}`)}
+			assert.NoError(t, manager.EvaluateToolUse(ctx, tool, call), "expected allow: %s", url)
+		}
+
+		for _, url := range []string{
+			"https://example.com.attacker.net/",
+			"https://notexample.com/",
+		} {
+			call := &llm.ToolUseContent{Name: "WebFetch", Input: []byte(`{"url": ` + jsonQuote(url) + `}`)}
+			assert.Error(t, manager.EvaluateToolUse(ctx, tool, call), "expected deny: %s", url)
+		}
+	})
+
+	t.Run("bare domain pattern is treated as a domain match", func(t *testing.T) {
+		config := &Config{
+			Mode: ModeDontAsk,
+			Rules: Rules{
+				AllowSpecifierRule("WebFetch", "example.com"),
+			},
+		}
+		manager := NewManager(config, nil)
+		tool := &mockTool{name: "WebFetch"}
+
+		ok := &llm.ToolUseContent{Name: "WebFetch", Input: []byte(`{"url": "https://api.example.com/v1"}`)}
+		assert.NoError(t, manager.EvaluateToolUse(context.Background(), tool, ok))
+
+		bad := &llm.ToolUseContent{Name: "WebFetch", Input: []byte(`{"url": "https://example.com.evil.io/"}`)}
+		assert.Error(t, manager.EvaluateToolUse(context.Background(), tool, bad))
+	})
+
+	t.Run("deny by domain is not escaped by case or trailing dot", func(t *testing.T) {
+		config := &Config{
+			Mode: ModeDefault,
+			Rules: Rules{
+				DenySpecifierRule("WebFetch", "domain:internal.corp", "internal hosts blocked"),
+			},
+		}
+		manager := NewManager(config, nil)
+		tool := &mockTool{name: "WebFetch"}
+
+		for _, url := range []string{
+			"https://internal.corp/secrets",
+			"HTTPS://INTERNAL.CORP/secrets",
+			"https://internal.corp./secrets",
+			"https://api.internal.corp/secrets",
+		} {
+			call := &llm.ToolUseContent{Name: "WebFetch", Input: []byte(`{"url": ` + jsonQuote(url) + `}`)}
+			assert.Error(t, manager.EvaluateToolUse(context.Background(), tool, call), "expected deny: %s", url)
+		}
+	})
+}
+
+func TestSplitCommand(t *testing.T) {
+	tests := []struct {
+		command  string
+		segments []string
+		hasSub   bool
+	}{
+		{"ls", []string{"ls"}, false},
+		{"ls -la /tmp", []string{"ls -la /tmp"}, false},
+		{"ls; rm -rf /tmp/dive-test-no-such-dir", []string{"ls", "rm -rf /tmp/dive-test-no-such-dir"}, false},
+		{"ls && rm -rf /tmp/dive-test-no-such-dir", []string{"ls", "rm -rf /tmp/dive-test-no-such-dir"}, false},
+		{"ls || rm -rf /tmp/dive-test-no-such-dir", []string{"ls", "rm -rf /tmp/dive-test-no-such-dir"}, false},
+		{"ls | grep foo", []string{"ls", "grep foo"}, false},
+		{"ls & rm -rf /tmp/dive-test-no-such-dir", []string{"ls", "rm -rf /tmp/dive-test-no-such-dir"}, false},
+		{"ls\nrm -rf /tmp/dive-test-no-such-dir", []string{"ls", "rm -rf /tmp/dive-test-no-such-dir"}, false},
+		{"echo 'a; b'", []string{"echo 'a; b'"}, false},
+		{`echo "a && b"`, []string{`echo "a && b"`}, false},
+		{`echo a\;b`, []string{`echo a\;b`}, false},
+		{"echo $(whoami)", []string{"echo $(whoami)"}, true},
+		{"echo `whoami`", []string{"echo `whoami`"}, true},
+		{`echo "$(whoami)"`, []string{`echo "$(whoami)"`}, true},
+		{"echo '$(whoami)'", []string{"echo '$(whoami)'"}, false},
+		{"diff <(ls a) b", []string{"diff <(ls a) b"}, true},
+		{"echo $HOME", []string{"echo $HOME"}, false},
+		{"", nil, false},
+		{"  ;  ; ", nil, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.command, func(t *testing.T) {
+			segments, hasSub := SplitCommand(tt.command)
+			assert.Equal(t, tt.segments, segments)
+			assert.Equal(t, tt.hasSub, hasSub)
+		})
+	}
+}
+
+func TestMatchCommand(t *testing.T) {
+	t.Run("allow", func(t *testing.T) {
+		assert.True(t, MatchCommandAllow("go test *", "go test ./..."))
+		assert.False(t, MatchCommandAllow("go test *", "go test ./...; rm -rf /tmp/dive-test-no-such-dir"))
+		assert.False(t, MatchCommandAllow("go test *", "go test $(rm -rf /tmp/dive-test-no-such-dir)"))
+		assert.False(t, MatchCommandAllow("go test *", ""))
+		// Both segments must match the pattern
+		assert.True(t, MatchCommandAllow("git *", "git fetch && git status"))
+		assert.False(t, MatchCommandAllow("git *", "cd /tmp && git status"))
+	})
+
+	t.Run("deny", func(t *testing.T) {
+		assert.True(t, MatchCommandDeny("rm *", "rm -rf /tmp/dive-test-no-such-dir"))
+		assert.True(t, MatchCommandDeny("rm *", "ls; rm -rf /tmp/dive-test-no-such-dir"))
+		assert.True(t, MatchCommandDeny("*rm*", "ls\nrm -rf /tmp/dive-test-no-such-dir"))
+		assert.False(t, MatchCommandDeny("rm *", "ls -la"))
+	})
+}
+
+func TestMatchURLSpecifier(t *testing.T) {
+	// domain: prefix
+	assert.True(t, MatchURLSpecifier("domain:example.com", "https://example.com/x"))
+	assert.True(t, MatchURLSpecifier("domain:example.com", "https://a.example.com/x"))
+	assert.False(t, MatchURLSpecifier("domain:example.com", "https://example.com.evil.net/x"))
+
+	// bare domain
+	assert.True(t, MatchURLSpecifier("example.com", "https://example.com/x"))
+	assert.False(t, MatchURLSpecifier("example.com", "https://example.com.evil.net/x"))
+
+	// glob fallback for patterns with wildcards or paths
+	assert.True(t, MatchURLSpecifier("https://example.com/api/*", "https://example.com/api/users"))
+	assert.False(t, MatchURLSpecifier("https://example.com/api/*", "https://example.com/admin"))
+}
+
+// jsonQuote returns s as a JSON string literal.
+func jsonQuote(s string) string {
+	b, _ := json.Marshal(s)
+	return string(b)
+}


### PR DESCRIPTION
## Summary

Addresses **all of section 1 (permission — security-critical)** of the 2026-06-09 API review (`docs/reviews/2026-06-09-api-review.md`). Until now the `permission` package was advisory: deny rules were bypassable four independent ways. This PR makes deny rules absolute and matching evasion-resistant.

### §1.1 CRITICAL — Session allowlist bypassed deny rules ✅
`EvaluateToolUse` now evaluates **deny rules first**, before the session allowlist. New order:

```
Deny Rules -> Session Allowlist -> Allow Rules -> Ask Rules -> Mode -> Default (confirm)
```

The review's exact reproduction (`DenySpecifierRule("Bash", "*rm -rf*")` + prior `AllowForSession("bash")` allowing `rm -rf /`) is now a regression test.

### §1.2 CRITICAL — Category-scoped session grants ✅
Dialog "allow for session" approvals now grant **(tool, specifier)** scope instead of a substring-matched category:
- Bash / file tools: the exact approved command/path (compared by **equality**, so glob characters in an approved command can't widen the grant)
- WebFetch: the URL's domain (`domain:<host>`)
- No extractable specifier: that tool only — never a category

New `AllowToolForSession(tool, pattern)` for programmatic scoped grants (e.g. `"git status*"`). `AllowForSession`/`IsSessionAllowed` are deprecated but still honored for back-compat; dialog approvals no longer create category grants. The experimental CLI's "allow all X this session" label now describes the actual grant scope via `Manager.SessionGrantLabel`.

### §1.3 HIGH — Deny rules fail closed on unextractable specifiers ✅
A specifier-bearing deny rule now **matches** when no specifier can be extracted (unknown tool shape, missing field, unparsable JSON — including the `InputMatch` path). Allow/ask rules still fail open.

### §1.4 HIGH — Command-aware Bash matching ✅
New `SplitCommand` (quote-aware) + `MatchCommandAllow`/`MatchCommandDeny`, wired in as the default Bash specifier matcher:
- **Allow**: every segment split on unquoted `;` `&&` `||` `|` `&` / newlines must match; command/process substitution (`$(...)`, backticks, `<(...)`) never matches. `Bash(go test *)` no longer authorizes `go test ./...; rm -rf /`.
- **Deny**: matches the full command **or any segment**, and glob `.` now matches newlines (`(?s)`), so `Bash(*rm*)` catches newline-separated payloads.

### §1.5 HIGH — Path specifier normalization ✅
Read/Write/Edit specifiers are `filepath.Clean`ed and matched with segment-aware `MatchPath`: `/safe/dir/../../etc/shadow` no longer matches `Read(/safe/dir/*)`, and `*` no longer crosses `/` (use `**`). Deny rules also match the absolutized form of relative paths (`../../etc/shadow` is caught by `Read(/etc/**)`).

### §1.6 MEDIUM — Domain matching fixed and wired in ✅
`MatchDomain` is now case-insensitive and trailing-dot tolerant (`HTTPS://EXAMPLE.COM.` matches `example.com`). New `MatchURLSpecifier` is the default WebFetch matcher: `domain:example.com` or bare-domain patterns match the host (exact/subdomain), so lookalikes like `https://example.com.attacker.net` no longer slip past; wildcard/path patterns still glob the full URL.

All matching dispatches per tool through `DefaultSpecifierMatchers`, overridable via `Config.SpecifierMatchers` (new `SpecifierMatcherFunc` is rule-type-aware so deny can be generous while allow stays strict).

## Behavior changes (intentional, security-motivated)

- Deny rules beat session grants (previously inverted).
- Path rules: `*` stays within one path segment; existing rules relying on `*` crossing `/` need `**`.
- Bash allow rules no longer match compound commands; a compound command must have **all** segments matched by a single rule, otherwise it falls through to ask.
- Dialog session approvals create scoped grants; `IsSessionAllowed(category)` no longer reflects them.
- Bare-domain WebFetch patterns (no wildcards/scheme/path) are now domain matches, not globs.

## Documented open issues (deliberately out of scope)

- **§8.1 structural redesign** (typed per-kind matchers as rule fields, retiring the single glob string, retiring `GetToolCategory`) — next-major work; this PR fixes the semantics behind the existing API.
- **Symlinks are not resolved** in path matching — a deny on `/etc/**` can be evaded via a symlink elsewhere. Filesystem-level enforcement belongs to the toolkit's workspace validation (`PathValidator`); documented in the guide.
- **Cross-rule compound-command allow** (segments individually covered by *different* allow rules) falls through to ask rather than allowing — conservative by design; revisit if it causes prompt fatigue.

## Testing

- New `security_test.go` with regression tests keyed to each review finding (§1.1–§1.6), including the review's exact reproductions, plus unit tests for `SplitCommand`, `MatchCommandAllow/Deny`, and `MatchURLSpecifier`.
- Destructive-looking command literals in tests use a nonexistent path (`/tmp/dive-test-no-such-dir`) so they'd be harmless even if ever executed.
- `go test ./...` passes across the repo; experimental CLI builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Permissions guide expanded with clarified deny-rule behavior and detailed specifier-matching explanations.

* **Bug Fixes**
  * Deny rules are now absolute and cannot be bypassed by session grants or permission modes.
  * Session grants now scope to approved values (commands, paths, domains) rather than entire categories.
  * Permission dialog labels improved for accuracy.

* **New Features**
  * Enhanced command parsing with proper quote and escape-sequence handling.
  * Improved URL/domain matching: case-insensitive and trailing-dot tolerant.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->