### PR TITLE
Prompt caching, usage cost estimation, and CLI token/cost visibility

### DIFF
--- a/experimental/cmd/dive/app.go
+++ b/experimental/cmd/dive/app.go
@@ -2030,6 +2030,10 @@ func (a *App) handleCommand(input string) bool {
 	case "model":
 		a.handleModelCommand(cmdArgs)
 		return true
+
+	case "usage", "cost":
+		a.printUsageReport()
+		return true
 	}
 
 	// Check for custom slash commands and skills
@@ -2141,6 +2145,7 @@ func (a *App) printHelp() {
 		tui.Text("  /compact       Compact conversation to save context"),
 		tui.Text("  /model         Switch model"),
 		tui.Text("  /todos, /t     Toggle todo list"),
+		tui.Text("  /usage, /cost  Show token & cache usage breakdown"),
 		tui.Text("  /help, /?      Show this help"),
 	}
 
@@ -2173,6 +2178,127 @@ func (a *App) printHelp() {
 	)
 
 	a.runner.Print(tui.Stack(views...))
+}
+
+// printUsageReport prints the detailed token + cache usage breakdown to
+// scrollback, or a placeholder when nothing has been recorded yet.
+func (a *App) printUsageReport() {
+	view := a.usageReportView()
+	if view == nil {
+		a.runner.Printf("No token usage recorded yet.")
+		return
+	}
+	a.runner.Print(view)
+}
+
+// usageReportView builds a detailed token + cache usage breakdown (turn and,
+// when it differs, session) followed by a short legend. It is the persistent,
+// fully-labeled counterpart to the compact status-line panel. Returns nil when
+// no usage has been recorded yet.
+func (a *App) usageReportView() tui.View {
+	turn := a.interactionUsage
+	sess := a.sessionUsage
+	turnHas := turn != nil && hasUsage(turn)
+	sessHas := sess != nil && hasUsage(sess)
+	if !turnHas && !sessHas {
+		return nil
+	}
+	if turn == nil {
+		turn = &llm.Usage{}
+	}
+	if sess == nil {
+		sess = &llm.Usage{}
+	}
+
+	labelStyle := tui.NewStyle().WithFgRGB(tui.RGB{R: 110, G: 110, B: 120})
+	rowLabelStyle := tui.NewStyle().WithFgRGB(tui.RGB{R: 160, G: 160, B: 170})
+	valStyle := tui.NewStyle().WithFgRGB(tui.RGB{R: 220, G: 220, B: 230}).WithBold()
+
+	const (
+		labelW = 16
+		colW   = 12
+	)
+	left := func(w int, s string, st tui.Style) tui.View {
+		return tui.Width(w, tui.Stack(tui.Text("%s", s).Style(st)).Align(tui.AlignLeft))
+	}
+	right := func(w int, s string, st tui.Style) tui.View {
+		return tui.Width(w, tui.Stack(tui.Text("%s", s).Style(st)).Align(tui.AlignRight))
+	}
+
+	type scopeCol struct {
+		name string
+		u    *llm.Usage
+	}
+	cols := []scopeCol{{"turn", turn}}
+	if sessHas && a.sessionUsageDiffers() {
+		cols = append(cols, scopeCol{"session", sess})
+	}
+
+	tokRow := func(label string, get func(*llm.Usage) int) tui.View {
+		cells := []tui.View{left(labelW, "  "+label, rowLabelStyle)}
+		for _, c := range cols {
+			cells = append(cells, right(colW, formatTokenCount(get(c.u)), valStyle))
+		}
+		return tui.Group(cells...)
+	}
+
+	headerCells := []tui.View{left(labelW, "", labelStyle)}
+	for _, c := range cols {
+		headerCells = append(headerCells, right(colW, c.name, labelStyle))
+	}
+
+	views := []tui.View{
+		tui.Text(""),
+		tui.Text("Token usage").Bold(),
+		tui.Group(headerCells...),
+		tokRow("input", func(u *llm.Usage) int { return u.InputTokens }),
+		tokRow("cache read", func(u *llm.Usage) int { return u.CacheReadInputTokens }),
+		tokRow("cache write", func(u *llm.Usage) int { return u.CacheCreationInputTokens }),
+		tokRow("output", func(u *llm.Usage) int { return u.OutputTokens }),
+	}
+	if turn.ReasoningTokens > 0 || sess.ReasoningTokens > 0 {
+		views = append(views, tokRow("reasoning", func(u *llm.Usage) int { return u.ReasoningTokens }))
+	}
+	views = append(views, tokRow("total input", func(u *llm.Usage) int {
+		return u.InputTokens + u.CacheReadInputTokens + u.CacheCreationInputTokens
+	}))
+
+	hitCells := []tui.View{left(labelW, "  cache hit", rowLabelStyle)}
+	for _, c := range cols {
+		rate, _ := cacheHitRate(c.u)
+		hitCells = append(hitCells, right(colW, rate, valStyle))
+	}
+	views = append(views, tui.Group(hitCells...))
+
+	hasCost := false
+	for _, c := range cols {
+		if c.u.Cost != nil {
+			hasCost = true
+		}
+	}
+	if hasCost {
+		costCells := []tui.View{left(labelW, "  est. cost", rowLabelStyle)}
+		for _, c := range cols {
+			costCells = append(costCells, right(colW, costString(c.u), valStyle))
+		}
+		views = append(views, tui.Group(costCells...))
+	}
+
+	views = append(views,
+		tui.Text(""),
+		tui.Text("  cache read  — prompt tokens served from cache (cheap, ~0.1x)").Style(labelStyle),
+		tui.Text("  cache write — prompt tokens written to cache (premium, 1.25-2x)").Style(labelStyle),
+		tui.Text("  cache hit   — cache read / (cache read + cache write)").Style(labelStyle),
+	)
+	if hasCost {
+		views = append(views, tui.Text("  est. cost   — estimated at list prices; not a bill").Style(labelStyle))
+	}
+	if a.lastUsage != nil && a.lastUsage.Speed != "" {
+		views = append(views, tui.Text("  speed       — %s mode", a.lastUsage.Speed).Style(labelStyle))
+	}
+	views = append(views, tui.Text(""))
+
+	return tui.Stack(views...)
 }
 
 func (a *App) printTodosToScrollback() {
@@ -2478,7 +2604,7 @@ func fuzzyMatch(pattern, text string) int {
 // getCommandMatches returns slash commands matching the prefix for autocomplete
 func (a *App) getCommandMatches(prefix string) []string {
 	// Built-in commands
-	builtins := []string{"clear", "compact", "help", "model", "quit", "todos"}
+	builtins := []string{"clear", "compact", "cost", "help", "model", "quit", "todos", "usage"}
 
 	var matches []string
 

--- a/experimental/cmd/dive/app.go
+++ b/experimental/cmd/dive/app.go
@@ -2229,8 +2229,13 @@ func (a *App) usageReportView() tui.View {
 		name string
 		u    *llm.Usage
 	}
-	cols := []scopeCol{{"turn", turn}}
-	if sessHas && a.sessionUsageDiffers() {
+	// Only show scopes that actually have usage, so session-only data is not
+	// hidden behind an empty turn column.
+	var cols []scopeCol
+	if turnHas {
+		cols = append(cols, scopeCol{"turn", turn})
+	}
+	if sessHas && (!turnHas || a.sessionUsageDiffers()) {
 		cols = append(cols, scopeCol{"session", sess})
 	}
 

--- a/experimental/cmd/dive/render.go
+++ b/experimental/cmd/dive/render.go
@@ -61,29 +61,15 @@ func (a *App) statusLineView() tui.View {
 			tui.Text("%s", branch).Style(accentStyle),
 		)
 	}
-	// Right-aligned token usage lines (turn above session)
-	sectionStyle := tui.NewStyle().WithFgRGB(tui.RGB{R: 160, G: 160, B: 170}).WithBold()
-	var usageLines []tui.View
-	if u := a.interactionUsage; u != nil && hasUsage(u) {
-		usageLines = append(usageLines, tui.Group(
-			tui.Width(9, tui.Stack(tui.Text("turn").Style(sectionStyle)).Align(tui.AlignRight)),
-			tui.Text("  "),
-			usageView(u),
-		))
-	}
-	if u := a.sessionUsage; u != nil && hasUsage(u) && a.sessionUsageDiffers() {
-		usageLines = append(usageLines, tui.Group(
-			tui.Width(9, tui.Stack(tui.Text("session").Style(sectionStyle)).Align(tui.AlignRight)),
-			tui.Text("  "),
-			usageView(u),
-		))
+	// Speed badge — fast mode bills at a different rate, so surface it.
+	if a.lastUsage != nil && a.lastUsage.Speed == "fast" {
+		parts = append(parts, tui.Text(" ⚡fast").Style(
+			tui.NewStyle().WithFgRGB(tui.RGB{R: 230, G: 190, B: 80}).WithBold()))
 	}
 
-	// Line 2: progress bar with context %
-	var line2LeftParts []tui.View
-	line2LeftParts = append(line2LeftParts, tui.Text(" ").Style(mutedStyle))
+	rows := []tui.View{tui.Group(parts...)}
 
-	// Context usage progress bar (show after first LLM response)
+	// Line 2: context-window usage bar (shown after the first LLM response).
 	if a.lastUsage != nil {
 		contextPct := a.contextPercent()
 		barColor := accentDim
@@ -98,41 +84,23 @@ func (a *App) statusLineView() tui.View {
 			HidePercent().
 			Style(tui.NewStyle().WithFgRGB(barColor)).
 			EmptyStyle(tui.NewStyle().WithFgRGB(tui.RGB{R: 80, G: 80, B: 90}))
-		line2LeftParts = append(line2LeftParts, bar)
-		line2LeftParts = append(line2LeftParts, tui.Text(" %d%%", contextPct).Style(mutedStyle))
+		rows = append(rows, tui.Group(
+			tui.Text(" ").Style(mutedStyle),
+			bar,
+			tui.Text(" %d%% context", contextPct).Style(mutedStyle),
+		))
 	}
 
-	hasLine2Left := len(line2LeftParts) > 1
-	hasUsageLines := len(usageLines) > 0
-
-	if !hasLine2Left && !hasUsageLines {
-		return tui.Group(parts...)
+	// Tokens panel: a clearly-labeled per-scope breakdown of input, cache
+	// reads (hits) vs writes (misses), output, and hit rate.
+	if panel := a.tokensPanelView(); panel != nil {
+		rows = append(rows, panel)
 	}
 
-	// Build the line 1 row: model info on left, turn usage on right
-	line1Row := tui.Group(parts...)
-	if len(usageLines) > 0 {
-		line1Row = tui.Group(tui.Group(parts...), tui.Spacer(), usageLines[0], tui.Text(" "))
+	if len(rows) == 1 {
+		return rows[0]
 	}
-
-	// Build the line 2 row: context bar on left, session usage on right
-	if hasLine2Left || len(usageLines) > 1 {
-		var line2Left tui.View
-		if hasLine2Left {
-			line2Left = tui.Group(line2LeftParts...)
-		} else {
-			line2Left = tui.Text("")
-		}
-		var line2Row tui.View
-		if len(usageLines) > 1 {
-			line2Row = tui.Group(line2Left, tui.Spacer(), usageLines[1], tui.Text(" "))
-		} else {
-			line2Row = line2Left
-		}
-		return tui.Stack(line1Row, line2Row).Gap(0)
-	}
-
-	return line1Row
+	return tui.Stack(rows...).Gap(0)
 }
 
 // formatTokenCount formats a token count for display (e.g. 1234 -> "1.2k", 56 -> "56").
@@ -151,21 +119,145 @@ func hasUsage(u *llm.Usage) bool {
 	return u.InputTokens > 0 || u.OutputTokens > 0 || u.CacheReadInputTokens > 0 || u.CacheCreationInputTokens > 0
 }
 
-// usageView renders a compact token usage display with right-aligned number columns:
+// tokensPanelView renders a clearly-labeled token + cache breakdown table, one
+// row per scope (turn / session). It makes cache reads (hits, cheap) and cache
+// writes (misses, premium) explicit and adds a per-scope hit rate, so cache
+// thrash is immediately visible. Returns nil before the first response.
 //
-//	"in:  13.7k  cache:  13.5k  out:    53"
-func usageView(u *llm.Usage) tui.View {
-	labelStyle := tui.NewStyle().WithFgRGB(tui.RGB{R: 100, G: 100, B: 110})
-	valueStyle := tui.NewStyle().WithFgRGB(tui.RGB{R: 220, G: 220, B: 230}).WithBold()
-	totalIn := u.InputTokens + u.CacheCreationInputTokens + u.CacheReadInputTokens
-	col := func(val string) tui.View {
-		return tui.Width(6, tui.Stack(tui.Text("%s", val).Style(valueStyle)).Align(tui.AlignRight))
+//	tokens       input   cache read   cache write   output    hit
+//	turn          1.2k        13.5k          0.5k       53     96%
+//	session       4.8k        54.0k          1.2k      892     98%
+func (a *App) tokensPanelView() tui.View {
+	turn := a.interactionUsage
+	if turn == nil || !hasUsage(turn) {
+		return nil
 	}
-	return tui.Group(
-		tui.Text("in: ").Style(labelStyle), col(formatTokenCount(totalIn)),
-		tui.Text("  cache: ").Style(labelStyle), col(formatTokenCount(u.CacheReadInputTokens)),
-		tui.Text("  out: ").Style(labelStyle), col(formatTokenCount(u.OutputTokens)),
+	sess := a.sessionUsage
+	showSession := sess != nil && hasUsage(sess) && a.sessionUsageDiffers()
+	showReasoning := turn.ReasoningTokens > 0 || (showSession && sess.ReasoningTokens > 0)
+	showCost := turn.Cost != nil || (showSession && sess.Cost != nil)
+
+	headerStyle := tui.NewStyle().WithFgRGB(tui.RGB{R: 110, G: 110, B: 120})
+	scopeStyle := tui.NewStyle().WithFgRGB(tui.RGB{R: 160, G: 160, B: 170}).WithBold()
+	valStyle := tui.NewStyle().WithFgRGB(tui.RGB{R: 220, G: 220, B: 230}).WithBold()
+	readStyle := tui.NewStyle().WithFgRGB(tui.RGB{R: 110, G: 200, B: 130}).WithBold() // green: cheap hits
+	writeStyle := tui.NewStyle().WithFgRGB(tui.RGB{R: 225, G: 175, B: 80}).WithBold() // amber: premium writes
+	costStyle := tui.NewStyle().WithFgRGB(tui.RGB{R: 120, G: 205, B: 150}).WithBold() // green: money
+
+	const (
+		labelW = 10
+		inW    = 8
+		readW  = 13
+		writeW = 14
+		outW   = 9
+		reasW  = 9
+		hitW   = 7
+		costW  = 10
 	)
+
+	left := func(w int, s string, st tui.Style) tui.View {
+		return tui.Width(w, tui.Stack(tui.Text("%s", s).Style(st)).Align(tui.AlignLeft))
+	}
+	right := func(w int, s string, st tui.Style) tui.View {
+		return tui.Width(w, tui.Stack(tui.Text("%s", s).Style(st)).Align(tui.AlignRight))
+	}
+
+	header := []tui.View{
+		left(labelW, " tokens", headerStyle),
+		right(inW, "input", headerStyle),
+		right(readW, "cache read", headerStyle),
+		right(writeW, "cache write", headerStyle),
+		right(outW, "output", headerStyle),
+	}
+	if showReasoning {
+		header = append(header, right(reasW, "reason", headerStyle))
+	}
+	header = append(header, right(hitW, "hit", headerStyle))
+	if showCost {
+		header = append(header, right(costW, "cost", headerStyle))
+	}
+
+	dataRow := func(label string, u *llm.Usage) tui.View {
+		cells := []tui.View{
+			left(labelW, " "+label, scopeStyle),
+			right(inW, formatTokenCount(u.InputTokens), valStyle),
+			right(readW, formatTokenCount(u.CacheReadInputTokens), readStyle),
+			right(writeW, formatTokenCount(u.CacheCreationInputTokens), writeStyle),
+			right(outW, formatTokenCount(u.OutputTokens), valStyle),
+		}
+		if showReasoning {
+			cells = append(cells, right(reasW, formatTokenCount(u.ReasoningTokens), valStyle))
+		}
+		rate, ok := cacheHitRate(u)
+		cells = append(cells, right(hitW, rate, cacheHitStyle(u, ok)))
+		if showCost {
+			cells = append(cells, right(costW, costString(u), costStyle))
+		}
+		return tui.Group(cells...)
+	}
+
+	rows := []tui.View{
+		tui.Group(header...),
+		dataRow("turn", turn),
+	}
+	if showSession {
+		rows = append(rows, dataRow("session", sess))
+	}
+	return tui.Stack(rows...).Gap(0)
+}
+
+// cacheHitRate returns the share of cacheable prompt tokens served from cache
+// (reads) versus freshly written (writes), as a percentage string. ok is false
+// when no caching occurred for the scope (zero denominator).
+func cacheHitRate(u *llm.Usage) (string, bool) {
+	denom := u.CacheReadInputTokens + u.CacheCreationInputTokens
+	if denom == 0 {
+		return "—", false
+	}
+	pct := (u.CacheReadInputTokens * 100) / denom
+	return fmt.Sprintf("%d%%", pct), true
+}
+
+// cacheHitStyle colors the hit rate by health: green (>=80%), amber (50-79%),
+// red (<50%, i.e. cache thrash). Muted when no caching occurred.
+func cacheHitStyle(u *llm.Usage, ok bool) tui.Style {
+	if !ok {
+		return tui.NewStyle().WithFgRGB(tui.RGB{R: 100, G: 100, B: 110})
+	}
+	denom := u.CacheReadInputTokens + u.CacheCreationInputTokens
+	pct := (u.CacheReadInputTokens * 100) / denom
+	switch {
+	case pct >= 80:
+		return tui.NewStyle().WithFgRGB(tui.RGB{R: 110, G: 200, B: 130}).WithBold()
+	case pct >= 50:
+		return tui.NewStyle().WithFgRGB(tui.RGB{R: 225, G: 175, B: 80}).WithBold()
+	default:
+		return tui.NewStyle().WithFgRGB(tui.RGB{R: 220, G: 90, B: 90}).WithBold()
+	}
+}
+
+// costString renders a usage's estimated total cost, or an em dash when cost is
+// unknown (no pricing for the model) — distinct from a known $0 (local models).
+func costString(u *llm.Usage) string {
+	if u.Cost == nil {
+		return "—"
+	}
+	return formatCost(u.Cost.Total)
+}
+
+// formatCost formats a USD amount with precision that scales to the magnitude,
+// so sub-cent estimates stay legible (e.g. "$0.0021", "$0.043", "$1.27").
+func formatCost(c float64) string {
+	switch {
+	case c <= 0:
+		return "$0"
+	case c < 0.01:
+		return fmt.Sprintf("$%.4f", c)
+	case c < 1:
+		return fmt.Sprintf("$%.3f", c)
+	default:
+		return fmt.Sprintf("$%.2f", c)
+	}
 }
 
 // sessionUsageDiffers returns true if session usage differs from interaction usage

--- a/experimental/cmd/dive/render_test.go
+++ b/experimental/cmd/dive/render_test.go
@@ -111,6 +111,20 @@ func TestUsageReportView_NilWhenNoUsage(t *testing.T) {
 	assert.Nil(t, app.usageReportView(), "report should be nil before any tokens are recorded")
 }
 
+func TestUsageReportView_SessionOnly(t *testing.T) {
+	// When only session usage is present (empty/nil turn), the report must
+	// still render the session column rather than hide it behind an empty turn.
+	app := newTestApp()
+	app.interactionUsage = &llm.Usage{} // empty turn
+	app.sessionUsage = &llm.Usage{InputTokens: 4800, OutputTokens: 892}
+
+	view := app.usageReportView()
+	assert.NotNil(t, view, "report should render when only session has usage")
+	text := tui.Sprint(view, tui.WithWidth(100))
+	assert.True(t, strings.Contains(text, "session"), "should show the session column")
+	assert.True(t, strings.Contains(text, "4.8k"), "should show session input tokens")
+}
+
 func TestUsageReportView_IncludesTotalsAndLegend(t *testing.T) {
 	app := newTestApp()
 	app.interactionUsage = &llm.Usage{

--- a/experimental/cmd/dive/render_test.go
+++ b/experimental/cmd/dive/render_test.go
@@ -1,0 +1,136 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/deepnoodle-ai/dive/llm"
+	"github.com/deepnoodle-ai/wonton/assert"
+	"github.com/deepnoodle-ai/wonton/tui"
+)
+
+func TestFormatTokenCount(t *testing.T) {
+	assert.Equal(t, "56", formatTokenCount(56))
+	assert.Equal(t, "1.2k", formatTokenCount(1234))
+	assert.Equal(t, "13.5k", formatTokenCount(13500))
+	assert.Equal(t, "1.0M", formatTokenCount(1000000))
+}
+
+func TestCacheHitRate(t *testing.T) {
+	// Healthy: mostly reads.
+	rate, ok := cacheHitRate(&llm.Usage{CacheReadInputTokens: 13500, CacheCreationInputTokens: 500})
+	assert.True(t, ok, "rate should be defined when caching occurred")
+	assert.Equal(t, "96%", rate)
+
+	// Thrash: writes dominate reads (the Heartbeat failure mode).
+	rate, ok = cacheHitRate(&llm.Usage{CacheReadInputTokens: 1000, CacheCreationInputTokens: 9000})
+	assert.True(t, ok)
+	assert.Equal(t, "10%", rate)
+
+	// No caching at all: undefined, rendered as a dash.
+	rate, ok = cacheHitRate(&llm.Usage{InputTokens: 1000})
+	assert.False(t, ok, "rate should be undefined with no cache activity")
+	assert.Equal(t, "—", rate)
+}
+
+func TestTokensPanelView_NilWhenNoUsage(t *testing.T) {
+	app := newTestApp()
+	app.interactionUsage = &llm.Usage{}
+	assert.Nil(t, app.tokensPanelView(), "panel should be nil before any tokens are recorded")
+}
+
+func TestTokensPanelView_ShowsCacheReadsWritesAndHitRate(t *testing.T) {
+	app := newTestApp()
+	app.interactionUsage = &llm.Usage{
+		InputTokens:              1200,
+		CacheReadInputTokens:     13500,
+		CacheCreationInputTokens: 500,
+		OutputTokens:             53,
+	}
+	app.sessionUsage = &llm.Usage{
+		InputTokens:              4800,
+		CacheReadInputTokens:     54000,
+		CacheCreationInputTokens: 1200,
+		OutputTokens:             892,
+	}
+
+	panel := app.tokensPanelView()
+	assert.NotNil(t, panel, "panel should render when usage is present")
+
+	text := tui.Sprint(panel, tui.WithWidth(100))
+
+	// Labels make hits vs misses unambiguous.
+	assert.True(t, strings.Contains(text, "cache read"), "should label cache reads")
+	assert.True(t, strings.Contains(text, "cache write"), "should label cache writes")
+	assert.True(t, strings.Contains(text, "hit"), "should show a hit-rate column")
+
+	// Both scopes are present and differ.
+	assert.True(t, strings.Contains(text, "turn"), "should show the turn row")
+	assert.True(t, strings.Contains(text, "session"), "should show the session row")
+
+	// The cache-write count (the previously hidden miss signal) is now visible.
+	assert.True(t, strings.Contains(text, "500"), "cache write tokens should be shown")
+	// And the per-scope hit rate.
+	assert.True(t, strings.Contains(text, "96%"), "turn hit rate should be shown")
+}
+
+func TestFormatCost(t *testing.T) {
+	assert.Equal(t, "$0", formatCost(0))
+	assert.Equal(t, "$0.0021", formatCost(0.0021))
+	assert.Equal(t, "$0.043", formatCost(0.043))
+	assert.Equal(t, "$1.27", formatCost(1.273))
+}
+
+func TestCostString(t *testing.T) {
+	assert.Equal(t, "—", costString(&llm.Usage{}), "unknown cost should render as a dash")
+	assert.Equal(t, "$0", costString(&llm.Usage{Cost: &llm.Cost{Total: 0}}), "known zero cost is $0, not a dash")
+	assert.Equal(t, "$1.27", costString(&llm.Usage{Cost: &llm.Cost{Total: 1.273}}))
+}
+
+func TestTokensPanelView_ShowsCostWhenPresent(t *testing.T) {
+	app := newTestApp()
+	app.interactionUsage = &llm.Usage{
+		InputTokens:  1234,
+		OutputTokens: 53,
+		Cost:         &llm.Cost{Total: 0.0149, Currency: "USD"},
+	}
+	text := tui.Sprint(app.tokensPanelView(), tui.WithWidth(100))
+	assert.True(t, strings.Contains(text, "cost"), "should show a cost column header")
+	assert.True(t, strings.Contains(text, "$0.015"), "should show the formatted turn cost")
+}
+
+func TestTokensPanelView_NoCostColumnWhenUnknown(t *testing.T) {
+	app := newTestApp()
+	app.interactionUsage = &llm.Usage{InputTokens: 1234, OutputTokens: 53} // no Cost
+	text := tui.Sprint(app.tokensPanelView(), tui.WithWidth(100))
+	assert.False(t, strings.Contains(text, "cost"), "cost column should be hidden when cost is unknown")
+}
+
+func TestUsageReportView_NilWhenNoUsage(t *testing.T) {
+	app := newTestApp()
+	assert.Nil(t, app.usageReportView(), "report should be nil before any tokens are recorded")
+}
+
+func TestUsageReportView_IncludesTotalsAndLegend(t *testing.T) {
+	app := newTestApp()
+	app.interactionUsage = &llm.Usage{
+		InputTokens:              1234,
+		CacheReadInputTokens:     13500,
+		CacheCreationInputTokens: 500,
+		OutputTokens:             53,
+	}
+	app.sessionUsage = app.interactionUsage.Copy() // same => single column
+
+	view := app.usageReportView()
+	assert.NotNil(t, view)
+
+	text := tui.Sprint(view, tui.WithWidth(100))
+	assert.True(t, strings.Contains(text, "Token usage"), "should have a heading")
+	assert.True(t, strings.Contains(text, "cache write"), "should break out cache writes")
+	assert.True(t, strings.Contains(text, "total input"), "should show total input")
+	assert.True(t, strings.Contains(text, "cache hit"), "should show the hit rate")
+	// total input = 1234 + 13500 + 500 = 15234 -> "15.2k"
+	assert.True(t, strings.Contains(text, "15.2k"), "should sum cached + uncached input")
+	// Legend explaining the metrics is present.
+	assert.True(t, strings.Contains(text, "served from cache"), "should include the legend")
+}

--- a/llm/cache_control.go
+++ b/llm/cache_control.go
@@ -10,3 +10,11 @@ const (
 func (c CacheControlType) String() string {
 	return string(c)
 }
+
+// Cache TTL values accepted by providers that support an extended cache
+// duration. The default (empty) TTL is the provider's standard 5-minute cache;
+// CacheTTL1h requests the 1-hour extended cache where supported.
+const (
+	CacheTTL5m = "5m"
+	CacheTTL1h = "1h"
+)

--- a/llm/content.go
+++ b/llm/content.go
@@ -56,6 +56,10 @@ func (c ContentSourceType) String() string {
 // CacheControl is used to control caching of content blocks.
 type CacheControl struct {
 	Type CacheControlType `json:"type"`
+	// TTL selects the cache lifetime when the provider supports an extended
+	// cache duration. Empty means the provider default (5 minutes); "1h"
+	// requests the extended 1-hour cache. See CacheTTL5m / CacheTTL1h.
+	TTL string `json:"ttl,omitempty"`
 }
 
 // ContentChunk is used within a Content block to pass chunks of content.
@@ -420,9 +424,10 @@ func (c *DocumentContent) CloneContent() Content {
 */
 
 type ToolUseContent struct {
-	ID    string          `json:"id"`
-	Name  string          `json:"name"`
-	Input json.RawMessage `json:"input"`
+	ID           string          `json:"id"`
+	Name         string          `json:"name"`
+	Input        json.RawMessage `json:"input"`
+	CacheControl *CacheControl   `json:"cache_control,omitempty"`
 }
 
 func (c *ToolUseContent) Type() ContentType {
@@ -438,16 +443,28 @@ func (c *ToolUseContent) MarshalJSON() ([]byte, error) {
 		return nil, fmt.Errorf("invalid JSON in tool_use input for %q (id=%s): %s", c.Name, c.ID, string(input))
 	}
 	return json.Marshal(struct {
-		Type  ContentType     `json:"type"`
-		ID    string          `json:"id"`
-		Name  string          `json:"name"`
-		Input json.RawMessage `json:"input"`
+		Type         ContentType     `json:"type"`
+		ID           string          `json:"id"`
+		Name         string          `json:"name"`
+		Input        json.RawMessage `json:"input"`
+		CacheControl *CacheControl   `json:"cache_control,omitempty"`
 	}{
-		Type:  ContentTypeToolUse,
-		ID:    c.ID,
-		Name:  c.Name,
-		Input: input,
+		Type:         ContentTypeToolUse,
+		ID:           c.ID,
+		Name:         c.Name,
+		Input:        input,
+		CacheControl: c.CacheControl,
 	})
+}
+
+func (c *ToolUseContent) SetCacheControl(cacheControl *CacheControl) {
+	c.CacheControl = cacheControl
+}
+
+func (c *ToolUseContent) CloneContent() Content {
+	cp := *c
+	cp.CacheControl = nil
+	return &cp
 }
 
 // ToolResultContent carries the result of a tool call back to the LLM.

--- a/llm/cost.go
+++ b/llm/cost.go
@@ -1,0 +1,43 @@
+package llm
+
+import "sync/atomic"
+
+// CostResolver returns the pricing for a model at a given speed (fast vs.
+// standard). ok is false when no pricing is known for the model.
+type CostResolver func(model string, fast bool) (PricingInfo, bool)
+
+// costResolver is set by the providers package (via SetCostResolver) so the
+// llm package can resolve pricing without importing providers, which would be
+// an import cycle. It is consulted from PopulateCost.
+var costResolver atomic.Pointer[CostResolver]
+
+// SetCostResolver installs the global pricing resolver. The providers package
+// wires this up in init() so that PopulateCost — and therefore the streaming
+// accumulator — can attach cost to usage automatically. Passing nil clears it.
+func SetCostResolver(r CostResolver) {
+	if r == nil {
+		costResolver.Store(nil)
+		return
+	}
+	costResolver.Store(&r)
+}
+
+// PopulateCost sets u.Cost from the resolved pricing for the model, when a
+// resolver is installed and pricing is known. It is a no-op (leaving u.Cost
+// nil — i.e. "unknown") when there is no resolver, no pricing, or no usage.
+// fast selects fast-mode pricing where a provider distinguishes it.
+func PopulateCost(model string, fast bool, u *Usage) {
+	if u == nil {
+		return
+	}
+	rp := costResolver.Load()
+	if rp == nil {
+		return
+	}
+	pricing, ok := (*rp)(model, fast)
+	if !ok {
+		return
+	}
+	cost := pricing.CostOf(u)
+	u.Cost = &cost
+}

--- a/llm/cost_test.go
+++ b/llm/cost_test.go
@@ -1,0 +1,135 @@
+package llm
+
+import (
+	"testing"
+
+	"github.com/deepnoodle-ai/wonton/assert"
+)
+
+func TestPricingInfoCostOf(t *testing.T) {
+	p := PricingInfo{
+		Model:           "test-model",
+		InputPrice:      5.00,  // $5 / 1M
+		OutputPrice:     25.00, // $25 / 1M
+		CacheReadPrice:  0.50,  // 0.1x input
+		CacheWritePrice: 6.25,  // 1.25x input
+		Currency:        "USD",
+	}
+	u := &Usage{
+		InputTokens:              1_000_000,
+		OutputTokens:             1_000_000,
+		CacheReadInputTokens:     1_000_000,
+		CacheCreationInputTokens: 1_000_000,
+	}
+	c := p.CostOf(u)
+	assert.Equal(t, 5.00, c.Input)
+	assert.Equal(t, 25.00, c.Output)
+	assert.Equal(t, 0.50, c.CacheRead)
+	assert.Equal(t, 6.25, c.CacheWrite)
+	assert.Equal(t, 36.75, c.Total)
+	assert.Equal(t, "USD", c.Currency)
+	assert.Equal(t, "test-model", c.Model)
+}
+
+func TestPricingInfoCostOf_ZeroCachePrices(t *testing.T) {
+	// A provider that does not bill cache separately: cache tokens contribute 0.
+	p := PricingInfo{InputPrice: 3.00, OutputPrice: 15.00, Currency: "USD"}
+	u := &Usage{InputTokens: 2_000_000, OutputTokens: 100_000, CacheReadInputTokens: 9_000_000}
+	c := p.CostOf(u)
+	assert.Equal(t, 6.00, c.Input)
+	assert.Equal(t, 1.50, c.Output)
+	assert.Equal(t, 0.0, c.CacheRead)
+	assert.Equal(t, 7.50, c.Total)
+}
+
+func TestUsageCostAddAndCopy(t *testing.T) {
+	a := &Usage{InputTokens: 100, Cost: &Cost{Input: 1.0, Total: 1.0, Currency: "USD"}}
+	b := &Usage{InputTokens: 50, Cost: &Cost{Input: 0.5, Output: 0.25, Total: 0.75}}
+
+	a.Add(b)
+	assert.Equal(t, 150, a.InputTokens)
+	assert.NotNil(t, a.Cost)
+	assert.Equal(t, 1.5, a.Cost.Input)
+	assert.Equal(t, 0.25, a.Cost.Output)
+	assert.Equal(t, 1.75, a.Cost.Total)
+	assert.Equal(t, "USD", a.Cost.Currency)
+
+	// Copy is deep: mutating the copy must not affect the original.
+	cp := a.Copy()
+	cp.Cost.Total = 999
+	assert.Equal(t, 1.75, a.Cost.Total, "original cost must be unchanged after mutating copy")
+}
+
+func TestUsageAdd_NilCostSummand(t *testing.T) {
+	a := &Usage{InputTokens: 10}
+	a.Add(&Usage{InputTokens: 5}) // neither has cost
+	assert.Nil(t, a.Cost, "no cost should remain nil")
+
+	a.Add(&Usage{InputTokens: 5, Cost: &Cost{Total: 2.0}})
+	assert.NotNil(t, a.Cost)
+	assert.Equal(t, 2.0, a.Cost.Total)
+}
+
+func TestPopulateCost_ResolverRoundTrip(t *testing.T) {
+	t.Cleanup(func() { SetCostResolver(nil) })
+
+	SetCostResolver(func(model string, fast bool) (PricingInfo, bool) {
+		if model != "known" {
+			return PricingInfo{}, false
+		}
+		in := 5.0
+		if fast {
+			in = 10.0
+		}
+		return PricingInfo{Model: model, InputPrice: in, Currency: "USD"}, true
+	})
+
+	// Unknown model -> cost stays nil.
+	u := &Usage{InputTokens: 1_000_000}
+	PopulateCost("unknown", false, u)
+	assert.Nil(t, u.Cost)
+
+	// Known model, standard speed.
+	PopulateCost("known", false, u)
+	assert.NotNil(t, u.Cost)
+	assert.Equal(t, 5.0, u.Cost.Total)
+
+	// Known model, fast speed uses fast pricing.
+	u2 := &Usage{InputTokens: 1_000_000}
+	PopulateCost("known", true, u2)
+	assert.Equal(t, 10.0, u2.Cost.Total)
+}
+
+func TestPopulateCost_NoResolver(t *testing.T) {
+	SetCostResolver(nil)
+	u := &Usage{InputTokens: 1_000_000}
+	PopulateCost("anything", false, u)
+	assert.Nil(t, u.Cost, "without a resolver, cost must remain unknown (nil)")
+}
+
+func TestResponseAccumulatorPopulatesCost(t *testing.T) {
+	t.Cleanup(func() { SetCostResolver(nil) })
+	SetCostResolver(func(model string, fast bool) (PricingInfo, bool) {
+		if model != "priced-model" {
+			return PricingInfo{}, false
+		}
+		return PricingInfo{Model: model, InputPrice: 3.0, OutputPrice: 15.0, Currency: "USD"}, true
+	})
+
+	acc := NewResponseAccumulator()
+	assert.NoError(t, acc.AddEvent(&Event{
+		Type:    EventTypeMessageStart,
+		Message: &Response{ID: "msg_1", Role: Assistant, Model: "priced-model"},
+	}))
+	assert.NoError(t, acc.AddEvent(&Event{
+		Type:  EventTypeMessageDelta,
+		Delta: &EventDelta{StopReason: "end_turn"},
+		Usage: &Usage{InputTokens: 1_000_000, OutputTokens: 1_000_000},
+	}))
+	assert.NoError(t, acc.AddEvent(&Event{Type: EventTypeMessageStop}))
+
+	cost := acc.Response().Usage.Cost
+	assert.NotNil(t, cost, "streaming accumulator should attach cost at completion")
+	assert.Equal(t, 18.0, cost.Total) // 3 (input) + 15 (output)
+	assert.Equal(t, "priced-model", cost.Model)
+}

--- a/llm/cost_test.go
+++ b/llm/cost_test.go
@@ -31,6 +31,14 @@ func TestPricingInfoCostOf(t *testing.T) {
 	assert.Equal(t, "test-model", c.Model)
 }
 
+func TestPricingInfoCostOf_NilUsage(t *testing.T) {
+	p := PricingInfo{Model: "m", InputPrice: 5, Currency: "USD"}
+	c := p.CostOf(nil) // must not panic
+	assert.Equal(t, 0.0, c.Total)
+	assert.Equal(t, "USD", c.Currency)
+	assert.Equal(t, "m", c.Model)
+}
+
 func TestPricingInfoCostOf_ZeroCachePrices(t *testing.T) {
 	// A provider that does not bill cache separately: cache tokens contribute 0.
 	p := PricingInfo{InputPrice: 3.00, OutputPrice: 15.00, Currency: "USD"}

--- a/llm/pricing.go
+++ b/llm/pricing.go
@@ -47,7 +47,11 @@ func (c *Cost) Add(other *Cost) {
 }
 
 // CostOf computes the estimated cost of the given usage at these prices.
+// A nil usage yields a zero cost (still tagged with currency and model).
 func (p PricingInfo) CostOf(u *Usage) Cost {
+	if u == nil {
+		return Cost{Currency: p.Currency, Model: p.Model}
+	}
 	const perMillion = 1_000_000.0
 	c := Cost{
 		Input:      float64(u.InputTokens) * p.InputPrice / perMillion,

--- a/llm/pricing.go
+++ b/llm/pricing.go
@@ -5,8 +5,60 @@ type PricingInfo struct {
 	Model       string  `json:"model"`
 	InputPrice  float64 `json:"input_price_per_1m_tokens"`  // per 1M input tokens (USD)
 	OutputPrice float64 `json:"output_price_per_1m_tokens"` // per 1M output tokens (USD)
-	Currency    string  `json:"currency"`
-	UpdatedAt   string  `json:"updated_at"` // YYYY-MM-DD format
+	// CacheReadPrice is the price per 1M tokens read from the prompt cache (a
+	// cache hit). Zero means the provider does not bill cache reads separately.
+	CacheReadPrice float64 `json:"cache_read_price_per_1m_tokens,omitempty"`
+	// CacheWritePrice is the price per 1M tokens written to the prompt cache (a
+	// cache miss). For providers with multiple cache TTLs this is the default
+	// (shortest) TTL rate. Zero means the provider does not surcharge writes.
+	CacheWritePrice float64 `json:"cache_write_price_per_1m_tokens,omitempty"`
+	Currency        string  `json:"currency"`
+	UpdatedAt       string  `json:"updated_at"` // YYYY-MM-DD format
+}
+
+// Cost is an estimated monetary cost broken out by token category. It is an
+// estimate computed from a PricingInfo snapshot (list prices as of its
+// UpdatedAt date), not an authoritative billing figure.
+type Cost struct {
+	Input      float64 `json:"input"`
+	Output     float64 `json:"output"`
+	CacheRead  float64 `json:"cache_read"`
+	CacheWrite float64 `json:"cache_write"`
+	Total      float64 `json:"total"`
+	Currency   string  `json:"currency,omitempty"`
+	Model      string  `json:"model,omitempty"`
+}
+
+// Add accumulates another Cost into this one. It is nil-safe on the argument.
+// Each summand was computed at its own call's prices, so summing per-call costs
+// stays correct even across model or speed changes within a session.
+func (c *Cost) Add(other *Cost) {
+	if c == nil || other == nil {
+		return
+	}
+	c.Input += other.Input
+	c.Output += other.Output
+	c.CacheRead += other.CacheRead
+	c.CacheWrite += other.CacheWrite
+	c.Total += other.Total
+	if c.Currency == "" {
+		c.Currency = other.Currency
+	}
+}
+
+// CostOf computes the estimated cost of the given usage at these prices.
+func (p PricingInfo) CostOf(u *Usage) Cost {
+	const perMillion = 1_000_000.0
+	c := Cost{
+		Input:      float64(u.InputTokens) * p.InputPrice / perMillion,
+		Output:     float64(u.OutputTokens) * p.OutputPrice / perMillion,
+		CacheRead:  float64(u.CacheReadInputTokens) * p.CacheReadPrice / perMillion,
+		CacheWrite: float64(u.CacheCreationInputTokens) * p.CacheWritePrice / perMillion,
+		Currency:   p.Currency,
+		Model:      p.Model,
+	}
+	c.Total = c.Input + c.Output + c.CacheRead + c.CacheWrite
+	return c
 }
 
 // ImagePricingInfo represents pricing for image generation services

--- a/llm/stream.go
+++ b/llm/stream.go
@@ -214,6 +214,13 @@ func (r *ResponseAccumulator) AddEvent(event *Event) error {
 	if event.ContextManagement != nil && r.response != nil {
 		r.response.ContextManagement = event.ContextManagement
 	}
+
+	// Once the message is complete, attach an estimated cost from resolved
+	// model pricing. No-op when no resolver/pricing is registered. Done here,
+	// after usage accumulation, so the final token counts are reflected.
+	if r.complete && r.response != nil {
+		PopulateCost(r.response.Model, r.response.Usage.Speed == string(SpeedFast), &r.response.Usage)
+	}
 	return nil
 }
 

--- a/llm/usage.go
+++ b/llm/usage.go
@@ -13,11 +13,16 @@ type Usage struct {
 	// Speed indicates which inference speed served the request, either "fast"
 	// or "standard". Populated by Anthropic when fast mode is requested.
 	Speed string `json:"speed,omitempty"`
+	// Cost is the estimated monetary cost of this usage, populated by the
+	// provider (or the streaming accumulator) when model pricing is known. Nil
+	// means cost is unknown — distinct from a known cost of zero (e.g. a local
+	// model). It is an estimate at list prices, not a billing figure.
+	Cost *Cost `json:"cost,omitempty"`
 }
 
 // Copy returns a deep copy of the usage data.
 func (u *Usage) Copy() *Usage {
-	return &Usage{
+	cp := &Usage{
 		InputTokens:              u.InputTokens,
 		OutputTokens:             u.OutputTokens,
 		CacheCreationInputTokens: u.CacheCreationInputTokens,
@@ -25,6 +30,11 @@ func (u *Usage) Copy() *Usage {
 		ReasoningTokens:          u.ReasoningTokens,
 		Speed:                    u.Speed,
 	}
+	if u.Cost != nil {
+		costCopy := *u.Cost
+		cp.Cost = &costCopy
+	}
+	return cp
 }
 
 // Add incremental usage to this usage object.
@@ -34,4 +44,10 @@ func (u *Usage) Add(other *Usage) {
 	u.CacheCreationInputTokens += other.CacheCreationInputTokens
 	u.CacheReadInputTokens += other.CacheReadInputTokens
 	u.ReasoningTokens += other.ReasoningTokens
+	if other.Cost != nil {
+		if u.Cost == nil {
+			u.Cost = &Cost{}
+		}
+		u.Cost.Add(other.Cost)
+	}
 }

--- a/providers/anthropic/anthropic.go
+++ b/providers/anthropic/anthropic.go
@@ -331,12 +331,14 @@ const (
 // The request's messages/system should already be copies (system is built
 // fresh; messages come from convertMessages) so mutation here is safe.
 func (p *Provider) applyCaching(req *Request, config *llm.Config) {
+	// Start from a clean slate so caller-provided cache markers never leak
+	// through — in particular on opt-out, where we strip them and bail.
+	clearRequestCacheControl(req)
 	if config.Caching != nil && !*config.Caching {
 		return
 	}
 
 	stableTTL := stablePrefixTTL(config)
-	clearRequestCacheControl(req)
 
 	// Total explicit block-level breakpoints used so far. The API allows 4; when
 	// automatic caching is on it consumes one, leaving 3 for explicit blocks.
@@ -427,6 +429,7 @@ func stablePrefixTTL(config *llm.Config) string {
 // the system blocks and message contents so placement starts from a clean
 // slate (some content types preserve CacheControl across convertMessages).
 func clearRequestCacheControl(req *Request) {
+	req.CacheControl = nil
 	for _, block := range req.System {
 		block.CacheControl = nil
 	}

--- a/providers/anthropic/anthropic.go
+++ b/providers/anthropic/anthropic.go
@@ -76,11 +76,11 @@ func (p *Provider) Generate(ctx context.Context, opts ...llm.Option) (*llm.Respo
 	if err != nil {
 		return nil, err
 	}
-	applyCacheControl(msgs, config)
 	if config.Prefill != "" {
 		msgs = append(msgs, llm.NewAssistantTextMessage(config.Prefill))
 	}
 	request.Messages = msgs
+	p.applyCaching(&request, config)
 
 	body, err := json.Marshal(request)
 	if err != nil {
@@ -132,6 +132,7 @@ func (p *Provider) Generate(ctx context.Context, opts ...llm.Option) (*llm.Respo
 	if len(result.Content) == 0 {
 		return nil, fmt.Errorf("empty response from anthropic api")
 	}
+	logCacheThrash(config, &result.Usage)
 	if config.Prefill != "" {
 		if err := addPrefill(result.Content, config.Prefill, config.PrefillClosingTag); err != nil {
 			return nil, err
@@ -166,12 +167,12 @@ func (p *Provider) Stream(ctx context.Context, opts ...llm.Option) (llm.StreamIt
 	if err != nil {
 		return nil, fmt.Errorf("error converting messages: %w", err)
 	}
-	applyCacheControl(msgs, config)
 	if config.Prefill != "" {
 		msgs = append(msgs, llm.NewAssistantTextMessage(config.Prefill))
 	}
 	request.Messages = msgs
 	request.Stream = true
+	p.applyCaching(&request, config)
 
 	body, err := json.Marshal(request)
 	if err != nil {
@@ -296,30 +297,200 @@ func convertMessages(messages []*llm.Message) ([]*llm.Message, error) {
 	return copied, nil
 }
 
-// applyCacheControl sets ephemeral cache control on the last content block of
-// the last message. This is applied automatically unless the user explicitly
-// opts out by setting Caching to false. The messages slice should already be a
-// copy (from convertMessages) so mutation is safe.
-func applyCacheControl(messages []*llm.Message, config *llm.Config) {
+const (
+	// cacheLookbackWindow is the number of trailing content blocks Anthropic
+	// searches backward from a cache breakpoint to find a reusable cache entry.
+	// A breakpoint further than this from the prior cached prefix forces a full
+	// rewrite of the intervening blocks.
+	cacheLookbackWindow = 20
+	// cacheAnchorGap is the maximum number of content blocks we allow between
+	// consecutive breakpoints. Kept safely under cacheLookbackWindow so the
+	// chain of breakpoints stays reachable even when a single turn appends a
+	// large fan-out of tool-call / tool-result blocks.
+	cacheAnchorGap = 15
+)
+
+// applyCaching places cache-control breakpoints across the request using the
+// hybrid strategy from docs/specs/anthropic-prompt-caching-hybrid.md:
+//
+//   - An explicit breakpoint on the last system block caches the stable
+//     tools+system prefix independently of the moving message tail, so a
+//     message-tier cache miss reads the (large) prefix instead of rewriting it.
+//   - The moving conversation tail is cached via Anthropic automatic caching
+//     (a top-level cache_control) when the endpoint supports it, or via an
+//     explicit tail breakpoint on endpoints that don't (Bedrock / Vertex /
+//     custom).
+//   - Explicit anchor breakpoints are placed walking backward from the tail so
+//     no two breakpoints are more than cacheAnchorGap blocks apart, keeping the
+//     chain inside the 20-block lookback window during high tool-call fan-out.
+//
+// Stable-prefix breakpoints (system + anchors) use the 1-hour TTL when the
+// extended-cache feature is enabled; the tail stays at the default 5-minute
+// TTL. Breakpoints are capped at the 4 the API allows (automatic consumes one).
+//
+// The request's messages/system should already be copies (system is built
+// fresh; messages come from convertMessages) so mutation here is safe.
+func (p *Provider) applyCaching(req *Request, config *llm.Config) {
 	if config.Caching != nil && !*config.Caching {
 		return
 	}
-	if len(messages) == 0 {
+
+	stableTTL := stablePrefixTTL(config)
+	clearRequestCacheControl(req)
+
+	// Total explicit block-level breakpoints used so far. The API allows 4; when
+	// automatic caching is on it consumes one, leaving 3 for explicit blocks.
+	explicitUsed := 0
+	explicitBudget := 4
+
+	automatic := p.supportsAutomaticCaching()
+	if automatic {
+		explicitBudget = 3
+		req.CacheControl = &llm.CacheControl{Type: llm.CacheControlTypeEphemeral}
+	}
+
+	// Slot: stable tools+system prefix.
+	if setLastSystemBreakpoint(req.System, stableTTL) {
+		explicitUsed++
+	}
+
+	if len(req.Messages) == 0 {
 		return
 	}
-	// Clear any existing cache control
-	for _, message := range messages {
+
+	// Tail handling. Automatic caching owns the tail when supported; otherwise
+	// fall back to an explicit breakpoint on the last content block.
+	if !automatic {
+		if setLastMessageTailBreakpoint(req.Messages) {
+			explicitUsed++
+		}
+	}
+
+	// Anchors defend the 20-block lookback window for the recent conversation.
+	remaining := explicitBudget - explicitUsed
+	placeCacheAnchors(req.Messages, remaining, stableTTL)
+}
+
+// logCacheThrash surfaces prompt-cache thrash: when caching is enabled but a
+// request writes far more cache than it reads, a large prefix was rewritten
+// instead of reused (e.g. a breakpoint fell outside the 20-block lookback
+// window). It warns only on a meaningful write that dominates the read, so
+// steady-state cold starts and small requests stay quiet. No-ops without a
+// logger or when caching is disabled.
+func logCacheThrash(config *llm.Config, usage *llm.Usage) {
+	if config.Logger == nil || (config.Caching != nil && !*config.Caching) {
+		return
+	}
+	const minWriteTokens = 4096
+	write := usage.CacheCreationInputTokens
+	read := usage.CacheReadInputTokens
+	if write >= minWriteTokens && write > read {
+		config.Logger.Warn("prompt cache write exceeded read; prefix likely rewritten",
+			"cache_creation_tokens", write,
+			"cache_read_tokens", read,
+			"input_tokens", usage.InputTokens)
+	}
+}
+
+// supportsAutomaticCaching reports whether the configured endpoint supports
+// Anthropic automatic prompt caching (top-level cache_control). It is available
+// on the first-party Claude API but not on Bedrock or Vertex, which are reached
+// through different endpoints.
+func (p *Provider) supportsAutomaticCaching() bool {
+	return p.endpoint == DefaultEndpoint
+}
+
+// stablePrefixTTL returns the TTL to use for stable-prefix breakpoints (system
+// and anchors). The 1-hour cache is used only when the extended-cache feature
+// is enabled; otherwise the default 5-minute cache (empty TTL) applies.
+func stablePrefixTTL(config *llm.Config) string {
+	if config.IsFeatureEnabled(FeatureExtendedCache) {
+		return llm.CacheTTL1h
+	}
+	return ""
+}
+
+// clearRequestCacheControl removes any pre-existing cache_control markers from
+// the system blocks and message contents so placement starts from a clean
+// slate (some content types preserve CacheControl across convertMessages).
+func clearRequestCacheControl(req *Request) {
+	for _, block := range req.System {
+		block.CacheControl = nil
+	}
+	for _, message := range req.Messages {
 		for _, content := range message.Content {
 			if setter, ok := content.(llm.CacheControlSetter); ok {
 				setter.SetCacheControl(nil)
 			}
 		}
 	}
-	// Set cache control on the last content block of the last message
-	lastMessage := messages[len(messages)-1]
-	if contents := lastMessage.Content; len(contents) > 0 {
-		if setter, ok := contents[len(contents)-1].(llm.CacheControlSetter); ok {
+}
+
+// setLastSystemBreakpoint marks the final system block with cache control,
+// caching the tools+system prefix. Returns false when there is no system prompt.
+func setLastSystemBreakpoint(system []*SystemBlock, ttl string) bool {
+	if len(system) == 0 {
+		return false
+	}
+	system[len(system)-1].CacheControl = &llm.CacheControl{
+		Type: llm.CacheControlTypeEphemeral,
+		TTL:  ttl,
+	}
+	return true
+}
+
+// setLastMessageTailBreakpoint sets an explicit ephemeral (5-minute) breakpoint
+// on the last cacheable content block of the last message. Used as the
+// portability fallback when automatic caching is unavailable.
+func setLastMessageTailBreakpoint(messages []*llm.Message) bool {
+	contents := messages[len(messages)-1].Content
+	for i := len(contents) - 1; i >= 0; i-- {
+		if setter, ok := contents[i].(llm.CacheControlSetter); ok {
 			setter.SetCacheControl(&llm.CacheControl{Type: llm.CacheControlTypeEphemeral})
+			return true
+		}
+	}
+	return false
+}
+
+// placeCacheAnchors walks backward over the message content blocks and drops up
+// to maxAnchors explicit breakpoints so that consecutive breakpoints are never
+// more than cacheAnchorGap blocks apart. This keeps every breakpoint within the
+// API's lookback window even when one turn appends a large fan-out of blocks,
+// bounding a cache miss to a single gap instead of the whole message prefix.
+//
+// The tail block (whether owned by automatic caching or an explicit fallback
+// breakpoint) is counted toward the first gap but is never itself anchored.
+func placeCacheAnchors(messages []*llm.Message, maxAnchors int, ttl string) {
+	if maxAnchors <= 0 {
+		return
+	}
+	placed := 0
+	blocks := 0
+	first := true
+	for mi := len(messages) - 1; mi >= 0 && placed < maxAnchors; mi-- {
+		contents := messages[mi].Content
+		for bi := len(contents) - 1; bi >= 0 && placed < maxAnchors; bi-- {
+			// The tail block is already the tail breakpoint (automatic owns the
+			// real tail; the explicit fallback marked the last block). Count it
+			// toward the first gap but never anchor on it.
+			if first {
+				first = false
+				blocks++
+				continue
+			}
+			blocks++
+			if blocks < cacheAnchorGap {
+				continue
+			}
+			if setter, ok := contents[bi].(llm.CacheControlSetter); ok {
+				setter.SetCacheControl(&llm.CacheControl{
+					Type: llm.CacheControlTypeEphemeral,
+					TTL:  ttl,
+				})
+				placed++
+				blocks = 0
+			}
 		}
 	}
 }
@@ -394,7 +565,9 @@ func (p *Provider) applyRequestConfig(req *Request, config *llm.Config) error {
 		config.Logger.Warn("temperature is not supported by this model and will be ignored",
 			"model", req.Model)
 	}
-	req.System = config.SystemPrompt
+	if config.SystemPrompt != "" {
+		req.System = []*SystemBlock{{Type: "text", Text: config.SystemPrompt}}
+	}
 	return nil
 }
 
@@ -596,11 +769,11 @@ func (p *Provider) createRequest(ctx context.Context, body []byte, config *llm.C
 	}
 
 	var betaFeatures []string
+	// Prompt caching is GA and needs no beta header; the extended (1-hour) cache
+	// still advertises its beta. Both are only sent when explicitly enabled.
 	if config.IsFeatureEnabled(FeatureExtendedCache) {
 		betaFeatures = append(betaFeatures, FeatureExtendedCache)
 	} else if config.IsFeatureEnabled(FeaturePromptCaching) {
-		betaFeatures = append(betaFeatures, FeaturePromptCaching)
-	} else if config.Caching == nil || *config.Caching {
 		betaFeatures = append(betaFeatures, FeaturePromptCaching)
 	}
 

--- a/providers/anthropic/anthropic.go
+++ b/providers/anthropic/anthropic.go
@@ -132,7 +132,7 @@ func (p *Provider) Generate(ctx context.Context, opts ...llm.Option) (*llm.Respo
 	if len(result.Content) == 0 {
 		return nil, fmt.Errorf("empty response from anthropic api")
 	}
-	logCacheThrash(config, &result.Usage)
+	finalizeUsage(config, request.Model, &result.Usage)
 	if config.Prefill != "" {
 		if err := addPrefill(result.Content, config.Prefill, config.PrefillClosingTag); err != nil {
 			return nil, err
@@ -390,6 +390,19 @@ func logCacheThrash(config *llm.Config, usage *llm.Usage) {
 			"cache_read_tokens", read,
 			"input_tokens", usage.InputTokens)
 	}
+}
+
+// finalizeUsage runs post-response usage bookkeeping for the non-streaming
+// path: it logs cache thrash and attaches an estimated cost from registered
+// model pricing. Fast mode is detected from the served speed or the request so
+// premium fast-mode pricing is used when applicable. (Streamed responses get
+// the same cost treatment centrally via llm.ResponseAccumulator.)
+func finalizeUsage(config *llm.Config, model string, usage *llm.Usage) {
+	logCacheThrash(config, usage)
+	fast := usage.Speed == string(llm.SpeedFast) ||
+		config.Speed == llm.SpeedFast ||
+		config.IsFeatureEnabled(FeatureFastMode)
+	llm.PopulateCost(model, fast, usage)
 }
 
 // supportsAutomaticCaching reports whether the configured endpoint supports

--- a/providers/anthropic/anthropic_test.go
+++ b/providers/anthropic/anthropic_test.go
@@ -288,25 +288,218 @@ func TestDocumentContentHandling(t *testing.T) {
 	}
 }
 
-func TestApplyCacheControlDoesNotMutateOriginal(t *testing.T) {
-	// Build an original message with TextContent that has no CacheControl
+// applyTestCaching builds a Request from system/messages and runs the hybrid
+// cache placement against a provider configured for the default endpoint
+// (automatic caching supported) unless overridden.
+func applyTestCaching(t *testing.T, p *Provider, config *llm.Config, system string, messages []*llm.Message) *Request {
+	t.Helper()
+	converted, err := convertMessages(messages)
+	assert.NoError(t, err)
+	req := &Request{Messages: converted}
+	if system != "" {
+		req.System = []*SystemBlock{{Type: "text", Text: system}}
+	}
+	p.applyCaching(req, config)
+	return req
+}
+
+func lastBlockCacheControl(msg *llm.Message) *llm.CacheControl {
+	contents := msg.Content
+	switch c := contents[len(contents)-1].(type) {
+	case *llm.TextContent:
+		return c.CacheControl
+	case *llm.ToolResultContent:
+		return c.CacheControl
+	case *llm.ToolUseContent:
+		return c.CacheControl
+	}
+	return nil
+}
+
+func countMessageBreakpoints(messages []*llm.Message) int {
+	n := 0
+	for _, m := range messages {
+		for _, content := range m.Content {
+			switch c := content.(type) {
+			case *llm.TextContent:
+				if c.CacheControl != nil {
+					n++
+				}
+			case *llm.ToolResultContent:
+				if c.CacheControl != nil {
+					n++
+				}
+			case *llm.ToolUseContent:
+				if c.CacheControl != nil {
+					n++
+				}
+			}
+		}
+	}
+	return n
+}
+
+func TestApplyCachingDoesNotMutateOriginal(t *testing.T) {
+	// convertMessages clones content, so applyCaching must not touch the original.
 	original := &llm.TextContent{Text: "hello"}
 	messages := []*llm.Message{
 		{Role: llm.User, Content: []llm.Content{original}},
 	}
-
-	// convertMessages should clone content, so applyCacheControl won't touch the original
-	converted, err := convertMessages(messages)
-	assert.NoError(t, err)
-
-	config := &llm.Config{}
-	applyCacheControl(converted, config)
-
-	// The converted message's content should have cache control set
-	setter, ok := converted[0].Content[0].(llm.CacheControlSetter)
-	assert.True(t, ok)
-	_ = setter // applyCacheControl sets it on the last content of the last message
-
-	// The original content must NOT have been mutated
+	applyTestCaching(t, New(), &llm.Config{}, "you are helpful", messages)
 	assert.Nil(t, original.CacheControl)
+}
+
+func TestApplyCachingSystemBreakpoint(t *testing.T) {
+	// The system prefix gets its own breakpoint, independent of the message tail.
+	messages := []*llm.Message{llm.NewUserTextMessage("hi")}
+	req := applyTestCaching(t, New(), &llm.Config{}, "you are helpful", messages)
+
+	assert.Len(t, req.System, 1)
+	assert.NotNil(t, req.System[0].CacheControl)
+	assert.Equal(t, llm.CacheControlTypeEphemeral, req.System[0].CacheControl.Type)
+	assert.Equal(t, "", req.System[0].CacheControl.TTL) // default 5m without extended cache
+}
+
+func TestApplyCachingAutomaticOwnsTail(t *testing.T) {
+	// On the default endpoint, automatic caching owns the tail: top-level
+	// cache_control is set and the last message block carries no explicit marker.
+	messages := []*llm.Message{llm.NewUserTextMessage("hi")}
+	req := applyTestCaching(t, New(), &llm.Config{}, "sys", messages)
+
+	assert.NotNil(t, req.CacheControl)
+	assert.Equal(t, llm.CacheControlTypeEphemeral, req.CacheControl.Type)
+	assert.Nil(t, lastBlockCacheControl(req.Messages[len(req.Messages)-1]))
+}
+
+func TestApplyCachingPortabilityFallback(t *testing.T) {
+	// On a non-default endpoint (e.g. Bedrock/Vertex/custom) automatic caching
+	// is unavailable, so the tail gets an explicit breakpoint and no top-level
+	// cache_control is set.
+	p := New(WithEndpoint("https://bedrock.example.com/v1/messages"))
+	messages := []*llm.Message{llm.NewUserTextMessage("hi")}
+	req := applyTestCaching(t, p, &llm.Config{}, "sys", messages)
+
+	assert.Nil(t, req.CacheControl)
+	assert.NotNil(t, lastBlockCacheControl(req.Messages[len(req.Messages)-1]))
+	assert.NotNil(t, req.System[0].CacheControl)
+}
+
+func TestApplyCachingOptOut(t *testing.T) {
+	off := false
+	messages := []*llm.Message{llm.NewUserTextMessage("hi")}
+	req := applyTestCaching(t, New(), &llm.Config{Caching: &off}, "sys", messages)
+
+	assert.Nil(t, req.CacheControl)
+	assert.Nil(t, req.System[0].CacheControl)
+	assert.Equal(t, 0, countMessageBreakpoints(req.Messages))
+}
+
+func TestApplyCachingExtendedTTL(t *testing.T) {
+	// With the extended-cache feature enabled, the stable prefix uses the
+	// 1-hour TTL while the tail (automatic) stays at the default 5m.
+	config := &llm.Config{}
+	config.Apply(llm.WithFeatures(FeatureExtendedCache))
+	messages := []*llm.Message{llm.NewUserTextMessage("hi")}
+	req := applyTestCaching(t, New(), config, "sys", messages)
+
+	assert.Equal(t, llm.CacheTTL1h, req.System[0].CacheControl.TTL)
+	assert.Equal(t, "", req.CacheControl.TTL)
+}
+
+func TestApplyCachingNeverExceedsBudget(t *testing.T) {
+	// A turn with a large tool-call fan-out must keep total breakpoints within
+	// the API's 4-slot budget (automatic consumes one; explicit blocks <= 3).
+	var assistant []llm.Content
+	var results []llm.Content
+	for range 13 {
+		assistant = append(assistant, &llm.ToolUseContent{ID: "t", Name: "upsert", Input: json.RawMessage(`{}`)})
+		results = append(results, &llm.ToolResultContent{ToolUseID: "t", Content: "ok"})
+	}
+	messages := []*llm.Message{
+		llm.NewUserTextMessage("start"),
+		{Role: llm.Assistant, Content: assistant},
+		{Role: llm.User, Content: results},
+	}
+	req := applyTestCaching(t, New(), &llm.Config{}, "sys", messages)
+
+	explicit := countMessageBreakpoints(req.Messages)
+	if req.System[0].CacheControl != nil {
+		explicit++
+	}
+	// Automatic caching consumes one slot, so explicit must stay <= 3.
+	assert.True(t, explicit <= 3, "explicit breakpoints %d exceed budget", explicit)
+}
+
+func TestApplyCachingFanoutAnchorWithinWindow(t *testing.T) {
+	// Regression for the incident: a turn appending >20 content blocks must
+	// leave an anchor within the 20-block lookback window of the tail so the
+	// message history is not fully rewritten.
+	var assistant []llm.Content
+	var results []llm.Content
+	for range 13 {
+		assistant = append(assistant, &llm.ToolUseContent{ID: "t", Name: "upsert", Input: json.RawMessage(`{}`)})
+		results = append(results, &llm.ToolResultContent{ToolUseID: "t", Content: "ok"})
+	}
+	messages := []*llm.Message{
+		llm.NewUserTextMessage("start"),
+		{Role: llm.Assistant, Content: []llm.Content{llm.NewTextContent("older turn")}},
+		{Role: llm.User, Content: []llm.Content{llm.NewTextContent("older user")}},
+		{Role: llm.Assistant, Content: assistant},
+		{Role: llm.User, Content: results},
+	}
+	req := applyTestCaching(t, New(), &llm.Config{}, "sys", messages)
+
+	// Find the distance (in content blocks from the tail) of the nearest anchor.
+	nearest := -1
+	dist := 0
+	for mi := len(req.Messages) - 1; mi >= 0; mi-- {
+		contents := req.Messages[mi].Content
+		for bi := len(contents) - 1; bi >= 0; bi-- {
+			if cc := blockCacheControl(contents[bi]); cc != nil {
+				if nearest == -1 {
+					nearest = dist
+				}
+			}
+			dist++
+		}
+	}
+	assert.True(t, nearest >= 0, "expected at least one message anchor for the fan-out turn")
+	assert.True(t, nearest <= cacheLookbackWindow, "nearest anchor %d blocks from tail exceeds lookback window", nearest)
+}
+
+func TestApplyCachingWireFormat(t *testing.T) {
+	// The serialized request must render system as an array of text blocks (so a
+	// breakpoint can attach) and carry a top-level cache_control for automatic
+	// caching on the default endpoint.
+	messages := []*llm.Message{llm.NewUserTextMessage("hi")}
+	req := applyTestCaching(t, New(), &llm.Config{}, "you are helpful", messages)
+	req.Model = "claude-opus-4-8"
+
+	body, err := json.Marshal(req)
+	assert.NoError(t, err)
+	var decoded map[string]any
+	assert.NoError(t, json.Unmarshal(body, &decoded))
+
+	system, ok := decoded["system"].([]any)
+	assert.True(t, ok, "system should marshal as an array")
+	assert.Len(t, system, 1)
+	block := system[0].(map[string]any)
+	assert.Equal(t, "text", block["type"])
+	assert.NotNil(t, block["cache_control"])
+
+	cc, ok := decoded["cache_control"].(map[string]any)
+	assert.True(t, ok, "top-level cache_control should be present")
+	assert.Equal(t, "ephemeral", cc["type"])
+}
+
+func blockCacheControl(c llm.Content) *llm.CacheControl {
+	switch v := c.(type) {
+	case *llm.TextContent:
+		return v.CacheControl
+	case *llm.ToolResultContent:
+		return v.CacheControl
+	case *llm.ToolUseContent:
+		return v.CacheControl
+	}
+	return nil
 }

--- a/providers/anthropic/anthropic_test.go
+++ b/providers/anthropic/anthropic_test.go
@@ -394,6 +394,32 @@ func TestApplyCachingOptOut(t *testing.T) {
 	assert.Equal(t, 0, countMessageBreakpoints(req.Messages))
 }
 
+func TestApplyCachingOptOutClearsCallerMarkers(t *testing.T) {
+	// Opt-out must strip caller-provided cache markers so none leak into the
+	// request — including the top-level cache_control, system, and messages.
+	off := false
+	msgs, err := convertMessages([]*llm.Message{llm.NewUserTextMessage("hi")})
+	assert.NoError(t, err)
+	for _, m := range msgs {
+		for _, c := range m.Content {
+			if s, ok := c.(llm.CacheControlSetter); ok {
+				s.SetCacheControl(&llm.CacheControl{Type: llm.CacheControlTypeEphemeral})
+			}
+		}
+	}
+	req := &Request{
+		CacheControl: &llm.CacheControl{Type: llm.CacheControlTypeEphemeral},
+		System:       []*SystemBlock{{Type: "text", Text: "sys", CacheControl: &llm.CacheControl{Type: llm.CacheControlTypeEphemeral}}},
+		Messages:     msgs,
+	}
+
+	New().applyCaching(req, &llm.Config{Caching: &off})
+
+	assert.Nil(t, req.CacheControl, "top-level cache_control should be cleared on opt-out")
+	assert.Nil(t, req.System[0].CacheControl, "system marker should be cleared on opt-out")
+	assert.Equal(t, 0, countMessageBreakpoints(req.Messages), "message markers should be cleared on opt-out")
+}
+
 func TestApplyCachingExtendedTTL(t *testing.T) {
 	// With the extended-cache feature enabled, the stable prefix uses the
 	// 1-hour TTL while the tail (automatic) stays at the default 5m.

--- a/providers/anthropic/cost_test.go
+++ b/providers/anthropic/cost_test.go
@@ -1,0 +1,58 @@
+package anthropic
+
+import (
+	"testing"
+
+	"github.com/deepnoodle-ai/dive/llm"
+	"github.com/deepnoodle-ai/dive/providers"
+	"github.com/deepnoodle-ai/wonton/assert"
+)
+
+func TestRegisteredPricingHasDerivedCacheRates(t *testing.T) {
+	p, ok := providers.PricingFor(ModelClaudeOpus48, false)
+	assert.True(t, ok, "Opus 4.8 standard pricing should be registered")
+	assert.Equal(t, 5.0, p.InputPrice)
+	assert.Equal(t, 25.0, p.OutputPrice)
+	assert.Equal(t, 0.5, p.CacheReadPrice)   // 0.1x input
+	assert.Equal(t, 6.25, p.CacheWritePrice) // 1.25x input
+}
+
+func TestRegisteredFastPricing(t *testing.T) {
+	p, ok := providers.PricingFor(ModelClaudeOpus48, true)
+	assert.True(t, ok, "Opus 4.8 fast-mode pricing should be registered")
+	assert.Equal(t, 10.0, p.InputPrice) // fast premium
+	assert.Equal(t, 50.0, p.OutputPrice)
+}
+
+func TestFinalizeUsageAttachesCost(t *testing.T) {
+	usage := &llm.Usage{
+		InputTokens:              1_000_000,
+		OutputTokens:             1_000_000,
+		CacheReadInputTokens:     1_000_000,
+		CacheCreationInputTokens: 1_000_000,
+	}
+	finalizeUsage(&llm.Config{}, ModelClaudeOpus48, usage)
+	assert.NotNil(t, usage.Cost, "finalizeUsage should attach cost for a known model")
+	// 5 (in) + 25 (out) + 0.5 (read) + 6.25 (write)
+	assert.Equal(t, 36.75, usage.Cost.Total)
+	assert.Equal(t, ModelClaudeOpus48, usage.Cost.Model)
+}
+
+func TestFinalizeUsageUsesFastPricingWhenServedFast(t *testing.T) {
+	usage := &llm.Usage{InputTokens: 1_000_000, Speed: string(llm.SpeedFast)}
+	finalizeUsage(&llm.Config{}, ModelClaudeOpus48, usage)
+	assert.NotNil(t, usage.Cost)
+	assert.Equal(t, 10.0, usage.Cost.Total, "fast speed should bill at fast-mode input price")
+}
+
+func TestFinalizeUsageUnknownModelLeavesCostNil(t *testing.T) {
+	usage := &llm.Usage{InputTokens: 1_000_000}
+	finalizeUsage(&llm.Config{}, "totally-unknown-model", usage)
+	assert.Nil(t, usage.Cost, "unknown model should leave cost unknown (nil)")
+}
+
+func TestWithCachePricing(t *testing.T) {
+	out := withCachePricing(llm.PricingInfo{Model: "x", InputPrice: 4})
+	assert.Equal(t, 0.4, out.CacheReadPrice)
+	assert.Equal(t, 5.0, out.CacheWritePrice)
+}

--- a/providers/anthropic/register.go
+++ b/providers/anthropic/register.go
@@ -15,6 +15,33 @@ func init() {
 
 	// Register as the fallback provider (for unknown models)
 	providers.SetFallback(factory)
+
+	registerPricing()
+}
+
+// registerPricing publishes Anthropic model pricing — with derived prompt-cache
+// rates — to the central pricing registry so usage cost can be attached.
+func registerPricing() {
+	for _, p := range TextModelPricing {
+		providers.RegisterPricing(withCachePricing(p), false)
+	}
+	for _, p := range FastModeTextPricing {
+		providers.RegisterPricing(withCachePricing(p), true)
+	}
+}
+
+// withCachePricing fills Anthropic's prompt-cache rates relative to the base
+// input price: cache reads bill at 0.1x, and cache writes at the default
+// 5-minute TTL bill at 1.25x. (The 1-hour TTL is 2x, but usage does not carry
+// a per-TTL split, so the default rate is used.)
+func withCachePricing(p llm.PricingInfo) llm.PricingInfo {
+	if p.CacheReadPrice == 0 {
+		p.CacheReadPrice = p.InputPrice * 0.10
+	}
+	if p.CacheWritePrice == 0 {
+		p.CacheWritePrice = p.InputPrice * 1.25
+	}
+	return p
 }
 
 func factory(model, endpoint string) llm.LLM {

--- a/providers/anthropic/types.go
+++ b/providers/anthropic/types.go
@@ -6,9 +6,19 @@ import (
 )
 
 const (
-	CacheControlTypeEphemeral  = "ephemeral"
-	CacheControlTypePersistent = "persistent"
+	CacheControlTypeEphemeral = "ephemeral"
 )
+
+// SystemBlock is a single system-prompt content block. The Anthropic API
+// accepts the system prompt either as a plain string or as an array of text
+// blocks; the array form is required to attach a cache_control breakpoint to
+// the system prompt so the tools+system prefix caches independently of the
+// moving message tail.
+type SystemBlock struct {
+	Type         string            `json:"type"`
+	Text         string            `json:"text"`
+	CacheControl *llm.CacheControl `json:"cache_control,omitempty"`
+}
 
 type ImageSource struct {
 	Type      string `json:"type"`
@@ -36,11 +46,17 @@ type OutputConfig struct {
 }
 
 type Request struct {
-	Model             string                       `json:"model"`
-	Messages          []*llm.Message               `json:"messages"`
-	MaxTokens         *int                         `json:"max_tokens,omitempty"`
-	Temperature       *float64                     `json:"temperature,omitempty"`
-	System            string                       `json:"system,omitempty"`
+	Model       string         `json:"model"`
+	Messages    []*llm.Message `json:"messages"`
+	MaxTokens   *int           `json:"max_tokens,omitempty"`
+	Temperature *float64       `json:"temperature,omitempty"`
+	System      []*SystemBlock `json:"system,omitempty"`
+	// CacheControl, when set, enables Anthropic automatic prompt caching: the
+	// API places (and advances) a cache breakpoint on the moving conversation
+	// tail, consuming one of the 4 available breakpoint slots. Not supported on
+	// Bedrock or Vertex; the provider falls back to an explicit tail breakpoint
+	// there.
+	CacheControl      *llm.CacheControl            `json:"cache_control,omitempty"`
 	Stream            bool                         `json:"stream,omitempty"`
 	Speed             string                       `json:"speed,omitempty"`
 	Tools             []map[string]any             `json:"tools,omitempty"`

--- a/providers/google/google.go
+++ b/providers/google/google.go
@@ -149,6 +149,8 @@ func (p *Provider) Generate(ctx context.Context, opts ...llm.Option) (*llm.Respo
 		return nil, err
 	}
 
+	llm.PopulateCost(result.Model, result.Usage.Speed == string(llm.SpeedFast), &result.Usage)
+
 	if err := config.FireHooks(ctx, &llm.HookContext{
 		Type: llm.AfterGenerate,
 		Request: &llm.HookRequestContext{

--- a/providers/google/pricing_register.go
+++ b/providers/google/pricing_register.go
@@ -1,0 +1,11 @@
+package google
+
+import "github.com/deepnoodle-ai/dive/providers"
+
+// init publishes this provider's model pricing to the central registry so usage
+// cost can be attached automatically (see providers.PricingFor / llm.PopulateCost).
+func init() {
+	for _, p := range TextModelPricing {
+		providers.RegisterPricing(p, false)
+	}
+}

--- a/providers/grok/pricing_register.go
+++ b/providers/grok/pricing_register.go
@@ -1,0 +1,11 @@
+package grok
+
+import "github.com/deepnoodle-ai/dive/providers"
+
+// init publishes this provider's model pricing to the central registry so usage
+// cost can be attached automatically (see providers.PricingFor / llm.PopulateCost).
+func init() {
+	for _, p := range TextModelPricing {
+		providers.RegisterPricing(p, false)
+	}
+}

--- a/providers/mistral/pricing.go
+++ b/providers/mistral/pricing.go
@@ -1,13 +1,6 @@
 package mistral
 
-// PricingInfo represents pricing information for a specific service
-type PricingInfo struct {
-	Model       string  `json:"model"`
-	InputPrice  float64 `json:"input_price_per_1m_tokens"`  // per 1M input tokens (USD)
-	OutputPrice float64 `json:"output_price_per_1m_tokens"` // per 1M output tokens (USD)
-	Currency    string  `json:"currency"`
-	UpdatedAt   string  `json:"updated_at"` // YYYY-MM-DD format
-}
+import "github.com/deepnoodle-ai/dive/llm"
 
 // ImagePricingInfo represents pricing for image generation services
 type ImagePricingInfo struct {
@@ -27,7 +20,7 @@ type EmbeddingPricingInfo struct {
 }
 
 // TextModelPricing contains pricing for all text generation models
-var TextModelPricing = map[string]PricingInfo{
+var TextModelPricing = map[string]llm.PricingInfo{
 	ModelMistralLarge2411: {
 		Model:       ModelMistralLarge2411,
 		InputPrice:  2.0,

--- a/providers/mistral/pricing_register.go
+++ b/providers/mistral/pricing_register.go
@@ -1,0 +1,11 @@
+package mistral
+
+import "github.com/deepnoodle-ai/dive/providers"
+
+// init publishes this provider's model pricing to the central registry so usage
+// cost can be attached automatically (see providers.PricingFor / llm.PopulateCost).
+func init() {
+	for _, p := range TextModelPricing {
+		providers.RegisterPricing(p, false)
+	}
+}

--- a/providers/ollama/pricing_register.go
+++ b/providers/ollama/pricing_register.go
@@ -1,0 +1,12 @@
+package ollama
+
+import "github.com/deepnoodle-ai/dive/providers"
+
+// init publishes this provider's model pricing to the central registry so usage
+// cost can be attached automatically. Ollama runs locally, so its registered
+// prices are zero — yielding a known cost of $0 (distinct from unknown/nil).
+func init() {
+	for _, p := range TextModelPricing {
+		providers.RegisterPricing(p, false)
+	}
+}

--- a/providers/openai/cost_test.go
+++ b/providers/openai/cost_test.go
@@ -1,0 +1,35 @@
+package openai
+
+import (
+	"testing"
+
+	"github.com/deepnoodle-ai/dive/llm"
+	"github.com/deepnoodle-ai/dive/providers"
+	"github.com/deepnoodle-ai/wonton/assert"
+)
+
+func TestOpenAIPricingRegistered(t *testing.T) {
+	for model := range TextModelPricing {
+		_, ok := providers.PricingFor(model, false)
+		assert.True(t, ok, "openai pricing should be registered: "+model)
+		return
+	}
+	t.Skip("no openai pricing entries")
+}
+
+func TestOpenAIPopulateCost(t *testing.T) {
+	var model string
+	for m, p := range TextModelPricing {
+		if p.InputPrice > 0 {
+			model = m
+			break
+		}
+	}
+	if model == "" {
+		t.Skip("no priced openai model")
+	}
+	u := &llm.Usage{InputTokens: 1_000_000, OutputTokens: 1_000_000}
+	llm.PopulateCost(model, false, u)
+	assert.NotNil(t, u.Cost, "cost should populate via the registry resolver")
+	assert.True(t, u.Cost.Total > 0, "priced model should yield positive cost")
+}

--- a/providers/openai/cost_test.go
+++ b/providers/openai/cost_test.go
@@ -9,12 +9,13 @@ import (
 )
 
 func TestOpenAIPricingRegistered(t *testing.T) {
+	if len(TextModelPricing) == 0 {
+		t.Skip("no openai pricing entries")
+	}
 	for model := range TextModelPricing {
 		_, ok := providers.PricingFor(model, false)
 		assert.True(t, ok, "openai pricing should be registered: "+model)
-		return
 	}
-	t.Skip("no openai pricing entries")
 }
 
 func TestOpenAIPopulateCost(t *testing.T) {

--- a/providers/openai/pricing_register.go
+++ b/providers/openai/pricing_register.go
@@ -1,0 +1,11 @@
+package openai
+
+import "github.com/deepnoodle-ai/dive/providers"
+
+// init publishes this provider's model pricing to the central registry so usage
+// cost can be attached automatically (see providers.PricingFor / llm.PopulateCost).
+func init() {
+	for _, p := range TextModelPricing {
+		providers.RegisterPricing(p, false)
+	}
+}

--- a/providers/openai/provider.go
+++ b/providers/openai/provider.go
@@ -130,6 +130,8 @@ func (p *Provider) Generate(ctx context.Context, opts ...llm.Option) (*llm.Respo
 		return nil, err
 	}
 
+	llm.PopulateCost(result.Model, result.Usage.Speed == string(llm.SpeedFast), &result.Usage)
+
 	if err := config.FireHooks(ctx, &llm.HookContext{
 		Type: llm.AfterGenerate,
 		Request: &llm.HookRequestContext{

--- a/providers/openaicompletions/openai.go
+++ b/providers/openaicompletions/openai.go
@@ -205,6 +205,8 @@ func (p *Provider) Generate(ctx context.Context, opts ...llm.Option) (*llm.Respo
 		Usage:   result.Usage.toLLMUsage(),
 	}
 
+	llm.PopulateCost(response.Model, response.Usage.Speed == string(llm.SpeedFast), &response.Usage)
+
 	if err := config.FireHooks(ctx, &llm.HookContext{
 		Type: llm.AfterGenerate,
 		Request: &llm.HookRequestContext{

--- a/providers/openaicompletions/pricing_register.go
+++ b/providers/openaicompletions/pricing_register.go
@@ -1,0 +1,11 @@
+package openaicompletions
+
+import "github.com/deepnoodle-ai/dive/providers"
+
+// init publishes this provider's model pricing to the central registry so usage
+// cost can be attached automatically (see providers.PricingFor / llm.PopulateCost).
+func init() {
+	for _, p := range TextModelPricing {
+		providers.RegisterPricing(p, false)
+	}
+}

--- a/providers/openrouter/pricing_register.go
+++ b/providers/openrouter/pricing_register.go
@@ -1,0 +1,11 @@
+package openrouter
+
+import "github.com/deepnoodle-ai/dive/providers"
+
+// init publishes this provider's model pricing to the central registry so usage
+// cost can be attached automatically (see providers.PricingFor / llm.PopulateCost).
+func init() {
+	for _, p := range TextModelPricing {
+		providers.RegisterPricing(p, false)
+	}
+}

--- a/providers/pricing.go
+++ b/providers/pricing.go
@@ -1,0 +1,53 @@
+package providers
+
+import (
+	"sync"
+
+	"github.com/deepnoodle-ai/dive/llm"
+)
+
+// Pricing registry. Providers register their per-model pricing here from
+// init(), mirroring how they register model factories. A central registry lets
+// any consumer resolve cost by model name without importing every provider
+// package, and lets the llm streaming accumulator attach cost automatically via
+// the resolver wired up in init below.
+var (
+	pricingMu       sync.RWMutex
+	standardPricing = map[string]llm.PricingInfo{}
+	fastPricing     = map[string]llm.PricingInfo{}
+)
+
+func init() {
+	// Wire the llm package's cost resolver to this registry so that
+	// llm.PopulateCost (and therefore streamed responses) can price usage
+	// without an import cycle.
+	llm.SetCostResolver(PricingFor)
+}
+
+// RegisterPricing records pricing for a model. fast indicates the entry applies
+// to fast-mode requests (e.g. Anthropic's premium fast inference); register the
+// standard entry with fast=false. Typically called from a provider's init().
+func RegisterPricing(info llm.PricingInfo, fast bool) {
+	pricingMu.Lock()
+	defer pricingMu.Unlock()
+	if fast {
+		fastPricing[info.Model] = info
+	} else {
+		standardPricing[info.Model] = info
+	}
+}
+
+// PricingFor returns the registered pricing for a model at the given speed.
+// When fast is requested but no fast-specific entry exists, it falls back to
+// the standard entry. ok is false when no pricing is registered for the model.
+func PricingFor(model string, fast bool) (llm.PricingInfo, bool) {
+	pricingMu.RLock()
+	defer pricingMu.RUnlock()
+	if fast {
+		if p, ok := fastPricing[model]; ok {
+			return p, true
+		}
+	}
+	p, ok := standardPricing[model]
+	return p, ok
+}

--- a/providers/pricing_providers_test.go
+++ b/providers/pricing_providers_test.go
@@ -1,0 +1,54 @@
+package providers_test
+
+import (
+	"testing"
+
+	"github.com/deepnoodle-ai/dive/llm"
+	"github.com/deepnoodle-ai/dive/providers"
+	"github.com/deepnoodle-ai/dive/providers/anthropic"
+	"github.com/deepnoodle-ai/dive/providers/mistral"
+	"github.com/deepnoodle-ai/dive/providers/ollama"
+	"github.com/deepnoodle-ai/dive/providers/openaicompletions"
+	"github.com/deepnoodle-ai/dive/providers/openrouter"
+	"github.com/deepnoodle-ai/wonton/assert"
+)
+
+// assertRegistered verifies that importing a provider package registered its
+// pricing table with the central registry, by resolving one of its own models.
+// (openai/google/grok live in separate modules and are covered by their own
+// tests; these are the providers that share the root module.)
+func assertRegistered(t *testing.T, name string, table map[string]llm.PricingInfo) {
+	t.Helper()
+	for model := range table {
+		_, ok := providers.PricingFor(model, false)
+		assert.True(t, ok, name+" pricing should be registered for "+model)
+		return
+	}
+	t.Skipf("%s has no pricing entries", name)
+}
+
+func TestProvidersRegisterPricing(t *testing.T) {
+	assertRegistered(t, "anthropic", anthropic.TextModelPricing)
+	assertRegistered(t, "openaicompletions", openaicompletions.TextModelPricing)
+	assertRegistered(t, "mistral", mistral.TextModelPricing)
+	assertRegistered(t, "openrouter", openrouter.TextModelPricing)
+	// Ollama runs locally; entries (if any) are free.
+	assertRegistered(t, "ollama", ollama.TextModelPricing)
+}
+
+func TestPopulateCostForMistralModel(t *testing.T) {
+	var model string
+	for m, p := range mistral.TextModelPricing {
+		if p.InputPrice > 0 {
+			model = m
+			break
+		}
+	}
+	if model == "" {
+		t.Skip("no priced mistral model")
+	}
+	u := &llm.Usage{InputTokens: 1_000_000, OutputTokens: 1_000_000}
+	llm.PopulateCost(model, false, u)
+	assert.NotNil(t, u.Cost, "cost should populate via the registry resolver")
+	assert.True(t, u.Cost.Total > 0, "priced model should yield a positive cost")
+}

--- a/providers/pricing_providers_test.go
+++ b/providers/pricing_providers_test.go
@@ -19,12 +19,14 @@ import (
 // tests; these are the providers that share the root module.)
 func assertRegistered(t *testing.T, name string, table map[string]llm.PricingInfo) {
 	t.Helper()
+	if len(table) == 0 {
+		t.Skipf("%s has no pricing entries", name)
+		return
+	}
 	for model := range table {
 		_, ok := providers.PricingFor(model, false)
 		assert.True(t, ok, name+" pricing should be registered for "+model)
-		return
 	}
-	t.Skipf("%s has no pricing entries", name)
 }
 
 func TestProvidersRegisterPricing(t *testing.T) {

--- a/providers/pricing_test.go
+++ b/providers/pricing_test.go
@@ -1,0 +1,43 @@
+package providers
+
+import (
+	"testing"
+
+	"github.com/deepnoodle-ai/dive/llm"
+	"github.com/deepnoodle-ai/wonton/assert"
+)
+
+func TestPricingRegistryLookup(t *testing.T) {
+	RegisterPricing(llm.PricingInfo{Model: "reg-test-model", InputPrice: 3, OutputPrice: 15, Currency: "USD"}, false)
+	RegisterPricing(llm.PricingInfo{Model: "reg-test-model", InputPrice: 6, OutputPrice: 30, Currency: "USD"}, true)
+
+	p, ok := PricingFor("reg-test-model", false)
+	assert.True(t, ok)
+	assert.Equal(t, 3.0, p.InputPrice)
+
+	// Fast lookup gets the fast entry.
+	p, ok = PricingFor("reg-test-model", true)
+	assert.True(t, ok)
+	assert.Equal(t, 6.0, p.InputPrice)
+
+	// Unknown model.
+	_, ok = PricingFor("does-not-exist", false)
+	assert.False(t, ok)
+}
+
+func TestPricingFor_FastFallsBackToStandard(t *testing.T) {
+	RegisterPricing(llm.PricingInfo{Model: "reg-standard-only", InputPrice: 2, Currency: "USD"}, false)
+	// No fast entry registered; fast lookup should fall back to standard.
+	p, ok := PricingFor("reg-standard-only", true)
+	assert.True(t, ok)
+	assert.Equal(t, 2.0, p.InputPrice)
+}
+
+func TestCostResolverIsWired(t *testing.T) {
+	// init() should have installed PricingFor as the llm cost resolver.
+	RegisterPricing(llm.PricingInfo{Model: "reg-wired-model", InputPrice: 5, Currency: "USD"}, false)
+	u := &llm.Usage{InputTokens: 1_000_000}
+	llm.PopulateCost("reg-wired-model", false, u)
+	assert.NotNil(t, u.Cost, "providers init should wire llm.SetCostResolver to PricingFor")
+	assert.Equal(t, 5.0, u.Cost.Total)
+}


### PR DESCRIPTION
## Overview

This PR grew from a single caching fix into three related pieces that build on each other, all threaded through Anthropic cache economics:

1. **Hybrid prompt caching** — stops the Anthropic provider paying for rewritten prefixes (stable-prefix breakpoint + 20-block fan-out defense).
2. **Usage cost estimation** — makes the dollar cost of cache hits vs misses *computable*, as a first-class field on `llm.Usage`, accurate per provider and populated across all providers.
3. **CLI token/cache/cost visibility** — makes it all *visible*: a clearly-labeled status panel and a `/usage` command surfacing reads vs writes, hit rate, and cost.

---

## 1. Hybrid prompt caching

Replaces the Anthropic provider's single tail-only cache breakpoint with a **hybrid automatic + explicit 4-slot** strategy. This improves handling of Anthropic's 20-block lookback limit, which becomes relevant with wide fan-outs on parallel tool calls.

**`llm/` (shared types)**
- `CacheControl` gains a `TTL` field (`llm/content.go`); adds `CacheTTL5m`/`CacheTTL1h` constants (`llm/cache_control.go`) — **item 4**, makes the previously-dead 1h cache functional.
- `ToolUseContent` is now anchorable: carries `cache_control`, implements `SetCacheControl`/`CloneContent`, serializes the marker — so anchors can land *inside* a parallel tool-call fan-out turn rather than being forced past the 20-block window.

**`providers/anthropic/types.go`**
- `Request.System` is now `[]*SystemBlock` instead of `string` — **item 1**, enables the stable-prefix breakpoint.
- Adds top-level `Request.CacheControl` for automatic caching — **item 2**.
- Removes the invalid `CacheControlTypePersistent` constant — **item 5**.

**`providers/anthropic/anthropic.go`**
- Replaces `applyCacheControl` with `Provider.applyCaching` implementing the hybrid 4-slot strategy:
  - **Slot 2** — explicit breakpoint on the last system block (caches tools+system; survives message-tier misses).
  - **Slot 1** — top-level automatic `cache_control` owns the moving tail on the first-party endpoint; portability fallback to an explicit tail breakpoint on Bedrock/Vertex/custom endpoints (`supportsAutomaticCaching` keys off `DefaultEndpoint`).
  - **Slots 3–4** — `placeCacheAnchors` walks backward keeping ≤15 blocks between breakpoints, bounded by the remaining budget (3 explicit when automatic is on, 4 in fallback) — **item 3**, the 20-block defense.
  - TTL: 1h on the stable prefix (system + anchors) only when `FeatureExtendedCache` is on; tail stays 5m. Longest-TTL-first ordering holds naturally.
- Drops the GA `prompt-caching-2024-07-31` default beta header (sent only on explicit opt-in now) — **item 5**.
- Adds `logCacheThrash` — warns when cache writes dominate reads — **item 6**.

**Tests:** `anthropic_test.go` covers system breakpoint, automatic-owns-tail, portability fallback, opt-out, extended TTL, budget cap under fan-out, the **incident regression** (anchor within the lookback window), and a wire-format check.

---

## 2. Usage cost estimation

Makes monetary cost a first-class, provider-accurate part of every generation. Cost is computed **where the tokens are produced** — so per-call costs sum correctly even across model/speed changes — and rides along on `llm.Usage`, so the agent loop, streamed responses, and any direct caller get it for free.

**`llm/` core**
- `PricingInfo` gains `CacheReadPrice`/`CacheWritePrice`; new `Cost` breakdown type and `PricingInfo.CostOf(usage)`.
- `Usage` gains `Cost *Cost` — a pointer, so **nil = unknown** is distinct from a known **$0** (local models). `Usage.Add`/`Copy` are cost-aware.
- New cost resolver hook (`SetCostResolver` / `PopulateCost`) lets `llm` price usage without importing `providers` (avoids an import cycle). The streaming `ResponseAccumulator` attaches cost at message completion — covering streaming centrally for **all** providers.

**`providers/` registry**
- `RegisterPricing` / `PricingFor(model, fast)`, populated from each provider's `init()` (mirroring the model-factory registry); `init()` wires `llm.SetCostResolver(PricingFor)`. This finally connects the previously **unused** per-provider `TextModelPricing` tables.

**Provider wiring**
- **Anthropic**: registers standard + fast pricing with derived prompt-cache rates (read 0.1×, write 1.25× of input); non-streaming path now calls `finalizeUsage` (cache-thrash log + cost), fast-mode aware.
- **openai / openaicompletions / google**: populate cost in `Generate` (the only other real `Generate` impls — grok→openai, mistral/openrouter→openaicompletions, ollama→anthropic inherit it).
- All providers register pricing; Mistral's bespoke `PricingInfo` is standardized to `llm.PricingInfo`.

**Caveats (documented in code):** cache-write cost uses the 5-minute TTL rate (usage carries no per-TTL split); cost is an estimate at list prices, not a bill; non-Anthropic cache-write economics are not modeled.

**Tests:** `CostOf` math, `Usage` `Add`/`Copy` deep-copy, resolver round-trip, streaming-accumulator injection, registry lookup + cross-provider registration, Anthropic derived rates / fast pricing / `finalizeUsage`, and the openai module.

---

## 3. CLI token/cache/cost visibility

Replaces the ambiguous `in / cache / out` status line (which folded cache writes into the input total and labeled only reads) with a clearly-labeled per-scope table, and surfaces the cost now carried on `llm.Usage`.

**Status panel** (turn + session rows):
```
 tokens      input   cache read   cache write   output    hit      cost
 turn         1.2k        13.5k           500       53    96%    $0.015
 session      4.8k        12.0k         41.0k      892    22%     $1.27
```
- Distinct columns: input, cache read (green hits), cache write (amber misses), output, hit rate, and cost.
- Hit rate is colored by health (green ≥80%, amber 50–79%, red <50%), so cache thrash — the failure mode §1 addresses — is immediately visible.
- Cost column appears only when pricing is known; `—` marks an unknown per-scope cost (distinct from a known `$0`). A reasoning column appears when present; a fast-mode badge shows on the model line.

**New `/usage` (alias `/cost`) command:** a persistent, fully-labeled breakdown (input/read/write/output/reasoning/total + hit rate + est. cost per scope) with a legend explaining each metric — the detail that can't fit in the compact panel. Wired into help and autocomplete.

**Tests:** hit-rate / token / cost formatting, and rendered-panel assertions that reads, writes, hit rate, and cost all appear (and that the cost column hides when pricing is unknown).

---

## Verification

- `go build ./...` and `go vet` clean across the root module, the separate `providers/{openai,google,grok}` modules, and the CLI module; gofmt clean.
- `go test ./...` passes for `llm/`, `providers/`, `providers/anthropic/`, the openai module, and the CLI module. (Network integration tests like `TestHelloWorld` need `ANTHROPIC_API_KEY` and weren't run.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added exported cache TTL options (default **5m**, extended **1h** where supported) and optional TTL support for cache control.
  * Tool-use blocks can now carry cache-control settings.
  * Expanded cost-aware CLI reporting with `/usage` and `/cost`, including detailed token/cache breakdown and estimated pricing.

* **Improvements**
  * Enhanced prompt-caching behavior (including improved breakpoint placement and opt-out handling) for the Anthropic provider.
  * Added shared pricing/cost estimation across providers, including cache read/write cost components.

* **Tests**
  * Expanded caching and TUI rendering tests, plus new pricing/cost registry and cost-population coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
