### PR TITLE
Support Anthropic summarized thinking

### DIFF
--- a/docs/guides/llm-guide.md
+++ b/docs/guides/llm-guide.md
@@ -155,6 +155,10 @@ encrypted signature. Dive preserves both normal `thinking` blocks and
 the assistant message content back unchanged so Anthropic can verify the
 signatures.
 
+In the Dive CLI, pass `--show-thinking` (or set `DIVE_SHOW_THINKING=true`) to
+request adaptive summarized thinking and render visible thinking summaries in
+the interactive transcript.
+
 When thinking is active, Anthropic only allows `tool_choice` `auto` or `none`.
 Dive returns a request-building error for forced tool choices (`any` or a
 specific tool), prefilled assistant responses, and manual thinking budgets that

--- a/docs/guides/llm-guide.md
+++ b/docs/guides/llm-guide.md
@@ -157,7 +157,10 @@ signatures.
 
 In the Dive CLI, pass `--show-thinking` (or set `DIVE_SHOW_THINKING=true`) to
 request adaptive summarized thinking and render visible thinking summaries in
-the interactive transcript.
+the interactive transcript. Add `--thinking-effort high` (or set
+`DIVE_THINKING_EFFORT=high`) to choose the thinking effort level. Supported
+provider-neutral values are `none`, `minimal`, `low`, `medium`, `high`, `xhigh`,
+and `max`; provider-specific values pass through to compatible backends.
 
 When thinking is active, Anthropic only allows `tool_choice` `auto` or `none`.
 Dive returns a request-building error for forced tool choices (`any` or a

--- a/docs/guides/llm-guide.md
+++ b/docs/guides/llm-guide.md
@@ -9,7 +9,7 @@ Dive supports multiple LLM providers through a unified interface. Each provider 
 ```go
 import "github.com/deepnoodle-ai/dive/providers/anthropic"
 
-model := anthropic.New() // defaults to claude-opus-4-5
+model := anthropic.New() // defaults to claude-opus-4-8
 ```
 
 **Env:** `ANTHROPIC_API_KEY`
@@ -132,21 +132,38 @@ Provider implementations normalize `ReasoningEffort` only where the model
 family is known. Unsupported providers may omit the option or pass it through
 for compatibility with custom OpenAI-compatible endpoints.
 
-### Reasoning on Claude Opus 4.7 / 4.8
+### Reasoning And Summarized Thinking On Claude
 
-Opus 4.7 and 4.8 support **only adaptive thinking** — the model decides when and
-how much to think — and reject manual `budget_tokens`. Use the `effort`
-parameter to guide depth:
+Newer Claude models prefer **adaptive thinking** — the model decides when and how
+much to think — with `effort` guiding depth. Opus 4.7, Opus 4.8, Sonnet 5, Fable
+5, and Mythos 5 reject manual `budget_tokens`; Dive keeps older callers working
+by mapping `ReasoningBudget` to adaptive thinking on those models.
 
 ```go
 ModelSettings: &dive.ModelSettings{
     ReasoningEffort: llm.ReasoningEffortXHigh,   // -> output_config.effort
     Thinking:        llm.ThinkingTypeAdaptive,   // -> thinking: {type: adaptive}
+    ThinkingDisplay: llm.ThinkingDisplaySummarized,
 }
 ```
 
-`WithReasoningBudget` still works against these models for backward
-compatibility — it transparently falls back to adaptive thinking. Fast mode
+`ThinkingDisplaySummarized` requests visible summarized thinking blocks. This is
+important on Sonnet 5, Fable 5, Mythos 5, Opus 4.7, and Opus 4.8, where Claude
+defaults to `omitted` display and returns an empty `thinking` field plus an
+encrypted signature. Dive preserves both normal `thinking` blocks and
+`redacted_thinking` blocks in responses; when continuing a tool-use turn, pass
+the assistant message content back unchanged so Anthropic can verify the
+signatures.
+
+When thinking is active, Anthropic only allows `tool_choice` `auto` or `none`.
+Dive returns a request-building error for forced tool choices (`any` or a
+specific tool), prefilled assistant responses, and manual thinking budgets that
+are not less than `MaxTokens` unless interleaved thinking is enabled.
+Temperature is ignored on thinking requests because Anthropic rejects sampling
+changes with extended thinking.
+
+`Usage.ReasoningTokens` includes Anthropic's reported
+`output_tokens_details.thinking_tokens` value when it is present. Fast mode
 (`Speed: llm.SpeedFast`) requires fast-mode access on your account and applies
 the `fast-mode-2026-02-01` beta header automatically.
 

--- a/experimental/cmd/dive/app.go
+++ b/experimental/cmd/dive/app.go
@@ -1405,6 +1405,7 @@ func (a *App) handleStreamThinking(text string) {
 	a.flushStreamBuffer()
 	a.needNewTextMessage = true
 	a.thinkingStreamBuffer += text
+	a.flushThinkingStreamBuffer()
 }
 
 func (a *App) flushStreamingBuffers() {
@@ -2402,26 +2403,32 @@ func (a *App) buildLiveView() tui.View {
 
 	elapsed := time.Since(a.processingStartTime)
 
-	// Show recent tool calls (last 3 max, in chronological order)
-	// Includes both completed and in-progress tool calls so users can see
-	// long-running operations like subagent tasks while they're working
-	var toolViews []tui.View
+	// Show recent live activity (tool calls and summarized thinking) in
+	// chronological order. This keeps streamed thinking visible before the turn
+	// is committed to scrollback.
+	var activityViews []tui.View
 	for i := len(a.messages) - 1; i >= 0; i-- {
 		msg := a.messages[i]
-		if msg.Role == "user" {
+		if msg.Role == "user" || msg.Role == "context" {
 			break
 		}
-		if msg.Type == MessageTypeToolCall {
+		switch {
+		case msg.Type == MessageTypeToolCall:
 			view := a.toolCallView(msg)
 			if view != nil {
-				toolViews = append([]tui.View{view}, toolViews...) // prepend for chronological order
+				activityViews = append([]tui.View{view}, activityViews...)
 			}
-			if len(toolViews) >= 3 {
-				break
+		case msg.Role == "reasoning":
+			view := a.textMessageView(msg, i)
+			if view != nil {
+				activityViews = append([]tui.View{view}, activityViews...)
 			}
 		}
+		if len(activityViews) >= 4 {
+			break
+		}
 	}
-	views = append(views, toolViews...)
+	views = append(views, activityViews...)
 
 	// Show compaction notification (if recent)
 	if a.lastCompactionEvent != nil && time.Since(a.compactionEventTime) < 3*time.Second {

--- a/experimental/cmd/dive/app.go
+++ b/experimental/cmd/dive/app.go
@@ -40,6 +40,11 @@ type streamTextEvent struct {
 	text string
 }
 
+type streamThinkingEvent struct {
+	baseEvent
+	text string
+}
+
 type toolCallEvent struct {
 	baseEvent
 	call *llm.ToolUseContent
@@ -151,7 +156,7 @@ type Todo struct {
 
 // Message represents a chat message
 type Message struct {
-	Role    string // "user", "assistant", "system", or "intro"
+	Role    string // "user", "assistant", "reasoning", "system", "context", or "intro"
 	Content string // Text content
 	Time    time.Time
 	Type    MessageType
@@ -258,6 +263,7 @@ type App struct {
 	// Chat state
 	messages              []Message
 	streamingMessageIndex int
+	thinkingMessageIndex  int
 	currentMessage        *Message
 
 	// Tool call tracking
@@ -286,8 +292,9 @@ type App struct {
 	autocompletePrefix  string
 	autocompleteType    string // "file" or "command"
 
-	// Streaming text buffer (flushed on tick for batched updates)
-	streamBuffer string
+	// Streaming buffers (flushed on tick for batched updates)
+	streamBuffer         string
+	thinkingStreamBuffer string
 
 	// Context for cancellation
 	ctx    context.Context
@@ -355,24 +362,26 @@ func NewApp(
 	}
 
 	return &App{
-		agent:             agent,
-		sessionStore:      sessionStore,
-		workspaceDir:      workspaceDir,
-		modelName:         modelName,
-		resumeSessionID:   resumeSessionID,
-		skills:            skills,
-		apiEndpoint:       apiEndpoint,
-		messages:          make([]Message, 0),
-		toolCallIndex:     make(map[string]int),
-		toolTitles:        toolTitles,
-		history:           make([]string, 0),
-		historyIndex:      -1,
-		ctx:               ctx,
-		cancel:            cancel,
-		initialPrompt:     initialPrompt,
-		compactionConfig:  compactionConfig,
-		contextWindowMax:  contextWindowForModel(modelName),
-		toolStreamBuffers: make(map[string]string),
+		agent:                 agent,
+		sessionStore:          sessionStore,
+		workspaceDir:          workspaceDir,
+		modelName:             modelName,
+		resumeSessionID:       resumeSessionID,
+		skills:                skills,
+		apiEndpoint:           apiEndpoint,
+		messages:              make([]Message, 0),
+		streamingMessageIndex: -1,
+		thinkingMessageIndex:  -1,
+		toolCallIndex:         make(map[string]int),
+		toolTitles:            toolTitles,
+		history:               make([]string, 0),
+		historyIndex:          -1,
+		ctx:                   ctx,
+		cancel:                cancel,
+		initialPrompt:         initialPrompt,
+		compactionConfig:      compactionConfig,
+		contextWindowMax:      contextWindowForModel(modelName),
+		toolStreamBuffers:     make(map[string]string),
 	}
 }
 
@@ -749,6 +758,8 @@ func (a *App) HandleEvent(event tui.Event) []tui.Cmd {
 		a.handleProcessingStart(e)
 	case streamTextEvent:
 		a.handleStreamText(e.text)
+	case streamThinkingEvent:
+		a.handleStreamThinking(e.text)
 	case toolCallEvent:
 		a.handleToolCall(e.call)
 	case toolResultEvent:
@@ -1107,6 +1118,9 @@ func (a *App) agentEventCallback(lastUsage **llm.Usage) dive.EventCallback {
 		switch item.Type {
 		case dive.ResponseItemTypeModelEvent:
 			if item.Event != nil && item.Event.Delta != nil {
+				if thinking := item.Event.Delta.Thinking; thinking != "" {
+					a.runner.SendEvent(streamThinkingEvent{baseEvent: newBaseEvent(), text: thinking})
+				}
 				if text := item.Event.Delta.Text; text != "" {
 					a.runner.SendEvent(streamTextEvent{baseEvent: newBaseEvent(), text: text})
 				}
@@ -1369,6 +1383,7 @@ func (a *App) handleProcessingStart(e processingStartEvent) {
 	}
 	a.messages = append(a.messages, *a.currentMessage)
 	a.streamingMessageIndex = len(a.messages) - 1
+	a.thinkingMessageIndex = -1
 	a.needNewTextMessage = false
 
 	a.processing = true
@@ -1380,8 +1395,21 @@ func (a *App) handleProcessingStart(e processingStartEvent) {
 }
 
 func (a *App) handleStreamText(text string) {
+	a.flushThinkingStreamBuffer()
+	a.thinkingMessageIndex = -1
 	// Buffer text for batched updates (flushed on tick)
 	a.streamBuffer += text
+}
+
+func (a *App) handleStreamThinking(text string) {
+	a.flushStreamBuffer()
+	a.needNewTextMessage = true
+	a.thinkingStreamBuffer += text
+}
+
+func (a *App) flushStreamingBuffers() {
+	a.flushThinkingStreamBuffer()
+	a.flushStreamBuffer()
 }
 
 func (a *App) flushStreamBuffer() {
@@ -1408,7 +1436,32 @@ func (a *App) flushStreamBuffer() {
 	a.streamBuffer = ""
 }
 
+func (a *App) flushThinkingStreamBuffer() {
+	if a.thinkingStreamBuffer == "" {
+		return
+	}
+
+	needNewMessage := a.thinkingMessageIndex < 0 ||
+		a.thinkingMessageIndex >= len(a.messages) ||
+		a.messages[a.thinkingMessageIndex].Role != "reasoning"
+
+	if needNewMessage {
+		a.messages = append(a.messages, Message{
+			Role:    "reasoning",
+			Content: "",
+			Time:    time.Now(),
+			Type:    MessageTypeText,
+		})
+		a.thinkingMessageIndex = len(a.messages) - 1
+	}
+
+	a.messages[a.thinkingMessageIndex].Content += a.thinkingStreamBuffer
+	a.thinkingStreamBuffer = ""
+}
+
 func (a *App) handleToolCall(call *llm.ToolUseContent) {
+	a.flushStreamingBuffers()
+
 	// Parse TodoWrite tool calls
 	if call.Name == "TodoWrite" {
 		a.parseTodoWriteInput(call.Input)
@@ -1433,6 +1486,7 @@ func (a *App) handleToolCall(call *llm.ToolUseContent) {
 	a.messages = append(a.messages, msg)
 	a.toolCallIndex[call.ID] = len(a.messages) - 1
 	a.needNewTextMessage = true
+	a.thinkingMessageIndex = -1
 }
 
 func (a *App) handleToolResult(result *dive.ToolCallResult) {
@@ -1512,8 +1566,8 @@ func (a *App) notifyMidTurnCompaction(event *compaction.CompactionEvent) {
 }
 
 func (a *App) handleProcessingEnd(err error) {
-	// Flush any remaining buffered text
-	a.flushStreamBuffer()
+	// Flush any remaining buffered model content.
+	a.flushStreamingBuffers()
 
 	if err != nil && err != context.Canceled {
 		errMsg := Message{
@@ -1530,8 +1584,12 @@ func (a *App) handleProcessingEnd(err error) {
 	// (without thinking animation), preventing orphaned blank lines.
 	a.processing = false
 	a.currentMessage = nil
+	a.streamingMessageIndex = -1
+	a.thinkingMessageIndex = -1
 	a.toolCallIndex = make(map[string]int)
 	a.toolStreamBuffers = make(map[string]string)
+	a.streamBuffer = ""
+	a.thinkingStreamBuffer = ""
 
 	// Now print to scrollback - the live view will be re-rendered with correct height
 	a.printRecentMessagesToScrollback()
@@ -1868,6 +1926,21 @@ func (a *App) convertLLMMessageToViews(msg *llm.Message, toolResults map[string]
 				views = append(views, tui.Text(""), view)
 			}
 
+		case *llm.ThinkingContent:
+			if strings.TrimSpace(c.Thinking) == "" {
+				continue
+			}
+			appMsg := Message{
+				Role:    "reasoning",
+				Content: c.Thinking,
+				Time:    time.Now(),
+				Type:    MessageTypeText,
+			}
+			view := a.textMessageViewStatic(appMsg)
+			if view != nil {
+				views = append(views, tui.Text(""), view)
+			}
+
 		case *llm.ToolUseContent:
 			// Find the corresponding result if available
 			result := toolResults[c.ID]
@@ -2001,7 +2074,10 @@ func (a *App) handleCommand(input string) bool {
 		a.toolCallIndex = make(map[string]int)
 		a.needNewTextMessage = false
 		a.currentMessage = nil
-		a.streamingMessageIndex = 0
+		a.streamingMessageIndex = -1
+		a.thinkingMessageIndex = -1
+		a.streamBuffer = ""
+		a.thinkingStreamBuffer = ""
 		a.firstUserSent = false
 		a.lastUsage = nil
 		a.sessionUsage = nil

--- a/experimental/cmd/dive/app_interactive_test.go
+++ b/experimental/cmd/dive/app_interactive_test.go
@@ -54,6 +54,28 @@ func TestAppLiveView(t *testing.T) {
 		app.messages = app.messages[:len(app.messages)-1]
 	})
 
+	t.Run("streamed thinking summary appears in live view", func(t *testing.T) {
+		app.processing = true
+		app.streamingMessageIndex = len(app.messages)
+		app.currentMessage = &Message{
+			Role:    "assistant",
+			Content: "",
+			Time:    time.Now(),
+		}
+		app.messages = append(app.messages, *app.currentMessage)
+
+		app.handleStreamThinking("I should inspect the request shape first.")
+		screen := renderLiveView(t, app, 80, 24)
+
+		termtest.AssertContains(t, screen, "inspect the request shape")
+
+		app.processing = false
+		app.currentMessage = nil
+		app.messages = app.messages[:0]
+		app.streamingMessageIndex = -1
+		app.thinkingMessageIndex = -1
+	})
+
 	t.Run("todo list renders when visible", func(t *testing.T) {
 		app.showTodos = true
 		app.todos = []Todo{

--- a/experimental/cmd/dive/app_test.go
+++ b/experimental/cmd/dive/app_test.go
@@ -1,12 +1,16 @@
 package main
 
 import (
+	"bytes"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/deepnoodle-ai/dive"
 	"github.com/deepnoodle-ai/dive/experimental/compaction"
+	"github.com/deepnoodle-ai/dive/llm"
 	"github.com/deepnoodle-ai/wonton/assert"
+	"github.com/deepnoodle-ai/wonton/tui"
 )
 
 func TestHandleCompaction(t *testing.T) {
@@ -57,4 +61,67 @@ func TestShouldDisplayToolError(t *testing.T) {
 		assert.True(t, shouldDisplayToolError("request_user_input", true, "Ask me another question please."))
 		assert.True(t, shouldDisplayToolError("AskUserQuestion", true, "No options provided for selection"))
 	})
+}
+
+func TestHandleStreamThinkingCreatesReasoningMessage(t *testing.T) {
+	app := NewApp(&dive.Agent{}, nil, "/tmp/test", "test-model", "", nil, "", nil, "")
+	var buf bytes.Buffer
+	app.runner = tui.NewInlineApp(
+		tui.WithInlineWidth(80),
+		tui.WithInlineOutput(&buf),
+	)
+	app.handleProcessingStart(processingStartEvent{baseEvent: newBaseEvent(), userInput: "explain this"})
+
+	app.handleStreamThinking("I should compare the code paths.")
+	app.flushThinkingStreamBuffer()
+	app.handleStreamText("The code paths differ here.")
+	app.flushStreamBuffer()
+
+	reasoningIdx := -1
+	answerIdx := -1
+	for i, msg := range app.messages {
+		switch msg.Role {
+		case "reasoning":
+			if strings.Contains(msg.Content, "compare the code paths") {
+				reasoningIdx = i
+			}
+		case "assistant":
+			if strings.Contains(msg.Content, "code paths differ") {
+				answerIdx = i
+			}
+		}
+	}
+	assert.True(t, reasoningIdx >= 0, "expected reasoning message")
+	assert.True(t, answerIdx >= 0, "expected assistant answer message")
+	assert.True(t, reasoningIdx < answerIdx, "reasoning should render before answer")
+}
+
+func TestConvertLLMMessageToViewsShowsThinkingContent(t *testing.T) {
+	app := NewApp(&dive.Agent{}, nil, "/tmp/test", "test-model", "", nil, "", nil, "")
+	views := app.convertLLMMessageToViews(&llm.Message{
+		Role: llm.Assistant,
+		Content: []llm.Content{
+			&llm.ThinkingContent{Thinking: "I considered the API contract."},
+			&llm.TextContent{Text: "The final answer."},
+		},
+	}, nil)
+
+	var buf bytes.Buffer
+	tui.Fprint(&buf, tui.Stack(views...), tui.WithWidth(80))
+	out := buf.String()
+	assert.Contains(t, out, "I considered the API contract.")
+	assert.Contains(t, out, "The final answer.")
+}
+
+func TestMessageThinkingText(t *testing.T) {
+	text := messageThinkingText(&llm.Message{
+		Role: llm.Assistant,
+		Content: []llm.Content{
+			&llm.ThinkingContent{Thinking: " first thought "},
+			&llm.TextContent{Text: "answer"},
+			&llm.ThinkingContent{Thinking: "second thought"},
+		},
+	})
+
+	assert.Equal(t, "first thought\n\nsecond thought", text)
 }

--- a/experimental/cmd/dive/main.go
+++ b/experimental/cmd/dive/main.go
@@ -121,6 +121,10 @@ func main() {
 				Default(false).
 				Env("DIVE_SHOW_THINKING").
 				Help("Request and show summarized model thinking when supported"),
+			cli.String("thinking-effort").
+				Default("").
+				Env("DIVE_THINKING_EFFORT").
+				Help("Thinking effort: none, minimal, low, medium, high, xhigh, max, or provider-specific value"),
 			cli.String("system-prompt").
 				Default("").
 				Help("System prompt to use for the session"),
@@ -327,18 +331,7 @@ func runInteractive(ctx *cli.Context) error {
 	}
 
 	// Create model settings
-	maxTokens := ctx.Int("max-tokens")
-	modelSettings := &dive.ModelSettings{
-		MaxTokens: &maxTokens,
-	}
-	if ctx.Bool("show-thinking") {
-		modelSettings.Thinking = llm.ThinkingTypeAdaptive
-		modelSettings.ThinkingDisplay = llm.ThinkingDisplaySummarized
-	}
-	if ctx.IsSet("temperature") {
-		t := ctx.Float64("temperature")
-		modelSettings.Temperature = &t
-	}
+	modelSettings, _ := newCLIModelSettings(ctx)
 
 	// Create agent options with hooks and extensions
 	agentOpts := dive.AgentOptions{
@@ -503,19 +496,7 @@ func runPrint(ctx *cli.Context) error {
 	tools = append(tools, grokServerSideTools(modelName)...)
 
 	// Create agent
-	maxTokens := ctx.Int("max-tokens")
-	printModelSettings := &dive.ModelSettings{
-		MaxTokens: &maxTokens,
-	}
-	showThinking := ctx.Bool("show-thinking")
-	if showThinking {
-		printModelSettings.Thinking = llm.ThinkingTypeAdaptive
-		printModelSettings.ThinkingDisplay = llm.ThinkingDisplaySummarized
-	}
-	if ctx.IsSet("temperature") {
-		t := ctx.Float64("temperature")
-		printModelSettings.Temperature = &t
-	}
+	printModelSettings, showThinking := newCLIModelSettings(ctx)
 
 	agent, err := dive.NewAgent(dive.AgentOptions{
 		SystemPrompt:  systemPrompt,
@@ -544,6 +525,50 @@ func runPrint(ctx *cli.Context) error {
 		return runPrintText(bgCtx, agent, input, showThinking)
 	default:
 		return fmt.Errorf("unsupported --output-format %q; valid values are: json, text", outputFormat)
+	}
+}
+
+func newCLIModelSettings(ctx *cli.Context) (*dive.ModelSettings, bool) {
+	maxTokens := ctx.Int("max-tokens")
+	modelSettings := &dive.ModelSettings{
+		MaxTokens: &maxTokens,
+	}
+	showThinking := ctx.Bool("show-thinking")
+	if showThinking {
+		modelSettings.Thinking = llm.ThinkingTypeAdaptive
+		modelSettings.ThinkingDisplay = llm.ThinkingDisplaySummarized
+	}
+	if effort := parseThinkingEffort(ctx.String("thinking-effort")); effort != "" {
+		modelSettings.ReasoningEffort = effort
+	}
+	if ctx.IsSet("temperature") {
+		t := ctx.Float64("temperature")
+		modelSettings.Temperature = &t
+	}
+	return modelSettings, showThinking
+}
+
+func parseThinkingEffort(value string) llm.ReasoningEffort {
+	value = strings.TrimSpace(value)
+	switch strings.ToLower(value) {
+	case "":
+		return ""
+	case string(llm.ReasoningEffortNone):
+		return llm.ReasoningEffortNone
+	case string(llm.ReasoningEffortMinimal):
+		return llm.ReasoningEffortMinimal
+	case string(llm.ReasoningEffortLow):
+		return llm.ReasoningEffortLow
+	case string(llm.ReasoningEffortMedium):
+		return llm.ReasoningEffortMedium
+	case string(llm.ReasoningEffortHigh):
+		return llm.ReasoningEffortHigh
+	case string(llm.ReasoningEffortXHigh):
+		return llm.ReasoningEffortXHigh
+	case string(llm.ReasoningEffortMax):
+		return llm.ReasoningEffortMax
+	default:
+		return llm.ReasoningEffort(value)
 	}
 }
 

--- a/experimental/cmd/dive/main.go
+++ b/experimental/cmd/dive/main.go
@@ -117,6 +117,10 @@ func main() {
 				Default(16000).
 				Env("DIVE_MAX_TOKENS").
 				Help("Maximum tokens in response"),
+			cli.Bool("show-thinking").
+				Default(false).
+				Env("DIVE_SHOW_THINKING").
+				Help("Request and show summarized model thinking when supported"),
 			cli.String("system-prompt").
 				Default("").
 				Help("System prompt to use for the session"),
@@ -327,6 +331,10 @@ func runInteractive(ctx *cli.Context) error {
 	modelSettings := &dive.ModelSettings{
 		MaxTokens: &maxTokens,
 	}
+	if ctx.Bool("show-thinking") {
+		modelSettings.Thinking = llm.ThinkingTypeAdaptive
+		modelSettings.ThinkingDisplay = llm.ThinkingDisplaySummarized
+	}
 	if ctx.IsSet("temperature") {
 		t := ctx.Float64("temperature")
 		modelSettings.Temperature = &t
@@ -499,6 +507,11 @@ func runPrint(ctx *cli.Context) error {
 	printModelSettings := &dive.ModelSettings{
 		MaxTokens: &maxTokens,
 	}
+	showThinking := ctx.Bool("show-thinking")
+	if showThinking {
+		printModelSettings.Thinking = llm.ThinkingTypeAdaptive
+		printModelSettings.ThinkingDisplay = llm.ThinkingDisplaySummarized
+	}
 	if ctx.IsSet("temperature") {
 		t := ctx.Float64("temperature")
 		printModelSettings.Temperature = &t
@@ -528,7 +541,7 @@ func runPrint(ctx *cli.Context) error {
 	case "json":
 		return runPrintJSON(bgCtx, agent, input)
 	case "text":
-		return runPrintText(bgCtx, agent, input)
+		return runPrintText(bgCtx, agent, input, showThinking)
 	default:
 		return fmt.Errorf("unsupported --output-format %q; valid values are: json, text", outputFormat)
 	}
@@ -580,16 +593,37 @@ func getInput(args []string) (string, error) {
 	return "", nil
 }
 
-func runPrintText(ctx context.Context, agent *dive.Agent, input string) error {
+func runPrintText(ctx context.Context, agent *dive.Agent, input string, showThinking bool) error {
 	var outputText strings.Builder
+	var thinkingText strings.Builder
+	thinkingStarted := false
+	textStarted := false
 
 	resp, err := agent.CreateResponse(ctx,
 		dive.WithInput(input),
 		dive.WithEventCallback(func(ctx context.Context, item *dive.ResponseItem) error {
 			if item.Type == dive.ResponseItemTypeModelEvent && item.Event != nil {
-				if item.Event.Delta != nil && item.Event.Delta.Text != "" {
-					fmt.Print(item.Event.Delta.Text)
-					outputText.WriteString(item.Event.Delta.Text)
+				if item.Event.Delta != nil {
+					if showThinking && item.Event.Delta.Thinking != "" {
+						if !thinkingStarted {
+							fmt.Println("Thinking:")
+							thinkingStarted = true
+						}
+						fmt.Print(item.Event.Delta.Thinking)
+						thinkingText.WriteString(item.Event.Delta.Thinking)
+					}
+					if item.Event.Delta.Text != "" {
+						if showThinking && thinkingStarted && !textStarted {
+							if thinkingText.Len() > 0 && !strings.HasSuffix(thinkingText.String(), "\n") {
+								fmt.Println()
+							}
+							fmt.Println()
+							fmt.Println("Response:")
+							textStarted = true
+						}
+						fmt.Print(item.Event.Delta.Text)
+						outputText.WriteString(item.Event.Delta.Text)
+					}
 				}
 			}
 			return nil
@@ -597,6 +631,14 @@ func runPrintText(ctx context.Context, agent *dive.Agent, input string) error {
 	)
 	if err != nil {
 		return fmt.Errorf("agent error: %w", err)
+	}
+
+	if showThinking && thinkingStarted && outputText.Len() == 0 {
+		if thinkingText.Len() > 0 && !strings.HasSuffix(thinkingText.String(), "\n") {
+			fmt.Println()
+		}
+		fmt.Println()
+		fmt.Println("Response:")
 	}
 
 	if outputText.Len() > 0 && !strings.HasSuffix(outputText.String(), "\n") {
@@ -618,6 +660,9 @@ func runPrintJSON(ctx context.Context, agent *dive.Agent, input string) error {
 		result["error"] = err.Error()
 	} else {
 		result["output"] = resp.OutputText()
+		if thinking := responseThinkingText(resp); thinking != "" {
+			result["thinking"] = thinking
+		}
 		if resp.Usage != nil {
 			result["usage"] = resp.Usage
 		}
@@ -626,6 +671,37 @@ func runPrintJSON(ctx context.Context, agent *dive.Agent, input string) error {
 	encoder := json.NewEncoder(os.Stdout)
 	encoder.SetIndent("", "  ")
 	return encoder.Encode(result)
+}
+
+func responseThinkingText(resp *dive.Response) string {
+	if resp == nil {
+		return ""
+	}
+	var parts []string
+	for _, item := range resp.Items {
+		if item.Type == dive.ResponseItemTypeMessage && item.Message != nil {
+			if thinking := messageThinkingText(item.Message); thinking != "" {
+				parts = append(parts, thinking)
+			}
+		}
+	}
+	return strings.Join(parts, "\n\n")
+}
+
+func messageThinkingText(msg *llm.Message) string {
+	if msg == nil {
+		return ""
+	}
+	var parts []string
+	for _, content := range msg.Content {
+		if thinking, ok := content.(*llm.ThinkingContent); ok {
+			text := strings.TrimSpace(thinking.Thinking)
+			if text != "" {
+				parts = append(parts, text)
+			}
+		}
+	}
+	return strings.Join(parts, "\n\n")
 }
 
 // monitorNotifier sends monitor line batches to the app's event loop.

--- a/experimental/cmd/dive/main_test.go
+++ b/experimental/cmd/dive/main_test.go
@@ -5,8 +5,11 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/deepnoodle-ai/dive"
+	"github.com/deepnoodle-ai/dive/llm"
 	"github.com/deepnoodle-ai/dive/toolkit"
 	"github.com/deepnoodle-ai/wonton/assert"
+	"github.com/deepnoodle-ai/wonton/cli"
 )
 
 func TestGetDefaultModel(t *testing.T) {
@@ -117,6 +120,71 @@ func TestDefaultPermissionRules_AllowsReadOnlyToolsByDefault(t *testing.T) {
 	assert.False(t, allowed["Write"], "Write should not be auto-allowed")
 	assert.False(t, allowed["Edit"], "Edit should not be auto-allowed")
 	assert.False(t, allowed["Bash"], "Bash should not be auto-allowed")
+}
+
+func TestNewCLIModelSettingsThinkingFlags(t *testing.T) {
+	app := cli.New("test")
+	var settings *dive.ModelSettings
+	var showThinking bool
+	app.Main().
+		Flags(
+			cli.Int("max-tokens").
+				Default(16000).
+				Env("DIVE_MAX_TOKENS"),
+			cli.Float("temperature", "t").
+				Env("DIVE_TEMPERATURE"),
+			cli.Bool("show-thinking").
+				Default(false).
+				Env("DIVE_SHOW_THINKING"),
+			cli.String("thinking-effort").
+				Default("").
+				Env("DIVE_THINKING_EFFORT"),
+		).
+		Run(func(ctx *cli.Context) error {
+			settings, showThinking = newCLIModelSettings(ctx)
+			return nil
+		})
+
+	result := app.Test(t, cli.TestArgs("--show-thinking", "--thinking-effort", "High"))
+	assert.True(t, result.Success(), result.Stderr)
+	assert.True(t, showThinking)
+	assert.Equal(t, settings.ReasoningEffort, llm.ReasoningEffortHigh)
+	assert.Equal(t, settings.Thinking, llm.ThinkingTypeAdaptive)
+	assert.Equal(t, settings.ThinkingDisplay, llm.ThinkingDisplaySummarized)
+}
+
+func TestNewCLIModelSettingsThinkingEffortEnv(t *testing.T) {
+	app := cli.New("test")
+	var settings *dive.ModelSettings
+	var showThinking bool
+	app.Main().
+		Flags(
+			cli.Int("max-tokens").
+				Default(16000).
+				Env("DIVE_MAX_TOKENS"),
+			cli.Bool("show-thinking").
+				Default(false).
+				Env("DIVE_SHOW_THINKING"),
+			cli.String("thinking-effort").
+				Default("").
+				Env("DIVE_THINKING_EFFORT"),
+		).
+		Run(func(ctx *cli.Context) error {
+			settings, showThinking = newCLIModelSettings(ctx)
+			return nil
+		})
+
+	result := app.Test(t, cli.TestEnv("DIVE_THINKING_EFFORT", "xhigh"))
+	assert.True(t, result.Success(), result.Stderr)
+	assert.False(t, showThinking)
+	assert.Equal(t, settings.ReasoningEffort, llm.ReasoningEffortXHigh)
+	assert.Equal(t, settings.Thinking, llm.ThinkingType(""))
+	assert.Equal(t, settings.ThinkingDisplay, llm.ThinkingDisplay(""))
+}
+
+func TestParseThinkingEffortAllowsProviderSpecificValues(t *testing.T) {
+	assert.Equal(t, parseThinkingEffort("  High  "), llm.ReasoningEffortHigh)
+	assert.Equal(t, parseThinkingEffort("vendor-custom"), llm.ReasoningEffort("vendor-custom"))
 }
 
 func TestLoadStartupInstructionAttachment_PrefersAgents(t *testing.T) {

--- a/experimental/cmd/dive/render.go
+++ b/experimental/cmd/dive/render.go
@@ -270,7 +270,8 @@ func (a *App) sessionUsageDiffers() bool {
 	return s.InputTokens != i.InputTokens ||
 		s.OutputTokens != i.OutputTokens ||
 		s.CacheReadInputTokens != i.CacheReadInputTokens ||
-		s.CacheCreationInputTokens != i.CacheCreationInputTokens
+		s.CacheCreationInputTokens != i.CacheCreationInputTokens ||
+		s.ReasoningTokens != i.ReasoningTokens
 }
 
 // modelDisplayName returns a human-friendly model name.
@@ -330,6 +331,17 @@ func (a *App) textMessageView(msg Message, index int) tui.View {
 		return tui.Group(
 			tui.Text("⏺ "),
 			tui.Text("%s", content).Wrap().Flex(1),
+		)
+
+	case "reasoning":
+		content := strings.TrimRight(msg.Content, "\n")
+		if content == "" {
+			return nil
+		}
+		reasoningStyle := tui.NewStyle().WithFgRGB(tui.RGB{R: 125, G: 125, B: 138})
+		return tui.Group(
+			tui.Text("◌ ").Style(reasoningStyle),
+			tui.Text("%s", content).Wrap().Style(reasoningStyle).Flex(1),
 		)
 
 	case "context":
@@ -788,6 +800,17 @@ func (a *App) textMessageViewStatic(msg Message) tui.View {
 			tui.PaddingLTRB(2, 0, 0, 0, tui.Markdown(content, nil).Theme(diveMarkdownTheme())),
 			tui.Text("⏺"),
 		).Align(tui.AlignLeft)
+
+	case "reasoning":
+		content := strings.TrimSpace(msg.Content)
+		if content == "" {
+			return nil
+		}
+		reasoningStyle := tui.NewStyle().WithFgRGB(tui.RGB{R: 125, G: 125, B: 138})
+		return tui.Group(
+			tui.Text("◌ ").Style(reasoningStyle),
+			tui.Text("%s", content).Wrap().Style(reasoningStyle).Flex(1),
+		)
 
 	case "context":
 		dimStyle := tui.NewStyle().WithFgRGB(tui.RGB{R: 100, G: 100, B: 110})

--- a/llm/options.go
+++ b/llm/options.go
@@ -284,8 +284,9 @@ const (
 	ThinkingDisplaySummarized ThinkingDisplay = "summarized"
 	// ThinkingDisplayOmitted returns thinking blocks with an empty thinking
 	// field (the encrypted signature is still present for multi-turn
-	// continuity). This is the default on Claude Opus 4.7 and 4.8 and reduces
-	// time-to-first text token when streaming.
+	// continuity). This is the default on Claude Fable 5, Mythos 5, Sonnet 5,
+	// Opus 4.7, and Opus 4.8, and reduces time-to-first text token when
+	// streaming.
 	ThinkingDisplayOmitted ThinkingDisplay = "omitted"
 )
 

--- a/llm/stream_test.go
+++ b/llm/stream_test.go
@@ -101,3 +101,52 @@ func TestResponseAccumulatorUsageIncludesReasoningAndSpeed(t *testing.T) {
 	assert.Equal(t, usage.ReasoningTokens, 7)
 	assert.Equal(t, usage.Speed, "fast")
 }
+
+func TestResponseAccumulatorPreservesOmittedThinkingSignature(t *testing.T) {
+	acc := NewResponseAccumulator()
+	idx0, idx1 := 0, 1
+
+	assert.NoError(t, acc.AddEvent(&Event{
+		Type:    EventTypeMessageStart,
+		Message: &Response{ID: "msg_1", Role: Assistant},
+	}))
+	assert.NoError(t, acc.AddEvent(&Event{
+		Type:  EventTypeContentBlockStart,
+		Index: &idx0,
+		ContentBlock: &EventContentBlock{
+			Type:      ContentTypeThinking,
+			Thinking:  "",
+			Signature: "",
+		},
+	}))
+	assert.NoError(t, acc.AddEvent(&Event{
+		Type:  EventTypeContentBlockDelta,
+		Index: &idx0,
+		Delta: &EventDelta{
+			Type:      EventDeltaTypeSignature,
+			Signature: "encrypted-thinking",
+		},
+	}))
+	assert.NoError(t, acc.AddEvent(&Event{Type: EventTypeContentBlockStop, Index: &idx0}))
+	assert.NoError(t, acc.AddEvent(&Event{
+		Type:         EventTypeContentBlockStart,
+		Index:        &idx1,
+		ContentBlock: &EventContentBlock{Type: ContentTypeText},
+	}))
+	assert.NoError(t, acc.AddEvent(&Event{
+		Type:  EventTypeContentBlockDelta,
+		Index: &idx1,
+		Delta: &EventDelta{Type: EventDeltaTypeText, Text: "done"},
+	}))
+	assert.NoError(t, acc.AddEvent(&Event{Type: EventTypeMessageStop}))
+
+	response := acc.Response()
+	assert.Len(t, response.Content, 2)
+	thinking, ok := response.Content[0].(*ThinkingContent)
+	assert.True(t, ok)
+	assert.Equal(t, "", thinking.Thinking)
+	assert.Equal(t, "encrypted-thinking", thinking.Signature)
+	text, ok := response.Content[1].(*TextContent)
+	assert.True(t, ok)
+	assert.Equal(t, "done", text.Text)
+}

--- a/llm/usage.go
+++ b/llm/usage.go
@@ -1,5 +1,7 @@
 package llm
 
+import "encoding/json"
+
 // Usage contains token usage information for an LLM response.
 type Usage struct {
 	InputTokens              int `json:"input_tokens"`
@@ -7,8 +9,9 @@ type Usage struct {
 	CacheCreationInputTokens int `json:"cache_creation_input_tokens,omitempty"`
 	CacheReadInputTokens     int `json:"cache_read_input_tokens,omitempty"`
 	// ReasoningTokens is the number of output tokens spent on reasoning, when
-	// the provider reports it separately (e.g. OpenAI o-series and Grok
-	// reasoning models). It is a subset of OutputTokens, not additive.
+	// the provider reports it separately (e.g. OpenAI o-series, Grok reasoning
+	// models, and Anthropic extended thinking). It is a subset of OutputTokens,
+	// not additive.
 	ReasoningTokens int `json:"reasoning_tokens,omitempty"`
 	// Speed indicates which inference speed served the request, either "fast"
 	// or "standard". Populated by Anthropic when fast mode is requested.
@@ -18,6 +21,32 @@ type Usage struct {
 	// means cost is unknown — distinct from a known cost of zero (e.g. a local
 	// model). It is an estimate at list prices, not a billing figure.
 	Cost *Cost `json:"cost,omitempty"`
+}
+
+// UnmarshalJSON accepts provider-native usage shapes and maps their reasoning
+// breakdowns onto ReasoningTokens.
+func (u *Usage) UnmarshalJSON(data []byte) error {
+	type usageAlias Usage
+	var raw struct {
+		usageAlias
+		OutputTokensDetails *struct {
+			ReasoningTokens int `json:"reasoning_tokens,omitempty"`
+			ThinkingTokens  int `json:"thinking_tokens,omitempty"`
+		} `json:"output_tokens_details,omitempty"`
+	}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	*u = Usage(raw.usageAlias)
+	if u.ReasoningTokens == 0 && raw.OutputTokensDetails != nil {
+		switch {
+		case raw.OutputTokensDetails.ReasoningTokens != 0:
+			u.ReasoningTokens = raw.OutputTokensDetails.ReasoningTokens
+		case raw.OutputTokensDetails.ThinkingTokens != 0:
+			u.ReasoningTokens = raw.OutputTokensDetails.ThinkingTokens
+		}
+	}
+	return nil
 }
 
 // Copy returns a deep copy of the usage data.

--- a/llm/usage_test.go
+++ b/llm/usage_test.go
@@ -1,0 +1,38 @@
+package llm
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/deepnoodle-ai/wonton/assert"
+)
+
+func TestUsageUnmarshalAnthropicThinkingTokens(t *testing.T) {
+	var usage Usage
+	err := json.Unmarshal([]byte(`{
+		"input_tokens": 25,
+		"output_tokens": 348,
+		"output_tokens_details": {
+			"thinking_tokens": 312
+		}
+	}`), &usage)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 25, usage.InputTokens)
+	assert.Equal(t, 348, usage.OutputTokens)
+	assert.Equal(t, 312, usage.ReasoningTokens)
+}
+
+func TestUsageUnmarshalOpenAIReasoningTokens(t *testing.T) {
+	var usage Usage
+	err := json.Unmarshal([]byte(`{
+		"input_tokens": 25,
+		"output_tokens": 348,
+		"output_tokens_details": {
+			"reasoning_tokens": 123
+		}
+	}`), &usage)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 123, usage.ReasoningTokens)
+}

--- a/providers/anthropic/anthropic.go
+++ b/providers/anthropic/anthropic.go
@@ -526,6 +526,9 @@ func (p *Provider) applyRequestConfig(req *Request, config *llm.Config) error {
 	if err := applyReasoningConfig(req, config); err != nil {
 		return err
 	}
+	if requestHasThinkingEnabled(req.Model, req.Thinking) && config.Prefill != "" {
+		return fmt.Errorf("anthropic extended thinking cannot be used with prefilled assistant responses")
+	}
 
 	if config.Speed != "" {
 		req.Speed = string(config.Speed)
@@ -558,6 +561,9 @@ func (p *Provider) applyRequestConfig(req *Request, config *llm.Config) error {
 	}
 
 	if config.ToolChoice != nil && len(config.Tools) > 0 {
+		if requestHasThinkingEnabled(req.Model, req.Thinking) && forcedToolChoice(config.ToolChoice.Type) {
+			return fmt.Errorf("anthropic extended thinking only supports tool_choice auto or none; got %q", config.ToolChoice.Type)
+		}
 		req.ToolChoice = &ToolChoice{
 			Type: ToolChoiceType(config.ToolChoice.Type),
 			Name: config.ToolChoice.Name,
@@ -575,10 +581,10 @@ func (p *Provider) applyRequestConfig(req *Request, config *llm.Config) error {
 		req.ContextManagement = config.ContextManagement
 	}
 
-	if !modelRejectsTemperature(req.Model) {
+	if !modelRejectsTemperature(req.Model) && !requestHasThinkingEnabled(req.Model, req.Thinking) {
 		req.Temperature = config.Temperature
 	} else if config.Temperature != nil && config.Logger != nil {
-		config.Logger.Warn("temperature is not supported by this model and will be ignored",
+		config.Logger.Warn("temperature is not supported by this Anthropic request and will be ignored",
 			"model", req.Model)
 	}
 	if config.SystemPrompt != "" {
@@ -630,6 +636,9 @@ func applyReasoningConfig(req *Request, config *llm.Config) error {
 	}
 
 	if thinking != nil {
+		if err := validateThinkingBudget(req, config, thinking); err != nil {
+			return err
+		}
 		if config.ThinkingDisplay != "" && thinking.Type != "disabled" {
 			thinking.Display = string(config.ThinkingDisplay)
 		}
@@ -725,6 +734,30 @@ func legacyEffortBudget(effort llm.ReasoningEffort) (int, error) {
 	}
 }
 
+func validateThinkingBudget(req *Request, config *llm.Config, thinking *Thinking) error {
+	if thinking.Type != "enabled" || config.IsFeatureEnabled(FeatureInterleavedThinking) {
+		return nil
+	}
+	if req.MaxTokens == nil {
+		return nil
+	}
+	if thinking.BudgetTokens >= *req.MaxTokens {
+		return fmt.Errorf("anthropic reasoning budget (%d) must be less than max_tokens (%d)", thinking.BudgetTokens, *req.MaxTokens)
+	}
+	return nil
+}
+
+func requestHasThinkingEnabled(model string, thinking *Thinking) bool {
+	if thinking != nil {
+		return thinking.Type != "disabled"
+	}
+	return modelRunsThinkingByDefault(model)
+}
+
+func forcedToolChoice(choice llm.ToolChoiceType) bool {
+	return choice == llm.ToolChoiceTypeAny || choice == llm.ToolChoiceTypeTool
+}
+
 // modelSupportsEffortParam reports whether the model accepts the native
 // output_config.effort parameter (Opus 4.5+, Sonnet 4.6, Fable 5, Mythos 5).
 func modelSupportsEffortParam(model string) bool {
@@ -790,6 +823,15 @@ func modelRejectsManualThinking(model string) bool {
 // default on but reject the explicit disable, so Dive omits the field for them).
 func modelDefaultsThinkingOn(model string) bool {
 	return strings.HasPrefix(model, "claude-sonnet-5")
+}
+
+// modelRunsThinkingByDefault reports whether omitting the thinking parameter
+// still leaves adaptive thinking active.
+func modelRunsThinkingByDefault(model string) bool {
+	return strings.HasPrefix(model, "claude-fable-5") ||
+		strings.HasPrefix(model, "claude-mythos-5") ||
+		strings.HasPrefix(model, "claude-mythos-preview") ||
+		modelDefaultsThinkingOn(model)
 }
 
 // createRequest creates an HTTP request with appropriate headers for Anthropic API calls

--- a/providers/anthropic/features.go
+++ b/providers/anthropic/features.go
@@ -45,6 +45,7 @@ const (
 	// Files API for upload/download/reuse
 	FeatureFilesAPI = "files-api-2025-04-14"
 
-	// Interleaved thinking (manual mode, Sonnet 4.6)
+	// Interleaved thinking beta for Opus 4.5 and earlier Claude 4 models.
+	// Adaptive-thinking models handle interleaved thinking automatically.
 	FeatureInterleavedThinking = "interleaved-thinking-2025-05-14"
 )

--- a/providers/anthropic/reasoning_test.go
+++ b/providers/anthropic/reasoning_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/deepnoodle-ai/dive/llm"
 	"github.com/deepnoodle-ai/wonton/assert"
+	"github.com/deepnoodle-ai/wonton/schema"
 )
 
 // buildReq applies the given options to a config for the given model and
@@ -18,6 +19,13 @@ func buildReq(t *testing.T, model string, opts ...llm.Option) *Request {
 	var req Request
 	assert.NoError(t, p.applyRequestConfig(&req, cfg))
 	return &req
+}
+
+func reasoningTestTool() llm.Tool {
+	return llm.NewToolDefinition().
+		WithName("lookup").
+		WithDescription("Look up a value").
+		WithSchema(&schema.Schema{Type: "object"})
 }
 
 func TestReasoningEffortOpus48UsesOutputConfig(t *testing.T) {
@@ -76,6 +84,15 @@ func TestThinkingDisplay(t *testing.T) {
 	assert.Equal(t, "summarized", req.Thinking.Display)
 }
 
+func TestSummarizedThinkingDisplayOnDefaultOmittedModel(t *testing.T) {
+	req := buildReq(t, ModelClaudeSonnet5,
+		llm.WithAdaptiveThinking(),
+		llm.WithThinkingDisplay(llm.ThinkingDisplaySummarized))
+	assert.NotNil(t, req.Thinking)
+	assert.Equal(t, "adaptive", req.Thinking.Type)
+	assert.Equal(t, "summarized", req.Thinking.Display)
+}
+
 func TestReasoningEffortAndAdaptiveCombine(t *testing.T) {
 	// Effort and adaptive thinking are orthogonal on Opus 4.8.
 	req := buildReq(t, ModelClaudeOpus48,
@@ -118,6 +135,90 @@ func TestThinkingDisabled(t *testing.T) {
 		llm.WithReasoningBudget(8000),
 		llm.WithThinking(llm.ThinkingTypeDisabled))
 	assert.Nil(t, req.Thinking)
+}
+
+func TestThinkingDropsTemperature(t *testing.T) {
+	req := buildReq(t, ModelClaudeOpus46,
+		llm.WithReasoningBudget(8000),
+		llm.WithTemperature(0.7))
+	assert.NotNil(t, req.Thinking)
+	assert.Nil(t, req.Temperature)
+}
+
+func TestThinkingWithPrefillErrors(t *testing.T) {
+	cfg := &llm.Config{}
+	cfg.Apply(
+		llm.WithModel(ModelClaudeOpus46),
+		llm.WithReasoningBudget(8000),
+		llm.WithPrefill("prefilled answer", ""),
+	)
+	var req Request
+	err := New().applyRequestConfig(&req, cfg)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "prefilled assistant responses")
+}
+
+func TestThinkingWithForcedToolChoiceErrors(t *testing.T) {
+	cfg := &llm.Config{}
+	cfg.Apply(
+		llm.WithModel(ModelClaudeOpus46),
+		llm.WithReasoningBudget(8000),
+		llm.WithTools(reasoningTestTool()),
+		llm.WithToolChoice(&llm.ToolChoice{
+			Type: llm.ToolChoiceTypeTool,
+			Name: "lookup",
+		}),
+	)
+	var req Request
+	err := New().applyRequestConfig(&req, cfg)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "tool_choice auto or none")
+}
+
+func TestDefaultThinkingWithForcedToolChoiceErrors(t *testing.T) {
+	cfg := &llm.Config{}
+	cfg.Apply(
+		llm.WithModel(ModelClaudeFable5),
+		llm.WithTools(reasoningTestTool()),
+		llm.WithToolChoice(llm.ToolChoiceAny),
+	)
+	var req Request
+	err := New().applyRequestConfig(&req, cfg)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "tool_choice auto or none")
+}
+
+func TestThinkingAllowsToolChoiceAutoAndNone(t *testing.T) {
+	for _, choice := range []*llm.ToolChoice{llm.ToolChoiceAuto, llm.ToolChoiceNone} {
+		req := buildReq(t, ModelClaudeOpus46,
+			llm.WithReasoningBudget(8000),
+			llm.WithTools(reasoningTestTool()),
+			llm.WithToolChoice(choice))
+		assert.NotNil(t, req.ToolChoice)
+		assert.Equal(t, ToolChoiceType(choice.Type), req.ToolChoice.Type)
+	}
+}
+
+func TestManualThinkingBudgetMustBeLessThanMaxTokens(t *testing.T) {
+	cfg := &llm.Config{}
+	cfg.Apply(
+		llm.WithModel(ModelClaudeOpus46),
+		llm.WithMaxTokens(4096),
+		llm.WithReasoningBudget(4096),
+	)
+	var req Request
+	err := New().applyRequestConfig(&req, cfg)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "must be less than max_tokens")
+}
+
+func TestInterleavedThinkingAllowsBudgetAtOrAboveMaxTokens(t *testing.T) {
+	req := buildReq(t, ModelClaudeOpus45,
+		llm.WithMaxTokens(4096),
+		llm.WithReasoningBudget(8192),
+		llm.WithFeatures(FeatureInterleavedThinking))
+	assert.NotNil(t, req.Thinking)
+	assert.Equal(t, 8192, req.Thinking.BudgetTokens)
 }
 
 func TestEffortWithThinkingDisabledLegacyModelErrors(t *testing.T) {
@@ -188,6 +289,10 @@ func TestModelCapabilityHelpers(t *testing.T) {
 	// Sonnet 5 rejects sampling params and defaults thinking on.
 	assert.True(t, modelRejectsTemperature(ModelClaudeSonnet5))
 	assert.True(t, modelDefaultsThinkingOn(ModelClaudeSonnet5))
+	assert.True(t, modelRunsThinkingByDefault(ModelClaudeFable5))
+	assert.True(t, modelRunsThinkingByDefault(ModelClaudeMythos5))
+	assert.True(t, modelRunsThinkingByDefault(ModelClaudeSonnet5))
+	assert.False(t, modelRunsThinkingByDefault(ModelClaudeOpus48))
 	assert.False(t, modelDefaultsThinkingOn(ModelClaudeFable5))
 	assert.False(t, modelDefaultsThinkingOn(ModelClaudeSonnet46))
 }


### PR DESCRIPTION
## Summary

- Add Anthropic request validation for extended thinking edge cases from the latest docs: forced tool choice, prefill, temperature, and manual budget vs. max token constraints.
- Preserve omitted thinking signatures in streamed responses and map Anthropic `output_tokens_details.thinking_tokens` into Dive's `Usage.ReasoningTokens`.
- Add Dive CLI summarized-thinking support: `--show-thinking` / `DIVE_SHOW_THINKING=true` requests adaptive summarized thinking and renders visible thinking summaries in the interactive transcript.
- Expose CLI thinking effort control via `--thinking-effort` / `DIVE_THINKING_EFFORT`, with known values normalized and provider-specific values passed through.
- Show streamed thinking summaries immediately in the live view, show completed thinking blocks when resuming session history, and include thinking text in JSON print output when present.
- Document how to request visible summarized thinking with `ThinkingDisplaySummarized` and the CLI flags.

## Validation

- `go test ./llm ./providers/anthropic`
- `go test ./...`
- `(cd experimental/cmd/dive && go test ./...)`
- `(cd experimental/cmd/dive && go run . --help | rg -- '--thinking-effort|show-thinking')`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option to show summarized model thinking in the CLI and print output.
  * Thinking content now appears separately from normal assistant responses in the UI.
  * JSON print output can now include a `thinking` field when present.

* **Bug Fixes**
  * Improved handling of reasoning token counts across providers.
  * Added validation for incompatible thinking configurations to prevent failed requests.

* **Documentation**
  * Expanded Claude guidance with updated model notes and clearer reasoning behavior details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
