### PR TITLE
Prepare v1.9.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,59 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [1.9.0] - 2026-06-20
+
+### Added
+
+- **Anthropic hybrid prompt caching** — the single tail-only cache breakpoint
+  is replaced with a 4-slot automatic + explicit strategy that fixes the
+  full-prefix rewrites and 20-block lookback overruns behind the prior cost
+  incident. Slot 2 puts an explicit breakpoint on the last system block
+  (caching tools + system); slot 1 lets the first-party endpoint's top-level
+  automatic `cache_control` own the moving tail, with a portability fallback to
+  an explicit tail breakpoint on Bedrock/Vertex/custom endpoints; slots 3–4
+  walk backward keeping ≤15 blocks between breakpoints within the remaining
+  budget. `ToolUseContent` is now anchorable so an anchor can land inside a
+  parallel tool-call fan-out turn. `CacheControl` gains a `TTL` field with
+  `CacheTTL5m`/`CacheTTL1h` constants (1h applied to the stable prefix only
+  when `FeatureExtendedCache` is on; the tail stays 5m), and a cache-thrash
+  warning fires when cache writes dominate reads.
+- **Per-call usage cost estimation** — monetary cost is now a first-class part
+  of every generation, computed where the tokens are produced so per-call
+  costs sum correctly across model/speed changes. `llm.PricingInfo` gains
+  `CacheReadPrice`/`CacheWritePrice` and a `Cost` breakdown via
+  `PricingInfo.CostOf(usage)`; `llm.Usage` carries `Cost *Cost` (nil = unknown,
+  distinct from a known $0) with cost-aware `Add`/`Copy`. A cost-resolver hook
+  (`SetCostResolver`/`PopulateCost`) lets `llm` price usage without importing
+  providers, and the streaming accumulator attaches cost at message completion
+  for all providers. The providers registry adds
+  `RegisterPricing`/`PricingFor`, populated from each provider's `init()`,
+  wiring up the previously unused per-provider pricing tables across Anthropic,
+  OpenAI, Google, Grok, Mistral, Ollama, OpenRouter, and openaicompletions.
+- **CLI token/cost visibility** — the ambiguous "in / cache / out" status line
+  is replaced with a labeled per-scope table (input, cache read, cache write,
+  output, hit rate, cost) that colors the hit rate by health so cache thrash is
+  immediately visible, with a fast-mode badge and a reasoning column when
+  present. A new `/usage` command (alias `/cost`) renders a persistent,
+  fully-labeled breakdown per scope with a legend. The cost column appears only
+  when pricing is known; "—" marks an unknown per-scope cost, and cost is
+  labeled an estimate at list prices, not a bill.
+
+### Changed
+
+- **`wonton` upgraded to v0.0.36** across all 11 modules, with call sites
+  adapted to the updated API: CLI option constructors drop the empty short-flag
+  argument, the image example's binary fetch moves to `fetch.Download`,
+  firecrawl maps API errors onto the new `fetch.Error` struct, and the
+  firecrawl/google/kagi web-search adapters return `[]web.SearchItem` value
+  slices. Adds locking around the focused-`InputField` key-routing contract
+  introduced in wonton ≥ v0.0.35.
+- **Anthropic request shape** — `Request.System` is now `[]*SystemBlock`
+  instead of a string, and a top-level `Request.CacheControl` supports
+  automatic caching. The GA `prompt-caching-2024-07-31` beta header is no
+  longer sent by default and the invalid `CacheControlTypePersistent` constant
+  is removed.
+
 ## [1.8.1] - 2026-06-09
 
 ### Fixed

--- a/a2a/go.mod
+++ b/a2a/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/a2aproject/a2a-go/v2 v2.2.0
-	github.com/deepnoodle-ai/dive v1.8.0
+	github.com/deepnoodle-ai/dive v1.9.0
 	github.com/deepnoodle-ai/wonton v0.0.36
 )
 

