### PR TITLE
Upgrade wonton to v0.0.36 across all modules

### DIFF
--- a/a2a/go.mod
+++ b/a2a/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 require (
 	github.com/a2aproject/a2a-go/v2 v2.2.0
 	github.com/deepnoodle-ai/dive v1.8.0
-	github.com/deepnoodle-ai/wonton v0.0.34
+	github.com/deepnoodle-ai/wonton v0.0.36
 )
 
 require (

--- a/a2a/go.sum
+++ b/a2a/go.sum
@@ -1,7 +1,7 @@
 github.com/a2aproject/a2a-go/v2 v2.2.0 h1:eayiNXYpyTOLVhhQrGmIHlcy8GnOdnwaNdYQPvS84Ik=
 github.com/a2aproject/a2a-go/v2 v2.2.0/go.mod h1:htTxMwicNXXXEwwfjuB/Pd1g7UHDrswhSievncmTVcE=
-github.com/deepnoodle-ai/wonton v0.0.34 h1:0jE1KtbwZkKPuoxnV0CdYWrQdnYO+r3O3jWnFvZgV40=
-github.com/deepnoodle-ai/wonton v0.0.34/go.mod h1:rQ484HIdk0XfBACtcBuLDMTfn3keow1DspiXZv4IlL8=
+github.com/deepnoodle-ai/wonton v0.0.36 h1:CTL1rBVvVwy3adwNohJj+FwcHX0bEKz1wn7RJ+uLOJ8=
+github.com/deepnoodle-ai/wonton v0.0.36/go.mod h1:rQ484HIdk0XfBACtcBuLDMTfn3keow1DspiXZv4IlL8=
 github.com/gobwas/glob v0.2.3 h1:A4xDbljILXROh+kObIiy5kIaPYD8e96x1tgBhUI5J+Y=
 github.com/gobwas/glob v0.2.3/go.mod h1:d3Ez4x06l9bZtSvzIay5+Yzi0fmZzPgnTbPcKjJAkT8=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=

--- a/demos/colosseum/go.mod
+++ b/demos/colosseum/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/deepnoodle-ai/dive/providers/google v1.8.0
 	github.com/deepnoodle-ai/dive/providers/grok v1.8.0
 	github.com/deepnoodle-ai/dive/providers/openai v1.8.0
-	github.com/deepnoodle-ai/wonton v0.0.34
+	github.com/deepnoodle-ai/wonton v0.0.36
 )
 
 require (

--- a/demos/colosseum/go.sum
+++ b/demos/colosseum/go.sum
@@ -10,8 +10,8 @@ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UF
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/deepnoodle-ai/wonton v0.0.34 h1:0jE1KtbwZkKPuoxnV0CdYWrQdnYO+r3O3jWnFvZgV40=
-github.com/deepnoodle-ai/wonton v0.0.34/go.mod h1:rQ484HIdk0XfBACtcBuLDMTfn3keow1DspiXZv4IlL8=
+github.com/deepnoodle-ai/wonton v0.0.36 h1:CTL1rBVvVwy3adwNohJj+FwcHX0bEKz1wn7RJ+uLOJ8=
+github.com/deepnoodle-ai/wonton v0.0.36/go.mod h1:rQ484HIdk0XfBACtcBuLDMTfn3keow1DspiXZv4IlL8=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=

--- a/demos/noodleville/go.mod
+++ b/demos/noodleville/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/deepnoodle-ai/dive v1.8.0
-	github.com/deepnoodle-ai/wonton v0.0.34
+	github.com/deepnoodle-ai/wonton v0.0.36
 )
 
 require (

--- a/demos/noodleville/go.sum
+++ b/demos/noodleville/go.sum
@@ -1,5 +1,5 @@
-github.com/deepnoodle-ai/wonton v0.0.34 h1:0jE1KtbwZkKPuoxnV0CdYWrQdnYO+r3O3jWnFvZgV40=
-github.com/deepnoodle-ai/wonton v0.0.34/go.mod h1:rQ484HIdk0XfBACtcBuLDMTfn3keow1DspiXZv4IlL8=
+github.com/deepnoodle-ai/wonton v0.0.36 h1:CTL1rBVvVwy3adwNohJj+FwcHX0bEKz1wn7RJ+uLOJ8=
+github.com/deepnoodle-ai/wonton v0.0.36/go.mod h1:rQ484HIdk0XfBACtcBuLDMTfn3keow1DspiXZv4IlL8=
 github.com/gobwas/glob v0.2.3 h1:A4xDbljILXROh+kObIiy5kIaPYD8e96x1tgBhUI5J+Y=
 github.com/gobwas/glob v0.2.3/go.mod h1:d3Ez4x06l9bZtSvzIay5+Yzi0fmZzPgnTbPcKjJAkT8=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=

--- a/examples/go.mod
+++ b/examples/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/deepnoodle-ai/dive/providers/google v1.8.0
 	github.com/deepnoodle-ai/dive/providers/grok v1.8.0
 	github.com/deepnoodle-ai/dive/providers/openai v1.8.0
-	github.com/deepnoodle-ai/wonton v0.0.34
+	github.com/deepnoodle-ai/wonton v0.0.36
 	github.com/fatih/color v1.18.0
 	github.com/mark3labs/mcp-go v0.45.0
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.67.0

--- a/examples/go.sum
+++ b/examples/go.sum
@@ -16,8 +16,8 @@ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UF
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/deepnoodle-ai/wonton v0.0.34 h1:0jE1KtbwZkKPuoxnV0CdYWrQdnYO+r3O3jWnFvZgV40=
-github.com/deepnoodle-ai/wonton v0.0.34/go.mod h1:rQ484HIdk0XfBACtcBuLDMTfn3keow1DspiXZv4IlL8=
+github.com/deepnoodle-ai/wonton v0.0.36 h1:CTL1rBVvVwy3adwNohJj+FwcHX0bEKz1wn7RJ+uLOJ8=
+github.com/deepnoodle-ai/wonton v0.0.36/go.mod h1:rQ484HIdk0XfBACtcBuLDMTfn3keow1DspiXZv4IlL8=
 github.com/fatih/color v1.18.0 h1:S8gINlzdQ840/4pfAwic/ZE0djQEH3wM94VfqLTZcOM=
 github.com/fatih/color v1.18.0/go.mod h1:4FelSpRwEGDpQ12mAdzqdOukCy4u8WUtOY6lkT/6HfU=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=

--- a/examples/image_example/main.go
+++ b/examples/image_example/main.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/deepnoodle-ai/dive/llm"
 	"github.com/deepnoodle-ai/dive/providers/anthropic"
-	"github.com/deepnoodle-ai/wonton/web"
+	"github.com/deepnoodle-ai/wonton/fetch"
 )
 
 const DefaultImageURL = "https://images.unsplash.com/photo-1506744038136-46273834b3fb?w=400"
