### PR TITLE
Prepare v1.11.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [1.11.1] - 2026-07-03
+
+### Fixed
+
+- **OpenAI tool-result context ordering** — when a hook injects
+  `AdditionalContext`, Dive appended it as auxiliary text alongside the
+  `tool_result` blocks. Tool-result messages are now normalized so every tool
+  result precedes the auxiliary text, and the OpenAI **Chat Completions**
+  converter emits contiguous `tool` messages before the auxiliary `user`
+  message (previously it could interleave `tool`/`user`/`tool`, which the API
+  rejects). Tool results loaded from durable storage (JSON round-tripped) now
+  convert instead of erroring with `unsupported tool result content type`.
+- **OpenAI Responses API mixed tool-result content** — the Responses API
+  converter (default provider for `gpt-*`/`o3`/`o4`/`codex`, and embedded by
+  Grok) previously hard-errored with `tool result mixed with other content`
+  whenever a `tool_result` message also carried auxiliary text. It now emits
+  every tool output first and encodes the remaining content as a trailing user
+  message.
+
 ## [1.11.0] - 2026-06-30
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - **OpenAI tool-result ordering** — hook `AdditionalContext` text mixed with
   `tool_result` blocks no longer breaks the OpenAI providers. Tool results are
   now emitted before the auxiliary text on both Chat Completions and the
-  Responses API (which previously errored with `tool result mixed with other
-  content`; also covers Grok), and durable-storage tool results decode
-  correctly.
+  Responses API (which previously errored; also covers Grok), and
+  durable-storage tool results decode correctly.
 
 ## [1.11.0] - 2026-06-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,20 +10,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Fixed
 
-- **OpenAI tool-result context ordering** — when a hook injects
-  `AdditionalContext`, Dive appended it as auxiliary text alongside the
-  `tool_result` blocks. Tool-result messages are now normalized so every tool
-  result precedes the auxiliary text, and the OpenAI **Chat Completions**
-  converter emits contiguous `tool` messages before the auxiliary `user`
-  message (previously it could interleave `tool`/`user`/`tool`, which the API
-  rejects). Tool results loaded from durable storage (JSON round-tripped) now
-  convert instead of erroring with `unsupported tool result content type`.
-- **OpenAI Responses API mixed tool-result content** — the Responses API
-  converter (default provider for `gpt-*`/`o3`/`o4`/`codex`, and embedded by
-  Grok) previously hard-errored with `tool result mixed with other content`
-  whenever a `tool_result` message also carried auxiliary text. It now emits
-  every tool output first and encodes the remaining content as a trailing user
-  message.
+- **OpenAI tool-result ordering** — hook `AdditionalContext` text mixed with
+  `tool_result` blocks no longer breaks the OpenAI providers. Tool results are
+  now emitted before the auxiliary text on both Chat Completions and the
+  Responses API (which previously errored with `tool result mixed with other
+  content`; also covers Grok), and durable-storage tool results decode
+  correctly.
 
 ## [1.11.0] - 2026-06-30
 

--- a/a2a/go.mod
+++ b/a2a/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/a2aproject/a2a-go/v2 v2.2.0
-	github.com/deepnoodle-ai/dive v1.11.0
+	github.com/deepnoodle-ai/dive v1.11.1
 	github.com/deepnoodle-ai/wonton v0.0.36
 )
 

--- a/demos/colosseum/go.mod
+++ b/demos/colosseum/go.mod
@@ -3,11 +3,11 @@ module github.com/deepnoodle-ai/dive/demos/colosseum
 go 1.25.0
 
 require (
-	github.com/deepnoodle-ai/dive v1.11.0
-	github.com/deepnoodle-ai/dive/a2a v1.11.0
-	github.com/deepnoodle-ai/dive/providers/google v1.11.0
-	github.com/deepnoodle-ai/dive/providers/grok v1.11.0
-	github.com/deepnoodle-ai/dive/providers/openai v1.11.0
+	github.com/deepnoodle-ai/dive v1.11.1
+	github.com/deepnoodle-ai/dive/a2a v1.11.1
+	github.com/deepnoodle-ai/dive/providers/google v1.11.1
+	github.com/deepnoodle-ai/dive/providers/grok v1.11.1
+	github.com/deepnoodle-ai/dive/providers/openai v1.11.1
 	github.com/deepnoodle-ai/wonton v0.0.36
 )
 

--- a/demos/noodleville/go.mod
+++ b/demos/noodleville/go.mod
@@ -3,7 +3,7 @@ module github.com/deepnoodle-ai/dive/demos/noodleville
 go 1.25.0
 
 require (
-	github.com/deepnoodle-ai/dive v1.11.0
+	github.com/deepnoodle-ai/dive v1.11.1
 	github.com/deepnoodle-ai/wonton v0.0.36
 )
 