--- a/demos/colosseum/go.mod
+++ b/demos/colosseum/go.mod
@@ -3,11 +3,11 @@ module github.com/deepnoodle-ai/dive/demos/colosseum
 go 1.25.0
 
 require (
-	github.com/deepnoodle-ai/dive v1.8.0
-	github.com/deepnoodle-ai/dive/a2a v1.8.0
-	github.com/deepnoodle-ai/dive/providers/google v1.8.0
-	github.com/deepnoodle-ai/dive/providers/grok v1.8.0
-	github.com/deepnoodle-ai/dive/providers/openai v1.8.0
+	github.com/deepnoodle-ai/dive v1.9.0
+	github.com/deepnoodle-ai/dive/a2a v1.9.0
+	github.com/deepnoodle-ai/dive/providers/google v1.9.0
+	github.com/deepnoodle-ai/dive/providers/grok v1.9.0
+	github.com/deepnoodle-ai/dive/providers/openai v1.9.0
 	github.com/deepnoodle-ai/wonton v0.0.36
 )
 

--- a/demos/noodleville/go.mod
+++ b/demos/noodleville/go.mod
@@ -3,7 +3,7 @@ module github.com/deepnoodle-ai/dive/demos/noodleville
 go 1.25.0
 
 require (
-	github.com/deepnoodle-ai/dive v1.8.0
+	github.com/deepnoodle-ai/dive v1.9.0
 	github.com/deepnoodle-ai/wonton v0.0.36
 )
 

