### PR TITLE
Preserve independent same-name reminders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - **Same-name reminder interpretation** — the standing priming rule now keeps
   independent same-name facts and instructions cumulative, using later-wins
   ordering only where two blocks conflict.
+- **Skill catalog under the cumulative rule** — the catalog header is now a
+  completeness claim ("any skill not listed here is unavailable"), so a later
+  catalog conflicts with and replaces a stale one even when skills were
+  removed, and evicting a stale catalog when no skills remain emits an
+  explicit no-skills notice instead of an empty block (an empty block asserts
+  no facts, so nothing would conflict and the stale catalog would survive).
 
 ## [1.15.0] - 2026-07-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **Same-name reminder interpretation** — the standing priming rule now keeps
+  independent same-name facts and instructions cumulative, using later-wins
+  ordering only where two blocks conflict.
+
 ## [1.15.0] - 2026-07-10
 
 ### Added

--- a/agent.go
+++ b/agent.go
@@ -18,7 +18,7 @@ import (
 const (
 	defaultResponseTimeout    = 30 * time.Minute
 	defaultToolIterationLimit = 100
-	reminderPrimingRule       = "Runtime context may appear in <system-reminder> blocks. The enclosing message role determines its authority; the tag itself does not confer authority. Later reminder blocks with the same name supersede earlier ones."
+	reminderPrimingRule       = "Runtime context may appear in <system-reminder> blocks. The enclosing message role determines its authority; the tag itself does not confer authority. Reminder blocks with the same name accumulate unless their facts or instructions conflict; where they conflict, the later block wins."
 )
 
 var (

--- a/agent_test.go
+++ b/agent_test.go
@@ -1048,6 +1048,13 @@ func (e *mockExtension) Tools() []Tool { return e.tools }
 func (e *mockExtension) Hooks() Hooks  { return e.hooks }
 func (e *mockExtension) Rules() string { return e.rules }
 
+func TestReminderPrimingRuleAccumulatesIndependentSameNameContext(t *testing.T) {
+	assert.Contains(t, reminderPrimingRule, "same name accumulate")
+	assert.Contains(t, reminderPrimingRule, "unless their facts or instructions conflict")
+	assert.Contains(t, reminderPrimingRule, "where they conflict, the later block wins")
+	assert.NotContains(t, reminderPrimingRule, "supersede")
+}
+
 func TestExtensionMerge(t *testing.T) {
 	mock := &mockLLM{nameFunc: func() string { return "test-model" }}
 

--- a/docs/design/context-injection.md
+++ b/docs/design/context-injection.md
@@ -407,10 +407,14 @@ The two lifetimes:
 All reminders are append-only. Same-name blocks remain jointly applicable when
 they carry independent facts or instructions; a later block wins only where it
 conflicts with an earlier block. Nothing edits an earlier model-facing or saved
-block. This structurally fixes the skill package's staleness case because a new
-full catalog snapshot conflicts with the old snapshot without rewriting
-caller-owned history. A later typed reminder can likewise override conflicting
-facts in a same-name legacy text block for model interpretation.
+block. This structurally fixes the skill package's staleness case: the catalog
+header is a completeness claim ("any skill not listed here is unavailable"),
+so a new catalog snapshot conflicts with the old snapshot — including removed
+skills — without rewriting caller-owned history. Snapshot-shaped blocks must
+state completeness in their content this way; a merely additive list never
+conflicts with an earlier one, and absence alone asserts nothing. A later
+typed reminder can likewise override conflicting facts in a same-name legacy
+text block for model interpretation.
 
 ### Ordering
 
@@ -521,9 +525,11 @@ widened to conversation-wide behavior. The new surface is additive:
   permissive to export as-is; the legacy parser matches complete,
   well-formed blocks only.
 
-The skill package appends its catalog model-only. A later full catalog snapshot
-conflicts with and replaces stale legacy catalog facts without rewriting loaded
-history; its public API is untouched.
+The skill package appends its catalog model-only. Its catalog header states
+completeness, so a later catalog snapshot conflicts with and replaces stale
+legacy catalog facts without rewriting loaded history; when no skills remain
+it appends an explicit no-skills notice rather than an empty block, since an
+empty block asserts nothing and cannot conflict. Its public API is untouched.
 
 ## Compaction
 

--- a/docs/design/context-injection.md
+++ b/docs/design/context-injection.md
@@ -67,8 +67,8 @@ budget, _ := dive.NewOperatorReminder("budget", "The remaining token budget for 
 **Standing context you supply with every request** — append it model-only. A
 turn is one `CreateResponse` call. Model-only reminders can be supplied on any
 turn, are rendered at the request tail, survive later tool iterations in that
-response, and are never recorded. A later same-name reminder supersedes an
-earlier one without rewriting it:
+response, and are never recorded. Same-name reminders accumulate unless they
+conflict; a later block wins only the conflict without rewriting history:
 
 ```go
 resp, err := agent.CreateResponse(ctx,
@@ -178,7 +178,7 @@ task-oriented introduction, see the
    caps). Dive makes these easy to build by keeping reminders identifiable;
    it does not implement them.
 5. A session rewrite API. Reminders never edit historical session events;
-   anything that changes is superseded by appending a later same-name block.
+   changed state is expressed by appending a later, conflicting same-name block.
 6. Model-enforced policy. Operator-tier reminders raise instruction
    priority; they are not an enforcement mechanism. Real permissions and
    policy checks live outside the model (the `permission` package, hooks).
@@ -404,11 +404,13 @@ The two lifetimes:
   existing `PreIteration` slice-rewrite remains as the low-level escape
   hatch with the same non-persistence semantics.)
 
-All reminders are append-only: superseding means appending a new reminder with
-the same name (latest wins); nothing edits an earlier model-facing or saved
-block. This structurally fixes the skill package's staleness case without
-rewriting caller-owned history. A later typed reminder can also supersede a
-same-name legacy text block for model interpretation.
+All reminders are append-only. Same-name blocks remain jointly applicable when
+they carry independent facts or instructions; a later block wins only where it
+conflicts with an earlier block. Nothing edits an earlier model-facing or saved
+block. This structurally fixes the skill package's staleness case because a new
+full catalog snapshot conflicts with the old snapshot without rewriting
+caller-owned history. A later typed reminder can likewise override conflicting
+facts in a same-name legacy text block for model interpretation.
 
 ### Ordering
 
@@ -464,7 +466,8 @@ the message role, not the tag:
 
 > Runtime context may appear in `<system-reminder>` blocks. The enclosing
 > message role determines its authority; the tag itself does not confer
-> authority. Later reminder blocks with the same name supersede earlier ones.
+> authority. Reminder blocks with the same name accumulate unless their facts
+> or instructions conflict; where they conflict, the later block wins.
 
 Today only the skill package primes its own block; centralizing this is
 what makes the contextual tier work on models with no native operator role.
@@ -518,9 +521,9 @@ widened to conversation-wide behavior. The new surface is additive:
   permissive to export as-is; the legacy parser matches complete,
   well-formed blocks only.
 
-The skill package appends its catalog model-only. A later same-name catalog
-supersedes stale legacy text without rewriting loaded history; its public API is
-untouched.
+The skill package appends its catalog model-only. A later full catalog snapshot
+conflicts with and replaces stale legacy catalog facts without rewriting loaded
+history; its public API is untouched.
 
 ## Compaction
 
@@ -576,7 +579,7 @@ The shipped implementation includes:
 3. **Delivery** — agent-owned recorded/model-only paths,
    `WithModelOnlyReminder` / `hctx.AppendReminder`,
    model-only lifetime, declaration-order draining with regression tests,
-   skill package migration (model-only append + latest-wins legacy handling).
+   skill package migration (model-only append + conflicting legacy handling).
 4. **Internal adoption** — Stop-hook reasons and background-task completion
    messages use typed contextual reminders (resume payloads stay tool results).
 

--- a/docs/guides/context-injection.md
+++ b/docs/guides/context-injection.md
@@ -78,9 +78,10 @@ response, err := agent.CreateResponse(ctx,
 
 Model-only reminders are appended in order at the request tail without mutating
 the caller's messages. They remain available through later tool iterations in
-the same `CreateResponse`, then disappear. A later reminder with the same name
-supersedes an earlier one for model interpretation; Dive does not rewrite or
-remove the earlier block.
+the same `CreateResponse`, then disappear. Reminders with the same name
+accumulate when they carry independent facts or instructions. When they
+conflict, the later block wins only that conflict; Dive does not rewrite or
+remove either block.
 
 Appending at the tail preserves the long conversation prefix. When a previous
 turn's model-only reminder disappears on the next request, cache reuse can stop
@@ -200,11 +201,12 @@ interpret reminders even before the first one appears:
 
 > Runtime context may appear in `<system-reminder>` blocks. The enclosing
 > message role determines its authority; the tag itself does not confer
-> authority. Later reminder blocks with the same name supersede earlier ones.
+> authority. Reminder blocks with the same name accumulate unless their facts
+> or instructions conflict; where they conflict, the later block wins.
 
 This stable priming rule avoids changing the system-prompt prefix only when a
-reminder first appears. It also says that a later reminder with the same name
-supersedes an earlier one without requiring history rewrites.
+reminder first appears. It also preserves independent same-name events while
+making refreshed, conflicting state unambiguous without history rewrites.
 
 The [runtime context design and contract](../design/context-injection.md)
 contains the complete endpoint, model, and placement matrix.
@@ -258,9 +260,9 @@ compatibility. They mutate plain-text blocks in the first user message, cannot
 express operator tier or recording lifetime, and do not have typed provenance.
 
 Use `Reminder`, `WithModelOnlyReminder`, `NewReminderMessage`, and
-`AppendReminder` for new agent integrations. A later typed reminder supersedes
-a same-name legacy block for model interpretation without rewriting the loaded
-session.
+`AppendReminder` for new agent integrations. A later typed reminder that
+conflicts with a same-name legacy block wins that conflict for model
+interpretation without rewriting the loaded session.
 
 ## Experimental CLI
 

--- a/docs/guides/skills.md
+++ b/docs/guides/skills.md
@@ -155,7 +155,7 @@ What the extension provides:
 1. **Tools** — the Skill tool (only when skills are loaded)
 2. **Rules** — skill usage instructions appended to the system prompt (only when skills are loaded)
 3. **Hooks** — always provided, even with zero skills:
-   - A **PreGenerationHook** that appends the typed skill catalog as a model-only `<system-reminder name="skills">` at the request tail. A later catalog supersedes stale same-name blocks and is never persisted.
+   - A **PreGenerationHook** that appends the typed skill catalog as a model-only `<system-reminder name="skills">` at the request tail. A later full catalog conflicts with stale same-name catalog facts and is never persisted.
    - A **PostToolUseHook** that injects expanded skill instructions as `AdditionalContext` on the tool result message, keyed by tool call ID for correct association under parallel execution
 
 ### Three-Layer Architecture
@@ -181,8 +181,9 @@ Dive's skill integration follows Claude Code's three-layer architecture:
 The key insight: the skill catalog is created with `dive.NewContextReminder`
 and appended with `hctx.AppendReminder(..., dive.ModelOnly)`, not repeated in
 the tool description on every LLM request. The model sees it at the **request
-tail**. A later same-name catalog supersedes stale history without mutating or
-persisting loaded messages, while leaving the preceding conversation cacheable.
+tail**. A later full catalog conflicts with stale catalog history and wins those
+conflicts without mutating or persisting loaded messages, while leaving the
+preceding conversation cacheable.
 
 ### Catalog Injection
 
@@ -249,8 +250,8 @@ All toolkit tools accept a `Validator` field that takes precedence over `Workspa
 
 The catalog hook handles session resume correctly:
 
-- On a fresh process resuming a session, a later typed catalog supersedes a stale legacy catalog block without rewriting stored history
-- If no skills remain, an empty same-name model-only reminder supersedes the legacy block for model interpretation
+- On a fresh process resuming a session, a later typed full catalog conflicts with and replaces stale legacy catalog facts without rewriting stored history
+- If no skills remain, an empty same-name model-only reminder conflicts with the non-empty legacy catalog for model interpretation
 - Hooks are always returned by the extension (even with zero skills) specifically to handle this cleanup
 
 ## Provider System

--- a/docs/guides/skills.md
+++ b/docs/guides/skills.md
@@ -155,7 +155,7 @@ What the extension provides:
 1. **Tools** — the Skill tool (only when skills are loaded)
 2. **Rules** — skill usage instructions appended to the system prompt (only when skills are loaded)
 3. **Hooks** — always provided, even with zero skills:
-   - A **PreGenerationHook** that appends the typed skill catalog as a model-only `<system-reminder name="skills">` at the request tail. A later full catalog conflicts with stale same-name catalog facts and is never persisted.
+   - A **PreGenerationHook** that appends the typed skill catalog as a model-only `<system-reminder name="skills">` at the request tail. The catalog header is a completeness claim ("any skill not listed here is unavailable"), so a later catalog conflicts with stale same-name catalog facts — including removed skills — and is never persisted.
    - A **PostToolUseHook** that injects expanded skill instructions as `AdditionalContext` on the tool result message, keyed by tool call ID for correct association under parallel execution
 
 ### Three-Layer Architecture
@@ -181,9 +181,11 @@ Dive's skill integration follows Claude Code's three-layer architecture:
 The key insight: the skill catalog is created with `dive.NewContextReminder`
 and appended with `hctx.AppendReminder(..., dive.ModelOnly)`, not repeated in
 the tool description on every LLM request. The model sees it at the **request
-tail**. A later full catalog conflicts with stale catalog history and wins those
-conflicts without mutating or persisting loaded messages, while leaving the
-preceding conversation cacheable.
+tail**. Because the catalog is a completeness claim, a later catalog conflicts
+with stale catalog history and wins those conflicts without mutating or
+persisting loaded messages, while leaving the preceding conversation cacheable.
+Same-name reminder blocks otherwise accumulate; a merely additive list would
+never conflict with an earlier one, and removed skills would linger.
 
 ### Catalog Injection
 
@@ -191,7 +193,7 @@ The catalog is injected at the request tail as a named `<system-reminder>` block
 
 ```xml
 <system-reminder name="skills">
-The following skills are available for use with the Skill tool:
+Complete list of skills available for use with the Skill tool; any skill not listed here is unavailable:
 
 - code-reviewer: Review code for best practices and potential issues.
   Location: /home/user/.dive/skills/code-reviewer/SKILL.md
@@ -250,8 +252,9 @@ All toolkit tools accept a `Validator` field that takes precedence over `Workspa
 
 The catalog hook handles session resume correctly:
 
-- On a fresh process resuming a session, a later typed full catalog conflicts with and replaces stale legacy catalog facts without rewriting stored history
-- If no skills remain, an empty same-name model-only reminder conflicts with the non-empty legacy catalog for model interpretation
+- On a fresh process resuming a session, a later typed full catalog conflicts with and replaces stale legacy catalog facts without rewriting stored history — the header's completeness claim is what makes the whole stale catalog conflict, not just skills whose descriptions changed
+- If no skills remain, an explicit no-skills notice ("No skills are available via the Skill tool; any skill listed earlier is no longer available.") conflicts with the non-empty legacy catalog for model interpretation. An empty block would not: it asserts no facts, so under the accumulate-unless-conflict rule it would coexist with the stale catalog instead of replacing it
+- The notice is only appended when loaded history actually contains a stale catalog; a skill-less agent with clean history gets no `skills` reminder at all
 - Hooks are always returned by the extension (even with zero skills) specifically to handle this cleanup
 
 ## Provider System

--- a/docs/plans/plan-02-skills.md
+++ b/docs/plans/plan-02-skills.md
@@ -32,7 +32,7 @@ Aligned with Claude Code's architecture based on direct investigation:
 ### Three Layers
 
 1. **Rules** — skill usage instructions appended to system prompt by `ConfigureAgent`
-2. **Catalog** — skill names/descriptions/triggers created as a typed contextual reminder and appended at the request tail via `hctx.AppendReminder(..., dive.ModelOnly)`. A later same-name block supersedes stale history without rewriting it.
+2. **Catalog** — skill names/descriptions/triggers created as a typed contextual reminder and appended at the request tail via `hctx.AppendReminder(..., dive.ModelOnly)`. A later full catalog wins conflicts with stale catalog history without rewriting it.
 3. **Tool** — trigger mechanism. Returns `"Launching skill: X"`. Full content delivered via PostToolUseHook as `AdditionalContext` on the tool result message, keyed by tool call ID for parallel safety.
 
 ### What Was Built
@@ -51,12 +51,12 @@ Aligned with Claude Code's architecture based on direct investigation:
 - **`skill.ConfigureAgent(&opts, loader)`** avoids circular import (skill→dive, not dive→skill). Follows the same one-call pattern as `AgentOptions.Session`.
 - **Hooks always installed** — even with zero skills, hooks are registered so that stale catalog blocks from a previous session can be cleaned up on resume.
 - **Request tail** for catalog — appending does not rewrite the first user message as the conversation grows, so the long session prefix remains cacheable.
-- **Typed model-only reminder** — the catalog hook uses `NewContextReminder` plus `hctx.AppendReminder(..., dive.ModelOnly)`. A later same-name block supersedes older values, does not mutate loaded messages, and is not persisted.
+- **Typed model-only reminder** — the catalog hook uses `NewContextReminder` plus `hctx.AppendReminder(..., dive.ModelOnly)`. A later full snapshot wins conflicts with older catalog values, does not mutate loaded messages, and is not persisted.
 - **Per-call-ID content association** — `tool.Call()` reads `dive.ToolCallID(ctx)` to key pending instructions; the PostToolUse hook reads `hctx.Call.ID` to retrieve the correct content. This is safe under parallel tool execution where results arrive out of order.
 - **No tool restrictions** — `allowed-tools` is parsed as metadata but not enforced at runtime. Simplifies the implementation and avoids the complexity of skill activation/deactivation lifecycle.
 - **No HTTP provider** — removed due to security implications (remote code could exploit shell expansion). The `Provider` interface remains extensible for custom backends.
 - **Shell expansion gated by `IsLocal()`** — only skills with `file://` or empty `SourceURI` can have `!{command}` expanded, regardless of global config.
-- **Session resume** — catalog hook detects legacy `<system-reminder name="skills">` blocks and appends a same-name typed reminder so stale text is superseded without rewriting history.
+- **Session resume** — catalog hook detects legacy `<system-reminder name="skills">` blocks and appends a same-name typed full snapshot so stale catalog conflicts resolve without rewriting history.
 - **Base directory** included in skill content so the agent can resolve relative paths to reference files within the skill directory.
 - **File path in catalog** — each catalog entry includes `Location:` so the agent can answer "where is this skill?" without guessing.
 - **Symlink resolution** — filesystem provider resolves symlinked skill directories, so `~/.claude/skills/` entries that are symlinks are discovered correctly.

--- a/docs/plans/plan-07-context-injection-demos.md
+++ b/docs/plans/plan-07-context-injection-demos.md
@@ -14,7 +14,7 @@ Last Updated: 2026-07-10
 Before this work, Dive's experimental CLI demonstrated static model-only context and
 one-time operator reminders through `--context` and `--operator-reminder`. Those
 flags proved the wire format, but they did not show why typed reminders are
-useful in an agent loop: context can be superseded as reality changes, derived
+useful in an agent loop: conflicting context can be refreshed as reality changes, derived
 from tool use, scoped to one response, and assigned contextual or operator
 authority. We wanted a small set of opt-in demos that make those properties
 visible without turning advisory reminders into permission or policy
@@ -40,7 +40,7 @@ The divergent pass produced twelve candidates before evaluation:
 These clustered into live state (1, 5, 6, 10, 11), evidence and continuity
 (2, 7, 12), and tool-loop guidance (3, 4, 8, 9). The initial four had high
 day-to-day value, need no external service or additional user configuration,
-and collectively demonstrate latest-wins reminders, accumulated context,
+and collectively demonstrate later-wins conflict resolution, accumulated context,
 late-arriving operator events, model-only recording, and failure hooks. The
 remaining ideas are useful follow-ups but either need a richer contract or
 overlap with the selected patterns.

--- a/docs/plans/plan-08-reminder-delivery-simplification.md
+++ b/docs/plans/plan-08-reminder-delivery-simplification.md
@@ -117,8 +117,9 @@ new recorded or model-only reminders
   existing tagged-user fallback elsewhere.
 
 Dive does not replace or remove an earlier same-name reminder. The standing
-priming rule says that later same-name blocks supersede earlier ones, preserving
-append-only history while making refreshed state unambiguous.
+priming rule says same-name blocks accumulate unless their facts or instructions
+conflict; a later block wins only the conflict. This preserves append-only
+events while making refreshed state unambiguous.
 
 ### Prompt caching
 
@@ -130,10 +131,10 @@ the old behavior where changing live state rewrote the first user message.
 
 ### Legacy sessions
 
-A newly appended typed reminder can supersede a same-name legacy plain-text
-block for model interpretation. Dive leaves caller-owned and stored messages
-unchanged. Typed inspection helpers continue to distinguish genuine reminder
-content from legacy text and user-authored lookalikes.
+A newly appended typed reminder can override conflicting facts in a same-name
+legacy plain-text block for model interpretation. Dive leaves caller-owned and
+stored messages unchanged. Typed inspection helpers continue to distinguish
+genuine reminder content from legacy text and user-authored lookalikes.
 
 ## CLI and built-in adoption
 
@@ -161,7 +162,7 @@ actually achieve the requested two-lifetime model.
 
 Rejected because replacement would recreate a hidden third behavior and make
 “append” misleading. Demos instead skip unchanged payloads, while changed
-values append chronologically and rely on latest-wins interpretation.
+values append chronologically and rely on later-wins conflict resolution.
 
 ### Use only recorded reminders
 
@@ -172,8 +173,9 @@ should not automatically become conversation history.
 
 - Repeated changed values within one long response consume context until that
   response ends. Demos suppress identical repeats to bound the common case.
-- Recorded same-name reminders remain visible in history; the model relies on
-  the latest-wins rule rather than historical rewriting.
+- Recorded same-name reminders remain visible in history; the model keeps
+  independent context and uses later-wins only for conflicts rather than
+  historical rewriting.
 - The direct request API is intentionally asymmetric:
   `WithModelOnlyReminder` is needed for non-recorded context, while recorded
   input already has the ordinary `NewReminderMessage` path.

--- a/docs/prds/prd-02-skills.md
+++ b/docs/prds/prd-02-skills.md
@@ -113,7 +113,7 @@ agent, _ := dive.NewAgent(opts)
 1. **Always registers hooks** — even with zero skills. This ensures stale catalog blocks from a previous session can be cleaned up on resume.
 2. **Registers the Skill tool** (only when skills are loaded) — static description, no skill listing. The tool is a trigger: returns `"Launching skill: X"` and stores expanded instructions keyed by tool call ID for the PostToolUse hook.
 3. **Appends skill usage rules** to the system prompt (only when skills are loaded).
-4. **Registers a PreGenerationHook** that creates the skill catalog with `dive.NewContextReminder` and appends it with `hctx.AppendReminder(..., dive.ModelOnly)`. The typed block appears at the request tail, supersedes stale same-name blocks, and is not persisted.
+4. **Registers a PreGenerationHook** that creates the skill catalog with `dive.NewContextReminder` and appends it with `hctx.AppendReminder(..., dive.ModelOnly)`. The typed block appears at the request tail, conflicts with stale same-name catalog facts, and is not persisted.
 5. **Registers a PostToolUseHook** that reads `hctx.Call.ID` to retrieve the correct expanded instructions from the per-call-ID map and sets them as `hctx.AdditionalContext`. Safe under parallel tool execution.
 
 ### The Skill Tool (Trigger)
@@ -247,7 +247,7 @@ Promoted `experimental/skill/` to `skill/` with:
 3. **`skill/agent.go`** — `ConfigureAgent` wires tool, PreGenerationHook (catalog), PostToolUseHook (skill content)
 4. **`reminder.go` and `llm/reminder.go`** — typed reminder construction, recorded/model-only lifetimes, and provider-edge rendering (`system_reminder.go` remains the legacy text compatibility layer)
 5. **`context.go`** — `dive.WithToolCallID/ToolCallID` for tool call ID propagation via context
-6. **Catalog injection** — typed model-only `<system-reminder name="skills">` at the request tail, with later same-name blocks superseding stale legacy values on resume
+6. **Catalog injection** — typed model-only `<system-reminder name="skills">` at the request tail, with a later full snapshot winning conflicts with stale legacy catalog values on resume
 7. **Skill content injection** — PostToolUseHook sets `AdditionalContext` with expanded instructions + base directory, keyed by call ID
 8. **CLI updated** to use `skill.ConfigureAgent`
 
@@ -259,7 +259,7 @@ Promoted `experimental/skill/` to `skill/` with:
 
 ## Open Questions
 
-1. ~~**Should the catalog be injected on every generation or only the first?**~~ **Resolved.** The PreGeneration hook appends the typed catalog model-only on each `CreateResponse`. Dive places it at the request tail and does not persist it. On resume, the later same-name reminder supersedes stale legacy text for model interpretation.
+1. ~~**Should the catalog be injected on every generation or only the first?**~~ **Resolved.** The PreGeneration hook appends the typed catalog model-only on each `CreateResponse`. Dive places it at the request tail and does not persist it. On resume, the later full snapshot wins conflicts with stale same-name legacy catalog text for model interpretation.
 
 2. **Should command expansion timeout be configurable?** The 10-second default for `!{command}` may be too short for some use cases (e.g., `!{go test ./...}`). Recommendation: make it configurable via `ExpandOptions` with a sensible default. Currently configurable via `WithShellTimeout`.
 

--- a/docs/prds/prd-02-skills.md
+++ b/docs/prds/prd-02-skills.md
@@ -131,7 +131,7 @@ Built by `skill.BuildCatalog(loader)` and appended model-only at the request tai
 
 ```xml
 <system-reminder name="skills">
-The following skills are available for use with the Skill tool:
+Complete list of skills available for use with the Skill tool; any skill not listed here is unavailable:
 
 - code-reviewer: Review code for best practices and potential issues.
   Location: /home/user/.dive/skills/code-reviewer/SKILL.md

--- a/skill/agent.go
+++ b/skill/agent.go
@@ -24,9 +24,9 @@ func (l *Loader) Tools() []dive.Tool {
 }
 
 // Hooks returns the catalog injection and skill content hooks.
-// Hooks are always returned even when no skills are loaded so an empty catalog
-// can conflict with and replace a stale legacy catalog from an older session.
-// Implements dive.Extension.
+// Hooks are always returned even when no skills are loaded so a stale legacy
+// catalog from an older session can be evicted with an explicit no-skills
+// notice. Implements dive.Extension.
 func (l *Loader) Hooks() dive.Hooks {
 	return dive.Hooks{
 		PreGeneration: []dive.PreGenerationHook{catalogHook(l)},
@@ -125,17 +125,26 @@ func skillContentHook(loader *Loader) dive.PostToolUseHook {
 // skillReminderName is the system-reminder block name for the skill catalog.
 const skillReminderName = "skills"
 
+// emptyCatalogNotice evicts a stale catalog when no skills remain. Absence
+// must be stated as a fact: under the accumulate-unless-conflict priming rule
+// an empty block asserts nothing, so it would coexist with a stale catalog
+// instead of conflicting with and replacing it.
+const emptyCatalogNotice = "No skills are available via the Skill tool; any skill listed earlier is no longer available."
+
 // catalogHook returns a PreGenerationHook that appends the skill catalog as a
 // model-only <system-reminder> block at the request tail.
 func catalogHook(loader *Loader) dive.PreGenerationHook {
 	return func(_ context.Context, hctx *dive.HookContext) error {
 		catalog := BuildCatalog(loader)
-		// A fresh empty catalog has nothing to inject. Append an empty reminder
-		// only when loaded history contains a stale catalog; the new full snapshot
-		// conflicts with that old snapshot and replaces it for interpretation
-		// without mutating persisted messages.
-		if catalog == "" && !dive.HasSystemReminder(hctx.Messages, skillReminderName) {
-			return nil
+		// A fresh empty catalog has nothing to inject unless loaded history
+		// contains a stale catalog. That stale snapshot is evicted with an
+		// explicit no-skills sentence whose facts conflict with it, without
+		// mutating persisted messages.
+		if catalog == "" {
+			if !dive.HasSystemReminder(hctx.Messages, skillReminderName) {
+				return nil
+			}
+			catalog = emptyCatalogNotice
 		}
 		reminder, err := dive.NewContextReminder(skillReminderName, catalog)
 		if err != nil {

--- a/skill/agent.go
+++ b/skill/agent.go
@@ -25,7 +25,7 @@ func (l *Loader) Tools() []dive.Tool {
 
 // Hooks returns the catalog injection and skill content hooks.
 // Hooks are always returned even when no skills are loaded so an empty catalog
-// can supersede a stale legacy block from an older session.
+// can conflict with and replace a stale legacy catalog from an older session.
 // Implements dive.Extension.
 func (l *Loader) Hooks() dive.Hooks {
 	return dive.Hooks{
@@ -131,8 +131,9 @@ func catalogHook(loader *Loader) dive.PreGenerationHook {
 	return func(_ context.Context, hctx *dive.HookContext) error {
 		catalog := BuildCatalog(loader)
 		// A fresh empty catalog has nothing to inject. Append an empty reminder
-		// only when loaded history contains a stale catalog so latest-wins
-		// semantics supersede it without mutating persisted messages.
+		// only when loaded history contains a stale catalog; the new full snapshot
+		// conflicts with that old snapshot and replaces it for interpretation
+		// without mutating persisted messages.
 		if catalog == "" && !dive.HasSystemReminder(hctx.Messages, skillReminderName) {
 			return nil
 		}

--- a/skill/agent_test.go
+++ b/skill/agent_test.go
@@ -417,7 +417,7 @@ func TestCatalogHook_SkipsFreshEmptyCatalog(t *testing.T) {
 	assert.False(t, ok)
 }
 
-func TestCatalogHook_QueuesEmptyValueForStaleCatalog(t *testing.T) {
+func TestCatalogHook_QueuesNoSkillsNoticeForStaleCatalog(t *testing.T) {
 	// Simulate: skills were available in a previous process, which wrote
 	// a catalog block. Now skills are gone and a fresh process resumes
 	// the session with that block still in history.
@@ -431,12 +431,12 @@ func TestCatalogHook_QueuesEmptyValueForStaleCatalog(t *testing.T) {
 	hook := catalogHook(loader)
 	hctx := &dive.HookContext{Messages: []*llm.Message{existingMsg}}
 
-	// The hook queues an empty latest value without mutating the stale block.
+	// The hook queues the no-skills notice without mutating the stale block.
 	assert.NoError(t, hook(context.Background(), hctx))
 	assert.True(t, dive.HasSystemReminder(hctx.Messages, "skills"), "hook must not mutate loaded history")
 }
 
-func TestCatalogHook_QueuesEmptyValueAfterReload(t *testing.T) {
+func TestCatalogHook_NoNoticeAfterReloadWithoutPersistedCatalog(t *testing.T) {
 	loader := &Loader{
 		skills: map[string]*Skill{
 			"reviewer": {
@@ -460,7 +460,8 @@ func TestCatalogHook_QueuesEmptyValueAfterReload(t *testing.T) {
 	loader.skills = map[string]*Skill{}
 	loader.mu.Unlock()
 
-	// Next generation — queues an empty latest value without rewriting history.
+	// Next generation — the earlier catalog was model-only and never
+	// persisted, so history holds nothing stale and nothing is queued.
 	hctx2 := &dive.HookContext{Messages: []*llm.Message{firstMsg}}
 	assert.NoError(t, hook(context.Background(), hctx2))
 	assert.False(t, dive.HasSystemReminder(hctx2.Messages, "skills"))
@@ -521,7 +522,7 @@ func TestCatalogHook_AgentOwnedModelOnlyReminder(t *testing.T) {
 	assert.Contains(t, reminder.Content, "deploy: Deploy.")
 }
 
-func TestCatalogHook_SupersedesLegacyCatalogWhenEmpty(t *testing.T) {
+func TestCatalogHook_EvictsStaleLegacyCatalogWhenEmpty(t *testing.T) {
 	loader := &Loader{skills: map[string]*Skill{}}
 	model := &catalogCaptureLLM{}
 	agent, err := dive.NewAgent(dive.AgentOptions{Model: model, Extensions: []dive.Extension{loader}})
@@ -534,8 +535,20 @@ func TestCatalogHook_SupersedesLegacyCatalogWhenEmpty(t *testing.T) {
 	assert.True(t, dive.HasSystemReminder(model.messages, "skills"), "recorded history remains append-only")
 	reminder, ok := dive.FindLatestReminder(model.messages, "skills")
 	assert.True(t, ok)
-	assert.Equal(t, "", reminder.Content)
+	assert.Equal(t, emptyCatalogNotice, reminder.Content,
+		"eviction must state absence as a fact; an empty block asserts nothing and cannot conflict")
 	assert.True(t, dive.HasSystemReminder([]*llm.Message{legacy}, "skills"), "loaded history must remain unchanged")
+}
+
+func TestCatalogHook_NoReminderWithoutSkillsOrStaleCatalog(t *testing.T) {
+	loader := &Loader{skills: map[string]*Skill{}}
+	model := &catalogCaptureLLM{}
+	agent, err := dive.NewAgent(dive.AgentOptions{Model: model, Extensions: []dive.Extension{loader}})
+	assert.NoError(t, err)
+	_, err = agent.CreateResponse(context.Background(), dive.WithInput("Continue"))
+	assert.NoError(t, err)
+	assert.False(t, dive.HasSystemReminder(model.messages, "skills"),
+		"a skill-less agent with clean history must not pay for a no-skills block")
 }
 
 // TestCatalogHook_ConcurrentCreateResponse exercises catalog reads and writes

--- a/skill/catalog.go
+++ b/skill/catalog.go
@@ -21,7 +21,10 @@ func BuildCatalog(loader *Loader) string {
 	}
 
 	var sb strings.Builder
-	sb.WriteString("The following skills are available for use with the Skill tool:\n\n")
+	// The header is a completeness claim, not an additive one, so a later
+	// catalog's facts conflict with any earlier catalog's — including skills
+	// that were removed — and the priming rule resolves to the later block.
+	sb.WriteString("Complete list of skills available for use with the Skill tool; any skill not listed here is unavailable:\n\n")
 
 	for _, s := range skills {
 		fmt.Fprintf(&sb, "- %s: %s\n", s.Name, s.Description)

--- a/skill/catalog_test.go
+++ b/skill/catalog_test.go
@@ -35,7 +35,8 @@ func TestBuildCatalog(t *testing.T) {
 
 	catalog := BuildCatalog(loader)
 
-	assert.Contains(t, catalog, "The following skills are available")
+	assert.Contains(t, catalog, "Complete list of skills available")
+	assert.Contains(t, catalog, "any skill not listed here is unavailable")
 	assert.Contains(t, catalog, "reviewer: Review code for issues.")
 	assert.Contains(t, catalog, "deploy: Deploy to an environment.")
 	assert.Contains(t, catalog, "Location: /home/user/.dive/skills/reviewer/SKILL.md")


### PR DESCRIPTION
## Summary

- change Dive reminder priming so independent same-name facts and instructions accumulate
- resolve only actual conflicts with later-wins ordering
- align the runtime-context design, guides, plans, skill catalog wording, and changelog with the contract
- pin the priming sentence with a focused regression test

This unblocks Mobius recorded `memory-index` deltas and independent `user-nudge` events from adopting Dive v1.15 without telling the model to discard earlier same-name context.

## Verification

- `go test ./...`
- `go vet ./...`
- `go test ./...` in the Google, Grok, and OpenAI provider modules
- `go test ./...` in `experimental/cmd/dive`
- live OpenAI developer-item reminder check
- live Anthropic native-system reminder check
