### PR TITLE
[codex] Fix OpenAI tool result context ordering

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -1203,6 +1203,7 @@ func (rs *resumeState) AppendToolResults(contents []*llm.ToolResultContent) {
 	for _, c := range contents {
 		msg.Content = append(msg.Content, c)
 	}
+	msg.Content = toolResultsBeforeAuxiliaryContent(msg.Content)
 }
 
 // AppendToolResultTextContent appends an auxiliary text content block (from
@@ -1213,6 +1214,7 @@ func (rs *resumeState) AppendToolResultTextContent(tc *llm.TextContent) {
 	}
 	msg := rs.TurnMessages[rs.ToolResultMessageIdx]
 	msg.Content = append(msg.Content, tc)
+	msg.Content = toolResultsBeforeAuxiliaryContent(msg.Content)
 }
 
 // UpdateToolResultContent updates the tool_result content block for the given
@@ -1252,6 +1254,7 @@ func (rs *resumeState) UpdateToolResultContent(toolUseID string, result *ToolCal
 		msg.Content = append(msg.Content, &llm.TextContent{
 			Text: result.AdditionalContext,
 		})
+		msg.Content = toolResultsBeforeAuxiliaryContent(msg.Content)
 	}
 }
 
@@ -1392,6 +1395,7 @@ func (a *Agent) prepareResume(fullHistory []*llm.Message, state *SuspensionState
 		for _, aux := range mergedAux {
 			mergedMessage.Content = append(mergedMessage.Content, aux)
 		}
+		mergedMessage.Content = toolResultsBeforeAuxiliaryContent(mergedMessage.Content)
 		if toolResultIdx >= 0 {
 			turnMessages[toolResultIdx] = mergedMessage
 		} else {
@@ -1932,6 +1936,7 @@ func (a *Agent) generate(ctx context.Context, hctx *HookContext, messages []*llm
 			for _, tc := range getAdditionalContextContent(completedResults) {
 				toolResultMessage.Content = append(toolResultMessage.Content, tc)
 			}
+			toolResultMessage.Content = toolResultsBeforeAuxiliaryContent(toolResultMessage.Content)
 			newMessage(toolResultMessage)
 		}
 

--- a/agent_suspend_test.go
+++ b/agent_suspend_test.go
@@ -3346,6 +3346,126 @@ func TestResumePostHookMutationsPropagate(t *testing.T) {
 	assert.True(t, foundContext, "hook-injected AdditionalContext should appear in the tool_result sent to the LLM")
 }
 
+func TestAdditionalContextFollowsParallelToolResultBatch(t *testing.T) {
+	mock := &scriptedLLM{
+		script: []scriptedTurn{
+			toolUseAssistantTurn(
+				newScriptedToolUse("toolu_a", "tool_a", `{}`),
+				newScriptedToolUse("toolu_b", "tool_b", `{}`),
+				newScriptedToolUse("toolu_c", "tool_c", `{}`),
+			),
+			finalTextTurn("done"),
+		},
+	}
+	toolA := &scriptedTool{name: "tool_a", outcomes: []toolOutcome{{result: NewToolResultText("A")}}}
+	toolB := &scriptedTool{name: "tool_b", outcomes: []toolOutcome{{result: NewToolResultText("B")}}}
+	toolC := &scriptedTool{name: "tool_c", outcomes: []toolOutcome{{result: NewToolResultText("C")}}}
+
+	agent, err := NewAgent(AgentOptions{
+		Model:                 mock,
+		Tools:                 []Tool{toolA, toolB, toolC},
+		ParallelToolExecution: true,
+		Hooks: Hooks{
+			PostToolUse: []PostToolUseHook{
+				func(ctx context.Context, hctx *HookContext) error {
+					if hctx.Call.ID == "toolu_a" {
+						hctx.AdditionalContext = "extra context for tool A"
+					}
+					return nil
+				},
+			},
+		},
+	})
+	assert.NoError(t, err)
+
+	resp, err := agent.CreateResponse(context.Background(), WithInput("start"))
+	assert.NoError(t, err)
+	assert.Equal(t, resp.Status, ResponseStatusCompleted)
+
+	assert.True(t, len(mock.received) >= 2, "expected final LLM call")
+	finalCall := mock.received[1]
+	assertToolResultBatchBeforeAuxText(t, finalCall[len(finalCall)-1],
+		[]string{"toolu_a", "toolu_b", "toolu_c"},
+		[]string{"extra context for tool A"},
+	)
+}
+
+func TestResumeAdditionalContextStaysAfterMergedToolResultBatch(t *testing.T) {
+	mock := &scriptedLLM{
+		script: []scriptedTurn{
+			toolUseAssistantTurn(
+				newScriptedToolUse("toolu_a", "tool_a", `{}`),
+				newScriptedToolUse("toolu_b", "tool_b", `{}`),
+				newScriptedToolUse("toolu_c", "tool_c", `{}`),
+				newScriptedToolUse("toolu_d", "tool_d", `{}`),
+			),
+			finalTextTurn("done"),
+		},
+	}
+	toolA := &scriptedTool{name: "tool_a", outcomes: []toolOutcome{{result: NewToolResultText("A")}}}
+	toolB := &scriptedTool{name: "tool_b", outcomes: []toolOutcome{{result: NewSuspendResult("wait on B", nil)}}}
+	toolC := &scriptedTool{name: "tool_c", outcomes: []toolOutcome{{result: NewToolResultText("C")}}}
+	toolD := &scriptedTool{name: "tool_d", outcomes: []toolOutcome{{result: NewToolResultText("D")}}}
+	sess := session.New("resume-additional-context-order")
+
+	agent, err := NewAgent(AgentOptions{
+		Model:   mock,
+		Tools:   []Tool{toolA, toolB, toolC, toolD},
+		Session: sess,
+		Hooks: Hooks{
+			PostToolUse: []PostToolUseHook{
+				func(ctx context.Context, hctx *HookContext) error {
+					if hctx.Call.ID == "toolu_a" {
+						hctx.AdditionalContext = "extra context for tool A"
+					}
+					return nil
+				},
+			},
+		},
+	})
+	assert.NoError(t, err)
+
+	resp, err := agent.CreateResponse(context.Background(), WithInput("start"))
+	assert.NoError(t, err)
+	assert.Equal(t, resp.Status, ResponseStatusSuspended)
+
+	resp, err = agent.CreateResponse(context.Background(),
+		WithToolResults(map[string]*ToolResult{
+			"toolu_b": NewToolResultText("B"),
+		}),
+	)
+	assert.NoError(t, err)
+	assert.Equal(t, resp.Status, ResponseStatusCompleted)
+
+	assert.True(t, len(mock.received) >= 2, "expected resumed LLM call")
+	resumeCall := mock.received[1]
+	assertToolResultBatchBeforeAuxText(t, resumeCall[len(resumeCall)-1],
+		[]string{"toolu_a", "toolu_b", "toolu_c", "toolu_d"},
+		[]string{"extra context for tool A"},
+	)
+}
+
+func assertToolResultBatchBeforeAuxText(t *testing.T, msg *llm.Message, wantToolUseIDs []string, wantTexts []string) {
+	t.Helper()
+	assert.Equal(t, msg.Role, llm.User)
+
+	var gotToolUseIDs []string
+	var gotTexts []string
+	seenText := false
+	for _, c := range msg.Content {
+		switch c := c.(type) {
+		case *llm.ToolResultContent:
+			assert.False(t, seenText, "tool_result %q appeared after auxiliary text", c.ToolUseID)
+			gotToolUseIDs = append(gotToolUseIDs, c.ToolUseID)
+		case *llm.TextContent:
+			seenText = true
+			gotTexts = append(gotTexts, c.Text)
+		}
+	}
+	assert.Equal(t, gotToolUseIDs, wantToolUseIDs)
+	assert.Equal(t, gotTexts, wantTexts)
+}
+
 func TestCompletedToolCallsPreservedAcrossPartialResume(t *testing.T) {
 	// Verify that CompletedToolCall.Result and .Error survive across
 	// partial resumes — i.e. the second suspended response carries the

--- a/providers/anthropic/mixed_toolresult_test.go
+++ b/providers/anthropic/mixed_toolresult_test.go
@@ -1,0 +1,65 @@
+package anthropic
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/deepnoodle-ai/dive/llm"
+	"github.com/deepnoodle-ai/wonton/assert"
+	"github.com/deepnoodle-ai/wonton/schema"
+)
+
+// TestToolResultWithAuxiliaryContext_Live confirms against the real Anthropic
+// Messages API that a user message carrying a tool_result block followed by
+// auxiliary text (the shape a PostToolUse hook's AdditionalContext produces) is
+// accepted. Anthropic requires tool_result blocks to lead the message; the
+// agent-level normalization guarantees that ordering, and this exercises the
+// resulting shape end-to-end.
+func TestToolResultWithAuxiliaryContext_Live(t *testing.T) {
+	if os.Getenv("ANTHROPIC_API_KEY") == "" {
+		t.Skip("ANTHROPIC_API_KEY not set, skipping integration test")
+	}
+	ctx := context.Background()
+	provider := New(WithModel(ModelClaudeHaiku4520251001))
+
+	add := llm.NewToolDefinition().
+		WithName("add").
+		WithDescription("Returns the sum of two numbers, \"a\" and \"b\"").
+		WithSchema(&schema.Schema{
+			Type:     "object",
+			Required: []string{"a", "b"},
+			Properties: map[string]*schema.Property{
+				"a": {Type: "number", Description: "The first number"},
+				"b": {Type: "number", Description: "The second number"},
+			},
+		})
+
+	messages := []*llm.Message{
+		llm.NewUserTextMessage("Use the add tool to compute 567 + 111, then tell me the result."),
+		{
+			Role: llm.Assistant,
+			Content: []llm.Content{
+				&llm.ToolUseContent{ID: "toolu_add_1", Name: "add", Input: []byte(`{"a":567,"b":111}`)},
+			},
+		},
+		{
+			Role: llm.User,
+			Content: []llm.Content{
+				&llm.ToolResultContent{ToolUseID: "toolu_add_1", Content: "678"},
+				&llm.TextContent{Text: "(verification note: computed by calculator service v2)"},
+			},
+		},
+	}
+
+	response, err := provider.Generate(ctx,
+		llm.WithMessages(messages...),
+		llm.WithTools(add),
+	)
+	assert.NoError(t, err)
+	assert.NotNil(t, response)
+	text := response.Message().Text()
+	assert.True(t, strings.Contains(text, "678"),
+		"expected final answer to reflect the tool result, got: %q", text)
+}

--- a/providers/openai/encode.go
+++ b/providers/openai/encode.go
@@ -35,16 +35,34 @@ func encodeMessages(messages []*llm.Message) ([]responses.ResponseInputItemUnion
 			}
 			items = append(items, outMessages...)
 		case "tool_result":
+			// A single user message can carry tool_result blocks alongside
+			// auxiliary content (e.g. text injected via a PostToolUse hook's
+			// AdditionalContext). Emit every tool output first — the Responses
+			// API matches function_call_output items to their function_call by
+			// call_id — then encode the remaining content as a trailing user
+			// message rather than erroring on the mix.
+			var auxiliary []llm.Content
 			for _, c := range message.Content {
 				toolResultContent, ok := c.(*llm.ToolResultContent)
 				if !ok {
-					return nil, fmt.Errorf("tool result mixed with other content")
+					auxiliary = append(auxiliary, c)
+					continue
 				}
 				outMessage, err := encodeToolResultContent(toolResultContent)
 				if err != nil {
 					return nil, fmt.Errorf("error encoding tool result message: %w", err)
 				}
 				items = append(items, *outMessage)
+			}
+			if len(auxiliary) > 0 {
+				auxItems, err := encodeUserMessage(&llm.Message{
+					Role:    llm.User,
+					Content: auxiliary,
+				})
+				if err != nil {
+					return nil, fmt.Errorf("error encoding auxiliary tool result content: %w", err)
+				}
+				items = append(items, auxItems...)
 			}
 		}
 	}