--- a/examples/go.mod
+++ b/examples/go.mod
@@ -3,13 +3,13 @@ module github.com/deepnoodle-ai/dive/examples
 go 1.25.0
 
 require (
-	github.com/deepnoodle-ai/dive v1.8.0
-	github.com/deepnoodle-ai/dive/a2a v1.8.0
-	github.com/deepnoodle-ai/dive/experimental/mcp v1.8.0
-	github.com/deepnoodle-ai/dive/otel v1.8.0
-	github.com/deepnoodle-ai/dive/providers/google v1.8.0
-	github.com/deepnoodle-ai/dive/providers/grok v1.8.0
-	github.com/deepnoodle-ai/dive/providers/openai v1.8.0
+	github.com/deepnoodle-ai/dive v1.9.0
+	github.com/deepnoodle-ai/dive/a2a v1.9.0
+	github.com/deepnoodle-ai/dive/experimental/mcp v1.9.0
+	github.com/deepnoodle-ai/dive/otel v1.9.0
+	github.com/deepnoodle-ai/dive/providers/google v1.9.0
+	github.com/deepnoodle-ai/dive/providers/grok v1.9.0
+	github.com/deepnoodle-ai/dive/providers/openai v1.9.0
 	github.com/deepnoodle-ai/wonton v0.0.36
 	github.com/fatih/color v1.18.0
 	github.com/mark3labs/mcp-go v0.45.0

--- a/experimental/cmd/dive/go.mod
+++ b/experimental/cmd/dive/go.mod
@@ -3,10 +3,10 @@ module github.com/deepnoodle-ai/dive/experimental/cmd/dive
 go 1.25.0
 
 require (
-	github.com/deepnoodle-ai/dive v1.8.0
-	github.com/deepnoodle-ai/dive/providers/google v1.8.0
-	github.com/deepnoodle-ai/dive/providers/grok v1.8.0
-	github.com/deepnoodle-ai/dive/providers/openai v1.8.0
+	github.com/deepnoodle-ai/dive v1.9.0
+	github.com/deepnoodle-ai/dive/providers/google v1.9.0
+	github.com/deepnoodle-ai/dive/providers/grok v1.9.0
+	github.com/deepnoodle-ai/dive/providers/openai v1.9.0
 	github.com/deepnoodle-ai/wonton v0.0.36
 	github.com/mattn/go-runewidth v0.0.21
 )

--- a/experimental/mcp/go.mod
+++ b/experimental/mcp/go.mod
@@ -3,7 +3,7 @@ module github.com/deepnoodle-ai/dive/experimental/mcp
 go 1.25.0
 
 require (
-	github.com/deepnoodle-ai/dive v1.8.0
+	github.com/deepnoodle-ai/dive v1.9.0
 	github.com/deepnoodle-ai/wonton v0.0.36
 	github.com/mark3labs/mcp-go v0.45.0
 )

--- a/otel/go.mod
+++ b/otel/go.mod
@@ -3,7 +3,7 @@ module github.com/deepnoodle-ai/dive/otel
 go 1.25.0
 
 require (
-	github.com/deepnoodle-ai/dive v1.8.0
+	github.com/deepnoodle-ai/dive v1.9.0
 	go.opentelemetry.io/otel v1.43.0
 	go.opentelemetry.io/otel/metric v1.43.0
 	go.opentelemetry.io/otel/sdk v1.43.0

--- a/providers/google/go.mod
+++ b/providers/google/go.mod
@@ -3,7 +3,7 @@ module github.com/deepnoodle-ai/dive/providers/google
 go 1.25.0
 
 require (
-	github.com/deepnoodle-ai/dive v1.8.0
+	github.com/deepnoodle-ai/dive v1.9.0
 	github.com/deepnoodle-ai/wonton v0.0.36
 	google.golang.org/genai v1.51.0
 )

--- a/providers/grok/go.mod
+++ b/providers/grok/go.mod
@@ -3,8 +3,8 @@ module github.com/deepnoodle-ai/dive/providers/grok
 go 1.25.0
 
 require (
-	github.com/deepnoodle-ai/dive v1.8.0
-	github.com/deepnoodle-ai/dive/providers/openai v1.8.0
+	github.com/deepnoodle-ai/dive v1.9.0
+	github.com/deepnoodle-ai/dive/providers/openai v1.9.0
 	github.com/deepnoodle-ai/wonton v0.0.36
 	github.com/openai/openai-go/v3 v3.29.0
 	golang.org/x/image v0.38.0

--- a/providers/openai/go.mod
+++ b/providers/openai/go.mod
@@ -3,7 +3,7 @@ module github.com/deepnoodle-ai/dive/providers/openai
 go 1.25.0
 
 require (
-	github.com/deepnoodle-ai/dive v1.8.0
+	github.com/deepnoodle-ai/dive v1.9.0
 	github.com/deepnoodle-ai/wonton v0.0.36
 	github.com/openai/openai-go/v3 v3.29.0
 	golang.org/x/image v0.38.0


### PR DESCRIPTION
Prepares the v1.9.0 release covering everything merged since v1.8.1 (#197, #198).

## Changelog

### Added
- **Anthropic hybrid prompt caching** (#197) — replaces the single tail-only cache breakpoint with a 4-slot automatic + explicit strategy that fixes the full-prefix rewrites and 20-block lookback overruns behind the prior cost incident. Adds an anchorable `ToolUseContent`, a `CacheControl.TTL` field with `CacheTTL5m`/`CacheTTL1h` constants, and a cache-thrash warning.
- **Per-call usage cost estimation** (#197) — cost is now a first-class part of every generation, computed where tokens are produced. Adds `PricingInfo.CostOf`, `Usage.Cost`, a cost-resolver hook (`SetCostResolver`/`PopulateCost`), and a providers pricing registry (`RegisterPricing`/`PricingFor`) wiring up the previously-unused per-provider pricing tables across all providers.
- **CLI token/cost visibility** (#197) — labeled per-scope status table (input, cache read/write, output, hit rate, cost) with health-colored hit rate, plus a new `/usage` (alias `/cost`) command with a full breakdown and legend.

### Changed
- **`wonton` upgraded to v0.0.36** (#198) across all 11 modules, with call sites adapted to the updated API.
- **Anthropic request shape** (#197) — `Request.System` is now `[]*SystemBlock`, a top-level `Request.CacheControl` supports automatic caching, the GA `prompt-caching-2024-07-31` beta header is no longer sent by default, and the invalid `CacheControlTypePersistent` constant is removed.

## Release mechanics
- Added the `[1.9.0] - 2026-06-20` section to `CHANGELOG.md`.
- Bumped intra-repo module version pins from `v1.8.0` → `v1.9.0` across all sub-modules and the two demos.
- Ran `make tidy-all` (no `go.sum` changes — local `replace` directives mean the pins resolve to workspace paths).

`go build ./...` passes across all modules and `llm` unit tests pass. The only test failures are the live Anthropic integration tests (HTTP 401 — no `ANTHROPIC_API_KEY` in this environment), which are unrelated to the version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TPtjf9W4ChnS72xqhe97Jd

---
_Generated by [Claude Code](https://claude.ai/code/session_01TPtjf9W4ChnS72xqhe97Jd)_