### PR TITLE
Prepare v1.10.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [1.10.0] - 2026-06-29
+
+### Added
+
+- **Google Vertex AI backend** — `google.WithVertexAI(location)` routes a single
+  Google provider instance through the Vertex AI backend using Application
+  Default Credentials, independent of the process-wide
+  `GOOGLE_GENAI_USE_VERTEXAI` environment variable. An empty location is
+  resolved by the genai SDK from `GOOGLE_CLOUD_LOCATION`/`GOOGLE_CLOUD_REGION`
+  before defaulting to `global`. The provider's client initialization now
+  selects the backend explicitly: the Vertex path passes only project/location
+  (the genai SDK treats an API key as mutually exclusive with them), while the
+  Gemini API path passes only the API key.
+
 ## [1.9.0] - 2026-06-20
 
 ### Added

--- a/a2a/go.mod
+++ b/a2a/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/a2aproject/a2a-go/v2 v2.2.0
-	github.com/deepnoodle-ai/dive v1.9.0
+	github.com/deepnoodle-ai/dive v1.10.0
 	github.com/deepnoodle-ai/wonton v0.0.36
 )
 

--- a/demos/colosseum/go.mod
+++ b/demos/colosseum/go.mod
@@ -3,11 +3,11 @@ module github.com/deepnoodle-ai/dive/demos/colosseum
 go 1.25.0
 
 require (
-	github.com/deepnoodle-ai/dive v1.9.0
-	github.com/deepnoodle-ai/dive/a2a v1.9.0
-	github.com/deepnoodle-ai/dive/providers/google v1.9.0
-	github.com/deepnoodle-ai/dive/providers/grok v1.9.0
-	github.com/deepnoodle-ai/dive/providers/openai v1.9.0
+	github.com/deepnoodle-ai/dive v1.10.0
+	github.com/deepnoodle-ai/dive/a2a v1.10.0
+	github.com/deepnoodle-ai/dive/providers/google v1.10.0
+	github.com/deepnoodle-ai/dive/providers/grok v1.10.0
+	github.com/deepnoodle-ai/dive/providers/openai v1.10.0
 	github.com/deepnoodle-ai/wonton v0.0.36
 )
 

--- a/demos/noodleville/go.mod
+++ b/demos/noodleville/go.mod
@@ -3,7 +3,7 @@ module github.com/deepnoodle-ai/dive/demos/noodleville
 go 1.25.0
 
 require (
-	github.com/deepnoodle-ai/dive v1.9.0
+	github.com/deepnoodle-ai/dive v1.10.0
 	github.com/deepnoodle-ai/wonton v0.0.36
 )
 