--- a/providers/openai/mixed_toolresult_integration_test.go
+++ b/providers/openai/mixed_toolresult_integration_test.go
@@ -1,0 +1,61 @@
+//go:build integration
+
+package openai
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/deepnoodle-ai/dive/llm"
+	"github.com/deepnoodle-ai/wonton/assert"
+	"github.com/deepnoodle-ai/wonton/schema"
+)
+
+// TestIntegration_ToolResultWithAuxiliaryContext confirms against the real
+// OpenAI Responses API that a user message carrying a tool_result block
+// alongside auxiliary text (the shape a PostToolUse hook's AdditionalContext
+// produces) is accepted. Before the fix, encodeMessages rejected any such
+// message with "tool result mixed with other content".
+func TestIntegration_ToolResultWithAuxiliaryContext(t *testing.T) {
+	provider := setupIntegrationProvider(t)
+
+	add := llm.NewToolDefinition().
+		WithName("add").
+		WithDescription("Returns the sum of two numbers, \"a\" and \"b\"").
+		WithSchema(&schema.Schema{
+			Type:     "object",
+			Required: []string{"a", "b"},
+			Properties: map[string]*schema.Property{
+				"a": {Type: "number", Description: "The first number"},
+				"b": {Type: "number", Description: "The second number"},
+			},
+		})
+
+	messages := []*llm.Message{
+		llm.NewUserTextMessage("Use the add tool to compute 567 + 111, then tell me the result."),
+		{
+			Role: llm.Assistant,
+			Content: []llm.Content{
+				&llm.ToolUseContent{ID: "call_add_1", Name: "add", Input: []byte(`{"a":567,"b":111}`)},
+			},
+		},
+		{
+			Role: llm.User,
+			Content: []llm.Content{
+				&llm.ToolResultContent{ToolUseID: "call_add_1", Content: "678"},
+				&llm.TextContent{Text: "(verification note: computed by calculator service v2)"},
+			},
+		},
+	}
+
+	response, err := provider.Generate(context.Background(),
+		llm.WithMessages(messages...),
+		llm.WithTools(add),
+	)
+	assert.NoError(t, err)
+	assert.NotNil(t, response)
+	text := response.Message().Text()
+	assert.True(t, strings.Contains(text, "678"),
+		"expected final answer to reflect the tool result, got: %q", text)
+}

