### PR TITLE
Patch v1.8.1: background context cancellation, CLI temperature zero-value, Claude 5 temperature rejection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [1.8.1] - 2026-06-09
+
+### Fixed
+
+- **Background task cancellation** — background goroutines spawned by tools
+  were prematurely cancelled when their tool batch completed, because they
+  inherited the batch-scoped `childCtx`. They now receive the outer
+  `CreateResponse` context via a new `withBackgroundCtx`/`backgroundCtxFrom`
+  helper, so background tasks live for the full agent turn.
+- **CLI temperature zero-value** — the `--temperature` flag was always written
+  to `ModelSettings.Temperature` (even when not set), forcing every request to
+  `temperature=0`. The CLI now uses `ctx.IsSet("temperature")` and only sets
+  the field when the flag is explicitly provided.
+- **Claude 5 temperature rejection** — Fable 5 and Mythos 5 reject the
+  temperature parameter at the API level. The Anthropic provider now skips
+  setting temperature for these models, and logs a warning when a non-nil
+  temperature is silently dropped.
+
 ## [1.8.0] - 2026-06-09
 
 ### Added

--- a/agent.go
+++ b/agent.go
@@ -2143,6 +2143,12 @@ func (a *Agent) executeToolCallsParallel(
 	childCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
+	// Store the outer ctx so background goroutines started by tools can use it
+	// via backgroundCtxFrom. The batch-level cancel fires when runToolBatch
+	// returns, which would prematurely cancel background tasks if they used
+	// childCtx directly.
+	childCtx = withBackgroundCtx(childCtx, ctx)
+
 	// Phase 1: PreToolUse hooks (sequential)
 	preps := make([]toolCallPrep, len(toolCalls))
 	for i, toolCall := range toolCalls {

--- a/background.go
+++ b/background.go
@@ -11,6 +11,28 @@ import (
 	"github.com/google/uuid"
 )
 
+// backgroundCtxKey is the context key used to propagate a long-lived context
+// for background goroutines. The tool execution context is cancelled as soon as
+// the tool batch completes; background goroutines need a context tied to the
+// outer CreateResponse call, not the batch.
+type backgroundCtxKey struct{}
+
+// withBackgroundCtx stores the outer (pre-batch-cancel) context so that
+// newBackgroundResult can retrieve it. Called by runToolBatch in agent.go.
+func withBackgroundCtx(ctx, outer context.Context) context.Context {
+	return context.WithValue(ctx, backgroundCtxKey{}, outer)
+}
+
+// backgroundCtxFrom returns the background-safe context stored by
+// withBackgroundCtx, falling back to ctx if none was stored (e.g. in tests
+// that construct tool contexts directly).
+func backgroundCtxFrom(ctx context.Context) context.Context {
+	if val := ctx.Value(backgroundCtxKey{}); val != nil {
+		return val.(context.Context)
+	}
+	return ctx
+}
+
 // backgroundResult is the internal state carried on ToolResult.Background.
 // Tool authors do not construct this directly; they use NewBackgroundResult or
 // NewBackgroundResultFull.
@@ -90,13 +112,18 @@ func newBackgroundResult(ctx context.Context, description string, fn func(ctx co
 	ch := make(chan *ToolResult, 1)
 	id := uuid.New().String()
 
+	// Use the outer (pre-batch-cancel) context so the goroutine lives past
+	// the end of the tool batch. backgroundCtxFrom falls back to ctx when no
+	// outer context was injected (e.g. in unit tests).
+	bgCtx := backgroundCtxFrom(ctx)
+
 	go func() {
 		defer func() {
 			if r := recover(); r != nil {
 				ch <- NewToolResultError(fmt.Sprintf("background task panicked: %v\n%s", r, debug.Stack()))
 			}
 		}()
-		result := fn(ctx)
+		result := fn(bgCtx)
 		if result == nil {
 			result = NewToolResultText("")
 		}

--- a/experimental/cmd/dive/main.go
+++ b/experimental/cmd/dive/main.go
@@ -323,19 +323,22 @@ func runInteractive(ctx *cli.Context) error {
 	}
 
 	// Create model settings
-	temperature := ctx.Float64("temperature")
 	maxTokens := ctx.Int("max-tokens")
+	modelSettings := &dive.ModelSettings{
+		MaxTokens: &maxTokens,
+	}
+	if ctx.IsSet("temperature") {
+		t := ctx.Float64("temperature")
+		modelSettings.Temperature = &t
+	}
 
 	// Create agent options with hooks and extensions
 	agentOpts := dive.AgentOptions{
-		SystemPrompt: systemPrompt,
-		Model:        model,
-		Tools:        tools,
-		Extensions:   []dive.Extension{skills},
-		ModelSettings: &dive.ModelSettings{
-			Temperature: &temperature,
-			MaxTokens:   &maxTokens,
-		},
+		SystemPrompt:  systemPrompt,
+		Model:         model,
+		Tools:         tools,
+		Extensions:    []dive.Extension{skills},
+		ModelSettings: modelSettings,
 		Hooks: dive.Hooks{
 			PreToolUse: []dive.PreToolUseHook{permissionHook},
 		},
@@ -492,17 +495,20 @@ func runPrint(ctx *cli.Context) error {
 	tools = append(tools, grokServerSideTools(modelName)...)
 
 	// Create agent
-	temperature := ctx.Float64("temperature")
 	maxTokens := ctx.Int("max-tokens")
+	printModelSettings := &dive.ModelSettings{
+		MaxTokens: &maxTokens,
+	}
+	if ctx.IsSet("temperature") {
+		t := ctx.Float64("temperature")
+		printModelSettings.Temperature = &t
+	}
 
 	agent, err := dive.NewAgent(dive.AgentOptions{
-		SystemPrompt: systemPrompt,
-		Model:        model,
-		Tools:        tools,
-		ModelSettings: &dive.ModelSettings{
-			Temperature: &temperature,
-			MaxTokens:   &maxTokens,
-		},
+		SystemPrompt:  systemPrompt,
+		Model:         model,
+		Tools:         tools,
+		ModelSettings: printModelSettings,
 	})
 	if err != nil {
 		return fmt.Errorf("failed to create agent: %w", err)

--- a/providers/anthropic/anthropic.go
+++ b/providers/anthropic/anthropic.go
@@ -388,7 +388,12 @@ func (p *Provider) applyRequestConfig(req *Request, config *llm.Config) error {
 		req.ContextManagement = config.ContextManagement
 	}
 
-	req.Temperature = config.Temperature
+	if !modelRejectsTemperature(req.Model) {
+		req.Temperature = config.Temperature
+	} else if config.Temperature != nil && config.Logger != nil {
+		config.Logger.Warn("temperature is not supported by this model and will be ignored",
+			"model", req.Model)
+	}
 	req.System = config.SystemPrompt
 	return nil
 }
@@ -553,6 +558,13 @@ func modelSupportsMaxEffort(model string) bool {
 		strings.HasPrefix(model, "claude-opus-4-8") ||
 		strings.HasPrefix(model, "claude-sonnet-4-6") ||
 		strings.HasPrefix(model, "claude-fable-5") ||
+		strings.HasPrefix(model, "claude-mythos-5")
+}
+
+// modelRejectsTemperature reports whether the model rejects the temperature
+// parameter (Claude 5 models: Fable 5, Mythos 5).
+func modelRejectsTemperature(model string) bool {
+	return strings.HasPrefix(model, "claude-fable-5") ||
 		strings.HasPrefix(model, "claude-mythos-5")
 }
 


### PR DESCRIPTION
## Summary

Patch release fixing three bugs found in v1.8.0:

- **Background task cancellation** — background goroutines spawned by tools were prematurely cancelled when the tool batch completed, because they used the batch-scoped `childCtx`. A new `withBackgroundCtx`/`backgroundCtxFrom` helper stores the outer `CreateResponse` context so background tasks survive the full agent turn (`agent.go`, `background.go`).
- **CLI temperature zero-value** — `--temperature` was always written to `ModelSettings.Temperature`, forcing `temperature=0` on every request even when the user didn't pass the flag. Now uses `ctx.IsSet("temperature")` to only set the field when explicitly provided (`experimental/cmd/dive/main.go`).
- **Claude 5 temperature rejection** — Fable 5 and Mythos 5 reject the temperature parameter. The Anthropic provider now skips it for these models and logs a warning when a non-nil value is silently dropped (`providers/anthropic/anthropic.go`).

## Test plan

- [ ] Background tool task survives past its batch — goroutine uses outer context, not cancelled `childCtx`
- [ ] Running the CLI without `--temperature` no longer sends `temperature=0`
- [ ] Requests to Fable 5 / Mythos 5 succeed without temperature in the payload; warning is emitted when temperature was set

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Background tasks in agent execution now properly persist throughout full agent turns instead of being prematurely cancelled
* CLI `--temperature` flag now only sets temperature when explicitly provided, preventing unintended zero values
* Temperature parameter handling improved for specific Anthropic models, with warnings logged when temperature is unsupported

<!-- end of auto-generated comment: release notes by coderabbit.ai -->