### PR TITLE
Add artifact detail view to Colosseum web UI

### DIFF
--- a/demos/colosseum/cmd_serve.go
+++ b/demos/colosseum/cmd_serve.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"fmt"
 	"net/http"
+	"os"
 
 	"github.com/deepnoodle-ai/dive/demos/colosseum/web"
 )
@@ -11,17 +12,21 @@ import (
 func cmdServe(args []string) error {
 	fs := flag.NewFlagSet("serve", flag.ContinueOnError)
 	dir := fs.String("dir", "transcripts", "directory of match transcripts to serve")
+	artifactsDir := fs.String("artifacts", "artifacts", "directory of artifacts to serve in the Artifacts tab (optional)")
 	addr := fs.String("addr", ":8723", "listen address")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
 
-	srv, err := web.NewServer(*dir)
+	srv, err := web.NewServer(*dir, web.WithArtifactsDir(*artifactsDir))
 	if err != nil {
 		return err
 	}
 	fmt.Printf("🏛  The Colosseum replay viewer\n")
 	fmt.Printf("    serving transcripts from %q\n", *dir)
+	if info, err := os.Stat(*artifactsDir); err == nil && info.IsDir() {
+		fmt.Printf("    serving artifacts from %q\n", *artifactsDir)
+	}
 	fmt.Printf("    open http://localhost%s\n", normalizeAddr(*addr))
 	return http.ListenAndServe(*addr, srv.Handler())
 }

--- a/demos/colosseum/web/server.go
+++ b/demos/colosseum/web/server.go
@@ -9,11 +9,13 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/fs"
+	"mime"
 	"net/http"
 	"os"
 	"path/filepath"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/deepnoodle-ai/dive/demos/colosseum/analytics"
 	"github.com/deepnoodle-ai/dive/demos/colosseum/transcript"
@@ -24,16 +26,30 @@ var staticFS embed.FS
 
 // Server serves the viewer and API over a transcripts directory.
 type Server struct {
-	dir string
-	mux *http.ServeMux
+	dir          string // match transcripts
+	artifactsDir string // optional directory of renderable artifacts (images, video, markdown…)
+	mux          *http.ServeMux
+}
+
+// Option configures a Server.
+type Option func(*Server)
+
+// WithArtifactsDir serves files from dir under the /api/artifacts endpoints,
+// powering the Artifacts tab in the viewer. The directory is optional: if it is
+// empty or missing, the artifacts list simply renders empty.
+func WithArtifactsDir(dir string) Option {
+	return func(s *Server) { s.artifactsDir = dir }
 }
 
 // NewServer builds a server reading transcripts from dir.
-func NewServer(dir string) (*Server, error) {
+func NewServer(dir string, opts ...Option) (*Server, error) {
 	if info, err := os.Stat(dir); err != nil || !info.IsDir() {
 		return nil, fmt.Errorf("transcripts directory %q does not exist", dir)
 	}
 	s := &Server{dir: dir, mux: http.NewServeMux()}
+	for _, opt := range opts {
+		opt(s)
+	}
 	s.routes()
 	return s, nil
 }
@@ -48,6 +64,8 @@ func (s *Server) routes() {
 	s.mux.HandleFunc("GET /api/matches", s.handleMatches)
 	s.mux.HandleFunc("GET /api/matches/{id}", s.handleMatch)
 	s.mux.HandleFunc("GET /api/leaderboard", s.handleLeaderboard)
+	s.mux.HandleFunc("GET /api/artifacts", s.handleArtifacts)
+	s.mux.HandleFunc("GET /api/artifacts/{name}", s.handleArtifactContent)
 	s.mux.Handle("GET /", fileServer)
 }
 
@@ -136,6 +154,116 @@ func (s *Server) handleLeaderboard(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	writeJSON(w, map[string]any{"standings": rows})
+}
+
+// artifactInfo is one entry in the Artifacts tab: enough metadata for the
+// detail panel plus a kind hint so the frontend knows how to render it.
+type artifactInfo struct {
+	Name        string `json:"name"`
+	Size        int64  `json:"size"`
+	Modified    string `json:"modified"`     // RFC3339 UTC
+	ContentType string `json:"content_type"` // best-effort MIME type by extension
+	Kind        string `json:"kind"`         // image|video|audio|markdown|text|pdf|other
+}
+
+// handleArtifacts lists the (top-level) files in the artifacts directory,
+// newest first. A missing or unconfigured directory yields an empty list so the
+// frontend can show a friendly empty state rather than an error.
+func (s *Server) handleArtifacts(w http.ResponseWriter, r *http.Request) {
+	infos := []artifactInfo{}
+	if s.artifactsDir != "" {
+		entries, err := os.ReadDir(s.artifactsDir)
+		if err != nil && !os.IsNotExist(err) {
+			httpError(w, http.StatusInternalServerError, err)
+			return
+		}
+		for _, e := range entries {
+			if e.IsDir() {
+				continue
+			}
+			info, err := e.Info()
+			if err != nil {
+				continue
+			}
+			infos = append(infos, newArtifactInfo(e.Name(), info))
+		}
+		// Newest first; RFC3339 UTC strings sort chronologically.
+		sort.Slice(infos, func(i, j int) bool {
+			if infos[i].Modified != infos[j].Modified {
+				return infos[i].Modified > infos[j].Modified
+			}
+			return infos[i].Name < infos[j].Name
+		})
+	}
+	writeJSON(w, map[string]any{"artifacts": infos})
+}
+
+// handleArtifactContent serves a single artifact's raw bytes. It uses
+// http.ServeFile so range requests work (important for seeking video/audio) and
+// the Content-Type is set from the extension.
+func (s *Server) handleArtifactContent(w http.ResponseWriter, r *http.Request) {
+	if s.artifactsDir == "" {
+		httpError(w, http.StatusNotFound, fmt.Errorf("no artifacts configured"))
+		return
+	}
+	name := r.PathValue("name")
+	if !validName(name) {
+		httpError(w, http.StatusBadRequest, fmt.Errorf("invalid artifact name"))
+		return
+	}
+	full := filepath.Join(s.artifactsDir, name)
+	info, err := os.Stat(full)
+	if err != nil || info.IsDir() {
+		httpError(w, http.StatusNotFound, fmt.Errorf("artifact not found"))
+		return
+	}
+	http.ServeFile(w, r, full)
+}
+
+// newArtifactInfo builds the metadata record for a single file.
+func newArtifactInfo(name string, info os.FileInfo) artifactInfo {
+	ct := mime.TypeByExtension(filepath.Ext(name))
+	if ct == "" {
+		ct = "application/octet-stream"
+	}
+	return artifactInfo{
+		Name:        name,
+		Size:        info.Size(),
+		Modified:    info.ModTime().UTC().Format(time.RFC3339),
+		ContentType: ct,
+		Kind:        artifactKind(name, ct),
+	}
+}
+
+// artifactKind classifies a file so the frontend can pick a renderer.
+func artifactKind(name, contentType string) string {
+	switch strings.ToLower(filepath.Ext(name)) {
+	case ".md", ".markdown":
+		return "markdown"
+	}
+	switch {
+	case strings.HasPrefix(contentType, "image/"):
+		return "image"
+	case strings.HasPrefix(contentType, "video/"):
+		return "video"
+	case strings.HasPrefix(contentType, "audio/"):
+		return "audio"
+	case contentType == "application/pdf":
+		return "pdf"
+	case strings.HasPrefix(contentType, "text/"),
+		contentType == "application/json",
+		contentType == "application/xml":
+		return "text"
+	}
+	return "other"
+}
+
+// validName rejects names that could escape the artifacts directory.
+func validName(name string) bool {
+	if name == "" || strings.ContainsAny(name, "/\\") || strings.Contains(name, "..") {
+		return false
+	}
+	return true
 }
 
 // transcriptIDs lists the available match ids (filenames without .jsonl),

--- a/demos/colosseum/web/server_test.go
+++ b/demos/colosseum/web/server_test.go
@@ -2,6 +2,7 @@ package web
 
 import (
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -46,6 +47,21 @@ func newTestServer(t *testing.T) *httptest.Server {
 	dir := t.TempDir()
 	writeSampleTranscript(t, dir, "match-1")
 	srv, err := NewServer(dir)
+	assert.NoError(t, err)
+	return httptest.NewServer(srv.Handler())
+}
+
+// newTestServerWithArtifacts spins up a server backed by both a transcripts dir
+// (with one sample match) and an artifacts dir seeded by the caller.
+func newTestServerWithArtifacts(t *testing.T, seed func(artifactsDir string)) *httptest.Server {
+	t.Helper()
+	dir := t.TempDir()
+	writeSampleTranscript(t, dir, "match-1")
+	artDir := t.TempDir()
+	if seed != nil {
+		seed(artDir)
+	}
+	srv, err := NewServer(dir, WithArtifactsDir(artDir))
 	assert.NoError(t, err)
 	return httptest.NewServer(srv.Handler())
 }
@@ -146,6 +162,87 @@ func TestAPILeaderboard(t *testing.T) {
 	assert.Equal(t, 1, body.Standings[0].Rank)
 	// Village winners (seer, villager) should outrank the lynched wolf.
 	assert.Equal(t, "werewolf", lastModelRole(body.Standings))
+}
+
+func TestAPIArtifactsList(t *testing.T) {
+	ts := newTestServerWithArtifacts(t, func(dir string) {
+		assert.NoError(t, os.WriteFile(filepath.Join(dir, "diagram.png"), []byte("\x89PNG\r\n"), 0o644))
+		assert.NoError(t, os.WriteFile(filepath.Join(dir, "notes.md"), []byte("# Title\n\nbody"), 0o644))
+		assert.NoError(t, os.WriteFile(filepath.Join(dir, "clip.mp4"), []byte("fakevideo"), 0o644))
+		// A subdirectory must be skipped (only top-level files are listed).
+		assert.NoError(t, os.Mkdir(filepath.Join(dir, "nested"), 0o755))
+	})
+	defer ts.Close()
+
+	var body struct {
+		Artifacts []struct {
+			Name        string `json:"name"`
+			Size        int64  `json:"size"`
+			Kind        string `json:"kind"`
+			ContentType string `json:"content_type"`
+			Modified    string `json:"modified"`
+		} `json:"artifacts"`
+	}
+	code := getJSON(t, ts.URL+"/api/artifacts", &body)
+	assert.Equal(t, http.StatusOK, code)
+	assert.Equal(t, 3, len(body.Artifacts))
+
+	kinds := map[string]string{}
+	for _, a := range body.Artifacts {
+		kinds[a.Name] = a.Kind
+		assert.True(t, a.Modified != "")
+	}
+	assert.Equal(t, "image", kinds["diagram.png"])
+	assert.Equal(t, "markdown", kinds["notes.md"])
+	assert.Equal(t, "video", kinds["clip.mp4"])
+}
+
+func TestAPIArtifactsEmptyWhenMissingDir(t *testing.T) {
+	// artifactsDir points somewhere that does not exist: list is empty, not an error.
+	dir := t.TempDir()
+	writeSampleTranscript(t, dir, "match-1")
+	srv, err := NewServer(dir, WithArtifactsDir(filepath.Join(dir, "does-not-exist")))
+	assert.NoError(t, err)
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+
+	var body struct {
+		Artifacts []json.RawMessage `json:"artifacts"`
+	}
+	code := getJSON(t, ts.URL+"/api/artifacts", &body)
+	assert.Equal(t, http.StatusOK, code)
+	assert.Equal(t, 0, len(body.Artifacts))
+}
+
+func TestAPIArtifactContent(t *testing.T) {
+	ts := newTestServerWithArtifacts(t, func(dir string) {
+		assert.NoError(t, os.WriteFile(filepath.Join(dir, "notes.md"), []byte("# Hello"), 0o644))
+	})
+	defer ts.Close()
+
+	resp, err := http.Get(ts.URL + "/api/artifacts/notes.md")
+	assert.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	data, err := io.ReadAll(resp.Body)
+	assert.NoError(t, err)
+	assert.Equal(t, "# Hello", string(data))
+}
+
+func TestAPIArtifactNotFound(t *testing.T) {
+	ts := newTestServerWithArtifacts(t, nil)
+	defer ts.Close()
+	code := getJSON(t, ts.URL+"/api/artifacts/missing.png", nil)
+	assert.Equal(t, http.StatusNotFound, code)
+}
+
+func TestAPIArtifactRejectsTraversal(t *testing.T) {
+	ts := newTestServerWithArtifacts(t, nil)
+	defer ts.Close()
+	resp, err := http.Get(ts.URL + "/api/artifacts/..%2f..%2fetc%2fpasswd")
+	assert.NoError(t, err)
+	resp.Body.Close()
+	assert.NotEqual(t, http.StatusOK, resp.StatusCode)
 }
 
 // lastModelRole returns the model name of the lowest-ranked standing; in the

--- a/demos/colosseum/web/static/app.js
+++ b/demos/colosseum/web/static/app.js
@@ -71,6 +71,12 @@ async function fetchJSON(url) {
   return res.json();
 }
 
+async function fetchText(url) {
+  const res = await fetch(url);
+  if (!res.ok) throw new Error(`Request failed (${res.status})`);
+  return res.text();
+}
+
 /* ---- App state ----------------------------------------------------------- */
 const state = {
   matches: [],        // MatchSummary list (newest first)
@@ -102,7 +108,9 @@ function switchView(view) {
   });
   $("#view-replay").classList.toggle("is-active", view === "replay");
   $("#view-leaderboard").classList.toggle("is-active", view === "leaderboard");
+  $("#view-artifacts").classList.toggle("is-active", view === "artifacts");
   if (view === "leaderboard" && !leaderboardLoaded) loadLeaderboard();
+  if (view === "artifacts" && !artifactsLoaded) loadArtifacts();
 }
 
 /* ===========================================================================
@@ -726,6 +734,339 @@ function showLeaderboardStatus(msg, isError = false, isEmpty = false) {
 }
 function hideLeaderboardStatus() { $("#leaderboard-status").hidden = true; }
 
+/* ===========================================================================
+   Artifacts view — render images / video / audio / markdown / text / pdf with a
+   file-details panel alongside. All content fetched same-origin from
+   /api/artifacts (list) and /api/artifacts/{name} (raw bytes).
+   =========================================================================== */
+let artifactsLoaded = false;
+const artifactsState = {
+  items: [],        // [artifactInfo]
+  selected: null,   // currently shown artifact name
+};
+
+const KIND_ICONS = {
+  image: "🖼", video: "🎬", audio: "🎧",
+  markdown: "📝", text: "📄", pdf: "📕", other: "📦",
+};
+
+function artifactURL(name) {
+  return "/api/artifacts/" + encodeURIComponent(name);
+}
+
+async function loadArtifacts() {
+  artifactsLoaded = true;
+  showArtifactsStatus("Loading artifacts…");
+  let data;
+  try {
+    data = await fetchJSON("/api/artifacts");
+  } catch (err) {
+    showArtifactsStatus("Could not load artifacts: " + err.message, true);
+    artifactsLoaded = false; // allow retry on next tab switch
+    return;
+  }
+  artifactsState.items = Array.isArray(data.artifacts) ? data.artifacts : [];
+
+  if (artifactsState.items.length === 0) {
+    showArtifactsStatus(
+      "No artifacts yet — point the server at an artifacts directory with --artifacts.",
+      false, true
+    );
+    return;
+  }
+
+  hideArtifactsStatus();
+  $("#artifacts-body").hidden = false;
+  renderArtifactList();
+  selectArtifact(artifactsState.items[0].name);
+}
+
+function renderArtifactList() {
+  const list = $("#artifact-list");
+  clear(list);
+  for (const a of artifactsState.items) {
+    const active = a.name === artifactsState.selected;
+    const item = el("li", {
+      class: "artifact-item" + (active ? " active" : ""),
+      title: a.name,
+    }, [
+      el("span", { class: "artifact-icon", text: KIND_ICONS[a.kind] || KIND_ICONS.other }),
+      el("div", { class: "artifact-item-main" }, [
+        el("div", { class: "artifact-item-name", text: a.name }),
+        el("div", { class: "artifact-item-meta", text: `${a.kind} · ${humanSize(a.size)}` }),
+      ]),
+    ]);
+    item.addEventListener("click", () => selectArtifact(a.name));
+    list.appendChild(item);
+  }
+}
+
+function selectArtifact(name) {
+  artifactsState.selected = name;
+  const a = artifactsState.items.find((x) => x.name === name);
+  if (!a) return;
+
+  // Highlight the active row without re-rendering the whole list.
+  document.querySelectorAll("#artifact-list .artifact-item").forEach((li) => {
+    li.classList.toggle("active", li.title === name);
+  });
+
+  $("#artifact-name").textContent = a.name;
+  const dl = $("#artifact-download");
+  dl.href = artifactURL(a.name);
+  dl.setAttribute("download", a.name);
+  dl.hidden = false;
+
+  renderArtifactDetails(a);
+  renderArtifactPreview(a);
+}
+
+function renderArtifactDetails(a) {
+  const dl = $("#artifact-details");
+  clear(dl);
+  const rows = [
+    ["Name", a.name],
+    ["Kind", a.kind],
+    ["Type", a.content_type || "—"],
+    ["Size", humanSize(a.size)],
+    ["Modified", formatDate(a.modified)],
+  ];
+  for (const [k, v] of rows) {
+    dl.appendChild(el("dt", { text: k }));
+    dl.appendChild(el("dd", { text: v }));
+  }
+  // Image dimensions are filled in asynchronously once the preview loads.
+  if (a.kind === "image") {
+    dl.appendChild(el("dt", { text: "Dimensions" }));
+    dl.appendChild(el("dd", { id: "artifact-dimensions", text: "…" }));
+  }
+}
+
+function renderArtifactPreview(a) {
+  const wrap = $("#artifact-preview");
+  clear(wrap);
+  const url = artifactURL(a.name);
+
+  switch (a.kind) {
+    case "image": {
+      const img = el("img", { class: "preview-image", src: url, alt: a.name });
+      img.addEventListener("load", () => {
+        const dim = $("#artifact-dimensions");
+        if (dim) dim.textContent = `${img.naturalWidth} × ${img.naturalHeight}`;
+      });
+      img.addEventListener("error", () => showPreviewError(wrap, a));
+      wrap.appendChild(img);
+      return;
+    }
+    case "video": {
+      const video = el("video", { class: "preview-video", controls: "", preload: "metadata" }, [
+        el("source", { src: url, type: a.content_type || "" }),
+      ]);
+      wrap.appendChild(video);
+      return;
+    }
+    case "audio": {
+      wrap.appendChild(el("audio", { class: "preview-audio", controls: "", src: url }));
+      return;
+    }
+    case "pdf": {
+      wrap.appendChild(el("iframe", { class: "preview-pdf", src: url, title: a.name }));
+      return;
+    }
+    case "markdown":
+    case "text": {
+      // Fetch the text and render it; guard against a stale selection.
+      wrap.appendChild(el("div", { class: "preview-loading", text: "Loading…" }));
+      const requested = a.name;
+      fetchText(url).then((txt) => {
+        if (artifactsState.selected !== requested) return; // user moved on
+        clear(wrap);
+        if (a.kind === "markdown") {
+          wrap.appendChild(renderMarkdown(txt));
+        } else {
+          wrap.appendChild(el("pre", { class: "preview-text", text: txt }));
+        }
+      }).catch(() => showPreviewError(wrap, a));
+      return;
+    }
+    default:
+      showPreviewError(wrap, a, "No inline preview for this file type.");
+  }
+}
+
+function showPreviewError(wrap, a, msg) {
+  clear(wrap);
+  wrap.appendChild(el("div", { class: "preview-fallback" }, [
+    el("div", { class: "preview-fallback-icon", text: KIND_ICONS[a.kind] || KIND_ICONS.other }),
+    el("div", { text: msg || "This artifact could not be previewed." }),
+    el("a", { class: "artifact-download", href: artifactURL(a.name), download: a.name, text: "⤓ Download " + a.name }),
+  ]));
+}
+
+function showArtifactsStatus(msg, isError = false, isEmpty = false) {
+  const panel = $("#artifacts-status");
+  $("#artifacts-body").hidden = true;
+  panel.hidden = false;
+  panel.className = "status-panel" + (isError ? " error" : "");
+  clear(panel);
+  if (isEmpty) {
+    panel.appendChild(document.createTextNode("No artifacts yet — start the server with "));
+    panel.appendChild(el("code", { text: "colosseum serve --artifacts <dir>" }));
+    panel.appendChild(document.createTextNode("."));
+  } else {
+    panel.textContent = msg;
+  }
+}
+function hideArtifactsStatus() { $("#artifacts-status").hidden = true; }
+
+/* ===========================================================================
+   Minimal, dependency-free Markdown → DOM renderer.
+
+   Builds real DOM nodes (never innerHTML), so artifact content can't inject
+   markup. Supports headings, paragraphs, bold/italic/code/links inline,
+   fenced + indented code blocks, blockquotes, ordered/unordered lists, images,
+   and horizontal rules. Unknown syntax degrades to plain text.
+   =========================================================================== */
+function renderMarkdown(src) {
+  const root = el("div", { class: "markdown" });
+  const lines = src.replace(/\r\n?/g, "\n").split("\n");
+  let i = 0;
+
+  const flushParagraph = (buf) => {
+    if (buf.length === 0) return;
+    const p = el("p");
+    appendInline(p, buf.join(" "));
+    root.appendChild(p);
+    buf.length = 0;
+  };
+
+  const para = [];
+  while (i < lines.length) {
+    const line = lines[i];
+
+    // Fenced code block ```lang
+    const fence = line.match(/^```(.*)$/);
+    if (fence) {
+      flushParagraph(para);
+      const code = [];
+      i++;
+      while (i < lines.length && !/^```/.test(lines[i])) { code.push(lines[i]); i++; }
+      i++; // skip closing fence
+      const pre = el("pre", { class: "md-code" }, el("code", { text: code.join("\n") }));
+      root.appendChild(pre);
+      continue;
+    }
+
+    // Blank line ends a paragraph.
+    if (/^\s*$/.test(line)) { flushParagraph(para); i++; continue; }
+
+    // Horizontal rule
+    if (/^\s*([-*_])(\s*\1){2,}\s*$/.test(line)) {
+      flushParagraph(para);
+      root.appendChild(el("hr"));
+      i++;
+      continue;
+    }
+
+    // Heading
+    const h = line.match(/^(#{1,6})\s+(.*)$/);
+    if (h) {
+      flushParagraph(para);
+      const tag = "h" + h[1].length;
+      const node = el(tag);
+      appendInline(node, h[2].trim());
+      root.appendChild(node);
+      i++;
+      continue;
+    }
+
+    // Blockquote (consume consecutive '>' lines)
+    if (/^\s*>/.test(line)) {
+      flushParagraph(para);
+      const quote = [];
+      while (i < lines.length && /^\s*>/.test(lines[i])) {
+        quote.push(lines[i].replace(/^\s*>\s?/, ""));
+        i++;
+      }
+      const bq = el("blockquote");
+      appendInline(bq, quote.join(" "));
+      root.appendChild(bq);
+      continue;
+    }
+
+    // Lists (ordered or unordered)
+    if (/^\s*([-*+]|\d+\.)\s+/.test(line)) {
+      flushParagraph(para);
+      const ordered = /^\s*\d+\.\s+/.test(line);
+      const listEl = el(ordered ? "ol" : "ul");
+      while (i < lines.length && /^\s*([-*+]|\d+\.)\s+/.test(lines[i])) {
+        const item = lines[i].replace(/^\s*([-*+]|\d+\.)\s+/, "");
+        const li = el("li");
+        appendInline(li, item);
+        listEl.appendChild(li);
+        i++;
+      }
+      root.appendChild(listEl);
+      continue;
+    }
+
+    // Otherwise accumulate into the current paragraph.
+    para.push(line.trim());
+    i++;
+  }
+  flushParagraph(para);
+  return root;
+}
+
+// safeURL only allows http(s)/mailto and protocol-relative paths, blocking
+// javascript: and data: URIs in links.
+function safeURL(url) {
+  const u = (url || "").trim();
+  if (/^(https?:\/\/|mailto:|\/|\.\/|#)/i.test(u)) return u;
+  return null;
+}
+
+// appendInline parses inline markdown (images, links, bold, italic, code) into
+// text/element nodes appended to parent.
+function appendInline(parent, text) {
+  // Token regex, tried left-to-right at each position:
+  //  ![alt](src) | [text](href) | `code` | **bold** | *italic* | _italic_
+  const re = /!\[([^\]]*)\]\(([^)]+)\)|\[([^\]]+)\]\(([^)]+)\)|`([^`]+)`|\*\*([^*]+)\*\*|\*([^*]+)\*|_([^_]+)_/;
+  let rest = text;
+  let guard = 0;
+  while (rest && guard++ < 10000) {
+    const m = rest.match(re);
+    if (!m) { parent.appendChild(document.createTextNode(rest)); break; }
+    if (m.index > 0) parent.appendChild(document.createTextNode(rest.slice(0, m.index)));
+
+    if (m[1] !== undefined && m[2] !== undefined) {          // image
+      const src = safeURL(m[2]);
+      if (src) parent.appendChild(el("img", { class: "md-img", src, alt: m[1] }));
+      else parent.appendChild(document.createTextNode(m[0]));
+    } else if (m[3] !== undefined && m[4] !== undefined) {    // link
+      const href = safeURL(m[4]);
+      if (href) {
+        const a = el("a", { href, rel: "noopener noreferrer", target: "_blank" });
+        appendInline(a, m[3]);
+        parent.appendChild(a);
+      } else {
+        parent.appendChild(document.createTextNode(m[3]));
+      }
+    } else if (m[5] !== undefined) {                          // inline code
+      parent.appendChild(el("code", { class: "md-inline-code", text: m[5] }));
+    } else if (m[6] !== undefined) {                          // bold
+      const strong = el("strong");
+      appendInline(strong, m[6]);
+      parent.appendChild(strong);
+    } else if (m[7] !== undefined || m[8] !== undefined) {    // italic
+      const em = el("em");
+      appendInline(em, m[7] !== undefined ? m[7] : m[8]);
+      parent.appendChild(em);
+    }
+    rest = rest.slice(m.index + m[0].length);
+  }
+}
+
 /* ---- Formatting helpers -------------------------------------------------- */
 function pct(v) {
   return (typeof v === "number" && isFinite(v)) ? Math.round(v * 100) + "%" : "—";
@@ -734,6 +1075,22 @@ function num2(v) {
   return (typeof v === "number" && isFinite(v)) ? v.toFixed(2) : "—";
 }
 function cap(s) { return s ? s.charAt(0).toUpperCase() + s.slice(1) : s; }
+
+function humanSize(bytes) {
+  if (typeof bytes !== "number" || !isFinite(bytes) || bytes < 0) return "—";
+  if (bytes < 1024) return bytes + " B";
+  const units = ["KB", "MB", "GB", "TB"];
+  let v = bytes / 1024, u = 0;
+  while (v >= 1024 && u < units.length - 1) { v /= 1024; u++; }
+  return `${v.toFixed(v < 10 ? 1 : 0)} ${units[u]}`;
+}
+
+function formatDate(iso) {
+  if (!iso) return "—";
+  const d = new Date(iso);
+  if (isNaN(d.getTime())) return iso;
+  return d.toLocaleString();
+}
 
 /* ===========================================================================
    Boot

--- a/demos/colosseum/web/static/index.html
+++ b/demos/colosseum/web/static/index.html
@@ -17,6 +17,7 @@
     <nav class="tabs" role="tablist" aria-label="Views">
       <button class="tab is-active" data-view="replay" role="tab" aria-selected="true">Replay</button>
       <button class="tab" data-view="leaderboard" role="tab" aria-selected="false">Leaderboard</button>
+      <button class="tab" data-view="artifacts" role="tab" aria-selected="false">Artifacts</button>
     </nav>
   </header>
 
@@ -78,6 +79,36 @@
           <section class="panel">
             <h2 class="panel-title">Metrics</h2>
             <div id="metrics" class="metrics"></div>
+          </section>
+        </aside>
+      </div>
+    </section>
+
+    <!-- =================== Artifacts view =================== -->
+    <section id="view-artifacts" class="view" role="tabpanel">
+      <div id="artifacts-status" class="status-panel" hidden></div>
+
+      <!-- Detail layout: rendered preview (main) + file list & details (side) -->
+      <div id="artifacts-body" class="artifacts-layout" hidden>
+        <!-- Left column: the rendered artifact -->
+        <div class="artifacts-main">
+          <div class="artifact-titlebar">
+            <h2 id="artifact-name" class="artifact-name">—</h2>
+            <a id="artifact-download" class="artifact-download" download hidden>⤓ Download</a>
+          </div>
+          <div id="artifact-preview" class="artifact-preview" aria-live="polite"></div>
+        </div>
+
+        <!-- Right column: file picker + details -->
+        <aside class="artifacts-side">
+          <section class="panel">
+            <h2 class="panel-title">Files</h2>
+            <ul id="artifact-list" class="artifact-list"></ul>
+          </section>
+
+          <section class="panel">
+            <h2 class="panel-title">Details</h2>
+            <dl id="artifact-details" class="artifact-details"></dl>
           </section>
         </aside>
       </div>

--- a/demos/colosseum/web/static/style.css
+++ b/demos/colosseum/web/static/style.css
@@ -595,6 +595,157 @@ main {
 }
 .leaderboard tr.top td .rank { color: var(--gold); font-weight: 800; }
 
+/* ---- Artifacts ----------------------------------------------------------- */
+.artifacts-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 340px;
+  gap: 24px;
+  align-items: start;
+}
+.artifacts-main { min-width: 0; }
+.artifacts-side { display: flex; flex-direction: column; gap: 18px; position: sticky; top: 18px; }
+
+.artifact-titlebar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 14px;
+}
+.artifact-name {
+  margin: 0;
+  font-size: 1.1rem;
+  font-weight: 700;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.artifact-download {
+  flex: none;
+  font-size: 0.85rem;
+  font-weight: 600;
+  padding: 7px 14px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--line);
+  background: var(--bg-2);
+  color: var(--fg-dim);
+  transition: border-color 0.15s ease, color 0.15s ease, background 0.15s ease;
+}
+.artifact-download:hover { border-color: var(--night); color: var(--fg); background: var(--bg-3); text-decoration: none; }
+
+/* Preview surface — a neutral stage for whatever we render */
+.artifact-preview {
+  background: var(--bg-1);
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  padding: 18px;
+  min-height: 280px;
+  display: flex;
+  flex-direction: column;
+}
+.preview-image,
+.preview-video {
+  max-width: 100%;
+  max-height: 70vh;
+  margin: auto;
+  border-radius: var(--radius-sm);
+  box-shadow: var(--shadow);
+}
+.preview-audio { width: 100%; margin: auto 0; }
+.preview-pdf {
+  width: 100%;
+  height: 70vh;
+  border: none;
+  border-radius: var(--radius-sm);
+  background: #fff;
+}
+.preview-text {
+  margin: 0;
+  width: 100%;
+  overflow: auto;
+  font-family: var(--mono);
+  font-size: 0.85rem;
+  line-height: 1.6;
+  color: var(--fg);
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+.preview-loading { color: var(--fg-faint); margin: auto; }
+.preview-fallback {
+  margin: auto;
+  text-align: center;
+  color: var(--fg-dim);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+}
+.preview-fallback-icon { font-size: 2.4rem; }
+
+/* File picker list (sidebar) */
+.artifact-list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 6px; max-height: 50vh; overflow-y: auto; }
+.artifact-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 10px;
+  border-radius: var(--radius-sm);
+  background: var(--bg-2);
+  border: 1px solid var(--line-soft);
+  cursor: pointer;
+  transition: border-color 0.15s ease, background 0.15s ease;
+}
+.artifact-item:hover { border-color: var(--night); background: var(--bg-3); }
+.artifact-item.active { border-color: var(--gold); background: var(--bg-3); box-shadow: inset 2px 0 0 var(--gold); }
+.artifact-icon { font-size: 1.1rem; flex: none; }
+.artifact-item-main { min-width: 0; flex: 1; }
+.artifact-item-name { font-weight: 600; font-size: 0.88rem; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.artifact-item-meta { font-size: 0.74rem; color: var(--fg-faint); text-transform: capitalize; }
+
+/* Details definition list */
+.artifact-details { margin: 0; display: grid; grid-template-columns: auto 1fr; gap: 6px 12px; font-size: 0.85rem; }
+.artifact-details dt { color: var(--fg-faint); text-transform: uppercase; letter-spacing: 0.04em; font-size: 0.72rem; align-self: center; }
+.artifact-details dd { margin: 0; color: var(--fg); word-break: break-word; font-family: var(--mono); font-size: 0.8rem; }
+
+/* Rendered markdown */
+.markdown { color: var(--fg); line-height: 1.65; width: 100%; overflow-wrap: break-word; }
+.markdown h1, .markdown h2, .markdown h3, .markdown h4, .markdown h5, .markdown h6 {
+  margin: 1.2em 0 0.5em; line-height: 1.25; font-weight: 700;
+}
+.markdown h1 { font-size: 1.6rem; border-bottom: 1px solid var(--line); padding-bottom: 0.3em; }
+.markdown h2 { font-size: 1.3rem; border-bottom: 1px solid var(--line-soft); padding-bottom: 0.2em; }
+.markdown h3 { font-size: 1.1rem; }
+.markdown p { margin: 0.6em 0; }
+.markdown a { color: var(--night); }
+.markdown ul, .markdown ol { margin: 0.6em 0; padding-left: 1.6em; }
+.markdown li { margin: 0.25em 0; }
+.markdown blockquote {
+  margin: 0.8em 0;
+  padding: 0.4em 1em;
+  border-left: 3px solid var(--night);
+  background: var(--night-glow);
+  color: var(--fg-dim);
+}
+.markdown hr { border: none; border-top: 1px solid var(--line); margin: 1.4em 0; }
+.markdown img.md-img { max-width: 100%; border-radius: var(--radius-sm); }
+.markdown .md-inline-code {
+  font-family: var(--mono);
+  font-size: 0.85em;
+  background: var(--bg-3);
+  padding: 1px 6px;
+  border-radius: 5px;
+  color: var(--day);
+}
+.markdown pre.md-code {
+  background: var(--bg-0);
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  padding: 12px 14px;
+  overflow-x: auto;
+}
+.markdown pre.md-code code { font-family: var(--mono); font-size: 0.82rem; color: var(--fg); line-height: 1.5; }
+.markdown :first-child { margin-top: 0; }
+
 /* ---- Footer -------------------------------------------------------------- */
 .site-footer {
   max-width: 1400px;
@@ -607,8 +758,8 @@ main {
 
 /* ---- Responsive ---------------------------------------------------------- */
 @media (max-width: 980px) {
-  .replay-layout { grid-template-columns: 1fr; }
-  .replay-side { position: static; }
+  .replay-layout, .artifacts-layout { grid-template-columns: 1fr; }
+  .replay-side, .artifacts-side { position: static; }
 }
 @media (max-width: 560px) {
   .replay-toolbar { flex-direction: column; align-items: stretch; }


### PR DESCRIPTION
## Summary

Adds an **Artifacts** tab to the Colosseum web UI that renders artifacts in appropriate ways and shows file details in a panel alongside, as requested.

- **Images / video / audio / PDF** render inline (`<img>`, `<video>`, `<audio>`, `<iframe>`).
- **Markdown** is rendered to formatted HTML via a small, dependency-free, injection-safe Markdown→DOM renderer.
- **Text/JSON/XML** render in a monospaced viewer; unknown types fall back to a download card.
- A **Details panel** sits alongside the preview: name, kind, content type, human-readable size, modified time, and (for images) natural dimensions. A selectable **Files** list drives the view.

## Backend (`demos/colosseum/web`)

- New endpoints:
  - `GET /api/artifacts` — lists top-level files with metadata + a `kind` hint (`image|video|audio|markdown|text|pdf|other`), newest first.
  - `GET /api/artifacts/{name}` — serves raw bytes via `http.ServeFile` so range requests work (video/audio seeking).
- `web.WithArtifactsDir(dir)` option on `NewServer` (backwards compatible — existing `NewServer(dir)` calls still compile).
- New `-artifacts <dir>` flag on `colosseum serve` (defaults to `artifacts`; a missing dir simply yields an empty list).
- Filename validation rejects path traversal.

## Frontend (`static/`)

Vanilla JS, no build step, no dependencies — consistent with the existing viewer. All artifact-derived content is inserted via `textContent`/DOM nodes (never `innerHTML`); Markdown links/images are restricted to `http(s)`/`mailto`/relative URLs.

## Tests

`server_test.go` covers listing + kind classification, empty/missing artifacts dir, raw content fetch, 404, and path-traversal rejection. Also smoke-tested live (`go run . serve -artifacts …`): correct metadata, content types, traversal → 400, and the tab renders.

## Notes / assumptions

There are two demo web UIs (`colosseum`, `noodleville`) and no pre-existing artifact concept. I implemented this in **colosseum** because it's the repo's primary tabbed SPA + JSON API with a sidebar-panel layout that directly matches "detail view … panel alongside." Happy to retarget if a different UI was intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MxaQeaH32xahg2nZ2L57aw)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added artifact serving capability via optional command-line flag.
  * New "Artifacts" tab in the UI for browsing and previewing served files.
  * Multi-format preview support including images, videos, audio, PDFs, markdown, and plain text.
  * Built-in download functionality for all artifacts.

* **Tests**
  * Comprehensive test coverage for artifact endpoints, listing, and directory handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->