### PR TITLE
Add Claude Sonnet 5 model support

### DIFF
--- a/experimental/cmd/dive/models.go
+++ b/experimental/cmd/dive/models.go
@@ -23,6 +23,7 @@ var modelCatalog = []modelInfo{
 	{"claude-opus-4-6", "Opus 4.6", 1_000_000},
 	{"claude-opus-4-5", "Opus 4.5", 1_000_000},
 	{"claude-opus-4", "", 1_000_000},
+	{"claude-sonnet-5", "Sonnet 5", 1_000_000},
 	{"claude-sonnet-4-6", "Sonnet 4.6", 1_000_000},
 	{"claude-sonnet-4-5", "Sonnet 4.5", 1_000_000},
 	{"claude-sonnet-4", "", 1_000_000},
@@ -137,7 +138,7 @@ var providerCatalog = []providerInfo{
 		Models: []modelChoice{
 			{"claude-fable-5", "Fable 5", "Most capable for demanding reasoning and long-horizon work"},
 			{"claude-opus-4-8", "Opus 4.8", "Most capable Opus-tier model for complex work"},
-			{"claude-sonnet-4-6", "Sonnet 4.6", "Best for everyday tasks"},
+			{"claude-sonnet-5", "Sonnet 5", "Best combination of speed and intelligence"},
 			{"claude-haiku-4-5", "Haiku 4.5", "Fastest for quick answers"},
 		},
 	},

--- a/providers/anthropic/anthropic.go
+++ b/providers/anthropic/anthropic.go
@@ -630,7 +630,7 @@ func applyReasoningConfig(req *Request, config *llm.Config) error {
 	}
 
 	if thinking != nil {
-		if config.ThinkingDisplay != "" {
+		if config.ThinkingDisplay != "" && thinking.Type != "disabled" {
 			thinking.Display = string(config.ThinkingDisplay)
 		}
 		req.Thinking = thinking
@@ -645,6 +645,13 @@ func resolveThinking(model string, config *llm.Config) (*Thinking, error) {
 
 	switch config.Thinking {
 	case llm.ThinkingTypeDisabled:
+		// Models that default thinking on (Sonnet 5) require an explicit
+		// disable to actually turn thinking off; omitting the parameter would
+		// leave adaptive thinking enabled. All other models treat an omitted
+		// thinking parameter as off.
+		if modelDefaultsThinkingOn(model) {
+			return &Thinking{Type: "disabled"}, nil
+		}
 		return nil, nil
 	case llm.ThinkingTypeAdaptive:
 		return &Thinking{Type: "adaptive"}, nil
@@ -727,6 +734,7 @@ func modelSupportsEffortParam(model string) bool {
 		strings.HasPrefix(model, "claude-opus-4-7"),
 		strings.HasPrefix(model, "claude-opus-4-8"),
 		strings.HasPrefix(model, "claude-sonnet-4-6"),
+		strings.HasPrefix(model, "claude-sonnet-5"),
 		strings.HasPrefix(model, "claude-fable-5"),
 		strings.HasPrefix(model, "claude-mythos-5"):
 		return true
@@ -746,28 +754,42 @@ func modelSupportsMaxEffort(model string) bool {
 		strings.HasPrefix(model, "claude-opus-4-7") ||
 		strings.HasPrefix(model, "claude-opus-4-8") ||
 		strings.HasPrefix(model, "claude-sonnet-4-6") ||
+		strings.HasPrefix(model, "claude-sonnet-5") ||
 		strings.HasPrefix(model, "claude-fable-5") ||
 		strings.HasPrefix(model, "claude-mythos-5")
 }
 
 // modelRejectsTemperature reports whether the model rejects the temperature
-// parameter (Claude 5 models: Fable 5, Mythos 5).
+// parameter (Claude 5 models: Fable 5, Mythos 5, Sonnet 5).
 func modelRejectsTemperature(model string) bool {
 	return strings.HasPrefix(model, "claude-fable-5") ||
-		strings.HasPrefix(model, "claude-mythos-5")
+		strings.HasPrefix(model, "claude-mythos-5") ||
+		strings.HasPrefix(model, "claude-sonnet-5")
 }
 
 // modelRejectsManualThinking reports whether the model rejects manual extended
 // thinking budgets and supports only adaptive thinking (Opus 4.7/4.8, Fable 5,
-// Mythos 5). On the Claude 5 models adaptive thinking is always on and an
-// explicit thinking disable is also rejected by the API; Dive already omits
-// the thinking parameter entirely when thinking is disabled, so disables are
-// safe across all of these models.
+// Mythos 5, Sonnet 5). On Fable 5 and Mythos 5 adaptive thinking is always on
+// and an explicit thinking disable is also rejected by the API; Dive omits the
+// thinking parameter entirely when thinking is disabled, which is the accepted
+// form. Sonnet 5 also defaults thinking on but, unlike Fable/Mythos, accepts an
+// explicit disable — see modelDefaultsThinkingOn.
 func modelRejectsManualThinking(model string) bool {
 	return strings.HasPrefix(model, "claude-opus-4-7") ||
 		strings.HasPrefix(model, "claude-opus-4-8") ||
 		strings.HasPrefix(model, "claude-fable-5") ||
-		strings.HasPrefix(model, "claude-mythos-5")
+		strings.HasPrefix(model, "claude-mythos-5") ||
+		strings.HasPrefix(model, "claude-sonnet-5")
+}
+
+// modelDefaultsThinkingOn reports whether the model runs with adaptive thinking
+// when the request omits the thinking parameter. For these models a caller that
+// asks to disable thinking must send an explicit thinking:{type:"disabled"} —
+// omitting the field would leave thinking on. Currently only Sonnet 5 both
+// defaults thinking on and accepts an explicit disable (Fable 5 and Mythos 5
+// default on but reject the explicit disable, so Dive omits the field for them).
+func modelDefaultsThinkingOn(model string) bool {
+	return strings.HasPrefix(model, "claude-sonnet-5")
 }
 
 // createRequest creates an HTTP request with appropriate headers for Anthropic API calls

--- a/providers/anthropic/models.go
+++ b/providers/anthropic/models.go
@@ -32,7 +32,9 @@ const (
 	ModelClaudeOpus48 = "claude-opus-4-8"
 
 	// Claude 5 models (latest). Fable 5 is generally available; Mythos 5 is
-	// limited availability via Project Glasswing.
+	// limited availability via Project Glasswing. Sonnet 5 is a drop-in upgrade
+	// for Sonnet 4.6 with adaptive thinking on by default and a new tokenizer.
 	ModelClaudeFable5  = "claude-fable-5"
 	ModelClaudeMythos5 = "claude-mythos-5"
+	ModelClaudeSonnet5 = "claude-sonnet-5"
 )

--- a/providers/anthropic/pricing.go
+++ b/providers/anthropic/pricing.go
@@ -109,12 +109,13 @@ var TextModelPricing = map[string]llm.PricingInfo{
 		Currency:    "USD",
 		UpdatedAt:   "2026-06-09",
 	},
-	// Sonnet 5 launch pricing. Introductory rates of $2/$10 per MTok are in
-	// effect through 2026-08-31, after which standard pricing of $3/$15 applies.
+	// Sonnet 5 standard pricing. Introductory rates of $2/$10 per MTok are in
+	// effect through 2026-08-31; we use the long-term $3/$15 rates here to avoid
+	// a silent price cliff when the introductory period ends.
 	ModelClaudeSonnet5: {
 		Model:       ModelClaudeSonnet5,
-		InputPrice:  2.00,
-		OutputPrice: 10.00,
+		InputPrice:  3.00,
+		OutputPrice: 15.00,
 		Currency:    "USD",
 		UpdatedAt:   "2026-06-30",
 	},

--- a/providers/anthropic/pricing.go
+++ b/providers/anthropic/pricing.go
@@ -109,6 +109,15 @@ var TextModelPricing = map[string]llm.PricingInfo{
 		Currency:    "USD",
 		UpdatedAt:   "2026-06-09",
 	},
+	// Sonnet 5 launch pricing. Introductory rates of $2/$10 per MTok are in
+	// effect through 2026-08-31, after which standard pricing of $3/$15 applies.
+	ModelClaudeSonnet5: {
+		Model:       ModelClaudeSonnet5,
+		InputPrice:  2.00,
+		OutputPrice: 10.00,
+		Currency:    "USD",
+		UpdatedAt:   "2026-06-30",
+	},
 }
 
 // FastModeTextPricing contains premium pricing for models when fast mode

--- a/providers/anthropic/reasoning_test.go
+++ b/providers/anthropic/reasoning_test.go
@@ -165,12 +165,14 @@ func TestModelCapabilityHelpers(t *testing.T) {
 	assert.True(t, modelSupportsEffortParam(ModelClaudeOpus45))
 	assert.True(t, modelSupportsEffortParam(ModelClaudeFable5))
 	assert.True(t, modelSupportsEffortParam(ModelClaudeMythos5))
+	assert.True(t, modelSupportsEffortParam(ModelClaudeSonnet5))
 	assert.False(t, modelSupportsEffortParam(ModelClaude37Sonnet20250219))
 
 	assert.True(t, modelRejectsManualThinking(ModelClaudeOpus47))
 	assert.True(t, modelRejectsManualThinking(ModelClaudeOpus48))
 	assert.True(t, modelRejectsManualThinking(ModelClaudeFable5))
 	assert.True(t, modelRejectsManualThinking(ModelClaudeMythos5))
+	assert.True(t, modelRejectsManualThinking(ModelClaudeSonnet5))
 	assert.False(t, modelRejectsManualThinking(ModelClaudeOpus46))
 	assert.False(t, modelRejectsManualThinking(ModelClaudeSonnet46))
 
@@ -178,6 +180,16 @@ func TestModelCapabilityHelpers(t *testing.T) {
 	assert.True(t, modelSupportsMaxEffort(ModelClaudeFable5))
 	assert.True(t, modelSupportsXHighEffort(ModelClaudeMythos5))
 	assert.True(t, modelSupportsMaxEffort(ModelClaudeMythos5))
+
+	// Sonnet 5 supports max effort (like Sonnet 4.6) but not xhigh.
+	assert.False(t, modelSupportsXHighEffort(ModelClaudeSonnet5))
+	assert.True(t, modelSupportsMaxEffort(ModelClaudeSonnet5))
+
+	// Sonnet 5 rejects sampling params and defaults thinking on.
+	assert.True(t, modelRejectsTemperature(ModelClaudeSonnet5))
+	assert.True(t, modelDefaultsThinkingOn(ModelClaudeSonnet5))
+	assert.False(t, modelDefaultsThinkingOn(ModelClaudeFable5))
+	assert.False(t, modelDefaultsThinkingOn(ModelClaudeSonnet46))
 }
 
 func TestReasoningEffortFable5UsesOutputConfig(t *testing.T) {
@@ -202,4 +214,36 @@ func TestThinkingDisabledFable5OmitsThinkingParam(t *testing.T) {
 	// parameter entirely, which is the accepted form.
 	req := buildReq(t, ModelClaudeFable5, llm.WithThinking(llm.ThinkingTypeDisabled))
 	assert.Nil(t, req.Thinking)
+}
+
+func TestReasoningEffortSonnet5UsesOutputConfig(t *testing.T) {
+	// Sonnet 5 takes the native effort parameter. It does not support xhigh, so
+	// that request degrades to high rather than erroring.
+	req := buildReq(t, ModelClaudeSonnet5, llm.WithReasoningEffort(llm.ReasoningEffortXHigh))
+	assert.NotNil(t, req.OutputConfig)
+	assert.Equal(t, "high", req.OutputConfig.Effort)
+	assert.Nil(t, req.Thinking)
+}
+
+func TestReasoningBudgetSonnet5FallsBackToAdaptive(t *testing.T) {
+	// Manual extended thinking returns a 400 on Sonnet 5; a budget transparently
+	// becomes adaptive thinking so existing callers keep working.
+	req := buildReq(t, ModelClaudeSonnet5, llm.WithReasoningBudget(8000))
+	assert.NotNil(t, req.Thinking)
+	assert.Equal(t, "adaptive", req.Thinking.Type)
+	assert.Equal(t, 0, req.Thinking.BudgetTokens)
+}
+
+func TestThinkingDisabledSonnet5EmitsExplicitDisable(t *testing.T) {
+	// Sonnet 5 defaults thinking on, so a disable must be sent explicitly —
+	// omitting the parameter would leave adaptive thinking enabled.
+	req := buildReq(t, ModelClaudeSonnet5, llm.WithThinking(llm.ThinkingTypeDisabled))
+	assert.NotNil(t, req.Thinking)
+	assert.Equal(t, "disabled", req.Thinking.Type)
+}
+
+func TestSonnet5RejectsTemperature(t *testing.T) {
+	// Sampling parameters return a 400 on Sonnet 5; Dive drops temperature.
+	req := buildReq(t, ModelClaudeSonnet5, llm.WithTemperature(0.7))
+	assert.Nil(t, req.Temperature)
 }

--- a/providers/openrouter/models.go
+++ b/providers/openrouter/models.go
@@ -3,6 +3,7 @@ package openrouter
 const (
 	// Anthropic models
 	ModelClaudeFable5   = "anthropic/claude-fable-5"
+	ModelClaudeSonnet5  = "anthropic/claude-sonnet-5"
 	ModelClaudeOpus48   = "anthropic/claude-opus-4-8"
 	ModelClaudeOpus47   = "anthropic/claude-opus-4-7"
 	ModelClaudeOpus46   = "anthropic/claude-opus-4-6"


### PR DESCRIPTION
Adds support for **Claude Sonnet 5** (`claude-sonnet-5`), released today. Sonnet 5 is a drop-in upgrade for Sonnet 4.6 with three behavior changes and a new tokenizer.

## Changes

**Anthropic provider**
- Add the `ModelClaudeSonnet5` constant.
- Add pricing at the **standard $3 / $15** per MTok rates. Anthropic is offering introductory $2 / $10 rates through 2026-08-31, but we use the long-term rates here to avoid a silent price cliff when the introductory period ends and the checked-in constant would otherwise go stale.
- Wire Sonnet 5 into the reasoning/capability helpers:
  - **Native effort parameter** with `max` support (matches Sonnet 4.6). `xhigh` is not supported and degrades to `high`.
  - **Manual extended thinking removed** — now returns a 400, so a reasoning budget transparently falls back to adaptive thinking (`modelRejectsManualThinking`).
  - **Sampling parameters rejected** — `temperature` / `top_p` / `top_k` return a 400 and are dropped (`modelRejectsTemperature`).
  - **Adaptive thinking on by default** — the API enables adaptive thinking when the `thinking` field is omitted. So a caller asking to *disable* thinking must send an explicit `thinking: {type: "disabled"}` rather than omitting it, or thinking would stay on. New `modelDefaultsThinkingOn` helper handles this; Sonnet 5 accepts the explicit disable (unlike Fable 5 / Mythos 5, which reject it and must omit the field).

**CLI** (`experimental/cmd/dive`)
- Add Sonnet 5 to the context-window catalog (1M) and make it the recommended everyday Anthropic model.

**OpenRouter provider**
- Add the `anthropic/claude-sonnet-5` constant for consistency.

## Tests

Extended `reasoning_test.go` with Sonnet 5 coverage: effort mapping (xhigh → high), budget → adaptive fallback, explicit-disable emission, temperature rejection, and capability-helper assertions. `go build ./...` and the provider/llm/CLI test suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)