### PR TITLE
Prepare v1.12.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [1.12.0] - 2026-07-09
+
 ### Added
 
-- **Grok 4.5** — added `grok-4.5` plus `grok-4.5-latest` and
-  `grok-build-latest` aliases to the Grok provider catalog and pricing. Grok
-  now defaults to `grok-4.5`, with cached-input pricing represented in usage
-  cost estimates and CLI context metadata updated to 500k tokens.
+- **Grok 4.5** — `grok-4.5` (with `grok-4.5-latest` and `grok-build-latest`
+  aliases) added to the Grok catalog and pricing; now the Grok default, with
+  500k context and cached-input cost estimates.
+- **Anthropic summarized thinking** — `ThinkingDisplaySummarized` requests
+  visible summarized thinking on Claude models that otherwise omit it (Sonnet 5,
+  Opus 4.7/4.8, Fable/Mythos 5), and `Usage.ReasoningTokens` now counts
+  Anthropic's reported thinking tokens. The CLI gains `--show-thinking` and
+  `--thinking-effort` (env `DIVE_SHOW_THINKING` / `DIVE_THINKING_EFFORT`).
 
 ## [1.11.1] - 2026-07-03
 

--- a/a2a/go.mod
+++ b/a2a/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/a2aproject/a2a-go/v2 v2.2.0
-	github.com/deepnoodle-ai/dive v1.11.1
+	github.com/deepnoodle-ai/dive v1.12.0
 	github.com/deepnoodle-ai/wonton v0.0.36
 )
 

--- a/demos/colosseum/go.mod
+++ b/demos/colosseum/go.mod
@@ -3,11 +3,11 @@ module github.com/deepnoodle-ai/dive/demos/colosseum
 go 1.25.0
 
 require (
-	github.com/deepnoodle-ai/dive v1.11.1
-	github.com/deepnoodle-ai/dive/a2a v1.11.1
-	github.com/deepnoodle-ai/dive/providers/google v1.11.1
-	github.com/deepnoodle-ai/dive/providers/grok v1.11.1
-	github.com/deepnoodle-ai/dive/providers/openai v1.11.1
+	github.com/deepnoodle-ai/dive v1.12.0
+	github.com/deepnoodle-ai/dive/a2a v1.12.0
+	github.com/deepnoodle-ai/dive/providers/google v1.12.0
+	github.com/deepnoodle-ai/dive/providers/grok v1.12.0
+	github.com/deepnoodle-ai/dive/providers/openai v1.12.0
 	github.com/deepnoodle-ai/wonton v0.0.36
 )
 

--- a/demos/noodleville/go.mod
+++ b/demos/noodleville/go.mod
@@ -3,7 +3,7 @@ module github.com/deepnoodle-ai/dive/demos/noodleville
 go 1.25.0
 
 require (
-	github.com/deepnoodle-ai/dive v1.11.1
+	github.com/deepnoodle-ai/dive v1.12.0
 	github.com/deepnoodle-ai/wonton v0.0.36
 )
 

