### PR TITLE
Handle GPT-5.4 mini tool reasoning compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **GPT-5.4 mini Chat Completions tools** — requests that combine function
+  tools with a non-`none` reasoning effort now preserve the tools, use
+  `reasoning_effort: none`, and emit a warning instead of failing with an
+  OpenAI HTTP 400 response.
+
 ## [1.13.0] - 2026-07-09
 
 ### Added

--- a/providers/openaicompletions/openai.go
+++ b/providers/openaicompletions/openai.go
@@ -531,6 +531,15 @@ func (p *Provider) applyRequestConfig(req *Request, config *llm.Config) error {
 		return err
 	}
 	if includeReasoningEffort {
+		requestedReasoningEffort := config.ReasoningEffort
+		var adjusted bool
+		reasoningEffort, adjusted = normalizeToolReasoningEffort(req.Model, reasoningEffort, len(tools) > 0)
+		if adjusted && config.Logger != nil {
+			config.Logger.Warn("reasoning effort is not supported with function tools for this model in Chat Completions; using none",
+				"model", req.Model,
+				"requested_reasoning_effort", requestedReasoningEffort,
+				"effective_reasoning_effort", reasoningEffort)
+		}
 		req.ReasoningEffort = reasoningEffort
 	}
 	return nil

--- a/providers/openaicompletions/openai_test.go
+++ b/providers/openaicompletions/openai_test.go
@@ -100,6 +100,97 @@ func TestApplyRequestConfig_MistralOmitsReasoningEffort(t *testing.T) {
 	assert.Equal(t, ReasoningEffort(""), req.ReasoningEffort)
 }
 
+func TestApplyRequestConfig_NormalizesReasoningEffortForTools(t *testing.T) {
+	tool := llm.NewToolDefinition().
+		WithName("lookup").
+		WithDescription("Looks up a value").
+		WithSchema(&schema.Schema{Type: "object"})
+
+	tests := []struct {
+		name         string
+		model        string
+		effort       llm.ReasoningEffort
+		withTools    bool
+		want         ReasoningEffort
+		wantWarnings int
+	}{
+		{
+			name:         "gpt-5.4-mini uses none with function tools",
+			model:        ModelGPT54Mini,
+			effort:       llm.ReasoningEffortHigh,
+			withTools:    true,
+			want:         ReasoningEffortNone,
+			wantWarnings: 1,
+		},
+		{
+			name:         "gpt-5.4-mini snapshot uses none with function tools",
+			model:        "gpt-5.4-mini-2026-03-17",
+			effort:       llm.ReasoningEffortXHigh,
+			withTools:    true,
+			want:         ReasoningEffortNone,
+			wantWarnings: 1,
+		},
+		{
+			name:         "openai-prefixed gpt-5.4-mini uses none with function tools",
+			model:        "openai/gpt-5.4-mini",
+			effort:       llm.ReasoningEffortMedium,
+			withTools:    true,
+			want:         ReasoningEffortNone,
+			wantWarnings: 1,
+		},
+		{
+			name:      "gpt-5.4-mini preserves reasoning without tools",
+			model:     ModelGPT54Mini,
+			effort:    llm.ReasoningEffortHigh,
+			withTools: false,
+			want:      ReasoningEffortHigh,
+		},
+		{
+			name:      "gpt-5.4 preserves reasoning with tools",
+			model:     ModelGPT54,
+			effort:    llm.ReasoningEffortHigh,
+			withTools: true,
+			want:      ReasoningEffortHigh,
+		},
+		{
+			name:      "gpt-5.4-mini preserves none with tools",
+			model:     ModelGPT54Mini,
+			effort:    llm.ReasoningEffortNone,
+			withTools: true,
+			want:      ReasoningEffortNone,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logger := &recordingLogger{}
+			config := &llm.Config{ReasoningEffort: tt.effort, Logger: logger}
+			if tt.withTools {
+				config.Tools = []llm.Tool{tool}
+			}
+
+			provider := New(WithModel(tt.model))
+			var req Request
+			err := provider.applyRequestConfig(&req, config)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.want, req.ReasoningEffort)
+			assert.Len(t, logger.warnings, tt.wantWarnings)
+		})
+	}
+}
+
+type recordingLogger struct {
+	warnings []string
+}
+
+func (l *recordingLogger) Debug(string, ...any) {}
+func (l *recordingLogger) Info(string, ...any)  {}
+func (l *recordingLogger) Warn(msg string, _ ...any) {
+	l.warnings = append(l.warnings, msg)
+}
+func (l *recordingLogger) Error(string, ...any)   {}
+func (l *recordingLogger) With(...any) llm.Logger { return l }
+
 func skipIfNoAPIKey(t *testing.T) {
 	t.Helper()
 	if os.Getenv("OPENAI_API_KEY") == "" {

--- a/providers/openaicompletions/reasoning.go
+++ b/providers/openaicompletions/reasoning.go
@@ -35,6 +35,21 @@ func (p *Provider) resolveReasoningEffort(model string, config *llm.Config) (Rea
 	}
 }
 
+// normalizeToolReasoningEffort handles Chat Completions constraints that only
+// apply when function tools and reasoning are requested together. GPT-5.4 mini
+// rejects that combination unless reasoning_effort is "none".
+func normalizeToolReasoningEffort(model string, effort ReasoningEffort, hasFunctionTools bool) (ReasoningEffort, bool) {
+	if !hasFunctionTools || effort == ReasoningEffortNone {
+		return effort, false
+	}
+
+	model = strings.TrimPrefix(strings.ToLower(model), "openai/")
+	if model == ModelGPT54Mini || strings.HasPrefix(model, ModelGPT54Mini+"-") {
+		return ReasoningEffortNone, true
+	}
+	return effort, false
+}
+
 func normalizeOpenAIReasoningEffort(model string, effort llm.ReasoningEffort) (llm.ReasoningEffort, error) {
 	if strings.Contains(model, "codex") {
 		return effort, nil


### PR DESCRIPTION
## Summary

- preserve function tools when GPT-5.4 mini is used through Chat Completions with a non-`none` reasoning effort
- downgrade only the incompatible reasoning setting to `none` and emit a structured warning
- cover the base model, snapshots, `openai/`-prefixed models, and unaffected combinations
- document the behavior in the changelog

## Root cause

Dive normalized tool configuration and reasoning effort independently. OpenAI rejects GPT-5.4 mini Chat Completions requests that combine function tools with a non-`none` `reasoning_effort`, so a configuration that was valid in each dimension separately still failed at the provider boundary with HTTP 400.

## Impact

Agent turns keep their tools and continue instead of failing. Callers that explicitly request reasoning receive a warning showing the requested and effective reasoning effort. The Responses provider and application routing are unchanged.

## Validation

- `go test ./providers/openaicompletions`
- `go test ./...`
- `go test ./...` in `experimental/cmd/dive`
- `go vet ./...`
- `git diff --check`
- changed Go files pass `gofmt`; `CHANGELOG.md` passes Prettier

## Baseline notes

- repository-wide `make fmt-check` still reports 42 pre-existing Markdown formatting failures outside this diff
- `go test ./...` in the untouched `providers/openai` nested module requests a dependency tidy under local Go 1.26; the root and CI-covered CLI suites pass