### PR TITLE
[codex] Add Nano Banana image model catalog

### DIFF
--- a/docs/design/model-update-may-2026.md
+++ b/docs/design/model-update-may-2026.md
@@ -1,6 +1,6 @@
 # Model & Capability Update — May 2026
 
-_Last updated: 2026-05-28_
+_Last updated: 2026-06-30_
 
 This document records the latest models and pricing across providers (verified
 against official docs) and the changes made to Dive to add the new models and
@@ -16,7 +16,7 @@ here:
 - **Anthropic**: added Opus 4.7 and 4.8; fixed a bug that made effort/thinking
   unusable on 4.7/4.8; added the native `effort` parameter, adaptive thinking,
   fast mode, thinking-display control, and refusal `stop_details`.
-- **Google**: added Gemini 3.5 Flash, 3.1 Flash-Lite (stable), 3.1 Pro Image
+- **Google**: added Gemini 3.5 Flash, 3.1 Flash-Lite (stable), 3 Pro Image
   (Nano Banana Pro), 3.1 Flash Image (Nano Banana 2), 3.1 Flash Live, and the
   custom-tools Pro endpoint.
 - **xAI/Grok**: added Grok 4.3 (new default) and grok-build-0.1; corrected
@@ -46,7 +46,8 @@ header `fast-mode-2026-02-01`, requires account access).
 | `gemini-3.1-pro-preview` | $2.00 / $4.00 (>200k) | $12.00 / $18.00 | Flagship preview |
 | `gemini-3.1-flash-lite` | $0.25 | $1.50 | Stable; low-latency |
 | `gemini-3.1-flash-live-preview` | $0.75 (text) | $4.50 (text) | Live API, audio-to-audio |
-| `gemini-3.1-pro-image` | $2.00 | $120 (img tokens) | Nano Banana Pro, ~$0.134/image |
+| `gemini-3-pro-image` | $2.00 | $120 (img tokens) | Nano Banana Pro, ~$0.134/image |
+| `gemini-3.1-flash-lite-image` | $0.30 | $30 (img tokens) | Nano Banana family, ~$0.034/image |
 | `gemini-3.1-flash-image` | $0.50 | $60 (img tokens) | Nano Banana 2, ~$0.067/image |
 
 ### xAI (Grok)

