### PR TITLE
Prepare v1.10.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [1.10.2] - 2026-06-30
+
+### Fixed
+
+- **OpenRouter SSE keep-alive comments** — the OpenAI-completions stream parser
+  now skips SSE comment lines (any line beginning with `:`) per the SSE spec.
+  OpenRouter emits `: OPENROUTER PROCESSING` keep-alives while a model warms up,
+  which previously failed with `invalid character ':' looking for beginning of
+  value` on slower models.
+
 ## [1.10.1] - 2026-06-29
 
 ### Fixed

--- a/a2a/go.mod
+++ b/a2a/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/a2aproject/a2a-go/v2 v2.2.0
-	github.com/deepnoodle-ai/dive v1.10.1
+	github.com/deepnoodle-ai/dive v1.10.2
 	github.com/deepnoodle-ai/wonton v0.0.36
 )
 

--- a/demos/colosseum/go.mod
+++ b/demos/colosseum/go.mod
@@ -3,11 +3,11 @@ module github.com/deepnoodle-ai/dive/demos/colosseum
 go 1.25.0
 
 require (
-	github.com/deepnoodle-ai/dive v1.10.1
-	github.com/deepnoodle-ai/dive/a2a v1.10.1
-	github.com/deepnoodle-ai/dive/providers/google v1.10.1
-	github.com/deepnoodle-ai/dive/providers/grok v1.10.1
-	github.com/deepnoodle-ai/dive/providers/openai v1.10.1
+	github.com/deepnoodle-ai/dive v1.10.2
+	github.com/deepnoodle-ai/dive/a2a v1.10.2
+	github.com/deepnoodle-ai/dive/providers/google v1.10.2
+	github.com/deepnoodle-ai/dive/providers/grok v1.10.2
+	github.com/deepnoodle-ai/dive/providers/openai v1.10.2
 	github.com/deepnoodle-ai/wonton v0.0.36
 )
 

--- a/demos/noodleville/go.mod
+++ b/demos/noodleville/go.mod
@@ -3,7 +3,7 @@ module github.com/deepnoodle-ai/dive/demos/noodleville
 go 1.25.0
 
 require (
-	github.com/deepnoodle-ai/dive v1.10.1
+	github.com/deepnoodle-ai/dive v1.10.2
 	github.com/deepnoodle-ai/wonton v0.0.36
 )
 

