### PR TITLE
Add Grok 4.5 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Added
+
+- **Grok 4.5** — added `grok-4.5` plus `grok-4.5-latest` and
+  `grok-build-latest` aliases to the Grok provider catalog and pricing. Grok
+  now defaults to `grok-4.5`, with cached-input pricing represented in usage
+  cost estimates and CLI context metadata updated to 500k tokens.
+
 ## [1.11.1] - 2026-07-03
 
 ### Fixed

--- a/demos/colosseum/provider/registry.go
+++ b/demos/colosseum/provider/registry.go
@@ -69,7 +69,7 @@ var registry = []*Spec{
 		Aliases: []string{"xai"},
 		EnvKeys: []string{"XAI_API_KEY", "GROK_API_KEY"},
 		Cheap:   grok.ModelGrok41FastNonReasoning,
-		Premium: grok.ModelGrok43,
+		Premium: grok.ModelGrok45,
 		newLLM:  func(m string) llm.LLM { return grok.New(grok.WithModel(m)) },
 	},
 }

--- a/docs/design/model-update-may-2026.md
+++ b/docs/design/model-update-may-2026.md
@@ -1,6 +1,6 @@
 # Model & Capability Update — May 2026
 
-_Last updated: 2026-06-30_
+_Last updated: 2026-07-09_
 
 This document records the latest models and pricing across providers (verified
 against official docs) and the changes made to Dive to add the new models and
@@ -19,8 +19,9 @@ here:
 - **Google**: added Gemini 3.5 Flash, 3.1 Flash-Lite (stable), 3 Pro Image
   (Nano Banana Pro), 3.1 Flash Image (Nano Banana 2), 3.1 Flash Live, and the
   custom-tools Pro endpoint.
-- **xAI/Grok**: added Grok 4.3 (new default) and grok-build-0.1; corrected
-  Grok 4.20 pricing; added Grok Imagine image pricing.
+- **xAI/Grok**: added Grok 4.5 (new default), its `grok-4.5-latest` and
+  `grok-build-latest` aliases, Grok 4.3, and grok-build-0.1; corrected Grok
+  4.20 pricing; added Grok Imagine image pricing.
 
 ## Latest models & pricing (per 1M tokens, USD)
 
@@ -54,7 +55,8 @@ header `fast-mode-2026-02-01`, requires account access).
 
 | Model | Input | Output | Context |
 |-------|-------|--------|---------|
-| `grok-4.3` | $1.25 | $2.50 | 1M (new flagship/default) |
+| `grok-4.5` | $2.00 ($0.50 cached) | $6.00 | 500k (new default) |
+| `grok-4.3` | $1.25 | $2.50 | 1M |
 | `grok-4.20-*` | $1.25 | $2.50 | 1M (corrected from $2/$6) |
 | `grok-build-0.1` | $1.00 | $2.00 | 256k (coding) |
 | `grok-imagine-image` | $0.02/image | — | — |

--- a/docs/guides/grok.md
+++ b/docs/guides/grok.md
@@ -11,12 +11,18 @@ the server-side tool plumbing described below.
 ```go
 import "github.com/deepnoodle-ai/dive/providers/grok"
 
-model := grok.New() // defaults to grok-4.3
+model := grok.New() // defaults to grok-4.5
 ```
 
 **Env:** `XAI_API_KEY` (preferred) or `GROK_API_KEY`.
-**Models:** See `providers/grok/models.go`. `grok-4.3` is the current flagship
-and default; `grok-build-0.1` is the coding model.
+**Models:** See `providers/grok/models.go`. `grok-4.5` is the current default;
+`grok-4.5-latest` and `grok-build-latest` are aliases, and `grok-build-0.1`
+remains available as the coding model.
+
+`grok-4.5` supports text and image inputs, tool/function calling, structured
+outputs, and reasoning. Its context window is 500k tokens; list pricing is
+$2.00 per 1M input tokens, $0.50 per 1M cached input tokens, and $6.00 per 1M
+output tokens.
 
 ## Server-side tools
 

--- a/examples/grok_code_execution_example/main.go
+++ b/examples/grok_code_execution_example/main.go
@@ -32,7 +32,7 @@ func main() {
 		IncludeOutputs: true,
 	})
 
