### PR TITLE
[codex] Preserve Google tool thought signatures (v1.10.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [1.10.1] - 2026-06-29
+
+### Fixed
+
+- **Google thought signatures** — Gemini 3 returns an opaque `thought_signature`
+  on each function-call part and rejects later requests (HTTP 400) if it is not
+  echoed back. Tool calls now carry this signature on a new
+  `llm.ToolUseContent.Metadata` field (type `llm.ProviderMetadata`, an opaque
+  per-provider round-trip bag namespaced by provider key) and the Google
+  provider replays it on subsequent turns. Preserved across both streaming and
+  non-streaming responses and through session serialization.
+
 ## [1.10.0] - 2026-06-29
 
 ### Added

--- a/a2a/go.mod
+++ b/a2a/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/a2aproject/a2a-go/v2 v2.2.0
-	github.com/deepnoodle-ai/dive v1.10.0
+	github.com/deepnoodle-ai/dive v1.10.1
 	github.com/deepnoodle-ai/wonton v0.0.36
 )
 

--- a/demos/colosseum/go.mod
+++ b/demos/colosseum/go.mod
@@ -3,11 +3,11 @@ module github.com/deepnoodle-ai/dive/demos/colosseum
 go 1.25.0
 
 require (
-	github.com/deepnoodle-ai/dive v1.10.0
-	github.com/deepnoodle-ai/dive/a2a v1.10.0
-	github.com/deepnoodle-ai/dive/providers/google v1.10.0
-	github.com/deepnoodle-ai/dive/providers/grok v1.10.0
-	github.com/deepnoodle-ai/dive/providers/openai v1.10.0
+	github.com/deepnoodle-ai/dive v1.10.1
+	github.com/deepnoodle-ai/dive/a2a v1.10.1
+	github.com/deepnoodle-ai/dive/providers/google v1.10.1
+	github.com/deepnoodle-ai/dive/providers/grok v1.10.1
+	github.com/deepnoodle-ai/dive/providers/openai v1.10.1
 	github.com/deepnoodle-ai/wonton v0.0.36
 )
 

--- a/demos/noodleville/go.mod
+++ b/demos/noodleville/go.mod
@@ -3,7 +3,7 @@ module github.com/deepnoodle-ai/dive/demos/noodleville
 go 1.25.0
 
 require (
-	github.com/deepnoodle-ai/dive v1.10.0
+	github.com/deepnoodle-ai/dive v1.10.1
 	github.com/deepnoodle-ai/wonton v0.0.36
 )
 