--- a/examples/go.mod
+++ b/examples/go.mod
@@ -3,13 +3,13 @@ module github.com/deepnoodle-ai/dive/examples
 go 1.25.0
 
 require (
-	github.com/deepnoodle-ai/dive v1.10.1
-	github.com/deepnoodle-ai/dive/a2a v1.10.1
-	github.com/deepnoodle-ai/dive/experimental/mcp v1.10.1
-	github.com/deepnoodle-ai/dive/otel v1.10.1
-	github.com/deepnoodle-ai/dive/providers/google v1.10.1
-	github.com/deepnoodle-ai/dive/providers/grok v1.10.1
-	github.com/deepnoodle-ai/dive/providers/openai v1.10.1
+	github.com/deepnoodle-ai/dive v1.10.2
+	github.com/deepnoodle-ai/dive/a2a v1.10.2
+	github.com/deepnoodle-ai/dive/experimental/mcp v1.10.2
+	github.com/deepnoodle-ai/dive/otel v1.10.2
+	github.com/deepnoodle-ai/dive/providers/google v1.10.2
+	github.com/deepnoodle-ai/dive/providers/grok v1.10.2
+	github.com/deepnoodle-ai/dive/providers/openai v1.10.2
 	github.com/deepnoodle-ai/wonton v0.0.36
 	github.com/fatih/color v1.18.0
 	github.com/mark3labs/mcp-go v0.45.0

--- a/experimental/cmd/dive/go.mod
+++ b/experimental/cmd/dive/go.mod
@@ -3,10 +3,10 @@ module github.com/deepnoodle-ai/dive/experimental/cmd/dive
 go 1.25.0
 
 require (
-	github.com/deepnoodle-ai/dive v1.10.1
-	github.com/deepnoodle-ai/dive/providers/google v1.10.1
-	github.com/deepnoodle-ai/dive/providers/grok v1.10.1
-	github.com/deepnoodle-ai/dive/providers/openai v1.10.1
+	github.com/deepnoodle-ai/dive v1.10.2
+	github.com/deepnoodle-ai/dive/providers/google v1.10.2
+	github.com/deepnoodle-ai/dive/providers/grok v1.10.2
+	github.com/deepnoodle-ai/dive/providers/openai v1.10.2
 	github.com/deepnoodle-ai/wonton v0.0.36
 	github.com/mattn/go-runewidth v0.0.21
 )

--- a/experimental/mcp/go.mod
+++ b/experimental/mcp/go.mod
@@ -3,7 +3,7 @@ module github.com/deepnoodle-ai/dive/experimental/mcp
 go 1.25.0
 
 require (
-	github.com/deepnoodle-ai/dive v1.10.1
+	github.com/deepnoodle-ai/dive v1.10.2
 	github.com/deepnoodle-ai/wonton v0.0.36
 	github.com/mark3labs/mcp-go v0.45.0
 )

--- a/otel/go.mod
+++ b/otel/go.mod
@@ -3,7 +3,7 @@ module github.com/deepnoodle-ai/dive/otel
 go 1.25.0
 
 require (
-	github.com/deepnoodle-ai/dive v1.10.1
+	github.com/deepnoodle-ai/dive v1.10.2
 	go.opentelemetry.io/otel v1.43.0
 	go.opentelemetry.io/otel/metric v1.43.0
 	go.opentelemetry.io/otel/sdk v1.43.0

--- a/providers/google/go.mod
+++ b/providers/google/go.mod
@@ -3,7 +3,7 @@ module github.com/deepnoodle-ai/dive/providers/google
 go 1.25.0
 
 require (
-	github.com/deepnoodle-ai/dive v1.10.1
+	github.com/deepnoodle-ai/dive v1.10.2
 	github.com/deepnoodle-ai/wonton v0.0.36
 	google.golang.org/genai v1.51.0
 )

--- a/providers/grok/go.mod
+++ b/providers/grok/go.mod
@@ -3,8 +3,8 @@ module github.com/deepnoodle-ai/dive/providers/grok
 go 1.25.0
 
 require (
-	github.com/deepnoodle-ai/dive v1.10.1
-	github.com/deepnoodle-ai/dive/providers/openai v1.10.1
+	github.com/deepnoodle-ai/dive v1.10.2
+	github.com/deepnoodle-ai/dive/providers/openai v1.10.2
 	github.com/deepnoodle-ai/wonton v0.0.36
 	github.com/openai/openai-go/v3 v3.29.0
 	golang.org/x/image v0.38.0

--- a/providers/openai/go.mod
+++ b/providers/openai/go.mod
@@ -3,7 +3,7 @@ module github.com/deepnoodle-ai/dive/providers/openai
 go 1.25.0
 
 require (
-	github.com/deepnoodle-ai/dive v1.10.1
+	github.com/deepnoodle-ai/dive v1.10.2
 	github.com/deepnoodle-ai/wonton v0.0.36
 	github.com/openai/openai-go/v3 v3.29.0
 	golang.org/x/image v0.38.0


### PR DESCRIPTION
Prep for the v1.10.2 release.

- Add the v1.10.2 CHANGELOG entry covering the OpenRouter SSE keep-alive fix (#206): the OpenAI-completions stream parser now skips `:`-prefixed SSE comment lines, which OpenRouter emits as `: OPENROUTER PROCESSING` keep-alives while a model warms up.
- Bump intra-repo module version references from v1.10.1 → v1.10.2 across all sub-modules plus the two demos, and run `make tidy-all`.

After merge, tag the release on `main`:

```
git tag v1.10.2
make tag-modules VERSION=v1.10.2
git push origin --tags
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved streaming reliability by ignoring keep-alive comment lines, preventing parsing failures during model warm-up.

* **Chores**
  * Updated version references across examples, demos, and provider packages to the latest release.
  * Added a changelog entry for the fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->