### PR TITLE
Add per-instance Vertex AI backend option to Google provider

### DIFF
--- a/providers/google/google.go
+++ b/providers/google/google.go
@@ -35,6 +35,7 @@ type Provider struct {
 	projectID     string
 	location      string
 	apiKey        string
+	vertexAI      bool
 	model         string
 	maxTokens     int
 	maxRetries    int
@@ -72,11 +73,26 @@ func (p *Provider) initClient(ctx context.Context) (*genai.Client, error) {
 	if p.client != nil {
 		return p.client, nil
 	}
-	client, err := genai.NewClient(ctx, &genai.ClientConfig{
-		APIKey:   p.apiKey,
-		Project:  p.projectID,
-		Location: p.location,
-	})
+	var cfg *genai.ClientConfig
+	if p.vertexAI {
+		// Vertex AI authenticates with Application Default Credentials. An API
+		// key is mutually exclusive with project/location in the genai client
+		// config, and this backend resolves auth via ADC, so we pass only the
+		// project and location. An empty location is resolved by the SDK from
+		// GOOGLE_CLOUD_LOCATION/GOOGLE_CLOUD_REGION, defaulting to "global".
+		cfg = &genai.ClientConfig{
+			Backend:  genai.BackendVertexAI,
+			Project:  p.projectID,
+			Location: p.location,
+		}
+	} else {
+		// The Gemini API backend authenticates with an API key, which is
+		// mutually exclusive with project/location, so we pass only the key.
+		cfg = &genai.ClientConfig{
+			APIKey: p.apiKey,
+		}
+	}
+	client, err := genai.NewClient(ctx, cfg)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create google genai client: %v", err)
 	}

--- a/providers/google/google_test.go
+++ b/providers/google/google_test.go
@@ -136,6 +136,19 @@ func TestProviderOptions(t *testing.T) {
 	assert.Equal(t, 1000, provider.maxTokens)
 }
 
+func TestProviderVertexAIOption(t *testing.T) {
+	// By default the provider is on the Gemini API (key) backend.
+	assert.False(t, New().vertexAI, "vertexAI should default to false")
+
+	// WithVertexAI flips the backend and records the region. An API key, if
+	// present in the environment, is left untouched on the struct but is not
+	// passed to the Vertex client config (see initClient).
+	provider := New(WithVertexAI("us-central1"), WithProjectID("test-project"))
+	assert.True(t, provider.vertexAI, "WithVertexAI should enable the Vertex backend")
+	assert.Equal(t, "us-central1", provider.location)
+	assert.Equal(t, "test-project", provider.projectID)
+}
+
 // func TestConvertMessages(t *testing.T) {
 // 	messages := []*llm.Message{
 // 		llm.NewUserTextMessage("Hello"),

--- a/providers/google/options.go
+++ b/providers/google/options.go
@@ -62,3 +62,17 @@ func WithAPIKey(apiKey string) Option {
 		p.apiKey = apiKey
 	}
 }
+
+// WithVertexAI routes requests through the Vertex AI backend, authenticating
+// with Application Default Credentials instead of an API key. The location is
+// the Vertex region (e.g. "us-central1"); pass "" to let the SDK default it to
+// "global". The GCP project is taken from WithProjectID when set, otherwise the
+// SDK resolves it from the environment (GOOGLE_CLOUD_PROJECT). This forces the
+// backend on this provider instance, so it does not depend on the global
+// GOOGLE_GENAI_USE_VERTEXAI environment variable and never consumes an API key.
+func WithVertexAI(location string) Option {
+	return func(p *Provider) {
+		p.vertexAI = true
+		p.location = location
+	}
+}


### PR DESCRIPTION
## Summary

Adds `WithVertexAI(location)` to the Google provider so a single provider instance can route through the **Vertex AI** backend (authenticating via Application Default Credentials), independent of the process-wide `GOOGLE_GENAI_USE_VERTEXAI` environment variable.

```go
provider := google.New(
    google.WithVertexAI("us-central1"),
    google.WithProjectID("my-gcp-project"),
)
```

## Changes

- **New option** `WithVertexAI(location)` (`options.go`) — flips the backend to Vertex and records the region. Project comes from `WithProjectID` or the SDK's `GOOGLE_CLOUD_PROJECT` resolution.
- **`initClient` branches on backend** (`google.go`):
  - **Vertex:** passes `Backend`, `Project`, `Location` only. An empty location is left empty so the genai SDK resolves it from `GOOGLE_CLOUD_LOCATION`/`GOOGLE_CLOUD_REGION` before defaulting to `"global"` — we deliberately do **not** hardcode `"global"` here, which would suppress that env resolution.
  - **Gemini API:** passes only the API key. `Project`/`Location` are dropped because the SDK treats them as mutually exclusive with an API key (it errors otherwise whenever a project/location is also configured).
- **Test** `TestProviderVertexAIOption` covers the option wiring and defaults.

## Notes

- The test exercises option wiring only, not `initClient`, since constructing a real Vertex client requires credentials/network. The backend branch logic is verified by reading rather than by an automated test.

## Test plan

- [x] `go build ./...` (providers/google module)
- [x] `go test ./...` (providers/google module) — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option to connect Google-powered Gemini requests through Vertex AI.
  * Support now includes choosing the Google Cloud region and project when using this mode.
* **Bug Fixes**
  * Improved client setup so authentication is configured correctly for either API key or Vertex AI usage.
  * Added test coverage for the default configuration and the new Vertex AI option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->