--- a/docs/guides/experimental/media-generation.md
+++ b/docs/guides/experimental/media-generation.md
@@ -189,7 +189,7 @@ result, err := media.Transcribe(ctx, audio,
 | Provider | Models |
 |----------|--------|
 | OpenAI | `gpt-image-2`, `gpt-image-1.5`, `gpt-image-1`, `gpt-image-1-mini` |
-| Google | `imagen-4.0-generate-001`, `imagen-4.0-ultra-generate-001`, `imagen-4.0-fast-generate-001`, `gemini-2.5-flash-image`, `gemini-3.1-flash-image-preview` |
+| Google | `imagen-4.0-generate-001`, `imagen-4.0-ultra-generate-001`, `imagen-4.0-fast-generate-001`, `gemini-3.1-flash-lite-image`, `gemini-3.1-flash-image`, `gemini-3-pro-image`, `gemini-2.5-flash-image` |
 | Grok | `grok-imagine-image`, `grok-imagine-image-pro` |
 
 ### Video Models

--- a/docs/plans/plan-01-media-generation.md
+++ b/docs/plans/plan-01-media-generation.md
@@ -358,8 +358,11 @@ Model matchers: prefix-based for `gemini-*-image*`, `imagen-*`, `veo-*`.
 
 ```
 // Image models
-gemini-3.1-flash-image-preview
+gemini-3.1-flash-lite-image
+gemini-3.1-flash-image
+gemini-3-pro-image
 gemini-2.5-flash-image
+gemini-3.1-flash-image-preview
 gemini-3-pro-image-preview
 imagen-3.0-generate-001
 imagen-3.0-fast-generate-001

--- a/providers/google/media_test.go
+++ b/providers/google/media_test.go
@@ -14,9 +14,12 @@ import (
 func TestGoogleImageMatcher(t *testing.T) {
 	matcher := media.PrefixesMatcher("gemini-", "imagen-")
 	// Gemini image models
-	assert.True(t, matcher("gemini-3.1-flash-image-preview"))
-	assert.True(t, matcher("gemini-2.5-flash-image"))
-	assert.True(t, matcher("gemini-3-pro-image-preview"))
+	assert.True(t, matcher(ModelGemini31FlashLiteImage))
+	assert.True(t, matcher(ModelGemini31FlashImage))
+	assert.True(t, matcher(ModelGemini3ProImage))
+	assert.True(t, matcher(ModelGemini25FlashImage))
+	assert.True(t, matcher(ModelGemini31FlashImagePrev))
+	assert.True(t, matcher(ModelGemini3ProImagePreview))
 	// Imagen 4 models (current)
 	assert.True(t, matcher("imagen-4.0-generate-001"))
 	assert.True(t, matcher("imagen-4.0-ultra-generate-001"))
@@ -32,7 +35,7 @@ func TestGoogleVideoMatcher(t *testing.T) {
 	assert.True(t, matcher("veo-3-generate-preview"))
 	assert.True(t, matcher("veo-2-generate-preview"))
 	assert.True(t, !matcher("sora-2"))
-	assert.True(t, !matcher("gemini-3.1-flash-image-preview"))
+	assert.True(t, !matcher(ModelGemini31FlashImagePrev))
 }
 
 func TestGoogleSpeechMatcher(t *testing.T) {

--- a/providers/google/models.go
+++ b/providers/google/models.go
@@ -11,13 +11,17 @@ const (
 	ModelGemini31FlashLitePreview      = "gemini-3.1-flash-lite-preview"
 	ModelGemini31FlashLivePreview      = "gemini-3.1-flash-live-preview" // Live API (audio-to-audio)
 	ModelGemini31FlashTTSPreview       = "gemini-3.1-flash-tts-preview"
-	ModelGemini31ProImage              = "gemini-3.1-pro-image"   // Nano Banana Pro (stable)
-	ModelGemini31FlashImage            = "gemini-3.1-flash-image" // Nano Banana 2 (stable)
+	ModelGemini31FlashLiteImage        = "gemini-3.1-flash-lite-image" // Nano Banana family (stable)
+	ModelGemini31FlashImage            = "gemini-3.1-flash-image"      // Nano Banana 2 (stable)
 	ModelGemini31FlashImagePrev        = "gemini-3.1-flash-image-preview"
 
-	// Gemini 3 models (preview)
+	// Gemini 3 models
+	ModelGemini3ProImage        = "gemini-3-pro-image" // Nano Banana Pro (stable)
 	ModelGemini3ProImagePreview = "gemini-3-pro-image-preview"
 	ModelGemini3FlashPreview    = "gemini-3-flash-preview" // preview alias for Gemini 3.5 Flash
+
+	// Deprecated: use ModelGemini3ProImage.
+	ModelGemini31ProImage = ModelGemini3ProImage
 
 	// Deprecated: Model was shut down March 9, 2026. Use ModelGemini31ProPreview instead.
 	ModelGemini3ProPreview = "gemini-3-pro-preview"

--- a/providers/google/nano_banana_test.go
+++ b/providers/google/nano_banana_test.go
@@ -1,0 +1,29 @@
+package google
+
+import (
+	"testing"
+
+	"github.com/deepnoodle-ai/wonton/assert"
+)
+
+func TestNanoBananaModelCatalog(t *testing.T) {
+	models := []string{
+		ModelGemini31FlashLiteImage,
+		ModelGemini31FlashImage,
+		ModelGemini3ProImage,
+		ModelGemini25FlashImage,
+	}
+
+	assert.Equal(t, "gemini-3.1-flash-lite-image", ModelGemini31FlashLiteImage)
+	assert.Equal(t, "gemini-3.1-flash-image", ModelGemini31FlashImage)
+	assert.Equal(t, "gemini-3-pro-image", ModelGemini3ProImage)
+	assert.Equal(t, "gemini-2.5-flash-image", ModelGemini25FlashImage)
+	assert.Equal(t, ModelGemini3ProImage, ModelGemini31ProImage)
+
+	for _, model := range models {
+		pricing, ok := ImageModelPricing[model]
+		assert.True(t, ok, "missing Nano Banana image pricing for "+model)
+		assert.Equal(t, model, pricing.Model)
+		assert.True(t, pricing.Price > 0, "missing positive image price for "+model)
+	}
+}

--- a/providers/google/pricing.go
+++ b/providers/google/pricing.go
@@ -118,21 +118,28 @@ var ImageModelPricing = map[string]llm.ImagePricingInfo{
 		Price:     0.039, // $30 per 1M tokens, 1290 tokens per 1024x1024 image
 		MaxSize:   "1024x1024",
 		Currency:  "USD",
-		UpdatedAt: "2025-01-15",
+		UpdatedAt: "2026-06-30",
+	},
+	ModelGemini31FlashLiteImage: {
+		Model:     ModelGemini31FlashLiteImage,
+		Price:     0.0336, // $30 per 1M output tokens; 1120 tokens per 1K image
+		MaxSize:   "1024x1024",
+		Currency:  "USD",
+		UpdatedAt: "2026-06-30",
 	},
 	ModelGemini31FlashImage: {
 		Model:     ModelGemini31FlashImage,
 		Price:     0.067, // $60 per 1M output tokens; ~$0.067 per 1K-resolution image
-		MaxSize:   "1024x1024",
+		MaxSize:   "4096x4096",
 		Currency:  "USD",
-		UpdatedAt: "2026-05-28",
+		UpdatedAt: "2026-06-30",
 	},
-	ModelGemini31ProImage: {
-		Model:     ModelGemini31ProImage,
+	ModelGemini3ProImage: {
+		Model:     ModelGemini3ProImage,
 		Price:     0.134, // $120 per 1M output tokens; ~$0.134 per 1K/2K image ($0.24 at 4K)
-		MaxSize:   "2048x2048",
+		MaxSize:   "4096x4096",
 		Currency:  "USD",
-		UpdatedAt: "2026-05-28",
+		UpdatedAt: "2026-06-30",
 	},
 }
 


### PR DESCRIPTION
## Summary

- Add the current Nano Banana Gemini image model IDs from Google docs: `gemini-3.1-flash-lite-image`, `gemini-3.1-flash-image`, `gemini-3-pro-image`, and `gemini-2.5-flash-image`.
- Keep `ModelGemini31ProImage` as a deprecated compatibility alias that now resolves to the official `gemini-3-pro-image` ID.
- Refresh Google image pricing metadata and supported-model docs for the full Nano Banana family.
- Add a regression test that locks the constants and image pricing table to the supported Nano Banana model set.

Source checked: https://ai.google.dev/gemini-api/docs/image-generation and https://ai.google.dev/gemini-api/docs/pricing

## Validation

- `go test ./...` from repo root
- `go test ./...` from `providers/google`