--- a/examples/go.mod
+++ b/examples/go.mod
@@ -3,13 +3,13 @@ module github.com/deepnoodle-ai/dive/examples
 go 1.25.0
 
 require (
-	github.com/deepnoodle-ai/dive v1.10.0
-	github.com/deepnoodle-ai/dive/a2a v1.10.0
-	github.com/deepnoodle-ai/dive/experimental/mcp v1.10.0
-	github.com/deepnoodle-ai/dive/otel v1.10.0
-	github.com/deepnoodle-ai/dive/providers/google v1.10.0
-	github.com/deepnoodle-ai/dive/providers/grok v1.10.0
-	github.com/deepnoodle-ai/dive/providers/openai v1.10.0
+	github.com/deepnoodle-ai/dive v1.10.1
+	github.com/deepnoodle-ai/dive/a2a v1.10.1
+	github.com/deepnoodle-ai/dive/experimental/mcp v1.10.1
+	github.com/deepnoodle-ai/dive/otel v1.10.1
+	github.com/deepnoodle-ai/dive/providers/google v1.10.1
+	github.com/deepnoodle-ai/dive/providers/grok v1.10.1
+	github.com/deepnoodle-ai/dive/providers/openai v1.10.1
 	github.com/deepnoodle-ai/wonton v0.0.36
 	github.com/fatih/color v1.18.0
 	github.com/mark3labs/mcp-go v0.45.0

--- a/experimental/cmd/dive/go.mod
+++ b/experimental/cmd/dive/go.mod
@@ -3,10 +3,10 @@ module github.com/deepnoodle-ai/dive/experimental/cmd/dive
 go 1.25.0
 
 require (
-	github.com/deepnoodle-ai/dive v1.10.0
-	github.com/deepnoodle-ai/dive/providers/google v1.10.0
-	github.com/deepnoodle-ai/dive/providers/grok v1.10.0
-	github.com/deepnoodle-ai/dive/providers/openai v1.10.0
+	github.com/deepnoodle-ai/dive v1.10.1
+	github.com/deepnoodle-ai/dive/providers/google v1.10.1
+	github.com/deepnoodle-ai/dive/providers/grok v1.10.1
+	github.com/deepnoodle-ai/dive/providers/openai v1.10.1
 	github.com/deepnoodle-ai/wonton v0.0.36
 	github.com/mattn/go-runewidth v0.0.21
 )

--- a/experimental/mcp/go.mod
+++ b/experimental/mcp/go.mod
@@ -3,7 +3,7 @@ module github.com/deepnoodle-ai/dive/experimental/mcp
 go 1.25.0
 
 require (
-	github.com/deepnoodle-ai/dive v1.10.0
+	github.com/deepnoodle-ai/dive v1.10.1
 	github.com/deepnoodle-ai/wonton v0.0.36
 	github.com/mark3labs/mcp-go v0.45.0
 )

--- a/llm/content.go
+++ b/llm/content.go
@@ -424,10 +424,11 @@ func (c *DocumentContent) CloneContent() Content {
 */
 
 type ToolUseContent struct {
-	ID           string          `json:"id"`
-	Name         string          `json:"name"`
-	Input        json.RawMessage `json:"input"`
-	CacheControl *CacheControl   `json:"cache_control,omitempty"`
+	ID               string            `json:"id"`
+	Name             string            `json:"name"`
+	Input            json.RawMessage   `json:"input"`
+	CacheControl     *CacheControl     `json:"cache_control,omitempty"`
+	ProviderMetadata map[string]string `json:"provider_metadata,omitempty"`
 }
 
 func (c *ToolUseContent) Type() ContentType {
@@ -443,17 +444,19 @@ func (c *ToolUseContent) MarshalJSON() ([]byte, error) {
 		return nil, fmt.Errorf("invalid JSON in tool_use input for %q (id=%s): %s", c.Name, c.ID, string(input))
 	}
 	return json.Marshal(struct {
-		Type         ContentType     `json:"type"`
-		ID           string          `json:"id"`
-		Name         string          `json:"name"`
-		Input        json.RawMessage `json:"input"`
-		CacheControl *CacheControl   `json:"cache_control,omitempty"`
+		Type             ContentType       `json:"type"`
+		ID               string            `json:"id"`
+		Name             string            `json:"name"`
+		Input            json.RawMessage   `json:"input"`
+		CacheControl     *CacheControl     `json:"cache_control,omitempty"`
+		ProviderMetadata map[string]string `json:"provider_metadata,omitempty"`
 	}{
-		Type:         ContentTypeToolUse,
-		ID:           c.ID,
-		Name:         c.Name,
-		Input:        input,
-		CacheControl: c.CacheControl,
+		Type:             ContentTypeToolUse,
+		ID:               c.ID,
+		Name:             c.Name,
+		Input:            input,
+		CacheControl:     c.CacheControl,
+		ProviderMetadata: c.ProviderMetadata,
 	})
 }
 
@@ -464,6 +467,12 @@ func (c *ToolUseContent) SetCacheControl(cacheControl *CacheControl) {
 func (c *ToolUseContent) CloneContent() Content {
 	cp := *c
 	cp.CacheControl = nil
+	if c.ProviderMetadata != nil {
+		cp.ProviderMetadata = make(map[string]string, len(c.ProviderMetadata))
+		for k, v := range c.ProviderMetadata {
+			cp.ProviderMetadata[k] = v
+		}
+	}
 	return &cp
 }
 

--- a/llm/content.go
+++ b/llm/content.go
@@ -423,12 +423,36 @@ func (c *DocumentContent) CloneContent() Content {
 }
 */
 
+// ProviderMetadata carries opaque, provider-specific data attached to a content
+// block that must round-trip through the conversation unchanged for a later
+// request to the same provider. Keys are namespaced by provider to avoid
+// collisions (for example "google.thought_signature"). Values are strings;
+// binary payloads are base64-encoded by the provider that owns them. The core
+// library never interprets these values — only the originating provider reads
+// them back.
+type ProviderMetadata map[string]string
+
+// Clone returns a deep copy of the metadata, or nil if the receiver is nil.
+func (m ProviderMetadata) Clone() ProviderMetadata {
+	if m == nil {
+		return nil
+	}
+	cp := make(ProviderMetadata, len(m))
+	for k, v := range m {
+		cp[k] = v
+	}
+	return cp
+}
+
 type ToolUseContent struct {
-	ID               string            `json:"id"`
-	Name             string            `json:"name"`
-	Input            json.RawMessage   `json:"input"`
-	CacheControl     *CacheControl     `json:"cache_control,omitempty"`
-	ProviderMetadata map[string]string `json:"provider_metadata,omitempty"`
+	ID           string          `json:"id"`
+	Name         string          `json:"name"`
+	Input        json.RawMessage `json:"input"`
+	CacheControl *CacheControl   `json:"cache_control,omitempty"`
+	// Metadata carries opaque provider-specific data (see ProviderMetadata) that
+	// must be replayed to the provider on later requests — for example a Google
+	// function-call thought signature.
+	Metadata ProviderMetadata `json:"metadata,omitempty"`
 }
 
 func (c *ToolUseContent) Type() ContentType {
@@ -444,19 +468,19 @@ func (c *ToolUseContent) MarshalJSON() ([]byte, error) {
 		return nil, fmt.Errorf("invalid JSON in tool_use input for %q (id=%s): %s", c.Name, c.ID, string(input))
 	}
 	return json.Marshal(struct {
-		Type             ContentType       `json:"type"`
-		ID               string            `json:"id"`
-		Name             string            `json:"name"`
-		Input            json.RawMessage   `json:"input"`
-		CacheControl     *CacheControl     `json:"cache_control,omitempty"`
-		ProviderMetadata map[string]string `json:"provider_metadata,omitempty"`
+		Type         ContentType      `json:"type"`
+		ID           string           `json:"id"`
+		Name         string           `json:"name"`
+		Input        json.RawMessage  `json:"input"`
+		CacheControl *CacheControl    `json:"cache_control,omitempty"`
+		Metadata     ProviderMetadata `json:"metadata,omitempty"`
 	}{
-		Type:             ContentTypeToolUse,
-		ID:               c.ID,
-		Name:             c.Name,
-		Input:            input,
-		CacheControl:     c.CacheControl,
-		ProviderMetadata: c.ProviderMetadata,
+		Type:         ContentTypeToolUse,
+		ID:           c.ID,
+		Name:         c.Name,
+		Input:        input,
+		CacheControl: c.CacheControl,
+		Metadata:     c.Metadata,
 	})
 }
 
@@ -467,12 +491,7 @@ func (c *ToolUseContent) SetCacheControl(cacheControl *CacheControl) {
 func (c *ToolUseContent) CloneContent() Content {
 	cp := *c
 	cp.CacheControl = nil
-	if c.ProviderMetadata != nil {
-		cp.ProviderMetadata = make(map[string]string, len(c.ProviderMetadata))
-		for k, v := range c.ProviderMetadata {
-			cp.ProviderMetadata[k] = v
-		}
-	}
+	cp.Metadata = c.Metadata.Clone()
 	return &cp
 }
 

--- a/llm/response.go
+++ b/llm/response.go
@@ -74,18 +74,11 @@ func (r *Response) ToolCalls() []*ToolUseContent {
 	var toolCalls []*ToolUseContent
 	for _, content := range r.Content {
 		if toolUse, ok := content.(*ToolUseContent); ok {
-			var providerMetadata map[string]string
-			if toolUse.ProviderMetadata != nil {
-				providerMetadata = make(map[string]string, len(toolUse.ProviderMetadata))
-				for k, v := range toolUse.ProviderMetadata {
-					providerMetadata[k] = v
-				}
-			}
 			toolCalls = append(toolCalls, &ToolUseContent{
-				ID:               toolUse.ID,    // e.g. "toolu_01A09q90qw90lq917835lq9"
-				Name:             toolUse.Name,  // tool name e.g. "get_weather"
-				Input:            toolUse.Input, // tool call input JSON
-				ProviderMetadata: providerMetadata,
+				ID:       toolUse.ID,    // e.g. "toolu_01A09q90qw90lq917835lq9"
+				Name:     toolUse.Name,  // tool name e.g. "get_weather"
+				Input:    toolUse.Input, // tool call input JSON
+				Metadata: toolUse.Metadata.Clone(),
 			})
 		}
 	}

--- a/llm/response.go
+++ b/llm/response.go
@@ -74,10 +74,18 @@ func (r *Response) ToolCalls() []*ToolUseContent {
 	var toolCalls []*ToolUseContent
 	for _, content := range r.Content {
 		if toolUse, ok := content.(*ToolUseContent); ok {
+			var providerMetadata map[string]string
+			if toolUse.ProviderMetadata != nil {
+				providerMetadata = make(map[string]string, len(toolUse.ProviderMetadata))
+				for k, v := range toolUse.ProviderMetadata {
+					providerMetadata[k] = v
+				}
+			}
 			toolCalls = append(toolCalls, &ToolUseContent{
-				ID:    toolUse.ID,    // e.g. "toolu_01A09q90qw90lq917835lq9"
-				Name:  toolUse.Name,  // tool name e.g. "get_weather"
-				Input: toolUse.Input, // tool call input JSON
+				ID:               toolUse.ID,    // e.g. "toolu_01A09q90qw90lq917835lq9"
+				Name:             toolUse.Name,  // tool name e.g. "get_weather"
+				Input:            toolUse.Input, // tool call input JSON
+				ProviderMetadata: providerMetadata,
 			})
 		}
 	}

--- a/llm/stream.go
+++ b/llm/stream.go
@@ -37,13 +37,14 @@ type Event struct {
 
 // EventContentBlock carries the start of a content block in an LLM event.
 type EventContentBlock struct {
-	Type      ContentType     `json:"type"`
-	Text      string          `json:"text,omitempty"`
-	ID        string          `json:"id,omitempty"`
-	Name      string          `json:"name,omitempty"`
-	Input     json.RawMessage `json:"input,omitempty"`
-	Thinking  string          `json:"thinking,omitempty"`
-	Signature string          `json:"signature,omitempty"`
+	Type             ContentType       `json:"type"`
+	Text             string            `json:"text,omitempty"`
+	ID               string            `json:"id,omitempty"`
+	Name             string            `json:"name,omitempty"`
+	Input            json.RawMessage   `json:"input,omitempty"`
+	Thinking         string            `json:"thinking,omitempty"`
+	Signature        string            `json:"signature,omitempty"`
+	ProviderMetadata map[string]string `json:"provider_metadata,omitempty"`
 }
 
 // EventDeltaType indicates the type of delta in an LLM event.
@@ -113,9 +114,17 @@ func (r *ResponseAccumulator) AddEvent(event *Event) error {
 				Text: event.ContentBlock.Text,
 			}
 		case ContentTypeToolUse:
+			var providerMetadata map[string]string
+			if event.ContentBlock.ProviderMetadata != nil {
+				providerMetadata = make(map[string]string, len(event.ContentBlock.ProviderMetadata))
+				for k, v := range event.ContentBlock.ProviderMetadata {
+					providerMetadata[k] = v
+				}
+			}
 			content = &ToolUseContent{
-				ID:   event.ContentBlock.ID,
-				Name: event.ContentBlock.Name,
+				ID:               event.ContentBlock.ID,
+				Name:             event.ContentBlock.Name,
+				ProviderMetadata: providerMetadata,
 			}
 		case ContentTypeThinking:
 			content = &ThinkingContent{

--- a/llm/stream.go
+++ b/llm/stream.go
@@ -37,14 +37,14 @@ type Event struct {
 
 // EventContentBlock carries the start of a content block in an LLM event.
 type EventContentBlock struct {
-	Type             ContentType       `json:"type"`
-	Text             string            `json:"text,omitempty"`
-	ID               string            `json:"id,omitempty"`
-	Name             string            `json:"name,omitempty"`
-	Input            json.RawMessage   `json:"input,omitempty"`
-	Thinking         string            `json:"thinking,omitempty"`
-	Signature        string            `json:"signature,omitempty"`
-	ProviderMetadata map[string]string `json:"provider_metadata,omitempty"`
+	Type      ContentType      `json:"type"`
+	Text      string           `json:"text,omitempty"`
+	ID        string           `json:"id,omitempty"`
+	Name      string           `json:"name,omitempty"`
+	Input     json.RawMessage  `json:"input,omitempty"`
+	Thinking  string           `json:"thinking,omitempty"`
+	Signature string           `json:"signature,omitempty"`
+	Metadata  ProviderMetadata `json:"metadata,omitempty"`
 }
 
 // EventDeltaType indicates the type of delta in an LLM event.
@@ -114,17 +114,10 @@ func (r *ResponseAccumulator) AddEvent(event *Event) error {
 				Text: event.ContentBlock.Text,
 			}
 		case ContentTypeToolUse:
-			var providerMetadata map[string]string
-			if event.ContentBlock.ProviderMetadata != nil {
-				providerMetadata = make(map[string]string, len(event.ContentBlock.ProviderMetadata))
-				for k, v := range event.ContentBlock.ProviderMetadata {
-					providerMetadata[k] = v
-				}
-			}
 			content = &ToolUseContent{
-				ID:               event.ContentBlock.ID,
-				Name:             event.ContentBlock.Name,
-				ProviderMetadata: providerMetadata,
+				ID:       event.ContentBlock.ID,
+				Name:     event.ContentBlock.Name,
+				Metadata: event.ContentBlock.Metadata.Clone(),
 			}
 		case ContentTypeThinking:
 			content = &ThinkingContent{

--- a/otel/go.mod
+++ b/otel/go.mod
@@ -3,7 +3,7 @@ module github.com/deepnoodle-ai/dive/otel
 go 1.25.0
 
 require (
-	github.com/deepnoodle-ai/dive v1.10.0
+	github.com/deepnoodle-ai/dive v1.10.1
 	go.opentelemetry.io/otel v1.43.0
 	go.opentelemetry.io/otel/metric v1.43.0
 	go.opentelemetry.io/otel/sdk v1.43.0

--- a/providers/google/go.mod
+++ b/providers/google/go.mod
@@ -3,7 +3,7 @@ module github.com/deepnoodle-ai/dive/providers/google
 go 1.25.0
 
 require (
-	github.com/deepnoodle-ai/dive v1.10.0
+	github.com/deepnoodle-ai/dive v1.10.1
 	github.com/deepnoodle-ai/wonton v0.0.36
 	google.golang.org/genai v1.51.0
 )

--- a/providers/google/stream_iterator.go
+++ b/providers/google/stream_iterator.go
@@ -237,10 +237,10 @@ func (s *StreamIterator) queueFunctionCall(part *genai.Part) error {
 			Type:  llm.EventTypeContentBlockStart,
 			Index: &index,
 			ContentBlock: &llm.EventContentBlock{
-				Type:             llm.ContentTypeToolUse,
-				ID:               toolCallID,
-				Name:             call.Name,
-				ProviderMetadata: providerMetadataForGooglePart(part),
+				Type:     llm.ContentTypeToolUse,
+				ID:       toolCallID,
+				Name:     call.Name,
+				Metadata: providerMetadataForGooglePart(part),
 			},
 		},
 		&llm.Event{

--- a/providers/google/stream_iterator.go
+++ b/providers/google/stream_iterator.go
@@ -167,7 +167,7 @@ func (s *StreamIterator) processChunk(response *genai.GenerateContentResponse) e
 	for _, part := range candidate.Content.Parts {
 		switch {
 		case part.FunctionCall != nil:
-			if err := s.queueFunctionCall(part.FunctionCall); err != nil {
+			if err := s.queueFunctionCall(part); err != nil {
 				return err
 			}
 		case part.Text != "":
@@ -213,7 +213,8 @@ func (s *StreamIterator) queueText(text string) {
 // is no partial-JSON streaming), so the block starts, receives its full input
 // as one delta, and stops immediately. Parallel calls each get their own
 // sequential block index.
-func (s *StreamIterator) queueFunctionCall(call *genai.FunctionCall) error {
+func (s *StreamIterator) queueFunctionCall(part *genai.Part) error {
+	call := part.FunctionCall
 	args, err := json.Marshal(call.Args)
 	if err != nil {
 		return fmt.Errorf("error marshaling function call args: %w", err)
@@ -236,9 +237,10 @@ func (s *StreamIterator) queueFunctionCall(call *genai.FunctionCall) error {
 			Type:  llm.EventTypeContentBlockStart,
 			Index: &index,
 			ContentBlock: &llm.EventContentBlock{
-				Type: llm.ContentTypeToolUse,
-				ID:   toolCallID,
-				Name: call.Name,
+				Type:             llm.ContentTypeToolUse,
+				ID:               toolCallID,
+				Name:             call.Name,
+				ProviderMetadata: providerMetadataForGooglePart(part),
 			},
 		},
 		&llm.Event{

--- a/providers/google/stream_iterator_test.go
+++ b/providers/google/stream_iterator_test.go
@@ -100,7 +100,7 @@ func TestStreamIteratorParallelFunctionCalls(t *testing.T) {
 						{FunctionCall: &genai.FunctionCall{
 							Name: "get_weather",
 							Args: map[string]any{"city": "Paris"},
-						}},
+						}, ThoughtSignature: []byte("paris-sig")},
 						{FunctionCall: &genai.FunctionCall{
 							Name: "get_weather",
 							Args: map[string]any{"city": "Tokyo"},
@@ -145,6 +145,7 @@ func TestStreamIteratorParallelFunctionCalls(t *testing.T) {
 	assert.True(t, ok)
 	assert.Equal(t, "get_weather", first.Name)
 	assert.True(t, strings.Contains(string(first.Input), "Paris"))
+	assert.Equal(t, "cGFyaXMtc2ln", first.ProviderMetadata[googleThoughtSignatureMetadataKey])
 
 	second, ok := response.Content[2].(*llm.ToolUseContent)
 	assert.True(t, ok)

--- a/providers/google/stream_iterator_test.go
+++ b/providers/google/stream_iterator_test.go
@@ -145,7 +145,7 @@ func TestStreamIteratorParallelFunctionCalls(t *testing.T) {
 	assert.True(t, ok)
 	assert.Equal(t, "get_weather", first.Name)
 	assert.True(t, strings.Contains(string(first.Input), "Paris"))
-	assert.Equal(t, "cGFyaXMtc2ln", first.ProviderMetadata[googleThoughtSignatureMetadataKey])
+	assert.Equal(t, "cGFyaXMtc2ln", first.Metadata[googleThoughtSignatureMetadataKey])
 
 	second, ok := response.Content[2].(*llm.ToolUseContent)
 	assert.True(t, ok)

--- a/providers/google/thought_signature_test.go
+++ b/providers/google/thought_signature_test.go
@@ -1,0 +1,148 @@
+package google
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/deepnoodle-ai/dive/llm"
+	"github.com/deepnoodle-ai/wonton/assert"
+	"google.golang.org/genai"
+)
+
+// minimalGenerateResponse is a valid (if empty) GenerateContent response body so
+// the provider's response conversion succeeds and the call returns without error.
+const minimalGenerateResponse = `{"candidates":[{"content":{"role":"model","parts":[{"text":"ok"}]},"finishReason":"STOP"}],"usageMetadata":{}}`
+
+// requestPayload mirrors the subset of the Gemini GenerateContent request body
+// we need to inspect: the function-call parts and their sibling thought
+// signatures.
+type requestPayload struct {
+	Contents []struct {
+		Role  string `json:"role"`
+		Parts []struct {
+			FunctionCall *struct {
+				Name string `json:"name"`
+			} `json:"functionCall"`
+			ThoughtSignature string `json:"thoughtSignature"`
+		} `json:"parts"`
+	} `json:"contents"`
+}
+
+// TestGoogleThoughtSignatureSentOnWire is the end-to-end confirmation of the
+// fix: when a prior assistant tool call carries a Google thought signature, the
+// actual HTTP request sent for the next turn must include that signature on the
+// functionCall part. Without it Gemini 3 rejects the request with HTTP 400
+// ("Function call is missing a thought_signature in functionCall parts"). The
+// test drives a real genai client against an httptest server and inspects the
+// captured request body, exercising the genai SDK's own request serialization
+// rather than asserting on intermediate structs.
+func TestGoogleThoughtSignatureSentOnWire(t *testing.T) {
+	sigA := []byte("signature-for-tool-a")
+	sigB := []byte("signature-for-tool-b")
+
+	var capturedBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		capturedBody = body
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(minimalGenerateResponse))
+	}))
+	defer server.Close()
+
+	client, err := genai.NewClient(context.Background(), &genai.ClientConfig{
+		APIKey:      "test-key",
+		HTTPOptions: genai.HTTPOptions{BaseURL: server.URL},
+	})
+	assert.NoError(t, err)
+
+	// Same-package test: inject the test-server-backed client so initClient
+	// short-circuits and no real network call is made.
+	p := New(WithModel("gemini-3.1-flash-lite"), WithMaxRetries(0))
+	p.client = client
+
+	// Two parallel function calls in the assistant turn, each with its own
+	// signature — mirrors the reported failure ("...position 2") where a second
+	// function call was missing its signature.
+	messages := []*llm.Message{
+		llm.NewUserTextMessage("status?"),
+		{
+			Role: llm.Assistant,
+			Content: []llm.Content{
+				&llm.ToolUseContent{
+					ID:    "call_a",
+					Name:  "tool_a",
+					Input: []byte(`{"command":"status"}`),
+					Metadata: llm.ProviderMetadata{
+						googleThoughtSignatureMetadataKey: base64.StdEncoding.EncodeToString(sigA),
+					},
+				},
+				&llm.ToolUseContent{
+					ID:    "call_b",
+					Name:  "tool_b",
+					Input: []byte(`{"command":"version"}`),
+					Metadata: llm.ProviderMetadata{
+						googleThoughtSignatureMetadataKey: base64.StdEncoding.EncodeToString(sigB),
+					},
+				},
+			},
+		},
+		llm.NewToolResultMessage(
+			&llm.ToolResultContent{ToolUseID: "call_a", Content: "ok"},
+			&llm.ToolResultContent{ToolUseID: "call_b", Content: "v1"},
+		),
+	}
+
+	_, err = p.Generate(context.Background(), llm.WithMessages(messages...))
+	assert.NoError(t, err)
+	assert.True(t, len(capturedBody) > 0, "expected the request body to be captured")
+
+	var payload requestPayload
+	assert.NoError(t, json.Unmarshal(capturedBody, &payload))
+
+	// Collect the signature actually serialized for each function call on the
+	// wire, decoding back to the raw bytes Gemini originally issued.
+	sigByName := map[string][]byte{}
+	for _, content := range payload.Contents {
+		for _, part := range content.Parts {
+			if part.FunctionCall == nil {
+				continue
+			}
+			assert.True(t, part.ThoughtSignature != "",
+				"function call %q is missing its thought signature on the wire", part.FunctionCall.Name)
+			decoded, derr := base64.StdEncoding.DecodeString(part.ThoughtSignature)
+			assert.NoError(t, derr)
+			sigByName[part.FunctionCall.Name] = decoded
+		}
+	}
+
+	assert.Equal(t, sigA, sigByName["tool_a"])
+	assert.Equal(t, sigB, sigByName["tool_b"])
+}
+
+// TestGoogleNoThoughtSignatureWhenAbsent guards the inverse: a tool call with no
+// stored signature must not fabricate one. messagesToContents should succeed and
+// leave the function-call part's ThoughtSignature empty.
+func TestGoogleNoThoughtSignatureWhenAbsent(t *testing.T) {
+	contents, err := messagesToContents([]*llm.Message{
+		llm.NewUserTextMessage("hi"),
+		{
+			Role: llm.Assistant,
+			Content: []llm.Content{
+				&llm.ToolUseContent{
+					ID:    "call_1",
+					Name:  "tool_a",
+					Input: []byte(`{}`),
+				},
+			},
+		},
+		llm.NewToolResultMessage(&llm.ToolResultContent{ToolUseID: "call_1", Content: "ok"}),
+	})
+	assert.NoError(t, err)
+	assert.NotNil(t, contents[1].Parts[0].FunctionCall)
+	assert.Equal(t, 0, len(contents[1].Parts[0].ThoughtSignature))
+}

--- a/providers/google/util.go
+++ b/providers/google/util.go
@@ -1,6 +1,7 @@
 package google
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"reflect"
@@ -12,6 +13,8 @@ import (
 	"github.com/deepnoodle-ai/wonton/schema"
 	"google.golang.org/genai"
 )
+
+const googleThoughtSignatureMetadataKey = "google.thought_signature"
 
 // convertGoogleResponse converts a Google GenAI response to a Dive LLM response
 func convertGoogleResponse(resp *genai.GenerateContentResponse, model string) (*llm.Response, error) {
@@ -43,9 +46,10 @@ func convertGoogleResponse(resp *genai.GenerateContentResponse, model string) (*
 				toolCallID = generateToolCallID(part.FunctionCall.Name)
 			}
 			content = append(content, &llm.ToolUseContent{
-				ID:    toolCallID,
-				Name:  part.FunctionCall.Name,
-				Input: json.RawMessage(args),
+				ID:               toolCallID,
+				Name:             part.FunctionCall.Name,
+				Input:            json.RawMessage(args),
+				ProviderMetadata: providerMetadataForGooglePart(part),
 			})
 		} else {
 			// Handle other types as text (fallback)
@@ -127,13 +131,19 @@ func convertToolUseToFunctionCall(toolUse *llm.ToolUseContent) (*genai.Part, err
 		args = map[string]any{}
 	}
 
-	return &genai.Part{
+	part := &genai.Part{
 		FunctionCall: &genai.FunctionCall{
 			ID:   toolUse.ID,
 			Name: toolUse.Name,
 			Args: args,
 		},
-	}, nil
+	}
+	signature, err := googleThoughtSignatureFromToolUse(toolUse)
+	if err != nil {
+		return nil, err
+	}
+	part.ThoughtSignature = signature
+	return part, nil
 }
 
 // convertToolResultToFunctionResponse converts a generic llm.ToolResultContent to a genai.FunctionResponse part
@@ -169,6 +179,30 @@ func convertToolResultToFunctionResponse(content *llm.ToolResultContent, functio
 			Response: responseData,
 		},
 	}, nil
+}
+
+func providerMetadataForGooglePart(part *genai.Part) map[string]string {
+	if part == nil || len(part.ThoughtSignature) == 0 {
+		return nil
+	}
+	return map[string]string{
+		googleThoughtSignatureMetadataKey: base64.StdEncoding.EncodeToString(part.ThoughtSignature),
+	}
+}
+
+func googleThoughtSignatureFromToolUse(toolUse *llm.ToolUseContent) ([]byte, error) {
+	if toolUse == nil || toolUse.ProviderMetadata == nil {
+		return nil, nil
+	}
+	encoded := strings.TrimSpace(toolUse.ProviderMetadata[googleThoughtSignatureMetadataKey])
+	if encoded == "" {
+		return nil, nil
+	}
+	signature, err := base64.StdEncoding.DecodeString(encoded)
+	if err != nil {
+		return nil, fmt.Errorf("invalid Google thought signature for tool %q: %w", toolUse.Name, err)
+	}
+	return signature, nil
 }
 
 // messagesToContents converts Dive messages to genai.Content format for GenerateContent API

--- a/providers/google/util.go
+++ b/providers/google/util.go
@@ -46,10 +46,10 @@ func convertGoogleResponse(resp *genai.GenerateContentResponse, model string) (*
 				toolCallID = generateToolCallID(part.FunctionCall.Name)
 			}
 			content = append(content, &llm.ToolUseContent{
-				ID:               toolCallID,
-				Name:             part.FunctionCall.Name,
-				Input:            json.RawMessage(args),
-				ProviderMetadata: providerMetadataForGooglePart(part),
+				ID:       toolCallID,
+				Name:     part.FunctionCall.Name,
+				Input:    json.RawMessage(args),
+				Metadata: providerMetadataForGooglePart(part),
 			})
 		} else {
 			// Handle other types as text (fallback)
@@ -181,20 +181,20 @@ func convertToolResultToFunctionResponse(content *llm.ToolResultContent, functio
 	}, nil
 }
 
-func providerMetadataForGooglePart(part *genai.Part) map[string]string {
+func providerMetadataForGooglePart(part *genai.Part) llm.ProviderMetadata {
 	if part == nil || len(part.ThoughtSignature) == 0 {
 		return nil
 	}
-	return map[string]string{
+	return llm.ProviderMetadata{
 		googleThoughtSignatureMetadataKey: base64.StdEncoding.EncodeToString(part.ThoughtSignature),
 	}
 }
 
 func googleThoughtSignatureFromToolUse(toolUse *llm.ToolUseContent) ([]byte, error) {
-	if toolUse == nil || toolUse.ProviderMetadata == nil {
+	if toolUse == nil || toolUse.Metadata == nil {
 		return nil, nil
 	}
-	encoded := strings.TrimSpace(toolUse.ProviderMetadata[googleThoughtSignatureMetadataKey])
+	encoded := strings.TrimSpace(toolUse.Metadata[googleThoughtSignatureMetadataKey])
 	if encoded == "" {
 		return nil, nil
 	}

--- a/providers/google/util_test.go
+++ b/providers/google/util_test.go
@@ -35,7 +35,7 @@ func TestMessagesToContentsToolRoundTrip(t *testing.T) {
 					ID:    id,
 					Name:  "calculator",
 					Input: []byte(`{"expression":"1+1"}`),
-					ProviderMetadata: map[string]string{
+					Metadata: llm.ProviderMetadata{
 						googleThoughtSignatureMetadataKey: base64.StdEncoding.EncodeToString([]byte("sig-123")),
 					},
 				},
@@ -86,7 +86,7 @@ func TestGoogleThoughtSignatureSurvivesMessageRoundTrip(t *testing.T) {
 
 	toolUse, ok := converted.Content[0].(*llm.ToolUseContent)
 	assert.True(t, ok)
-	assert.Equal(t, base64.StdEncoding.EncodeToString(signature), toolUse.ProviderMetadata[googleThoughtSignatureMetadataKey])
+	assert.Equal(t, base64.StdEncoding.EncodeToString(signature), toolUse.Metadata[googleThoughtSignatureMetadataKey])
 
 	body, err := json.Marshal(converted.Message())
 	assert.NoError(t, err)

--- a/providers/google/util_test.go
+++ b/providers/google/util_test.go
@@ -1,10 +1,13 @@
 package google
 
 import (
+	"encoding/base64"
+	"encoding/json"
 	"testing"
 
 	"github.com/deepnoodle-ai/dive/llm"
 	"github.com/deepnoodle-ai/wonton/assert"
+	"google.golang.org/genai"
 )
 
 func TestGenerateToolCallIDUnique(t *testing.T) {
@@ -32,6 +35,9 @@ func TestMessagesToContentsToolRoundTrip(t *testing.T) {
 					ID:    id,
 					Name:  "calculator",
 					Input: []byte(`{"expression":"1+1"}`),
+					ProviderMetadata: map[string]string{
+						googleThoughtSignatureMetadataKey: base64.StdEncoding.EncodeToString([]byte("sig-123")),
+					},
 				},
 			},
 		},
@@ -45,7 +51,56 @@ func TestMessagesToContentsToolRoundTrip(t *testing.T) {
 	assert.Len(t, contents, 3)
 	assert.NotNil(t, contents[1].Parts[0].FunctionCall)
 	assert.Equal(t, contents[1].Parts[0].FunctionCall.ID, id)
+	assert.Equal(t, []byte("sig-123"), contents[1].Parts[0].ThoughtSignature)
 	assert.NotNil(t, contents[2].Parts[0].FunctionResponse)
 	assert.Equal(t, contents[2].Parts[0].FunctionResponse.ID, id)
 	assert.Equal(t, contents[2].Parts[0].FunctionResponse.Name, "calculator")
+}
+
+func TestGoogleThoughtSignatureSurvivesMessageRoundTrip(t *testing.T) {
+	signature := []byte("opaque-google-signature")
+	resp := &genai.GenerateContentResponse{
+		Candidates: []*genai.Candidate{
+			{
+				Index: 0,
+				Content: &genai.Content{
+					Role: "model",
+					Parts: []*genai.Part{
+						{
+							FunctionCall: &genai.FunctionCall{
+								ID:   "call_1",
+								Name: "default_api:mobius",
+								Args: map[string]any{"command": "status"},
+							},
+							ThoughtSignature: signature,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	converted, err := convertGoogleResponse(resp, "gemini-3.1-flash-lite")
+	assert.NoError(t, err)
+	assert.Len(t, converted.Content, 1)
+
+	toolUse, ok := converted.Content[0].(*llm.ToolUseContent)
+	assert.True(t, ok)
+	assert.Equal(t, base64.StdEncoding.EncodeToString(signature), toolUse.ProviderMetadata[googleThoughtSignatureMetadataKey])
+
+	body, err := json.Marshal(converted.Message())
+	assert.NoError(t, err)
+	var replayed llm.Message
+	assert.NoError(t, json.Unmarshal(body, &replayed))
+
+	contents, err := messagesToContents([]*llm.Message{
+		&replayed,
+		llm.NewToolResultMessage(&llm.ToolResultContent{
+			ToolUseID: toolUse.ID,
+			Content:   "ok",
+		}),
+	})
+	assert.NoError(t, err)
+	assert.Len(t, contents, 2)
+	assert.Equal(t, signature, contents[0].Parts[0].ThoughtSignature)
 }

--- a/providers/grok/go.mod
+++ b/providers/grok/go.mod
@@ -3,8 +3,8 @@ module github.com/deepnoodle-ai/dive/providers/grok
 go 1.25.0
 
 require (
-	github.com/deepnoodle-ai/dive v1.10.0
-	github.com/deepnoodle-ai/dive/providers/openai v1.10.0
+	github.com/deepnoodle-ai/dive v1.10.1
+	github.com/deepnoodle-ai/dive/providers/openai v1.10.1
 	github.com/deepnoodle-ai/wonton v0.0.36
 	github.com/openai/openai-go/v3 v3.29.0
 	golang.org/x/image v0.38.0

--- a/providers/openai/go.mod
+++ b/providers/openai/go.mod
@@ -3,7 +3,7 @@ module github.com/deepnoodle-ai/dive/providers/openai
 go 1.25.0
 
 require (
-	github.com/deepnoodle-ai/dive v1.10.0
+	github.com/deepnoodle-ai/dive v1.10.1
 	github.com/deepnoodle-ai/wonton v0.0.36
 	github.com/openai/openai-go/v3 v3.29.0
 	golang.org/x/image v0.38.0


### PR DESCRIPTION
## Summary

Preserves Google (Gemini 3.x) function-call **thought signatures** so replayed tool calls aren't rejected, models the carrier as a documented provider-metadata seam rather than an ad-hoc field, and ships the fix as **v1.10.1**.

- Add an opaque, per-provider round-trip bag (`llm.ProviderMetadata`) to tool-use content so provider-specific data survives JSON serialization (session persistence).
- Preserve Google `thoughtSignature` bytes on function-call parts and restore them when replaying tool-use messages back to Gemini — across both streaming and non-streaming responses.
- Promote the carrier into an official, named API and cut the v1.10.1 release.

## Root cause

Gemini 3.x returns an opaque `thought_signature` on each function-call part and **rejects later requests with HTTP 400** if it isn't echoed back:

> Function call is missing a thought_signature in functionCall parts. ... position 2.

The Google provider converted `genai.Part` values into generic `llm.ToolUseContent` blocks and dropped `Part.ThoughtSignature`, so reconstructed `FunctionCall` parts on the next turn had no signature.

## Design — an official metadata seam

Rather than a one-off field, the signature rides on a generic, documented extension point — the same pattern the Vercel AI SDK (`providerMetadata`) and others use for opaque provider data the abstraction must round-trip but never interpret:

- New `llm.ProviderMetadata` type (`map[string]string`) with a `Clone()` helper and a godoc contract: keys are provider-namespaced (e.g. `google.thought_signature`), binary payloads are base64-encoded by the owning provider, and core never interprets the values.
- Carried on `llm.ToolUseContent.Metadata` and `llm.EventContentBlock.Metadata` (json `metadata`), so it survives marshal/unmarshal and the streaming accumulator.
- `map[string]string` (not `map[string]any`) is deliberate: a `[]byte` in JSON is base64 either way, and `any` would silently return a `string` after persistence — destabilizing the round-trip. Keeping base64 explicit is the honest representation.
- `Clone()` replaces deep-copy boilerplate previously duplicated across `CloneContent`, `Response.ToolCalls`, and the stream accumulator.

## Testing

`providers/google/thought_signature_test.go` adds a **wire-level** regression test that drives a real `genai` client against an `httptest` server, captures the actual outgoing request body, and asserts the thought signature is serialized onto the `functionCall` part (the exact condition Gemini validates) — exercising the genai SDK's own request serialization, not just intermediate structs. It uses two parallel calls to cover the reported "position 2" case. Confirmed it **fails without the fix** (`function call "tool_a" is missing its thought signature on the wire`) and passes with it. A second test guards that no signature is fabricated when absent. Existing round-trip/streaming tests were updated to the new field.

## Release — v1.10.1 (patch)

A bugfix under `### Fixed`; the new exported types are supporting plumbing — consistent with the prior bugfix patch v1.8.1.

- CHANGELOG `[1.10.1]` entry.
- Intra-repo module version refs bumped `v1.10.0 → v1.10.1` across all sub-modules + the two demos; `make tidy-all` run.
- Tagging (`make tag-modules`) is intentionally **not** done here — that happens after merge.

## Validation

- `go test ./...` from the Dive root
- `go test ./...` from `providers/google`
- `go vet` + `gofmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
