### PR TITLE
Prepare v1.15.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [1.15.0] - 2026-07-10
+
 ### Added
 
 - **Dynamic context-injection demos** — the experimental CLI's repeatable

--- a/a2a/go.mod
+++ b/a2a/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/a2aproject/a2a-go/v2 v2.2.0
-	github.com/deepnoodle-ai/dive v1.14.0
+	github.com/deepnoodle-ai/dive v1.15.0
 	github.com/deepnoodle-ai/wonton v0.0.36
 )
 

--- a/demos/colosseum/go.mod
+++ b/demos/colosseum/go.mod
@@ -3,11 +3,11 @@ module github.com/deepnoodle-ai/dive/demos/colosseum
 go 1.25.0
 
 require (
-	github.com/deepnoodle-ai/dive v1.14.0
-	github.com/deepnoodle-ai/dive/a2a v1.14.0
-	github.com/deepnoodle-ai/dive/providers/google v1.14.0
-	github.com/deepnoodle-ai/dive/providers/grok v1.14.0
-	github.com/deepnoodle-ai/dive/providers/openai v1.14.0
+	github.com/deepnoodle-ai/dive v1.15.0
+	github.com/deepnoodle-ai/dive/a2a v1.15.0
+	github.com/deepnoodle-ai/dive/providers/google v1.15.0
+	github.com/deepnoodle-ai/dive/providers/grok v1.15.0
+	github.com/deepnoodle-ai/dive/providers/openai v1.15.0
 	github.com/deepnoodle-ai/wonton v0.0.36
 )
 

--- a/demos/noodleville/go.mod
+++ b/demos/noodleville/go.mod
@@ -3,7 +3,7 @@ module github.com/deepnoodle-ai/dive/demos/noodleville
 go 1.25.0
 
 require (
-	github.com/deepnoodle-ai/dive v1.14.0
+	github.com/deepnoodle-ai/dive v1.15.0
 	github.com/deepnoodle-ai/wonton v0.0.36
 )
 

--- a/examples/go.mod
+++ b/examples/go.mod
@@ -3,13 +3,13 @@ module github.com/deepnoodle-ai/dive/examples
 go 1.25.0
 
 require (
-	github.com/deepnoodle-ai/dive v1.14.0
-	github.com/deepnoodle-ai/dive/a2a v1.14.0
-	github.com/deepnoodle-ai/dive/experimental/mcp v1.14.0
-	github.com/deepnoodle-ai/dive/otel v1.14.0
-	github.com/deepnoodle-ai/dive/providers/google v1.14.0
-	github.com/deepnoodle-ai/dive/providers/grok v1.14.0
-	github.com/deepnoodle-ai/dive/providers/openai v1.14.0
+	github.com/deepnoodle-ai/dive v1.15.0
+	github.com/deepnoodle-ai/dive/a2a v1.15.0
+	github.com/deepnoodle-ai/dive/experimental/mcp v1.15.0
+	github.com/deepnoodle-ai/dive/otel v1.15.0
+	github.com/deepnoodle-ai/dive/providers/google v1.15.0
+	github.com/deepnoodle-ai/dive/providers/grok v1.15.0
+	github.com/deepnoodle-ai/dive/providers/openai v1.15.0
 	github.com/deepnoodle-ai/wonton v0.0.36
 	github.com/fatih/color v1.18.0
 	github.com/mark3labs/mcp-go v0.45.0

--- a/experimental/cmd/dive/go.mod
+++ b/experimental/cmd/dive/go.mod
@@ -3,10 +3,10 @@ module github.com/deepnoodle-ai/dive/experimental/cmd/dive
 go 1.25.0
 
 require (
-	github.com/deepnoodle-ai/dive v1.14.0
-	github.com/deepnoodle-ai/dive/providers/google v1.14.0
-	github.com/deepnoodle-ai/dive/providers/grok v1.14.0
-	github.com/deepnoodle-ai/dive/providers/openai v1.14.0
+	github.com/deepnoodle-ai/dive v1.15.0
+	github.com/deepnoodle-ai/dive/providers/google v1.15.0
+	github.com/deepnoodle-ai/dive/providers/grok v1.15.0
+	github.com/deepnoodle-ai/dive/providers/openai v1.15.0
 	github.com/deepnoodle-ai/wonton v0.0.36
 	github.com/mattn/go-runewidth v0.0.21
 )

--- a/experimental/mcp/go.mod
+++ b/experimental/mcp/go.mod
@@ -3,7 +3,7 @@ module github.com/deepnoodle-ai/dive/experimental/mcp
 go 1.25.0
 
 require (
-	github.com/deepnoodle-ai/dive v1.14.0
+	github.com/deepnoodle-ai/dive v1.15.0
 	github.com/deepnoodle-ai/wonton v0.0.36
 	github.com/mark3labs/mcp-go v0.45.0
 )

--- a/otel/go.mod
+++ b/otel/go.mod
@@ -3,7 +3,7 @@ module github.com/deepnoodle-ai/dive/otel
 go 1.25.0
 
 require (
-	github.com/deepnoodle-ai/dive v1.14.0
+	github.com/deepnoodle-ai/dive v1.15.0
 	go.opentelemetry.io/otel v1.43.0
 	go.opentelemetry.io/otel/metric v1.43.0
 	go.opentelemetry.io/otel/sdk v1.43.0

--- a/providers/google/go.mod
+++ b/providers/google/go.mod
@@ -3,7 +3,7 @@ module github.com/deepnoodle-ai/dive/providers/google
 go 1.25.0
 
 require (
-	github.com/deepnoodle-ai/dive v1.14.0
+	github.com/deepnoodle-ai/dive v1.15.0
 	github.com/deepnoodle-ai/wonton v0.0.36
 	google.golang.org/genai v1.51.0
 )

--- a/providers/grok/go.mod
+++ b/providers/grok/go.mod
@@ -3,8 +3,8 @@ module github.com/deepnoodle-ai/dive/providers/grok
 go 1.25.0
 
 require (
-	github.com/deepnoodle-ai/dive v1.14.0
-	github.com/deepnoodle-ai/dive/providers/openai v1.14.0
+	github.com/deepnoodle-ai/dive v1.15.0
+	github.com/deepnoodle-ai/dive/providers/openai v1.15.0
 	github.com/deepnoodle-ai/wonton v0.0.36
 	github.com/openai/openai-go/v3 v3.41.2-0.20260709175524-86bbd3d91826
 	golang.org/x/image v0.41.0

--- a/providers/openai/go.mod
+++ b/providers/openai/go.mod
@@ -3,7 +3,7 @@ module github.com/deepnoodle-ai/dive/providers/openai
 go 1.25.0
 
 require (
-	github.com/deepnoodle-ai/dive v1.14.0
+	github.com/deepnoodle-ai/dive v1.15.0
 	github.com/deepnoodle-ai/wonton v0.0.36
 	github.com/openai/openai-go/v3 v3.41.2-0.20260709175524-86bbd3d91826
 	golang.org/x/image v0.41.0


### PR DESCRIPTION
## Summary

Prepares Dive v1.15.0 for release.

- Adds the v1.15.0 changelog entry for dynamic context-injection demos and the failed Read status fix.
- Bumps all internal module references, including demos, from v1.14.0 to v1.15.0.

## Validation

- `go mod tidy` across every module
- `go test ./...` across the root, nested providers, experimental modules, examples, and demos
- `git diff --check`