--- a/providers/openai/provider_test.go
+++ b/providers/openai/provider_test.go
@@ -127,6 +127,43 @@ func TestEncodeMessages(t *testing.T) {
 			want: `[{"call_id":"tool_123","output":"The weather is sunny","type":"function_call_output"}]`,
 		},
 		{
+			// A PostToolUse hook's AdditionalContext lands as auxiliary
+			// TextContent in the same user message as the tool_result. The
+			// tool output must still be emitted as a function_call_output, and
+			// the auxiliary text follows as a separate user message rather than
+			// erroring on the mix.
+			name: "tool result with auxiliary text stays contiguous",
+			messages: []*llm.Message{
+				{
+					Role: llm.User,
+					Content: []llm.Content{
+						&llm.ToolResultContent{
+							ToolUseID: "tool_123",
+							Content:   "The weather is sunny",
+						},
+						&llm.TextContent{Text: "note: weather source verified"},
+					},
+				},
+			},
+			want: `[{"call_id":"tool_123","output":"The weather is sunny","type":"function_call_output"},{"content":[{"text":"note: weather source verified","type":"input_text"}],"role":"user"}]`,
+		},
+		{
+			// Even when a durable transcript stores the auxiliary text before
+			// a sibling tool_result, encoding emits all tool outputs first.
+			name: "tool results ahead of interleaved auxiliary text",
+			messages: []*llm.Message{
+				{
+					Role: llm.User,
+					Content: []llm.Content{
+						&llm.ToolResultContent{ToolUseID: "tool_a", Content: "A"},
+						&llm.TextContent{Text: "aux for A"},
+						&llm.ToolResultContent{ToolUseID: "tool_b", Content: "B"},
+					},
+				},
+			},
+			want: `[{"call_id":"tool_a","output":"A","type":"function_call_output"},{"call_id":"tool_b","output":"B","type":"function_call_output"},{"content":[{"text":"aux for A","type":"input_text"}],"role":"user"}]`,
+		},
+		{
 			name: "empty messages are skipped",
 			messages: []*llm.Message{
 				{

--- a/providers/openaicompletions/mixed_toolresult_test.go
+++ b/providers/openaicompletions/mixed_toolresult_test.go
@@ -1,0 +1,62 @@
+package openaicompletions
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/deepnoodle-ai/dive/llm"
+	"github.com/deepnoodle-ai/wonton/assert"
+	"github.com/deepnoodle-ai/wonton/schema"
+)
+
+// TestToolResultWithAuxiliaryContext_Live confirms against the real OpenAI Chat
+// Completions API that a user message carrying a tool_result block alongside
+// auxiliary text (the shape a PostToolUse hook's AdditionalContext produces) is
+// accepted. Before the ordering fix this could surface interleaved tool/user
+// messages and be rejected by the API.
+func TestToolResultWithAuxiliaryContext_Live(t *testing.T) {
+	skipIfNoAPIKey(t)
+	ctx := context.Background()
+	provider := New()
+
+	add := llm.NewToolDefinition().
+		WithName("add").
+		WithDescription("Returns the sum of two numbers, \"a\" and \"b\"").
+		WithSchema(&schema.Schema{
+			Type:     "object",
+			Required: []string{"a", "b"},
+			Properties: map[string]*schema.Property{
+				"a": {Type: "number", Description: "The first number"},
+				"b": {Type: "number", Description: "The second number"},
+			},
+		})
+
+	messages := []*llm.Message{
+		llm.NewUserTextMessage("Use the add tool to compute 567 + 111, then tell me the result."),
+		{
+			Role: llm.Assistant,
+			Content: []llm.Content{
+				&llm.ToolUseContent{ID: "call_add_1", Name: "add", Input: []byte(`{"a":567,"b":111}`)},
+			},
+		},
+		{
+			Role: llm.User,
+			Content: []llm.Content{
+				&llm.ToolResultContent{ToolUseID: "call_add_1", Content: "678"},
+				&llm.TextContent{Text: "(verification note: computed by calculator service v2)"},
+			},
+		},
+	}
+
+	response, err := provider.Generate(ctx,
+		llm.WithModel("gpt-4o-mini"),
+		llm.WithMessages(messages...),
+		llm.WithTools(add),
+	)
+	assert.NoError(t, err)
+	assert.NotNil(t, response)
+	text := response.Message().Text()
+	assert.True(t, strings.Contains(text, "678"),
+		"expected final answer to reflect the tool result, got: %q", text)
+}

--- a/providers/openaicompletions/openai.go
+++ b/providers/openaicompletions/openai.go
@@ -362,36 +362,45 @@ func convertMessages(messages []*llm.Message) ([]Message, error) {
 			})
 		}
 
