### PR TITLE
Prepare v1.8.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,112 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [1.8.0] - 2026-06-09
+
+### Added
+
+- **Claude Fable 5 / Mythos 5** — new `ModelClaudeFable5` and
+  `ModelClaudeMythos5` constants with pricing (1M context / 128k output),
+  adaptive-thinking and native-effort support (all five levels including
+  `xhigh`/`max`), an OpenRouter `anthropic/claude-fable-5` ID, and a CLI
+  model-picker entry for Fable 5. The Anthropic default stays
+  `claude-opus-4-8`.
+- **`SequentialOnlyHint` tool annotation** — a tool that mutates shared state
+  can opt out of parallel execution; any batch containing such a tool runs
+  sequentially even when `ParallelToolExecution` is enabled.
+- **Scoped session permission grants** — `AllowToolForSession(tool, pattern)`
+  grants (tool, specifier)-scoped session approvals. Dialog approvals now
+  grant the exact approved command/path (or WebFetch domain) instead of a
+  whole tool category; `AllowForSession`/`IsSessionAllowed` are deprecated but
+  still honored.
+- **Partial-work error reporting** — a mid-turn LLM failure now returns
+  `*GenerationError` carrying the accumulated `Usage`, `OutputMessages`, and
+  `Items` (recover via `errors.As`). New sentinels: `ErrReentrantSession` (a
+  tool calling back into its own session fails fast instead of deadlocking)
+  and `ErrSessionNotSuspended` (resume against a non-suspended session is
+  detected before the LLM call, not after).
+- **Demos** — `demos/colosseum` (agent tournament arena with A2A remote
+  players) and `demos/noodleville` (agent-driven village simulation).
+
+### Security
+
+- **Permission deny rules are now absolute** — deny rules evaluate before the
+  session allowlist, and specifier-bearing deny rules fail closed when no
+  specifier can be extracted. Bash patterns match per command segment,
+  quote-aware (`Bash(go test *)` no longer authorizes
+  `go test ./...; rm -rf /`; command substitution never matches an allow
+  rule). File path specifiers are cleaned and segment-aware (`*` no longer
+  crosses `/`; `..` traversal can't escape an allowed prefix), and WebFetch
+  patterns match the real URL host so lookalike domains don't pass. Matching
+  dispatches per tool through `DefaultSpecifierMatchers`, overridable via
+  `Config.SpecifierMatchers`.
+- **Skill hardening** — `!{...}` shell expansion runs against the raw template
+  before argument substitution, so model-controlled arguments can't inject
+  commands (`$1`–`$9`/`$ARGUMENTS` are passed to the shell as data); the Skill
+  tool can no longer invoke user-invocable-only commands hidden from the
+  catalog; `allowed-tools` is documented as informational only.
+- **Toolkit fail-closed** — the file tools now return their workspace
+  validator construction error instead of silently granting unrestricted
+  filesystem access; Fetch's SSRF protection validates the IP actually dialed
+  after DNS resolution (closing the DNS-rebinding window); Glob/Grep default
+  excludes now match top-level directories like `node_modules/`.
+
+### Changed
+
+- **A2A final-answer extraction** — the server emits a single final artifact
+  built from the last renderable assistant message (previously one artifact
+  per message), and `RemoteAgent` extracts the latest artifact, so
+  `TaskResult.Text` is the final answer rather than a tool-use preamble.
+  Intermediate messages still stream as `working` status updates.
+- **FileStore session aliasing** — `FileStore` caches the live `*Session` per
+  ID, so every `Open` of the same ID returns the same shared, synchronized
+  instance (fixes double-Open divergence that could silently delete turns on
+  disk).
+- **`settings.local.json` deep-merges** with `settings.json` instead of
+  shadowing it: objects merge per key (local wins), arrays replace wholesale,
+  and scalar keys present in the local file win.
+- **OpenAI `WithMaxRetries`** is now the single retry knob: it configures
+  Dive's retry loop and SDK-internal retries are disabled, eliminating
+  double-retry amplification (up to 9 requests per persistent error). Also
+  applies to Grok.
+
+### Fixed
+
+- **Agent loop** — data race on the response-item accumulator under parallel
+  tool execution; extension `PostBackgroundToolUse` hooks were silently
+  dropped; a PostToolUse hook setting `Result = nil` no longer panics or
+  orphans the tool_use block; injected background-results messages are now
+  persisted to the session; hook `Messages`/`Iteration` refresh every loop
+  iteration; SessionStart hook `Values` are visible to later hooks; the
+  per-session lock is context-aware.
+- **Suspend/resume** — `WithResume` on a session-backed agent no longer drops
+  prior history; suspend-phase usage now accumulates into `TotalUsage()`;
+  sessions deep-copy messages on ingestion so later caller mutations can't
+  rewrite stored history; resume tool-result merges are deterministic and
+  survive message-replacing PreGeneration hooks.
+- **Session durability** — a torn final JSONL line no longer makes a FileStore
+  session permanently unreadable (healed on open); removed the 1 MB read cap
+  that broke sessions containing large events; fixed `Put`/`List` races; an
+  unrecognized header line no longer triggers a destructive overwrite.
+- **Providers** — openaicompletions streaming no longer reports zero token
+  usage (Mistral, OpenRouter); OpenAI stream content-block indices are no
+  longer off by one; Anthropic web-search error results decode instead of
+  failing the whole response; the Google stream iterator now emits usage, stop
+  reason, sequential indices, and parallel tool calls, with unique synthetic
+  tool-call IDs and no stdout debug logging; 502/529 are retryable while
+  permanent errors are no longer retried in openaicompletions; cached and
+  reasoning token details are parsed across providers; Anthropic no longer
+  mutates caller-owned messages; registry routing of `/`-containing model IDs
+  reaches the OpenRouter matcher.
+- **Toolkit** — Grep `offset` and `-n` are honored (working pagination and
+  line numbers on both search paths); Bash scanner failures return an error
+  instead of silently truncating output; ReadFile offset/limit reads handle
+  long lines; TextEditor's unbounded, racy file history was removed.
+- **MCP (experimental)** — `Client.Close` actually closes the underlying
+  client (no more subprocess leaks); the HTTP transport sends configured auth
+  headers; a second OAuth flow no longer panics and the configured token store
+  is honored; `RefreshTools` cleans up server-side-removed tools.
+
 ## [1.7.0] - 2026-05-29
 
 ### Added

--- a/a2a/go.mod
+++ b/a2a/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/a2aproject/a2a-go/v2 v2.2.0
-	github.com/deepnoodle-ai/dive v1.7.0
+	github.com/deepnoodle-ai/dive v1.8.0
 	github.com/deepnoodle-ai/wonton v0.0.34
 )
 