--- a/examples/go.mod
+++ b/examples/go.mod
@@ -3,13 +3,13 @@ module github.com/deepnoodle-ai/dive/examples
 go 1.25.0
 
 require (
-	github.com/deepnoodle-ai/dive v1.11.0
-	github.com/deepnoodle-ai/dive/a2a v1.11.0
-	github.com/deepnoodle-ai/dive/experimental/mcp v1.11.0
-	github.com/deepnoodle-ai/dive/otel v1.11.0
-	github.com/deepnoodle-ai/dive/providers/google v1.11.0
-	github.com/deepnoodle-ai/dive/providers/grok v1.11.0
-	github.com/deepnoodle-ai/dive/providers/openai v1.11.0
+	github.com/deepnoodle-ai/dive v1.11.1
+	github.com/deepnoodle-ai/dive/a2a v1.11.1
+	github.com/deepnoodle-ai/dive/experimental/mcp v1.11.1
+	github.com/deepnoodle-ai/dive/otel v1.11.1
+	github.com/deepnoodle-ai/dive/providers/google v1.11.1
+	github.com/deepnoodle-ai/dive/providers/grok v1.11.1
+	github.com/deepnoodle-ai/dive/providers/openai v1.11.1
 	github.com/deepnoodle-ai/wonton v0.0.36
 	github.com/fatih/color v1.18.0
 	github.com/mark3labs/mcp-go v0.45.0

--- a/experimental/cmd/dive/go.mod
+++ b/experimental/cmd/dive/go.mod
@@ -3,10 +3,10 @@ module github.com/deepnoodle-ai/dive/experimental/cmd/dive
 go 1.25.0
 
 require (
-	github.com/deepnoodle-ai/dive v1.11.0
-	github.com/deepnoodle-ai/dive/providers/google v1.11.0
-	github.com/deepnoodle-ai/dive/providers/grok v1.11.0
-	github.com/deepnoodle-ai/dive/providers/openai v1.11.0
+	github.com/deepnoodle-ai/dive v1.11.1
+	github.com/deepnoodle-ai/dive/providers/google v1.11.1
+	github.com/deepnoodle-ai/dive/providers/grok v1.11.1
+	github.com/deepnoodle-ai/dive/providers/openai v1.11.1
 	github.com/deepnoodle-ai/wonton v0.0.36
 	github.com/mattn/go-runewidth v0.0.21
 )

--- a/experimental/mcp/go.mod
+++ b/experimental/mcp/go.mod
@@ -3,7 +3,7 @@ module github.com/deepnoodle-ai/dive/experimental/mcp
 go 1.25.0
 
 require (
-	github.com/deepnoodle-ai/dive v1.11.0
+	github.com/deepnoodle-ai/dive v1.11.1
 	github.com/deepnoodle-ai/wonton v0.0.36
 	github.com/mark3labs/mcp-go v0.45.0
 )

--- a/otel/go.mod
+++ b/otel/go.mod
@@ -3,7 +3,7 @@ module github.com/deepnoodle-ai/dive/otel
 go 1.25.0
 
 require (
-	github.com/deepnoodle-ai/dive v1.11.0
+	github.com/deepnoodle-ai/dive v1.11.1
 	go.opentelemetry.io/otel v1.43.0
 	go.opentelemetry.io/otel/metric v1.43.0
 	go.opentelemetry.io/otel/sdk v1.43.0

--- a/providers/google/go.mod
+++ b/providers/google/go.mod
@@ -3,7 +3,7 @@ module github.com/deepnoodle-ai/dive/providers/google
 go 1.25.0
 
 require (
-	github.com/deepnoodle-ai/dive v1.11.0
+	github.com/deepnoodle-ai/dive v1.11.1
 	github.com/deepnoodle-ai/wonton v0.0.36
 	google.golang.org/genai v1.51.0
 )

--- a/providers/grok/go.mod
+++ b/providers/grok/go.mod
@@ -3,8 +3,8 @@ module github.com/deepnoodle-ai/dive/providers/grok
 go 1.25.0
 
 require (
-	github.com/deepnoodle-ai/dive v1.11.0
-	github.com/deepnoodle-ai/dive/providers/openai v1.11.0
+	github.com/deepnoodle-ai/dive v1.11.1
+	github.com/deepnoodle-ai/dive/providers/openai v1.11.1
 	github.com/deepnoodle-ai/wonton v0.0.36
 	github.com/openai/openai-go/v3 v3.29.0
 	golang.org/x/image v0.38.0

--- a/providers/openai/go.mod
+++ b/providers/openai/go.mod
@@ -3,7 +3,7 @@ module github.com/deepnoodle-ai/dive/providers/openai
 go 1.25.0
 
 require (
-	github.com/deepnoodle-ai/dive v1.11.0
+	github.com/deepnoodle-ai/dive v1.11.1
 	github.com/deepnoodle-ai/wonton v0.0.36
 	github.com/openai/openai-go/v3 v3.29.0
 	golang.org/x/image v0.38.0


### PR DESCRIPTION
## Summary

Patch release covering the one change landed since v1.11.0:

- **OpenAI tool-result context ordering** (#209) — normalizes tool-result messages so tool results precede hook `AdditionalContext` text; fixes Chat Completions contiguity, adds a durable-transcript decode fallback, and fixes the Responses API `tool result mixed with other content` hard-error (which also covers Grok).

A bug fix with no API changes, hence the **v1.11.1** patch bump.

## Changes

- Add the v1.11.1 CHANGELOG entry.
- Bump intra-repo module version references v1.11.0 → v1.11.1 across all sub-modules plus the two demos.
- `make tidy-all`.

## Validation

- `gofmt` clean, `go vet ./...` clean, `go test ./...` green (root).
- All 8 sub-modules build.
- Pre-existing repo-wide `prettier` markdown warnings (present on clean `main`, a prettier-version drift) are unrelated and left untouched; the new CHANGELOG entry is prettier-clean.

Tags (`v1.11.1` + 8 sub-module tags) will be created on the merge commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)