@@ -22,8 +22,7 @@ func main() {
 
 	ctx := context.Background()
 
-	fetcher := web.NewDefaultBinaryFetcher()
-	binary, err := fetcher.FetchBinary(ctx, &web.BinaryFetchInput{URL: url})
+	binary, err := fetch.Download(ctx, url, nil)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/experimental/cmd/dive/app.go
+++ b/experimental/cmd/dive/app.go
@@ -419,6 +419,22 @@ func (a *App) LiveView() tui.View {
 			Placeholder("Type a message... (@filename for autocomplete)").
 			Multiline(true).
 			MaxHeight(10).
+			OnChange(func(string) {
+				// A focused input consumes its own keystrokes (wonton
+				// >= v0.0.35), so refresh autocomplete on edits here
+				// rather than from HandleEvent.
+				a.updateAutocomplete()
+			}).
+			OnKey(func(e tui.KeyEvent) bool {
+				// Claim the keys the input would otherwise consume so
+				// autocomplete navigation and history recall still work
+				// while the input is focused.
+				if a.handleInputNavKey(e) {
+					a.updateAutocomplete()
+					return true
+				}
+				return false
+			}).
 			OnSubmit(func(value string) {
 				a.submitInput(value)
 			}),
@@ -924,26 +940,11 @@ func (a *App) handleKeyEvent(e tui.KeyEvent) []tui.Cmd {
 		return a.handleDialogKey(e)
 	}
 
-	// Handle autocomplete navigation
-	if len(a.autocompleteMatches) > 0 {
-		switch e.Key {
-		case tui.KeyArrowUp:
-			if a.autocompleteIndex > 0 {
-				a.autocompleteIndex--
-			}
-			return nil
-		case tui.KeyArrowDown:
-			if a.autocompleteIndex < len(a.autocompleteMatches)-1 {
-				a.autocompleteIndex++
-			}
-			return nil
-		case tui.KeyTab:
-			a.selectAutocomplete()
-			return nil
-		case tui.KeyEscape:
-			a.clearAutocomplete()
-			return nil
-		}
+	// Autocomplete navigation and command-history recall. These normally
+	// arrive through the focused input's OnKey hook; consulting them here too
+	// covers any key that reaches the app directly.
+	if a.handleInputNavKey(e) {
+		return nil
 	}
 
 	// Handle global keys
@@ -967,6 +968,42 @@ func (a *App) handleKeyEvent(e tui.KeyEvent) []tui.Cmd {
 			a.cancel()
 		}
 		return nil
+	}
+
+	return nil
+}
+
+// handleInputNavKey processes autocomplete navigation and command-history
+// recall for the main input, returning true when it consumes the key. Since
+// wonton >= v0.0.35 a focused InputField owns its keystrokes, this is wired
+// through the input's OnKey hook; handleKeyEvent also consults it for keys
+// that reach the app directly. Returning false lets the input handle the key
+// itself (e.g. moving the cursor when there is no history to recall).
+func (a *App) handleInputNavKey(e tui.KeyEvent) bool {
+	// Autocomplete navigation takes precedence while suggestions are shown.
+	if len(a.autocompleteMatches) > 0 {
+		switch e.Key {
+		case tui.KeyArrowUp:
+			if a.autocompleteIndex > 0 {
+				a.autocompleteIndex--
+			}
+			return true
+		case tui.KeyArrowDown:
+			if a.autocompleteIndex < len(a.autocompleteMatches)-1 {
+				a.autocompleteIndex++
+			}
+			return true
+		case tui.KeyTab:
+			a.selectAutocomplete()
+			return true
+		case tui.KeyEscape:
+			a.clearAutocomplete()
+			return true
+		}
+	}
+
+	// Command-history recall on Up/Down when the input is idle.
+	switch e.Key {
 	case tui.KeyArrowUp:
 		// History navigation (only when no autocomplete and input is empty or navigating)
 		if !a.processing && len(a.history) > 0 && len(a.autocompleteMatches) == 0 {
@@ -978,8 +1015,8 @@ func (a *App) handleKeyEvent(e tui.KeyEvent) []tui.Cmd {
 			if a.historyIndex >= 0 && a.historyIndex < len(a.history) {
 				a.inputText = a.history[a.historyIndex]
 			}
+			return true
 		}
-		return nil
 	case tui.KeyArrowDown:
 		// History navigation (only when no autocomplete)
 		if !a.processing && a.historyIndex >= 0 && len(a.autocompleteMatches) == 0 {
@@ -990,11 +1027,11 @@ func (a *App) handleKeyEvent(e tui.KeyEvent) []tui.Cmd {
 			} else {
 				a.inputText = a.history[a.historyIndex]
 			}
+			return true
 		}
-		return nil
 	}
 
-	return nil
+	return false
 }
 
 // submitInput handles input submission
@@ -1713,11 +1750,11 @@ func (a *App) printRecentMessagesToScrollback() {
 // Run starts the CLI application
 func (a *App) Run() error {
 	// Create InlineApp runner with 30 FPS for animations
-	a.runner = tui.NewInlineApp(tui.InlineAppConfig{
-		FPS:            30,
-		BracketedPaste: true,
-		KittyKeyboard:  true,
-	})
+	a.runner = tui.NewInlineApp(
+		tui.WithInlineFPS(30),
+		tui.WithInlineBracketedPaste(true),
+		tui.WithInlineKittyKeyboard(true),
+	)
 
 	// If resuming a session, print the conversation history instead of the intro
 	if a.resumeSessionID != "" {

--- a/experimental/cmd/dive/app_interactive_test.go
+++ b/experimental/cmd/dive/app_interactive_test.go
@@ -80,16 +80,16 @@ func TestAppWithInlineRunner(t *testing.T) {
 	app := NewApp(agent, nil, "/tmp/test", "test-model", "", nil, "", nil, "")
 
 	var buf bytes.Buffer
-	runner := tui.NewInlineApp(tui.InlineAppConfig{
-		Width:  80,
-		Output: &buf,
-	})
+	runner := tui.NewInlineApp(
+		tui.WithInlineWidth(80),
+		tui.WithInlineOutput(&buf),
+	)
 
 	// Wire up the runner
 	app.runner = runner
 
 	// Create a live printer for testing render cycles
-	live := tui.NewLivePrinter(tui.PrintConfig{Width: 80, Output: &buf})
+	live := tui.NewLivePrinter(tui.WithWidth(80), tui.WithOutput(&buf))
 
 	t.Run("render produces valid ANSI output", func(t *testing.T) {
 		// Manually render the live view
@@ -124,7 +124,7 @@ func TestAppFooterCollapse(t *testing.T) {
 		// Render to buffer to count actual output lines (not screen lines)
 		var buf bytes.Buffer
 		view := app.LiveView()
-		tui.Fprint(&buf, view, tui.PrintConfig{Width: 80})
+		tui.Fprint(&buf, view, tui.WithWidth(80))
 		output := buf.String()
 
 		// Count lines in the actual output
@@ -189,7 +189,7 @@ func renderLiveView(t *testing.T, app *App, width, height int) *termtest.Screen 
 
 	var buf bytes.Buffer
 	view := app.LiveView()
-	tui.Fprint(&buf, view, tui.PrintConfig{Width: width})
+	tui.Fprint(&buf, view, tui.WithWidth(width))
 
 	screen := termtest.NewScreen(width, height)
 	// Use Write (not WriteString) to process ANSI escape sequences
@@ -206,10 +206,10 @@ func TestAppEventHandling(t *testing.T) {
 
 	// Create a runner with captured output
 	var buf bytes.Buffer
-	app.runner = tui.NewInlineApp(tui.InlineAppConfig{
-		Width:  80,
-		Output: &buf,
-	})
+	app.runner = tui.NewInlineApp(
+		tui.WithInlineWidth(80),
+		tui.WithInlineOutput(&buf),
+	)
 
 	t.Run("Ctrl+C shows exit hint", func(t *testing.T) {
 		// Simulate first Ctrl+C

--- a/experimental/cmd/dive/go.mod
+++ b/experimental/cmd/dive/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/deepnoodle-ai/dive/providers/google v1.8.0
 	github.com/deepnoodle-ai/dive/providers/grok v1.8.0
 	github.com/deepnoodle-ai/dive/providers/openai v1.8.0
-	github.com/deepnoodle-ai/wonton v0.0.34
+	github.com/deepnoodle-ai/wonton v0.0.36
 	github.com/mattn/go-runewidth v0.0.21
 )
 

--- a/experimental/cmd/dive/go.sum
+++ b/experimental/cmd/dive/go.sum
@@ -16,8 +16,8 @@ github.com/clipperhouse/uax29/v2 v2.7.0 h1:+gs4oBZ2gPfVrKPthwbMzWZDaAFPGYK72F0NJ
 github.com/clipperhouse/uax29/v2 v2.7.0/go.mod h1:EFJ2TJMRUaplDxHKj1qAEhCtQPW2tJSwu5BF98AuoVM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/deepnoodle-ai/wonton v0.0.34 h1:0jE1KtbwZkKPuoxnV0CdYWrQdnYO+r3O3jWnFvZgV40=
-github.com/deepnoodle-ai/wonton v0.0.34/go.mod h1:rQ484HIdk0XfBACtcBuLDMTfn3keow1DspiXZv4IlL8=
+github.com/deepnoodle-ai/wonton v0.0.36 h1:CTL1rBVvVwy3adwNohJj+FwcHX0bEKz1wn7RJ+uLOJ8=
+github.com/deepnoodle-ai/wonton v0.0.36/go.mod h1:rQ484HIdk0XfBACtcBuLDMTfn3keow1DspiXZv4IlL8=
 github.com/dlclark/regexp2 v1.11.5 h1:Q/sSnsKerHeCkc/jSTNq1oCm7KiVgUMZRDUoRu0JQZQ=
 github.com/dlclark/regexp2 v1.11.5/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=

--- a/experimental/cmd/dive/input_nav_test.go
+++ b/experimental/cmd/dive/input_nav_test.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/deepnoodle-ai/dive"
+	"github.com/deepnoodle-ai/wonton/assert"
+	"github.com/deepnoodle-ai/wonton/tui"
+)
+
+// These tests lock in the contract the main input's OnKey hook relies on:
+// since wonton >= v0.0.35 a focused InputField owns its keystrokes, Dive routes
+// autocomplete navigation and history recall through handleInputNavKey, which
+// must report whether it consumed the key (true) or the input should handle it
+// itself (false, e.g. moving the cursor).
+
+func newTestApp() *App {
+	return NewApp(&dive.Agent{}, nil, "/tmp/test", "test-model", "", nil, "", nil, "")
+}
+
+func TestHandleInputNavKey_HistoryRecall(t *testing.T) {
+	a := newTestApp()
+	a.history = []string{"first", "second"}
+
+	// Up recalls the newest entry, then older ones.
+	assert.True(t, a.handleInputNavKey(tui.KeyEvent{Key: tui.KeyArrowUp}), "Up should be consumed for history")
+	assert.Equal(t, "second", a.inputText)
+	assert.True(t, a.handleInputNavKey(tui.KeyEvent{Key: tui.KeyArrowUp}))
+	assert.Equal(t, "first", a.inputText)
+
+	// Down walks forward and clears past the newest entry.
+	assert.True(t, a.handleInputNavKey(tui.KeyEvent{Key: tui.KeyArrowDown}))
+	assert.Equal(t, "second", a.inputText)
+	assert.True(t, a.handleInputNavKey(tui.KeyEvent{Key: tui.KeyArrowDown}))
+	assert.Equal(t, "", a.inputText)
+	assert.Equal(t, -1, a.historyIndex)
+}
+
+func TestHandleInputNavKey_PassthroughWhenNoHistory(t *testing.T) {
+	a := newTestApp()
+	// No history and no autocomplete: the key is not consumed, so the focused
+	// input gets it (e.g. to move the cursor within a multiline draft).
+	assert.False(t, a.handleInputNavKey(tui.KeyEvent{Key: tui.KeyArrowUp}))
+	assert.False(t, a.handleInputNavKey(tui.KeyEvent{Key: tui.KeyArrowDown}))
+	assert.False(t, a.handleInputNavKey(tui.KeyEvent{Rune: 'x'}))
+}
+
+func TestHandleInputNavKey_HistoryNotRecalledWhileProcessing(t *testing.T) {
+	a := newTestApp()
+	a.history = []string{"first"}
+	a.processing = true
+	// While a turn is in flight, Up is left to the input rather than recalling.
+	assert.False(t, a.handleInputNavKey(tui.KeyEvent{Key: tui.KeyArrowUp}))
+	assert.Equal(t, "", a.inputText)
+}
+
+func TestHandleInputNavKey_AutocompleteNavigation(t *testing.T) {
+	a := newTestApp()
+	a.autocompleteMatches = []string{"a", "b", "c"}
+	a.autocompleteIndex = 0
+
+	assert.True(t, a.handleInputNavKey(tui.KeyEvent{Key: tui.KeyArrowDown}))
+	assert.Equal(t, 1, a.autocompleteIndex)
+	assert.True(t, a.handleInputNavKey(tui.KeyEvent{Key: tui.KeyArrowDown}))
+	assert.Equal(t, 2, a.autocompleteIndex)
+	// Already at the last match: consumed but index stays in range.
+	assert.True(t, a.handleInputNavKey(tui.KeyEvent{Key: tui.KeyArrowDown}))
+	assert.Equal(t, 2, a.autocompleteIndex)
+	assert.True(t, a.handleInputNavKey(tui.KeyEvent{Key: tui.KeyArrowUp}))
+	assert.Equal(t, 1, a.autocompleteIndex)
+}
+
+func TestHandleInputNavKey_AutocompleteTabSelects(t *testing.T) {
+	a := newTestApp()
+	a.inputText = "/he"
+	a.autocompleteType = "command"
+	a.autocompleteMatches = []string{"help"}
+	a.autocompleteIndex = 0
+
+	assert.True(t, a.handleInputNavKey(tui.KeyEvent{Key: tui.KeyTab}))
+	assert.Equal(t, "/help ", a.inputText)
+	assert.Equal(t, 0, len(a.autocompleteMatches), "selecting clears autocomplete")
+}
+
+func TestHandleInputNavKey_AutocompleteTakesPrecedenceOverHistory(t *testing.T) {
+	a := newTestApp()
+	a.history = []string{"old"}
+	a.autocompleteMatches = []string{"a", "b"}
+	a.autocompleteIndex = 0
+
+	// Down moves the autocomplete cursor, not history, while suggestions show.
+	assert.True(t, a.handleInputNavKey(tui.KeyEvent{Key: tui.KeyArrowDown}))
+	assert.Equal(t, 1, a.autocompleteIndex)
+	assert.Equal(t, "", a.inputText)
+}

--- a/experimental/cmd/dive/main.go
+++ b/experimental/cmd/dive/main.go
@@ -45,10 +45,10 @@ func main() {
 			cli.String("model", "m").
 				Default("").
 				Help("Model to use (default: gpt-image-2)"),
-			cli.String("aspect", "").
+			cli.String("aspect").
 				Default("").
 				Help("Aspect ratio: 1:1, 16:9, 9:16"),
-			cli.String("format", "").
+			cli.String("format").
 				Default("").
 				Help("Output format: png, jpeg, webp"),
 			cli.String("out", "o").
@@ -62,7 +62,7 @@ func main() {
 			cli.Bool("edit", "e").
 				Default(false).
 				Help("Edit reference images instead of generating new ones"),
-			cli.Bool("open", "").
+			cli.Bool("open").
 				Default(false).
 				Help("Open result in default viewer"),
 		).
@@ -76,7 +76,7 @@ func main() {
 			cli.String("model", "m").
 				Default("").
 				Help("Model to use (default: veo-3.1-generate-preview)"),
-			cli.String("aspect", "").
+			cli.String("aspect").
 				Default("").
 				Help("Aspect ratio: 16:9, 9:16, 1:1"),
 			cli.String("duration", "d").
@@ -85,7 +85,7 @@ func main() {
 			cli.String("out", "o").
 				Default("").
 				Help("Output file path"),
-			cli.Bool("open", "").
+			cli.Bool("open").
 				Default(false).
 				Help("Open result in default viewer"),
 		).
@@ -113,31 +113,31 @@ func main() {
 			cli.Float("temperature", "t").
 				Env("DIVE_TEMPERATURE").
 				Help("Sampling temperature (0.0-1.0)"),
-			cli.Int("max-tokens", "").
+			cli.Int("max-tokens").
 				Default(16000).
 				Env("DIVE_MAX_TOKENS").
 				Help("Maximum tokens in response"),
-			cli.String("system-prompt", "").
+			cli.String("system-prompt").
 				Default("").
 				Help("System prompt to use for the session"),
 			cli.Bool("print", "p").
 				Default(false).
 				Help("Print response and exit (useful for pipes)"),
-			cli.String("output-format", "").
+			cli.String("output-format").
 				Default("text").
 				Help("Output format (only works with --print): \"text\" (default) or \"json\""),
-			cli.String("api-endpoint", "").
+			cli.String("api-endpoint").
 				Default("").
 				Env("DIVE_API_ENDPOINT").
 				Help("Override the API endpoint URL for the provider"),
 			cli.Bool("resume", "r").
 				Default(false).
 				Help("Resume a previous session"),
-			cli.Bool("compaction", "").
+			cli.Bool("compaction").
 				Default(true).
 				Env("DIVE_COMPACTION").
 				Help("Enable automatic context compaction"),
-			cli.Int("compaction-threshold", "").
+			cli.Int("compaction-threshold").
 				Default(100000).
 				Env("DIVE_COMPACTION_THRESHOLD").
 				Help("Token threshold for automatic context compaction"),

--- a/experimental/cmd/dive/session_picker.go
+++ b/experimental/cmd/dive/session_picker.go
@@ -76,10 +76,10 @@ func RunSessionPicker(store session.Store, filter string, workspaceDir string) (
 	}
 
 	// Run the picker
-	runner := tui.NewInlineApp(tui.InlineAppConfig{
-		FPS:           30,
-		KittyKeyboard: true,
-	})
+	runner := tui.NewInlineApp(
+		tui.WithInlineFPS(30),
+		tui.WithInlineKittyKeyboard(true),
+	)
 
 	if err := runner.Run(picker); err != nil {
 		return nil, err

--- a/experimental/mcp/go.mod
+++ b/experimental/mcp/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/deepnoodle-ai/dive v1.8.0
-	github.com/deepnoodle-ai/wonton v0.0.34
+	github.com/deepnoodle-ai/wonton v0.0.36
 	github.com/mark3labs/mcp-go v0.45.0
 )
 

--- a/experimental/mcp/go.sum
+++ b/experimental/mcp/go.sum
@@ -4,8 +4,8 @@ github.com/buger/jsonparser v1.1.2 h1:frqHqw7otoVbk5M8LlE/L7HTnIq2v9RX6EJ48i9AxJ
 github.com/buger/jsonparser v1.1.2/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/deepnoodle-ai/wonton v0.0.34 h1:0jE1KtbwZkKPuoxnV0CdYWrQdnYO+r3O3jWnFvZgV40=
-github.com/deepnoodle-ai/wonton v0.0.34/go.mod h1:rQ484HIdk0XfBACtcBuLDMTfn3keow1DspiXZv4IlL8=
+github.com/deepnoodle-ai/wonton v0.0.36 h1:CTL1rBVvVwy3adwNohJj+FwcHX0bEKz1wn7RJ+uLOJ8=
+github.com/deepnoodle-ai/wonton v0.0.36/go.mod h1:rQ484HIdk0XfBACtcBuLDMTfn3keow1DspiXZv4IlL8=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/gobwas/glob v0.2.3 h1:A4xDbljILXROh+kObIiy5kIaPYD8e96x1tgBhUI5J+Y=

--- a/experimental/toolkit/google/search.go
+++ b/experimental/toolkit/google/search.go
@@ -79,7 +79,7 @@ func (s *Client) Search(ctx context.Context, q *web.SearchInput) (*web.SearchOut
 		q.Limit = 10
 	}
 	pageCount := (q.Limit + 9) / 10 // Google always returns 10 results per page
-	var items []*web.SearchItem
+	var items []web.SearchItem
 	var curPage int
 	for curPage < pageCount {
 		params := url.Values{}
@@ -93,7 +93,7 @@ func (s *Client) Search(ctx context.Context, q *web.SearchInput) (*web.SearchOut
 			return nil, err
 		}
 		for _, item := range crs.Items {
-			items = append(items, &web.SearchItem{
+			items = append(items, web.SearchItem{
 				URL:         item.Link,
 				Title:       item.Title,
 				Description: item.Snippet,

--- a/experimental/toolkit/kagi/kagi.go
+++ b/experimental/toolkit/kagi/kagi.go
@@ -77,11 +77,11 @@ func (s *KagiClient) Search(ctx context.Context, q *web.SearchInput) (*web.Searc
 		return nil, err
 	}
 
-	var items []*web.SearchItem
+	var items []web.SearchItem
 
 	for _, item := range results.Data {
 		if item.Type == 0 {
-			items = append(items, &web.SearchItem{
+			items = append(items, web.SearchItem{
 				URL:         item.URL,
 				Title:       item.Title,
 				Description: item.Snippet,

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/deepnoodle-ai/dive
 go 1.25.0
 
 require (
-	github.com/deepnoodle-ai/wonton v0.0.34
+	github.com/deepnoodle-ai/wonton v0.0.36
 	github.com/gobwas/glob v0.2.3
 	github.com/google/uuid v1.6.0
 	golang.org/x/image v0.38.0

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,6 @@
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/deepnoodle-ai/wonton v0.0.34 h1:0jE1KtbwZkKPuoxnV0CdYWrQdnYO+r3O3jWnFvZgV40=
-github.com/deepnoodle-ai/wonton v0.0.34/go.mod h1:rQ484HIdk0XfBACtcBuLDMTfn3keow1DspiXZv4IlL8=
+github.com/deepnoodle-ai/wonton v0.0.36 h1:CTL1rBVvVwy3adwNohJj+FwcHX0bEKz1wn7RJ+uLOJ8=
+github.com/deepnoodle-ai/wonton v0.0.36/go.mod h1:rQ484HIdk0XfBACtcBuLDMTfn3keow1DspiXZv4IlL8=
 github.com/gobwas/glob v0.2.3 h1:A4xDbljILXROh+kObIiy5kIaPYD8e96x1tgBhUI5J+Y=
 github.com/gobwas/glob v0.2.3/go.mod h1:d3Ez4x06l9bZtSvzIay5+Yzi0fmZzPgnTbPcKjJAkT8=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=

--- a/otel/go.mod
+++ b/otel/go.mod
@@ -13,7 +13,7 @@ require (
 
 require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
-	github.com/deepnoodle-ai/wonton v0.0.34 // indirect
+	github.com/deepnoodle-ai/wonton v0.0.36 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/google/uuid v1.6.0 // indirect

--- a/otel/go.sum
+++ b/otel/go.sum
@@ -2,8 +2,8 @@ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UF
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/deepnoodle-ai/wonton v0.0.34 h1:0jE1KtbwZkKPuoxnV0CdYWrQdnYO+r3O3jWnFvZgV40=
-github.com/deepnoodle-ai/wonton v0.0.34/go.mod h1:rQ484HIdk0XfBACtcBuLDMTfn3keow1DspiXZv4IlL8=
+github.com/deepnoodle-ai/wonton v0.0.36 h1:CTL1rBVvVwy3adwNohJj+FwcHX0bEKz1wn7RJ+uLOJ8=
+github.com/deepnoodle-ai/wonton v0.0.36/go.mod h1:rQ484HIdk0XfBACtcBuLDMTfn3keow1DspiXZv4IlL8=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
 github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=

--- a/providers/google/go.mod
+++ b/providers/google/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/deepnoodle-ai/dive v1.8.0
-	github.com/deepnoodle-ai/wonton v0.0.34
+	github.com/deepnoodle-ai/wonton v0.0.36
 	google.golang.org/genai v1.51.0
 )
 

--- a/providers/google/go.sum
+++ b/providers/google/go.sum
@@ -8,8 +8,8 @@ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UF
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/deepnoodle-ai/wonton v0.0.34 h1:0jE1KtbwZkKPuoxnV0CdYWrQdnYO+r3O3jWnFvZgV40=
-github.com/deepnoodle-ai/wonton v0.0.34/go.mod h1:rQ484HIdk0XfBACtcBuLDMTfn3keow1DspiXZv4IlL8=
+github.com/deepnoodle-ai/wonton v0.0.36 h1:CTL1rBVvVwy3adwNohJj+FwcHX0bEKz1wn7RJ+uLOJ8=
+github.com/deepnoodle-ai/wonton v0.0.36/go.mod h1:rQ484HIdk0XfBACtcBuLDMTfn3keow1DspiXZv4IlL8=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=

--- a/providers/grok/go.mod
+++ b/providers/grok/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 require (
 	github.com/deepnoodle-ai/dive v1.8.0
 	github.com/deepnoodle-ai/dive/providers/openai v1.8.0
-	github.com/deepnoodle-ai/wonton v0.0.34
+	github.com/deepnoodle-ai/wonton v0.0.36
 	github.com/openai/openai-go/v3 v3.29.0
 	golang.org/x/image v0.38.0
 )

--- a/providers/grok/go.sum
+++ b/providers/grok/go.sum
@@ -1,5 +1,5 @@
-github.com/deepnoodle-ai/wonton v0.0.34 h1:0jE1KtbwZkKPuoxnV0CdYWrQdnYO+r3O3jWnFvZgV40=
-github.com/deepnoodle-ai/wonton v0.0.34/go.mod h1:rQ484HIdk0XfBACtcBuLDMTfn3keow1DspiXZv4IlL8=
+github.com/deepnoodle-ai/wonton v0.0.36 h1:CTL1rBVvVwy3adwNohJj+FwcHX0bEKz1wn7RJ+uLOJ8=
+github.com/deepnoodle-ai/wonton v0.0.36/go.mod h1:rQ484HIdk0XfBACtcBuLDMTfn3keow1DspiXZv4IlL8=
 github.com/gobwas/glob v0.2.3 h1:A4xDbljILXROh+kObIiy5kIaPYD8e96x1tgBhUI5J+Y=
 github.com/gobwas/glob v0.2.3/go.mod h1:d3Ez4x06l9bZtSvzIay5+Yzi0fmZzPgnTbPcKjJAkT8=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=

--- a/providers/openai/go.mod
+++ b/providers/openai/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/deepnoodle-ai/dive v1.8.0
-	github.com/deepnoodle-ai/wonton v0.0.34
+	github.com/deepnoodle-ai/wonton v0.0.36
 	github.com/openai/openai-go/v3 v3.29.0
 	golang.org/x/image v0.38.0
 )

--- a/providers/openai/go.sum
+++ b/providers/openai/go.sum
@@ -1,5 +1,5 @@
-github.com/deepnoodle-ai/wonton v0.0.34 h1:0jE1KtbwZkKPuoxnV0CdYWrQdnYO+r3O3jWnFvZgV40=
-github.com/deepnoodle-ai/wonton v0.0.34/go.mod h1:rQ484HIdk0XfBACtcBuLDMTfn3keow1DspiXZv4IlL8=
+github.com/deepnoodle-ai/wonton v0.0.36 h1:CTL1rBVvVwy3adwNohJj+FwcHX0bEKz1wn7RJ+uLOJ8=
+github.com/deepnoodle-ai/wonton v0.0.36/go.mod h1:rQ484HIdk0XfBACtcBuLDMTfn3keow1DspiXZv4IlL8=
 github.com/gobwas/glob v0.2.3 h1:A4xDbljILXROh+kObIiy5kIaPYD8e96x1tgBhUI5J+Y=
 github.com/gobwas/glob v0.2.3/go.mod h1:d3Ez4x06l9bZtSvzIay5+Yzi0fmZzPgnTbPcKjJAkT8=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=

--- a/toolkit/firecrawl/client.go
+++ b/toolkit/firecrawl/client.go
@@ -226,7 +226,11 @@ func (c *Client) Fetch(ctx context.Context, req *fetch.Request) (*fetch.Response
 	if err != nil {
 		var apiErr *apiError
 		if errors.As(err, &apiErr) {
-			return nil, fetch.NewRequestErrorf("%s", apiErr.message).WithStatusCode(apiErr.statusCode)
+			return nil, &fetch.Error{
+				StatusCode: apiErr.statusCode,
+				URL:        req.URL,
+				Err:        errors.New(apiErr.message),
+			}
 		}
 		return nil, err
 	}
@@ -271,9 +275,9 @@ func (a *searcherAdapter) Search(ctx context.Context, input *web.SearchInput) (*
 	if err != nil {
 		return nil, err
 	}
-	items := make([]*web.SearchItem, 0, len(resp.Data))
+	items := make([]web.SearchItem, 0, len(resp.Data))
 	for _, r := range resp.Data {
-		items = append(items, &web.SearchItem{
+		items = append(items, web.SearchItem{
 			URL:         r.URL,
 			Title:       r.Title,
 			Description: r.Description,
@@ -283,7 +287,7 @@ func (a *searcherAdapter) Search(ctx context.Context, input *web.SearchInput) (*
 }
 
 // apiError carries an HTTP status code through the error chain so Fetch can
-// convert it to a fetch.RequestError without exposing wonton in the core API.
+// convert it to a fetch.Error without exposing wonton in the core API.
 type apiError struct {
 	statusCode int
 	message    string

--- a/toolkit/firecrawl/client_test.go
+++ b/toolkit/firecrawl/client_test.go
@@ -206,10 +206,9 @@ func TestClientFetchErrorHandling(t *testing.T) {
 
 			_, err = client.Fetch(context.Background(), &fetch.Request{URL: "https://example.com"})
 			assert.Error(t, err)
-			assert.True(t, fetch.IsRequestError(err))
-			var reqErr *fetch.RequestError
+			var reqErr *fetch.Error
 			assert.True(t, errors.As(err, &reqErr))
-			assert.Equal(t, tt.statusCode, reqErr.StatusCode())
+			assert.Equal(t, tt.statusCode, reqErr.StatusCode)
 		})
 	}
 }

--- a/toolkit/web_search_test.go
+++ b/toolkit/web_search_test.go
@@ -18,9 +18,9 @@ func (m *mockSearcher) Search(ctx context.Context, input *web.SearchInput) (*web
 	m.receivedLimit = input.Limit
 
 	// Generate items up to the requested count
-	items := []*web.SearchItem{}
+	items := []web.SearchItem{}
 	for i := 0; i < m.itemCount; i++ {
-		items = append(items, &web.SearchItem{
+		items = append(items, web.SearchItem{
 			URL:         "https://example.com",
 			Title:       "Test Result",
 			Description: "Test description",


### PR DESCRIPTION
## Summary

Bumps `github.com/deepnoodle-ai/wonton` from **v0.0.34 → v0.0.36** in every module and adapts the call sites to its updated API. This was sitting as uncommitted working-tree changes; this PR captures it on a branch.

## Changes

**Dependency bump** (all 11 modules): root, `a2a`, `demos/colosseum`, `demos/noodleville`, `examples`, `experimental/cmd/dive`, `experimental/mcp`, `otel`, `providers/{google,grok,openai}`.

**API adaptations:**
- **dive CLI** — cli option constructors drop the empty short-flag argument (`cli.String("x", "")` → `cli.String("x")`) in `main.go`, `app.go`, `session_picker.go`.
- **image example** — binary fetch moves from `web.NewDefaultBinaryFetcher()` to `fetch.Download()`.
- **firecrawl** — maps API errors onto the new `fetch.Error` struct instead of `fetch.NewRequestErrorf`.
- **web search adapters** — return `[]web.SearchItem` (value slice) instead of `[]*web.SearchItem` in the firecrawl, google, and kagi toolkits.
- **new test** — `experimental/cmd/dive/input_nav_test.go` locks in the focused-`InputField` key-routing contract introduced in wonton ≥ v0.0.35.

## Testing

- `go build ./...` passes in all 11 modules.
- `go test ./...` passes in the modules with code changes (root, `examples`, `experimental/cmd/dive`).

Note: the generated `examples/suspend/async_webhook/async_webhook_sessions/demo-email-1.jsonl` runtime artifact was intentionally left out of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling in API requests with clearer status reporting

* **New Features**
  * Enhanced CLI keyboard navigation with command history recall and improved autocomplete support

* **Chores**
  * Updated dependencies for stability improvements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->