### PR TITLE
Skip SSE comment lines in OpenAI-completions stream parser

### DIFF
--- a/providers/openaicompletions/stream_iterator.go
+++ b/providers/openaicompletions/stream_iterator.go
@@ -110,6 +110,12 @@ func (s *StreamIterator) next() ([]*llm.Event, error) {
 	if len(bytes.TrimSpace(line)) == 0 {
 		return nil, nil
 	}
+	// Skip SSE comment lines. Per the SSE spec any line beginning with ':'
+	// is a comment and must be ignored. OpenRouter emits ": OPENROUTER
+	// PROCESSING" keep-alive comments while a model is queued/warming up.
+	if bytes.HasPrefix(bytes.TrimSpace(line), []byte(":")) {
+		return nil, nil
+	}
 	// Parse the event type from the SSE format
 	if bytes.HasPrefix(line, []byte("event: ")) {
 		return nil, nil

--- a/providers/openaicompletions/stream_iterator_test.go
+++ b/providers/openaicompletions/stream_iterator_test.go
@@ -72,6 +72,40 @@ func TestStreamIteratorUsageFromTrailingChunk(t *testing.T) {
 	assert.Equal(t, 7, response.Usage.OutputTokens)
 }
 
+// TestStreamIteratorSkipsSSEComments verifies that SSE comment lines (any
+// line beginning with ':') are ignored rather than parsed as JSON. OpenRouter
+// emits ": OPENROUTER PROCESSING" keep-alive comments while a model is queued
+// or warming up; parsing one as a data chunk previously failed with
+// "invalid character ':' looking for beginning of value".
+func TestStreamIteratorSkipsSSEComments(t *testing.T) {
+	body := strings.Join([]string{
+		`: OPENROUTER PROCESSING`,
+		``,
+		`data: {"id":"chatcmpl-3","object":"chat.completion.chunk","model":"z-ai/glm-5.2","choices":[{"index":0,"delta":{"role":"assistant","content":"Hi"}}]}`,
+		``,
+		`: OPENROUTER PROCESSING`,
+		``,
+		`data: {"id":"chatcmpl-3","object":"chat.completion.chunk","model":"z-ai/glm-5.2","choices":[{"index":0,"delta":{"content":" there"}}]}`,
+		``,
+		`data: {"id":"chatcmpl-3","object":"chat.completion.chunk","model":"z-ai/glm-5.2","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}`,
+		``,
+		`data: [DONE]`,
+		``,
+	}, "\n")
+
+	iterator := newTestStreamIterator(body)
+	defer iterator.Close()
+	events, accumulator := collectEvents(t, iterator)
+
+	assert.NotEmpty(t, events)
+	assert.Equal(t, llm.EventTypeMessageStop, events[len(events)-1].Type)
+	assert.True(t, accumulator.IsComplete())
+
+	response := accumulator.Response()
+	assert.Equal(t, "Hi there", response.Message().Text())
+	assert.Equal(t, "stop", response.StopReason)
+}
+
 // TestStreamIteratorToolUseWithTrailingUsage verifies that tool-use streams
 // still terminate correctly and report usage from the trailing usage chunk.
 func TestStreamIteratorToolUseWithTrailingUsage(t *testing.T) {


### PR DESCRIPTION
## Problem

Agent turns using OpenRouter models (GLM 5.2, Qwen3 Plus) failed with:

```
llm=openrouter: invalid character ':' looking for beginning of value
```

## Cause

OpenRouter emits SSE comment keep-alive lines (`: OPENROUTER PROCESSING`) while a model is queued or warming up. Per the [SSE spec](https://html.spec.whatwg.org/multipage/server-sent-events.html), any line starting with `:` is a comment and must be ignored.

The SSE parser in `providers/openaicompletions/stream_iterator.go` skipped blank / `event:` / `data:` / `[DONE]` lines but not comment lines — so `: OPENROUTER PROCESSING` fell through to `json.Unmarshal`, which choked on the leading colon. Only the slower models triggered it, since they're the ones that hit OpenRouter's processing keep-alive. Routing/provider detection worked fine.

## Solution

Add a 6-line skip for `:`-prefixed comment lines in the SSE parser, plus a `TestStreamIteratorSkipsSSEComments` regression test.

## Testing

- `go test ./providers/openaicompletions/` passes
- All provider tests pass; builds clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)