--- a/demos/colosseum/go.mod
+++ b/demos/colosseum/go.mod
@@ -4,9 +4,9 @@ go 1.25.0
 
 require (
 	github.com/deepnoodle-ai/dive v1.8.0
-	github.com/deepnoodle-ai/dive/a2a v1.6.0
-	github.com/deepnoodle-ai/dive/providers/google v1.6.0
-	github.com/deepnoodle-ai/dive/providers/grok v1.6.0
+	github.com/deepnoodle-ai/dive/a2a v1.8.0
+	github.com/deepnoodle-ai/dive/providers/google v1.8.0
+	github.com/deepnoodle-ai/dive/providers/grok v1.8.0
 	github.com/deepnoodle-ai/dive/providers/openai v1.8.0
 	github.com/deepnoodle-ai/wonton v0.0.34
 )

--- a/demos/colosseum/go.mod
+++ b/demos/colosseum/go.mod
@@ -3,11 +3,11 @@ module github.com/deepnoodle-ai/dive/demos/colosseum
 go 1.25.0
 
 require (
-	github.com/deepnoodle-ai/dive v1.7.0
+	github.com/deepnoodle-ai/dive v1.8.0
 	github.com/deepnoodle-ai/dive/a2a v1.6.0
 	github.com/deepnoodle-ai/dive/providers/google v1.6.0
 	github.com/deepnoodle-ai/dive/providers/grok v1.6.0
-	github.com/deepnoodle-ai/dive/providers/openai v1.7.0
+	github.com/deepnoodle-ai/dive/providers/openai v1.8.0
 	github.com/deepnoodle-ai/wonton v0.0.34
 )
 