--- a/examples/go.mod
+++ b/examples/go.mod
@@ -3,13 +3,13 @@ module github.com/deepnoodle-ai/dive/examples
 go 1.25.0
 
 require (
-	github.com/deepnoodle-ai/dive v1.11.1
-	github.com/deepnoodle-ai/dive/a2a v1.11.1
-	github.com/deepnoodle-ai/dive/experimental/mcp v1.11.1
-	github.com/deepnoodle-ai/dive/otel v1.11.1
-	github.com/deepnoodle-ai/dive/providers/google v1.11.1
-	github.com/deepnoodle-ai/dive/providers/grok v1.11.1
-	github.com/deepnoodle-ai/dive/providers/openai v1.11.1
+	github.com/deepnoodle-ai/dive v1.12.0
+	github.com/deepnoodle-ai/dive/a2a v1.12.0
+	github.com/deepnoodle-ai/dive/experimental/mcp v1.12.0
+	github.com/deepnoodle-ai/dive/otel v1.12.0
+	github.com/deepnoodle-ai/dive/providers/google v1.12.0
+	github.com/deepnoodle-ai/dive/providers/grok v1.12.0
+	github.com/deepnoodle-ai/dive/providers/openai v1.12.0
 	github.com/deepnoodle-ai/wonton v0.0.36
 	github.com/fatih/color v1.18.0
 	github.com/mark3labs/mcp-go v0.45.0

--- a/experimental/cmd/dive/go.mod
+++ b/experimental/cmd/dive/go.mod
@@ -3,10 +3,10 @@ module github.com/deepnoodle-ai/dive/experimental/cmd/dive
 go 1.25.0
 
 require (
-	github.com/deepnoodle-ai/dive v1.11.1
-	github.com/deepnoodle-ai/dive/providers/google v1.11.1
-	github.com/deepnoodle-ai/dive/providers/grok v1.11.1
-	github.com/deepnoodle-ai/dive/providers/openai v1.11.1
+	github.com/deepnoodle-ai/dive v1.12.0
+	github.com/deepnoodle-ai/dive/providers/google v1.12.0
+	github.com/deepnoodle-ai/dive/providers/grok v1.12.0
+	github.com/deepnoodle-ai/dive/providers/openai v1.12.0
 	github.com/deepnoodle-ai/wonton v0.0.36
 	github.com/mattn/go-runewidth v0.0.21
 )

--- a/experimental/mcp/go.mod
+++ b/experimental/mcp/go.mod
@@ -3,7 +3,7 @@ module github.com/deepnoodle-ai/dive/experimental/mcp
 go 1.25.0
 
 require (
-	github.com/deepnoodle-ai/dive v1.11.1
+	github.com/deepnoodle-ai/dive v1.12.0
 	github.com/deepnoodle-ai/wonton v0.0.36
 	github.com/mark3labs/mcp-go v0.45.0
 )

--- a/otel/go.mod
+++ b/otel/go.mod
@@ -3,7 +3,7 @@ module github.com/deepnoodle-ai/dive/otel
 go 1.25.0
 
 require (
-	github.com/deepnoodle-ai/dive v1.11.1
+	github.com/deepnoodle-ai/dive v1.12.0
 	go.opentelemetry.io/otel v1.43.0
 	go.opentelemetry.io/otel/metric v1.43.0
 	go.opentelemetry.io/otel/sdk v1.43.0

--- a/providers/google/go.mod
+++ b/providers/google/go.mod
@@ -3,7 +3,7 @@ module github.com/deepnoodle-ai/dive/providers/google
 go 1.25.0
 
 require (
-	github.com/deepnoodle-ai/dive v1.11.1
+	github.com/deepnoodle-ai/dive v1.12.0
 	github.com/deepnoodle-ai/wonton v0.0.36
 	google.golang.org/genai v1.51.0
 )

--- a/providers/grok/go.mod
+++ b/providers/grok/go.mod
@@ -3,8 +3,8 @@ module github.com/deepnoodle-ai/dive/providers/grok
 go 1.25.0
 
 require (
-	github.com/deepnoodle-ai/dive v1.11.1
-	github.com/deepnoodle-ai/dive/providers/openai v1.11.1
+	github.com/deepnoodle-ai/dive v1.12.0
+	github.com/deepnoodle-ai/dive/providers/openai v1.12.0
 	github.com/deepnoodle-ai/wonton v0.0.36
 	github.com/openai/openai-go/v3 v3.29.0
 	golang.org/x/image v0.38.0

--- a/providers/openai/go.mod
+++ b/providers/openai/go.mod
@@ -3,7 +3,7 @@ module github.com/deepnoodle-ai/dive/providers/openai
 go 1.25.0
 
 require (
-	github.com/deepnoodle-ai/dive v1.11.1
+	github.com/deepnoodle-ai/dive v1.12.0
 	github.com/deepnoodle-ai/wonton v0.0.36
 	github.com/openai/openai-go/v3 v3.29.0
 	golang.org/x/image v0.38.0


### PR DESCRIPTION
## Summary

Prepares the **v1.12.0** release, covering the two changes landed since v1.11.1. Both are additive, hence the minor bump.

### Changelog (v1.12.0)

**Added**
- **Grok 4.5** (#213) — `grok-4.5` (with `grok-4.5-latest`/`grok-build-latest` aliases) added to the Grok catalog and pricing; now the Grok default, with 500k context and cached-input cost estimates.
- **Anthropic summarized thinking** (#214) — `ThinkingDisplaySummarized` requests visible summarized thinking on Claude models that otherwise omit it (Sonnet 5, Opus 4.7/4.8, Fable/Mythos 5), and `Usage.ReasoningTokens` now counts Anthropic's reported thinking tokens. CLI gains `--show-thinking` and `--thinking-effort`.

### Release mechanics
- Cut the `[1.12.0] - 2026-07-09` section in `CHANGELOG.md`.
- Bumped intra-repo `deepnoodle-ai/dive` module version references `v1.11.1` → `v1.12.0` across all sub-modules and demos (testify's unrelated `v1.11.1` left untouched).
- Ran `make tidy-all`.

### Verification
- `go build ./...` and CLI `go build .` pass.
- `prettier --check CHANGELOG.md` passes.

### After merge
Tag the modules: `make tag-modules VERSION=v1.12.0` (plus the root `v1.12.0` tag), then `git push origin --tags`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)