-		// Process non-tool-use content blocks
-		if !hasToolUse || hasToolResult {
+		if hasToolResult {
+			for _, c := range msg.Content {
+				trc, ok := c.(*llm.ToolResultContent)
+				if !ok {
+					continue
+				}
+				toolMessage, err := convertToolResultContent(trc)
+				if err != nil {
+					return nil, err
+				}
+				result = append(result, toolMessage)
+			}
 			for _, c := range msg.Content {
 				switch c := c.(type) {
 				case *llm.TextContent:
 					if !hasToolUse {
 						result = append(result, Message{Role: role, Content: c.Text})
 					}
-				case *llm.ToolResultContent:
-					// Each tool result goes in its own message
-					var contentStr string
-					switch content := c.Content.(type) {
-					case string:
-						contentStr = content
-					case []*dive.ToolResultContent:
-						var texts []string
-						for _, c := range content {
-							if c.Text != "" {
-								texts = append(texts, c.Text)
-							}
-						}
-						contentStr = strings.Join(texts, "\n")
-					default:
-						return nil, fmt.Errorf("unsupported tool result content type")
-					}
-					result = append(result, Message{
-						Role:       "tool",
-						Content:    contentStr,
-						ToolCallID: c.ToolUseID,
-					})
+				case *llm.ToolResultContent, *llm.ToolUseContent:
+					// Already handled above
+				case *llm.ThinkingContent, *llm.RedactedThinkingContent:
+					// The Chat Completions API has no standard field for
+					// replaying assistant reasoning back to the server, so
+					// thinking content (which this provider's own stream
+					// iterator can produce from "reasoning" deltas) is
+					// skipped on encode rather than erroring.
+				default:
+					return nil, fmt.Errorf("unsupported content type: %s", c.Type())
+				}
+			}
+			continue
+		}
+
+		// Process non-tool-use content blocks
+		if !hasToolUse {
+			for _, c := range msg.Content {
+				switch c := c.(type) {
+				case *llm.TextContent:
+					result = append(result, Message{Role: role, Content: c.Text})
 				case *llm.ToolUseContent:
 					// Already handled above
 				case *llm.ThinkingContent, *llm.RedactedThinkingContent:
@@ -407,6 +416,43 @@ func convertMessages(messages []*llm.Message) ([]Message, error) {
 		}
 	}
 	return result, nil
+}
+
+func convertToolResultContent(c *llm.ToolResultContent) (Message, error) {
+	contentStr, err := toolResultContentString(c)
+	if err != nil {
+		return Message{}, err
+	}
+	return Message{
+		Role:       "tool",
+		Content:    contentStr,
+		ToolCallID: c.ToolUseID,
+	}, nil
+}
+
+func toolResultContentString(c *llm.ToolResultContent) (string, error) {
+	switch content := c.Content.(type) {
+	case string:
+		return content, nil
+	case []*dive.ToolResultContent:
+		return toolResultTextBlocks(content), nil
+	default:
+		var blocks []*dive.ToolResultContent
+		if err := c.DecodeContent(&blocks); err == nil && blocks != nil {
+			return toolResultTextBlocks(blocks), nil
+		}
+		return "", fmt.Errorf("unsupported tool result content type")
+	}
+}
+
+func toolResultTextBlocks(content []*dive.ToolResultContent) string {
+	var texts []string
+	for _, c := range content {
+		if c.Text != "" {
+			texts = append(texts, c.Text)
+		}
+	}
+	return strings.Join(texts, "\n")
 }
 
 func (p *Provider) applyRequestConfig(req *Request, config *llm.Config) error {

--- a/providers/openaicompletions/openai_test.go
+++ b/providers/openaicompletions/openai_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/deepnoodle-ai/dive"
 	"github.com/deepnoodle-ai/dive/llm"
 	"github.com/deepnoodle-ai/wonton/assert"
 	"github.com/deepnoodle-ai/wonton/schema"
@@ -481,6 +482,64 @@ func TestConvertToolUseAndResultMessages(t *testing.T) {
 	assert.Equal(t, "2", converted[2].Content)
 	assert.Equal(t, "call_999", converted[2].ToolCallID)
 
+}
+
+func TestConvertMixedToolResultsAndAuxTextKeepsToolBatchContiguous(t *testing.T) {
+	assistant := &llm.Message{
+		Role: llm.Assistant,
+		Content: []llm.Content{
+			&llm.ToolUseContent{ID: "call_K4TI", Name: "memory_recall", Input: []byte(`{}`)},
+			&llm.ToolUseContent{ID: "call_LQW", Name: "read_file", Input: []byte(`{}`)},
+			&llm.ToolUseContent{ID: "call_nSK", Name: "grep", Input: []byte(`{}`)},
+			&llm.ToolUseContent{ID: "call_xlO", Name: "list_dir", Input: []byte(`{}`)},
+		},
+	}
+	toolResults := (&llm.Message{
+		Role: llm.User,
+		Content: []llm.Content{
+			toolResult("call_K4TI", "memory result"),
+			&llm.TextContent{Text: "No memories matched this recall."},
+			toolResult("call_LQW", "read result"),
+			toolResult("call_nSK", "grep result"),
+			toolResult("call_xlO", "list result"),
+		},
+	}).Copy()
+
+	converted, err := convertMessages([]*llm.Message{assistant, toolResults})
+	assert.NoError(t, err)
+	assert.Len(t, converted, 6)
+
+	assert.Equal(t, converted[0].Role, "assistant")
+	assert.Len(t, converted[0].ToolCalls, 4)
+
+	for i, want := range []struct {
+		id      string
+		content string
+	}{
+		{id: "call_K4TI", content: "memory result"},
+		{id: "call_LQW", content: "read result"},
+		{id: "call_nSK", content: "grep result"},
+		{id: "call_xlO", content: "list result"},
+	} {
+		msg := converted[i+1]
+		assert.Equal(t, msg.Role, "tool")
+		assert.Equal(t, msg.ToolCallID, want.id)
+		assert.Equal(t, msg.Content, want.content)
+	}
+
+	assert.Equal(t, converted[5].Role, "user")
+	assert.Equal(t, converted[5].Content, "No memories matched this recall.")
+	assert.Equal(t, converted[5].ToolCallID, "")
+}
+
+func toolResult(id, text string) *llm.ToolResultContent {
+	return &llm.ToolResultContent{
+		ToolUseID: id,
+		Content: []*dive.ToolResultContent{{
+			Type: dive.ToolResultContentTypeText,
+			Text: text,
+		}},
+	}
 }
 
 // TestConvertMessagesSkipsThinkingContent verifies that ThinkingContent (which

--- a/utilities.go
+++ b/utilities.go
@@ -48,6 +48,28 @@ func getAdditionalContextContent(callResults []*ToolCallResult) []*llm.TextConte
 	return contexts
 }
 
+func toolResultsBeforeAuxiliaryContent(content []llm.Content) []llm.Content {
+	if len(content) < 2 {
+		return content
+	}
+	var results []llm.Content
+	var auxiliary []llm.Content
+	for _, c := range content {
+		if _, ok := c.(*llm.ToolResultContent); ok {
+			results = append(results, c)
+		} else {
+			auxiliary = append(auxiliary, c)
+		}
+	}
+	if len(results) == 0 || len(auxiliary) == 0 {
+		return content
+	}
+	out := make([]llm.Content, 0, len(content))
+	out = append(out, results...)
+	out = append(out, auxiliary...)
+	return out
+}
+
 // Ptr returns a pointer to the given value. This is useful for setting
 // optional pointer fields in structs like ModelSettings.
 func Ptr[T any](t T) *T {


### PR DESCRIPTION
## Summary

- keep Dive mixed tool-result messages ordered with all tool results before auxiliary text
- normalize normal execution and resume/merged tool-result paths that append hook AdditionalContext
- harden OpenAI Chat Completions conversion so legacy mixed messages emit contiguous tool messages before auxiliary user text
- harden the OpenAI **Responses API** converter (default provider for `gpt-*`/`o3`/`o4`/`codex`, and embedded by Grok) so a tool_result message carrying auxiliary text no longer hard-errors
- add regressions for parallel tool calls, resume merging, durable transcript-shaped OpenAI conversion, and live-API tests across OpenAI (Responses + Chat) and Anthropic

## Root Cause

Dive could store a user tool-result message with ToolResultContent, auxiliary TextContent from hook AdditionalContext, and then later sibling ToolResultContent blocks.

- The OpenAI **Chat Completions** converter preserved that block order as tool, user, tool, which violates OpenAI's requirement that all tool messages for an assistant tool_calls message immediately follow it.
- The OpenAI **Responses API** converter classified any message containing a ToolResultContent as a tool-result message and then errored with `tool result mixed with other content` as soon as it encountered the auxiliary TextContent. Because the default OpenAI provider uses the Responses API (and Grok embeds it), a PostToolUse hook setting AdditionalContext would break the agent loop. Source-level reordering alone cannot fix this — reordering does not un-mix the message — so the converter now emits every tool output first (matched to its function_call by call_id) and encodes the remaining content as a trailing user message.

## Validation

- go test ./...
- go test ./providers/openaicompletions
- go test ./providers/anthropic
- go test ./providers/openai (unit) and go test -tags integration ./providers/openai
- Live API tests confirmed green against the real OpenAI Responses API, OpenAI Chat Completions, and Anthropic Messages APIs