--- a/demos/noodleville/go.mod
+++ b/demos/noodleville/go.mod
@@ -3,7 +3,7 @@ module github.com/deepnoodle-ai/dive/demos/noodleville
 go 1.25.0
 
 require (
-	github.com/deepnoodle-ai/dive v1.7.0
+	github.com/deepnoodle-ai/dive v1.8.0
 	github.com/deepnoodle-ai/wonton v0.0.34
 )
 

--- a/examples/go.mod
+++ b/examples/go.mod
@@ -3,13 +3,13 @@ module github.com/deepnoodle-ai/dive/examples
 go 1.25.0
 
 require (
-	github.com/deepnoodle-ai/dive v1.7.0
+	github.com/deepnoodle-ai/dive v1.8.0
 	github.com/deepnoodle-ai/dive/a2a v1.7.0
-	github.com/deepnoodle-ai/dive/experimental/mcp v1.7.0
-	github.com/deepnoodle-ai/dive/otel v1.7.0
-	github.com/deepnoodle-ai/dive/providers/google v1.7.0
-	github.com/deepnoodle-ai/dive/providers/grok v1.7.0
-	github.com/deepnoodle-ai/dive/providers/openai v1.7.0
+	github.com/deepnoodle-ai/dive/experimental/mcp v1.8.0
+	github.com/deepnoodle-ai/dive/otel v1.8.0
+	github.com/deepnoodle-ai/dive/providers/google v1.8.0
+	github.com/deepnoodle-ai/dive/providers/grok v1.8.0
+	github.com/deepnoodle-ai/dive/providers/openai v1.8.0
 	github.com/deepnoodle-ai/wonton v0.0.34
 	github.com/fatih/color v1.18.0
 	github.com/mark3labs/mcp-go v0.45.0

--- a/examples/go.mod
+++ b/examples/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/deepnoodle-ai/dive v1.8.0
-	github.com/deepnoodle-ai/dive/a2a v1.7.0
+	github.com/deepnoodle-ai/dive/a2a v1.8.0
 	github.com/deepnoodle-ai/dive/experimental/mcp v1.8.0
 	github.com/deepnoodle-ai/dive/otel v1.8.0
 	github.com/deepnoodle-ai/dive/providers/google v1.8.0

--- a/experimental/cmd/dive/go.mod
+++ b/experimental/cmd/dive/go.mod
@@ -3,10 +3,10 @@ module github.com/deepnoodle-ai/dive/experimental/cmd/dive
 go 1.25.0
 
 require (
-	github.com/deepnoodle-ai/dive v1.7.0
-	github.com/deepnoodle-ai/dive/providers/google v1.7.0
-	github.com/deepnoodle-ai/dive/providers/grok v1.7.0
-	github.com/deepnoodle-ai/dive/providers/openai v1.7.0
+	github.com/deepnoodle-ai/dive v1.8.0
+	github.com/deepnoodle-ai/dive/providers/google v1.8.0
+	github.com/deepnoodle-ai/dive/providers/grok v1.8.0
+	github.com/deepnoodle-ai/dive/providers/openai v1.8.0
 	github.com/deepnoodle-ai/wonton v0.0.34
 	github.com/mattn/go-runewidth v0.0.21
 )

--- a/experimental/mcp/go.mod
+++ b/experimental/mcp/go.mod
@@ -3,7 +3,7 @@ module github.com/deepnoodle-ai/dive/experimental/mcp
 go 1.25.0
 
 require (
-	github.com/deepnoodle-ai/dive v1.7.0
+	github.com/deepnoodle-ai/dive v1.8.0
 	github.com/deepnoodle-ai/wonton v0.0.34
 	github.com/mark3labs/mcp-go v0.45.0
 )

--- a/otel/go.mod
+++ b/otel/go.mod
@@ -3,7 +3,7 @@ module github.com/deepnoodle-ai/dive/otel
 go 1.25.0
 
 require (
-	github.com/deepnoodle-ai/dive v1.7.0
+	github.com/deepnoodle-ai/dive v1.8.0
 	go.opentelemetry.io/otel v1.43.0
 	go.opentelemetry.io/otel/metric v1.43.0
 	go.opentelemetry.io/otel/sdk v1.43.0

--- a/providers/google/go.mod
+++ b/providers/google/go.mod
@@ -3,7 +3,7 @@ module github.com/deepnoodle-ai/dive/providers/google
 go 1.25.0
 
 require (
-	github.com/deepnoodle-ai/dive v1.7.0
+	github.com/deepnoodle-ai/dive v1.8.0
 	github.com/deepnoodle-ai/wonton v0.0.34
 	google.golang.org/genai v1.51.0
 )

--- a/providers/grok/go.mod
+++ b/providers/grok/go.mod
@@ -3,8 +3,8 @@ module github.com/deepnoodle-ai/dive/providers/grok
 go 1.25.0
 
 require (
-	github.com/deepnoodle-ai/dive v1.7.0
-	github.com/deepnoodle-ai/dive/providers/openai v1.7.0
+	github.com/deepnoodle-ai/dive v1.8.0
+	github.com/deepnoodle-ai/dive/providers/openai v1.8.0
 	github.com/deepnoodle-ai/wonton v0.0.34
 	github.com/openai/openai-go/v3 v3.29.0
 	golang.org/x/image v0.38.0

--- a/providers/openai/go.mod
+++ b/providers/openai/go.mod
@@ -3,7 +3,7 @@ module github.com/deepnoodle-ai/dive/providers/openai
 go 1.25.0
 
 require (
-	github.com/deepnoodle-ai/dive v1.7.0
+	github.com/deepnoodle-ai/dive v1.8.0
 	github.com/deepnoodle-ai/wonton v0.0.34
 	github.com/openai/openai-go/v3 v3.29.0
 	golang.org/x/image v0.38.0


### PR DESCRIPTION
## Summary

Release prep for **v1.8.0**, following the same pattern as #174 / #178:

- Add the `[1.8.0] - 2026-06-09` CHANGELOG entry covering everything since v1.7.0 (#179–#194):
  - **Added**: Claude Fable 5 / Mythos 5 model support (#180), `SequentialOnlyHint` tool annotation (#166), scoped session permission grants (#194), partial-work error reporting via `GenerationError` + new sentinels (#192, #189), Colosseum and Noodleville demos (#179)
  - **Security**: permission deny-first precedence and evasion-resistant matching (#194), skill expansion-injection and hidden-command hardening (#191), toolkit fail-closed workspace validation + SSRF dial pinning (#182, #190)
  - **Changed**: A2A final-answer extraction (#188), FileStore session aliasing (#187), `settings.local.json` deep-merge (#188), OpenAI single-layer retries (#193)
  - **Fixed**: agent-loop races and hook fixes (#186, #192), suspend/resume semantics (#189), session durability (#181), provider streaming/usage/retry correctness (#183, #185, #193), toolkit grep/bash/read fixes (#190), MCP client lifecycle (#184)
- Bump intra-repo module version references from v1.7.0 to v1.8.0 across all 8 sub-modules plus the two demos, and run `make tidy-all`.

## Verification

- `go build ./...` and `go test ./...` pass on the root module and on `providers/google`, `providers/openai`, `providers/grok`, `a2a`, `otel`, `experimental/mcp`, `experimental/cmd/dive`, `examples`, and both demos.

## After merge

```
git checkout main && git pull
git tag v1.8.0
make tag-modules VERSION=v1.8.0
git push origin --tags
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Claude Fable/Mythos 5 models with CLI picker
  * Introduced scoped session permission grants and partial-work error reporting
  * Added new demos

* **Security**
  * Hardened shell expansion, file access behavior, and SSRF protection
  * Enhanced deny-rule evaluation and pattern matching

* **Changes**
  * Updated agent loop behavior, session aliasing, and settings merge semantics
  * Consolidated retry configuration

* **Bug Fixes**
  * Fixed issues with agent concurrency, session durability, provider streaming, and toolkit behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->