-	provider := grok.New() // defaults to grok-4.3
+	provider := grok.New() // defaults to grok-4.5
 
 	response, err := provider.Generate(context.Background(),
 		llm.WithMessages(llm.NewUserTextMessage(prompt)),

--- a/examples/grok_search_example/main.go
+++ b/examples/grok_search_example/main.go
@@ -40,7 +40,7 @@ func main() {
 		log.Fatal(err)
 	}
 
-	provider := grok.New() // defaults to grok-4.3
+	provider := grok.New() // defaults to grok-4.5
 
 	response, err := provider.Generate(context.Background(),
 		llm.WithMessages(llm.NewUserTextMessage(prompt)),

--- a/experimental/cmd/dive/main_test.go
+++ b/experimental/cmd/dive/main_test.go
@@ -52,6 +52,13 @@ func TestGetDefaultModel(t *testing.T) {
 			},
 			expected: "gpt-5.5",
 		},
+		{
+			name: "grok key present",
+			envVars: map[string]string{
+				"XAI_API_KEY": "test",
+			},
+			expected: "grok-4.5",
+		},
 	}
 
 	for _, tt := range tests {

--- a/experimental/cmd/dive/models.go
+++ b/experimental/cmd/dive/models.go
@@ -68,6 +68,8 @@ var modelCatalog = []modelInfo{
 	{"o3", "o3", 200_000},
 
 	// Grok models
+	{"grok-4.5", "Grok 4.5", 500_000},
+	{"grok-build-latest", "Grok 4.5", 500_000},
 	{"grok-4.3", "Grok 4.3", 1_000_000},
 	{"grok-build-0.1", "Grok Build", 256_000},
 	{"grok-4.20-0309-reasoning", "Grok 4.20", 1_000_000},
@@ -165,7 +167,8 @@ var providerCatalog = []providerInfo{
 		Name:    "Grok",
 		EnvVars: []string{"XAI_API_KEY", "GROK_API_KEY"},
 		Models: []modelChoice{
-			{"grok-4.3", "Grok 4.3", "xAI's most intelligent and fastest model"},
+			{"grok-4.5", "Grok 4.5", "xAI flagship reasoning model with vision input"},
+			{"grok-4.3", "Grok 4.3", "Previous flagship model with 1M context"},
 			{"grok-4.20-0309-reasoning", "Grok 4.20", "Reasoning model with 1M context"},
 			{"grok-build-0.1", "Grok Build", "Optimized for coding tasks"},
 		},

--- a/experimental/cmd/dive/models_test.go
+++ b/experimental/cmd/dive/models_test.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/deepnoodle-ai/wonton/assert"
+)
+
+func TestGrok45ContextWindow(t *testing.T) {
+	tests := []struct {
+		model string
+		want  int
+	}{
+		{"grok-4.5", 500_000},
+		{"grok-4.5-latest", 500_000},
+		{"grok-build-latest", 500_000},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.model, func(t *testing.T) {
+			assert.Equal(t, tt.want, contextWindowForModel(tt.model))
+		})
+	}
+}

--- a/experimental/cmd/dive/providers.go
+++ b/experimental/cmd/dive/providers.go
@@ -20,7 +20,7 @@ import (
 )
 
 // defaultGrokModel is the default model used when a Grok API key is detected.
-var defaultGrokModel = grok.ModelGrok420Reasoning
+var defaultGrokModel = grok.ModelGrok45
 
 // createModel creates an LLM provider using the global registry.
 // Providers are registered via init() when imported above.

--- a/providers/grok/cost_test.go
+++ b/providers/grok/cost_test.go
@@ -1,0 +1,40 @@
+package grok
+
+import (
+	"testing"
+
+	"github.com/deepnoodle-ai/dive/llm"
+	"github.com/deepnoodle-ai/dive/providers"
+	"github.com/deepnoodle-ai/wonton/assert"
+)
+
+func TestGrok45Pricing(t *testing.T) {
+	for _, model := range []string{ModelGrok45, ModelGrok45Latest, ModelGrokBuildLatest} {
+		p, ok := TextModelPricing[model]
+		assert.True(t, ok, "pricing should exist for "+model)
+		assert.Equal(t, 2.0, p.InputPrice)
+		assert.Equal(t, 0.5, p.CacheReadPrice)
+		assert.Equal(t, 6.0, p.OutputPrice)
+	}
+}
+
+func TestGrokPricingRegistered(t *testing.T) {
+	for model := range TextModelPricing {
+		_, ok := providers.PricingFor(model, false)
+		assert.True(t, ok, "grok pricing should be registered: "+model)
+	}
+}
+
+func TestGrok45PopulateCostIncludesCacheReads(t *testing.T) {
+	u := &llm.Usage{
+		InputTokens:          1_000_000,
+		CacheReadInputTokens: 1_000_000,
+		OutputTokens:         1_000_000,
+	}
+	llm.PopulateCost(ModelGrok45, false, u)
+	assert.NotNil(t, u.Cost)
+	assert.Equal(t, 2.0, u.Cost.Input)
+	assert.Equal(t, 0.5, u.Cost.CacheRead)
+	assert.Equal(t, 6.0, u.Cost.Output)
+	assert.Equal(t, 8.5, u.Cost.Total)
+}

--- a/providers/grok/grok.go
+++ b/providers/grok/grok.go
@@ -8,7 +8,7 @@ import (
 )
 
 var (
-	DefaultModel     = ModelGrok43
+	DefaultModel     = ModelGrok45
 	DefaultEndpoint  = "https://api.x.ai/v1"
 	DefaultMaxTokens = 32768
 )

--- a/providers/grok/grok_test.go
+++ b/providers/grok/grok_test.go
@@ -25,7 +25,7 @@ func TestProvider_Name(t *testing.T) {
 }
 
 func TestProvider_DefaultModel(t *testing.T) {
-	assert.Equal(t, ModelGrok43, DefaultModel)
+	assert.Equal(t, ModelGrok45, DefaultModel)
 }
 
 func TestProvider_GetAPIKey(t *testing.T) {

--- a/providers/grok/models.go
+++ b/providers/grok/models.go
@@ -1,7 +1,12 @@
 package grok
 
 const (
-	// Grok 4.3 (latest, most intelligent and fastest, 1M context)
+	// Grok 4.5 (flagship reasoning model, 500K context)
+	ModelGrok45          = "grok-4.5"
+	ModelGrok45Latest    = "grok-4.5-latest"
+	ModelGrokBuildLatest = "grok-build-latest"
+
+	// Grok 4.3 (1M context)
 	ModelGrok43 = "grok-4.3"
 
 	// Grok 4.20 models (1M context)

--- a/providers/grok/pricing.go
+++ b/providers/grok/pricing.go
@@ -4,6 +4,30 @@ import "github.com/deepnoodle-ai/dive/llm"
 
 // TextModelPricing contains pricing for all text generation models
 var TextModelPricing = map[string]llm.PricingInfo{
+	ModelGrok45: {
+		Model:          ModelGrok45,
+		InputPrice:     2.00,
+		OutputPrice:    6.00,
+		CacheReadPrice: 0.50,
+		Currency:       "USD",
+		UpdatedAt:      "2026-07-09",
+	},
+	ModelGrok45Latest: {
+		Model:          ModelGrok45Latest,
+		InputPrice:     2.00,
+		OutputPrice:    6.00,
+		CacheReadPrice: 0.50,
+		Currency:       "USD",
+		UpdatedAt:      "2026-07-09",
+	},
+	ModelGrokBuildLatest: {
+		Model:          ModelGrokBuildLatest,
+		InputPrice:     2.00,
+		OutputPrice:    6.00,
+		CacheReadPrice: 0.50,
+		Currency:       "USD",
+		UpdatedAt:      "2026-07-09",
+	},
 	ModelGrok43: {
 		Model:       ModelGrok43,
 		InputPrice:  1.25,

--- a/providers/openai/reasoning.go
+++ b/providers/openai/reasoning.go
@@ -94,7 +94,9 @@ func normalizeGrokReasoningEffort(model string, effort llm.ReasoningEffort) (llm
 	model = strings.ToLower(strings.TrimPrefix(model, "x-ai/"))
 
 	switch {
-	case strings.HasPrefix(model, "grok-4.3"):
+	case strings.HasPrefix(model, "grok-4.5"),
+		strings.HasPrefix(model, "grok-4.3"),
+		strings.HasPrefix(model, "grok-build-latest"):
 		return mapReasoningEffort(model, effort,
 			[]llm.ReasoningEffort{
 				llm.ReasoningEffortNone,

--- a/providers/openai/responses_extra_test.go
+++ b/providers/openai/responses_extra_test.go
@@ -198,10 +198,16 @@ func TestBuildRequestParams_NormalizesGrokReasoningEffort(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name:   "grok 4.3 max maps to high",
-			model:  "grok-4.3",
+			name:   "grok 4.5 max maps to high",
+			model:  "grok-4.5",
 			effort: llm.ReasoningEffortMax,
 			want:   responses.ReasoningEffort("high"),
+		},
+		{
+			name:   "grok build latest alias minimal maps to low",
+			model:  "grok-build-latest",
+			effort: llm.ReasoningEffortMinimal,
+			want:   responses.ReasoningEffort("low"),
 		},
 		{
 			name:   "grok multi-agent max maps to xhigh",

--- a/providers/openaicompletions/openai_test.go
+++ b/providers/openaicompletions/openai_test.go
@@ -34,9 +34,15 @@ func TestApplyRequestConfig_NormalizesReasoningEffort(t *testing.T) {
 		},
 		{
 			name:   "openrouter x-ai grok max maps to high",
-			model:  "x-ai/grok-4.3",
+			model:  "x-ai/grok-4.5",
 			effort: llm.ReasoningEffortMax,
 			want:   ReasoningEffortHigh,
+		},
+		{
+			name:   "openrouter x-ai grok build latest minimal maps to low",
+			model:  "x-ai/grok-build-latest",
+			effort: llm.ReasoningEffortMinimal,
+			want:   ReasoningEffortLow,
 		},
 		{
 			name:   "unknown model effort passes through",

--- a/providers/openaicompletions/reasoning.go
+++ b/providers/openaicompletions/reasoning.go
@@ -111,7 +111,9 @@ func normalizeOpenAIReasoningEffort(model string, effort llm.ReasoningEffort) (l
 
 func normalizeGrokReasoningEffort(model string, effort llm.ReasoningEffort) (llm.ReasoningEffort, error) {
 	switch {
-	case strings.HasPrefix(model, "grok-4.3"):
+	case strings.HasPrefix(model, "grok-4.5"),
+		strings.HasPrefix(model, "grok-4.3"),
+		strings.HasPrefix(model, "grok-build-latest"):
 		return mapReasoningEffort(model, effort,
 			[]llm.ReasoningEffort{
 				llm.ReasoningEffortNone,


### PR DESCRIPTION
## Summary

Adds Grok 4.5 to Dive's Grok provider surface, including the canonical `grok-4.5` model plus `grok-4.5-latest` and `grok-build-latest` aliases.

## Changes

- Adds Grok 4.5 model constants, makes `grok.New()` and the CLI Grok default use `grok-4.5`, and updates the Colosseum premium Grok model.
- Registers Grok 4.5 pricing, including cached-input pricing, so usage cost estimates work for the canonical model and both aliases.
- Updates Grok reasoning-effort normalization in both OpenAI-compatible provider paths.
- Refreshes CLI model metadata, docs, examples, and changelog entries for Grok 4.5.
- Adds focused tests for default selection, alias context windows, pricing registration, cached-input cost, and reasoning normalization.

## Validation

- `go test ./...`
- `go test ./...` in `providers/grok`
- `go test ./...` in `providers/openai`
- `go test ./...` in `experimental/cmd/dive`
- `go test ./...` in `examples`
- `go test ./...` in `demos/colosseum`
- `git diff --check`
- `git diff --cached --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Grok 4.5 models and aliases, with Grok now defaulting to Grok 4.5.
  * Updated context limits and model listings to reflect the new 500k-token window.

* **Bug Fixes**
  * Cost estimates now include cached-input usage for more accurate billing.
  * Reasoning-effort settings are now applied consistently across Grok 4.5 and build-latest variants.

* **Documentation**
  * Refreshed Grok guides, examples, and changelog entries to match the latest model and pricing details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->