--- a/examples/go.mod
+++ b/examples/go.mod
@@ -3,13 +3,13 @@ module github.com/deepnoodle-ai/dive/examples
 go 1.25.0
 
 require (
-	github.com/deepnoodle-ai/dive v1.9.0
-	github.com/deepnoodle-ai/dive/a2a v1.9.0
-	github.com/deepnoodle-ai/dive/experimental/mcp v1.9.0
-	github.com/deepnoodle-ai/dive/otel v1.9.0
-	github.com/deepnoodle-ai/dive/providers/google v1.9.0
-	github.com/deepnoodle-ai/dive/providers/grok v1.9.0
-	github.com/deepnoodle-ai/dive/providers/openai v1.9.0
+	github.com/deepnoodle-ai/dive v1.10.0
+	github.com/deepnoodle-ai/dive/a2a v1.10.0
+	github.com/deepnoodle-ai/dive/experimental/mcp v1.10.0
+	github.com/deepnoodle-ai/dive/otel v1.10.0
+	github.com/deepnoodle-ai/dive/providers/google v1.10.0
+	github.com/deepnoodle-ai/dive/providers/grok v1.10.0
+	github.com/deepnoodle-ai/dive/providers/openai v1.10.0
 	github.com/deepnoodle-ai/wonton v0.0.36
 	github.com/fatih/color v1.18.0
 	github.com/mark3labs/mcp-go v0.45.0

--- a/experimental/cmd/dive/go.mod
+++ b/experimental/cmd/dive/go.mod
@@ -3,10 +3,10 @@ module github.com/deepnoodle-ai/dive/experimental/cmd/dive
 go 1.25.0
 
 require (
-	github.com/deepnoodle-ai/dive v1.9.0
-	github.com/deepnoodle-ai/dive/providers/google v1.9.0
-	github.com/deepnoodle-ai/dive/providers/grok v1.9.0
-	github.com/deepnoodle-ai/dive/providers/openai v1.9.0
+	github.com/deepnoodle-ai/dive v1.10.0
+	github.com/deepnoodle-ai/dive/providers/google v1.10.0
+	github.com/deepnoodle-ai/dive/providers/grok v1.10.0
+	github.com/deepnoodle-ai/dive/providers/openai v1.10.0
 	github.com/deepnoodle-ai/wonton v0.0.36
 	github.com/mattn/go-runewidth v0.0.21
 )

--- a/experimental/mcp/go.mod
+++ b/experimental/mcp/go.mod
@@ -3,7 +3,7 @@ module github.com/deepnoodle-ai/dive/experimental/mcp
 go 1.25.0
 
 require (
-	github.com/deepnoodle-ai/dive v1.9.0
+	github.com/deepnoodle-ai/dive v1.10.0
 	github.com/deepnoodle-ai/wonton v0.0.36
 	github.com/mark3labs/mcp-go v0.45.0
 )

--- a/otel/go.mod
+++ b/otel/go.mod
@@ -3,7 +3,7 @@ module github.com/deepnoodle-ai/dive/otel
 go 1.25.0
 
 require (
-	github.com/deepnoodle-ai/dive v1.9.0
+	github.com/deepnoodle-ai/dive v1.10.0
 	go.opentelemetry.io/otel v1.43.0
 	go.opentelemetry.io/otel/metric v1.43.0
 	go.opentelemetry.io/otel/sdk v1.43.0

--- a/providers/google/go.mod
+++ b/providers/google/go.mod
@@ -3,7 +3,7 @@ module github.com/deepnoodle-ai/dive/providers/google
 go 1.25.0
 
 require (
-	github.com/deepnoodle-ai/dive v1.9.0
+	github.com/deepnoodle-ai/dive v1.10.0
 	github.com/deepnoodle-ai/wonton v0.0.36
 	google.golang.org/genai v1.51.0
 )

--- a/providers/grok/go.mod
+++ b/providers/grok/go.mod
@@ -3,8 +3,8 @@ module github.com/deepnoodle-ai/dive/providers/grok
 go 1.25.0
 
 require (
-	github.com/deepnoodle-ai/dive v1.9.0
-	github.com/deepnoodle-ai/dive/providers/openai v1.9.0
+	github.com/deepnoodle-ai/dive v1.10.0
+	github.com/deepnoodle-ai/dive/providers/openai v1.10.0
 	github.com/deepnoodle-ai/wonton v0.0.36
 	github.com/openai/openai-go/v3 v3.29.0
 	golang.org/x/image v0.38.0

--- a/providers/openai/go.mod
+++ b/providers/openai/go.mod
@@ -3,7 +3,7 @@ module github.com/deepnoodle-ai/dive/providers/openai
 go 1.25.0
 
 require (
-	github.com/deepnoodle-ai/dive v1.9.0
+	github.com/deepnoodle-ai/dive v1.10.0
 	github.com/deepnoodle-ai/wonton v0.0.36
 	github.com/openai/openai-go/v3 v3.29.0
 	golang.org/x/image v0.38.0


### PR DESCRIPTION
## Summary

Release prep for **v1.10.0**. The only change since v1.9.0 is the new Google Vertex AI backend option ([#201](https://github.com/deepnoodle-ai/dive/pull/201)) — a backwards-compatible public API addition, so this is a minor bump.

## Changes

- **CHANGELOG.md** — new `[1.10.0] - 2026-06-29` entry documenting `google.WithVertexAI(location)`.
- **Module version bumps** — intra-repo `github.com/deepnoodle-ai/dive*` references bumped `v1.9.0 → v1.10.0` across all sub-modules (`a2a`, `otel`, `experimental/mcp`, `experimental/cmd/dive`, `examples`, `providers/{google,grok,openai}`) plus the two demos (`colosseum`, `noodleville`).
- Ran `make tidy-all` (and tidied the demo modules).

## Post-merge tagging

After this merges to `main`, the release is tagged on the merge commit:

```
git checkout main && git pull
git tag v1.10.0
make tag-modules VERSION=v1.10.0
git push origin --tags
```

Then cut the GitHub release from `v1.10.0` with the CHANGELOG entry as the notes.

## Test plan

- [x] `make build` — CLI builds
- [x] `go test ./...` (root module) — green
- [x] No stale `v1.9.0` intra-repo references remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)