### PR TITLE
Retry transient streaming failures across providers

### DIFF
--- a/docs/plans/plan-09-streaming-generation-retries.md
+++ b/docs/plans/plan-09-streaming-generation-retries.md
@@ -1,0 +1,407 @@
+---
+Title: Retry transient streaming generation failures before first event
+Author: Curtis Myzie
+Status: Implemented
+Last Updated: 2026-07-15
+---
+
+# Retry transient streaming generation failures before first event
+
+**Workflow:** Standard-tier spec, Dive team feedback, then implementation.
+
+## Context
+
+Mobius runs each agent turn through one Dive `CreateResponse` call. A single
+turn can therefore contain several model generations separated by tool calls:
+the model requests tools, Dive executes them and appends their results, and the
+next model generation continues from those results.
+
+On 2026-07-14, an Omni production turn using Grok 4.5 completed several
+side-effecting tools and then failed on a later model generation with:
+
+```text
+POST "https://api.x.ai/v1/responses": 429 Too Many Requests
+"The service is temporarily at capacity. Please retry your request shortly."
+```
+
+The Mobius transcript proves that the earlier document operations, six memory
+writes, two artifact writes, and their tool results were already durable before
+the 429. Dive returned the generation error, so Mobius correctly settled the
+turn as terminally failed. Reusing the turn's idempotency key returns that same
+failed turn; starting a new turn asks the model to reconstruct the work and can
+repeat completed external effects.
+
+This happened at least three times in the Omni development project that day.
+The clearest incident was turn `turn_01kxgqawxhfz19sycn88a3mxcs`, which ran for
+63.6 seconds before the capacity error. A second turn failed with the same 429
+after 30.9 seconds.
+
+The important terminology distinction is:
+
+- **Mid-turn:** the failure occurred in a later model iteration after earlier
+  tools had completed.
+- **Not necessarily mid-stream:** the failing provider request did not produce
+  a usable response before returning the capacity error.
+
+Retrying that one provider request inside the existing `CreateResponse` call is
+safe. Retrying the whole agent turn is not.
+
+```mermaid
+sequenceDiagram
+    participant A as Dive agent loop
+    participant P as Grok / OpenAI Responses
+    participant T as Side-effecting tool
+
+    A->>P: Generation iteration 1
+    P-->>A: Tool call
+    A->>T: Execute once
+    T-->>A: Completed tool result
+    A->>P: Generation iteration 2, attempt 1
+    P-->>A: 429 before first stream event
+    A->>P: Generation iteration 2, attempt 2
+    P-->>A: Successful response
+    Note over A,T: Prior tool is not executed again
+```
+
+## Current behavior and root cause
+
+`Agent.generate` chooses `generateStreaming` for every `llm.StreamingLLM`.
+That method consumes the iterator returned by the provider, publishes events,
+and returns the iterator's final error. It intentionally does not know about
+provider status codes or transport retry policy.
+
+Before this change, streaming retries were inconsistent across the four
+provider implementations and their adapters:
+
+- OpenAI Responses and Google use lazy SDK iterators. Request failures can
+  surface from the iterator only after `Stream` returns, so neither path had a
+  provider retry boundary around a pre-event failure.
+- Anthropic and OpenAI-compatible Chat Completions retried errors from the
+  initial HTTP request, but stopped retrying once a `200 OK` body had been
+  returned. A body read or parse failure before the first event therefore
+  bypassed the same retry budget.
+- Grok, Mistral, Ollama, and OpenRouter embed one of those providers. Their
+  behavior depended on the embedded implementation, and most did not expose a
+  provider-local `WithMaxRetries` option.
+
+The result was an accidental contract mismatch: the same transient failure
+could be retried or returned immediately based on provider family and on
+whether it happened during HTTP setup or during the first iterator read.
+
+## Goals
+
+- Apply one pre-first-event retry contract to every Dive streaming provider:
+  Anthropic, Google, OpenAI Responses, OpenAI-compatible Chat Completions,
+  Grok, Mistral, Ollama, and OpenRouter.
+- Use the existing `WithMaxRetries` budget and transient/permanent error
+  classification: 429, 500, 502, 503, 504, 520, 529, and transport failures
+  are retryable; invalid requests and authentication failures are not.
+- Share one retry budget across stream creation and lazy iterator failures.
+- Preserve all messages and completed tool results from earlier iterations in
+  the same `CreateResponse` call.
+- Never re-execute a tool merely because the following model generation was
+  retried.
+- Emit at most one visible stream for the successful attempt.
+- Respect context cancellation and deadlines during requests and backoff.
+- Keep the underlying OpenAI SDK retry count at zero so retry budgets do not
+  multiply.
+
+## Non-goals
+
+- Restart or resurrect a `CreateResponse` call after it has returned an error.
+- Resume a terminal Mobius turn.
+- Recover an agent turn across a process crash.
+- Retry a provider stream after any event has been emitted to the consumer.
+- Reconcile or retract partial text, reasoning, or tool-call deltas.
+- Retry the complete agent loop or replay already-completed tools.
+- Change non-streaming retry behavior.
+
+## Proposal
+
+Add a shared provider-layer iterator decorator in the root `providers`
+package. Each concrete provider builds the logical request and fires hooks
+once, then supplies a factory that creates one fresh transport stream attempt.
+
+The first call to the returned iterator's `Next()` owns the retry boundary:
+
+1. Call the factory and ask the resulting provider iterator for its first
+   event.
+2. If an event is returned, mark the stream **committed** and expose it.
+3. If stream creation fails, or the iterator stops with a transient error
+   before an event, close the failed attempt, back off, and call the factory
+   again.
+4. Charge creation errors and iterator errors to the same `maxRetries + 1`
+   attempt budget.
+5. If the error is permanent, the context is cancelled, or the retry budget is
+   exhausted, expose the final normalized error through `Err()`.
+6. Once committed, delegate subsequent iteration directly. Any later error is
+   returned without retry.
+
+The commit point must be **the first event of any kind**, not merely the first
+content-bearing delta. `response.created` becomes a Dive `message_start` event
+and may already have reached callbacks or UI state. Retrying after that point
+could expose two response IDs or duplicate lifecycle events even if no text was
+generated.
+
+The shared boundary has this shape:
+
+```go
+type StreamFactory func() (llm.StreamIterator, error)
+
+type StreamRetryConfig struct {
+    Provider       string
+    MaxRetries     int
+    RetryBaseWait  time.Duration
+    Logger         llm.Logger
+    NormalizeError func(error) error
+}
+
+func NewRetryingStreamIterator(
+    ctx context.Context,
+    config StreamRetryConfig,
+    factory StreamFactory,
+) llm.StreamIterator
+```
+
+Providers with SDK-specific error types supply `NormalizeError`; providers
+that already return Dive provider errors do not need one:
+
+- OpenAI Responses converts `*openai.Error` through `providers.NewError`.
+- Google applies its existing `wrapGoogleError` conversion.
+- Anthropic and Chat Completions return `providers.NewError` for non-200 HTTP
+  responses and ordinary errors for transport or body failures.
+- Treat transport failures as retryable unless the context was cancelled or
+  its deadline expired.
+- Preserve a useful final error for the caller; do not replace the provider
+  error with a generic "retry exhausted" message.
+
+Every `Provider.Stream` continues to build config and request parameters and
+fires `llm.BeforeGenerate` once. Google is brought into that contract because
+its streaming path previously omitted the hook. The transport-attempt factory
+must not fire hooks or mutate caller-owned messages.
+
+No change is required in the core agent loop. From
+`Agent.generateStreaming`'s perspective, the provider returns one iterator and
+one coherent event sequence. Earlier tool results remain in `updatedMessages`,
+and Dive only executes tool calls after a model response has been accumulated,
+so no tool from the failed pre-event attempt exists to execute.
+
+### Configuration
+
+Keep each base provider's existing default budget and backoff. Its
+`WithMaxRetries(n)` option governs both `Generate` and `Stream` where both are
+available. SDK-internal retries remain disabled where Dive already owns the
+budget.
+
+Add provider-local passthrough options for the adapters:
+
+- `grok.WithMaxRetries` -> OpenAI Responses;
+- `mistral.WithMaxRetries` and `openrouter.WithMaxRetries` -> OpenAI-compatible
+  Chat Completions;
+- `ollama.WithMaxRetries` -> Anthropic-compatible Messages.
+
+The embedded base provider also receives the adapter's provider name so retry
+logs identify Grok, Mistral, Ollama, or OpenRouter rather than the underlying
+protocol implementation.
+
+### Observability
+
+Log each retry through the configured `llm.Config.Logger` with structured,
+non-sensitive fields:
+
+- provider name;
+- attempt and maximum attempts;
+- HTTP status when known;
+- `before_first_event=true`;
+- backoff duration.
+
+Do not log prompts, response bodies, API keys, or tool results.
+
+The existing Dive chat span can continue to represent one logical generation
+iteration. HTTP instrumentation will show the individual attempts beneath it,
+and time-to-first-content should include retry/backoff time because that is the
+latency observed by the caller. No tracer API change is required.
+
+## Safety invariants
+
+The implementation should make these invariants explicit in comments and
+tests:
+
+1. A retry is allowed only before the first externally visible stream event.
+2. A failed stream is closed before a replacement is created.
+3. A committed stream is never replaced.
+4. Provider retry does not call `CreateResponse`, `Agent.generate`, hooks, or
+   tools again.
+5. Cancellation and deadline errors stop retries immediately.
+6. Total HTTP attempts equal `maxRetries + 1`; OpenAI SDK retries remain
+   disabled.
+
+## Tests
+
+The shared helper has provider-independent coverage for:
+
+1. First-attempt success and complete event passthrough.
+2. One retry budget shared across factory errors, lazy iterator errors, and
+   close errors, including exact exhaustion counts.
+3. Permanent errors, normalized SDK errors, nil factories/streams, empty
+   streams, and negative retry budgets.
+4. No retry after the first event commits the stream.
+5. Cancellation before the first attempt, cancellation from an attempt, and
+   cancellation interrupting backoff.
+6. Closing every failed attempt before replacement, closing a stream returned
+   alongside a factory error, and idempotent caller close.
+7. Structured status and transport-error logging without response bodies.
+
+These tests execute every statement in `providers/retrying_stream.go` and do
+not require a network or provider credential.
+
+Provider-level `httptest` coverage verifies `429 -> success` wiring for
+Anthropic, Google, OpenAI Responses, and OpenAI-compatible Chat Completions,
+including a complete accumulated assistant response and one `BeforeGenerate`
+hook invocation for the logical request. Injected response-body readers verify
+that Anthropic and Chat Completions retry a connection failure after `200 OK`
+but before the first event, close the failed body, and do not retry the same
+failure after an event. OpenAI Responses separately injects pre-header and
+post-event transport failures. Google verifies lazy permanent-error
+classification and that a rejected hook starts no request.
+
+OpenAI Responses additionally covers persistent 429, permanent 400, default
+attempt budgets, and cancellation. The Google normalizer is tested with both
+the value and pointer forms of `genai.APIError`; this caught and fixed a
+pre-existing mismatch with the SDK's value-form errors. Grok, Mistral, Ollama,
+and OpenRouter verify that `WithMaxRetries(1)` produces exactly two embedded
+transport attempts and preserves the adapter provider name.
+
+The end-to-end agent regression uses an `httptest` Responses endpoint:
+
+- generation one returns a tool call;
+- the tool increments a counter and returns successfully;
+- the first HTTP attempt for generation two returns 429;
+- its retry returns a final assistant response;
+- `CreateResponse` succeeds and the tool counter remains exactly one.
+
+That test is the strongest proof of the customer-visible contract: a later
+generation can retry without replaying an earlier side effect.
+
+## Alternatives considered
+
+### Retry the entire `CreateResponse` call in Mobius
+
+Rejected. A new call reconstructs the agent loop from durable history and can
+repeat model-selected side effects. It also changes Mobius's terminal-turn
+idempotency contract and turns a bounded provider failure into a distributed
+recovery problem.
+
+### Wrap `Agent.generateStreaming` in a generic retry loop
+
+Rejected. That layer receives a `StreamingLLM`, not a transport-attempt
+factory. Calling `Stream` again would replay provider hooks and request setup,
+and providers that retain their own retry behavior could produce nested retry
+budgets. It would also move provider-specific error normalization into the
+agent loop. The correct reusable boundary is lower: inside provider `Stream`,
+after one logical request is prepared but around creation and first iteration
+of each transport stream.
+
+### Retry after partial output
+
+Deferred. After any event is visible, a retry needs an attempt/reset protocol
+for callbacks, accumulators, response IDs, and UI previews. Without that
+protocol, the consumer can receive duplicate text or tool-call fragments. The
+reported xAI capacity failure does not require solving partial-stream replay.
+
+### Enable the OpenAI SDK's built-in retries
+
+Rejected. Dive deliberately disables them so `WithMaxRetries` is authoritative.
+Re-enabling a second retry layer would multiply attempts and backoff, and it
+would make OpenAI/Grok behave differently from the rest of Dive's provider
+configuration.
+
+## Tradeoffs and consequences
+
+- The proposal fixes pre-event failures but deliberately still fails a stream
+  that breaks after emitting an event. This is narrower than "retry every
+  transient stream failure," but it has a clean no-duplication guarantee.
+- Backoff increases time to first content during provider incidents. That is
+  preferable to terminally failing a multi-tool turn and asking the caller to
+  replay it.
+- Stream setup errors from Anthropic and Chat Completions now follow the same
+  lazy iterator contract as OpenAI Responses and Google: validation and hook
+  errors can still be returned by `Stream`, while transport-attempt errors are
+  reported by `Next`/`Err` after the shared retry budget is applied.
+- A small amount of retry state is centralized in `providers`, which keeps
+  policy identical without coupling the agent loop to provider transports.
+- The provider may bill a failed attempt even when it produced no event. Dive
+  cannot reliably recover usage for a request that never delivered usage data;
+  this proposal does not attempt to synthesize it.
+
+## Implementation
+
+The implementation follows the shared provider-layer design:
+
+- `providers/retrying_stream.go` owns the pre-first-event retry boundary,
+  context-aware backoff, one shared attempt budget, failed-stream cleanup, and
+  structured retry logging.
+- Anthropic, Google, OpenAI Responses, and OpenAI-compatible Chat Completions
+  build one logical request and give the helper a fresh-stream factory.
+- OpenAI Responses and Google supply their SDK error normalizers.
+- Google's normalizer handles both `genai.APIError` and `*genai.APIError`, so
+  permanent SDK errors do not consume the transient retry budget.
+- Grok, Mistral, Ollama, and OpenRouter expose `WithMaxRetries` and pass the
+  configured budget and adapter name into their embedded provider.
+- Provider SDK/internal retry layers remain disabled where Dive owns the
+  budget, so total transport attempts remain `maxRetries + 1`.
+
+No core agent-loop changes were needed.
+
+## Validation
+
+Focused tests cover the shared helper and every concrete provider surface:
+recoverable and persistent 429s, permanent 400s, cancellation during backoff,
+pre-header and post-`200 OK` transport failures, default attempt budgets,
+failed-stream cleanup, the no-retry-after-first-event commit point, full normal
+response accumulation, one-shot provider hooks, adapter names, retry-option
+passthrough, and structured retry fields without provider response bodies.
+
+The end-to-end agent regression runs two model generations around one tool
+call. The second generation receives `429 -> success`; both attempts carry the
+same request body and completed tool result, `CreateResponse` succeeds, and the
+side-effect counter remains exactly one.
+
+Build-tagged live streaming smoke tests also pass for OpenAI Responses and
+Grok. The regular suite exercised available Anthropic and OpenAI-compatible
+credentials. Providers without local credentials remain covered by
+deterministic HTTP/SSE fixtures and injected transport failures, so retry
+correctness does not depend on inducing a real provider outage.
+
+## Rollout and verification
+
+This is a backward-compatible behavioral fix and does not need a feature flag.
+
+The implementation and local verification are complete. The remaining release
+rollout is:
+
+1. Release the root, Google, OpenAI, and Grok modules together. Anthropic,
+   Chat Completions, Mistral, Ollama, and OpenRouter ship in the root module.
+2. Update Mobius Cloud's Dive provider pins.
+3. Exercise a synthetic `429 -> success` Grok turn in a non-production Mobius
+   environment.
+4. After production rollout, monitor terminal `generation_failed` turns whose
+   provider error is 429/5xx and confirm retry logs precede either success or
+   retry exhaustion.
+
+Success means the synthetic multi-iteration test completes with one tool
+execution, and the production class of pre-event xAI capacity errors no longer
+terminalizes a turn until the configured provider retry budget has been
+exhausted.
+
+## Decisions
+
+1. **Honor `Retry-After` in this change?** No. Preserve Dive's
+   existing retry/backoff behavior for parity with `Generate`; add
+   header-aware retry consistently across both paths in a separate change if
+   needed.
+2. **Generalize the pre-event wrapper across providers now?** Yes. Google is a
+   second lazy-stream implementation, while Anthropic and Chat Completions had
+   the same gap after a successful HTTP handshake but before their first
+   event. A shared provider-layer helper gives all implementations one commit
+   point and one retry budget without moving retries into the agent loop.

--- a/docs/plans/plan-09-streaming-generation-retries.md
+++ b/docs/plans/plan-09-streaming-generation-retries.md
@@ -195,10 +195,12 @@ budget.
 
 Add provider-local passthrough options for the adapters:
 
-- `grok.WithMaxRetries` -> OpenAI Responses;
-- `mistral.WithMaxRetries` and `openrouter.WithMaxRetries` -> OpenAI-compatible
-  Chat Completions;
-- `ollama.WithMaxRetries` -> Anthropic-compatible Messages.
+- `grok.WithMaxRetries` and `grok.WithRetryBaseWait` -> OpenAI Responses;
+- `mistral.WithMaxRetries`, `mistral.WithBaseWait`,
+  `openrouter.WithMaxRetries`, and `openrouter.WithBaseWait` ->
+  OpenAI-compatible Chat Completions;
+- `ollama.WithMaxRetries` and `ollama.WithBaseWait` -> Anthropic-compatible
+  Messages.
 
 The embedded base provider also receives the adapter's provider name so retry
 logs identify Grok, Mistral, Ollama, or OpenRouter rather than the underlying
@@ -343,11 +345,17 @@ The implementation follows the shared provider-layer design:
   structured retry logging.
 - Anthropic, Google, OpenAI Responses, and OpenAI-compatible Chat Completions
   build one logical request and give the helper a fresh-stream factory.
-- OpenAI Responses and Google supply their SDK error normalizers.
+- OpenAI Responses supplies its SDK error normalizer to the shared helper.
+- Google's exported stream iterator normalizes its lazy SDK errors before they
+  reach the helper, avoiding a redundant second normalization pass.
 - Google's normalizer handles both `genai.APIError` and `*genai.APIError`, so
   permanent SDK errors do not consume the transient retry budget.
-- Grok, Mistral, Ollama, and OpenRouter expose `WithMaxRetries` and pass the
-  configured budget and adapter name into their embedded provider.
+- Grok, Mistral, Ollama, and OpenRouter expose retry-budget and base-wait
+  options and pass those values plus the adapter name into their embedded
+  provider.
+- If pre-commit stream reading and cleanup both fail, the iterator preserves
+  both errors for diagnosis while retaining retry classification through the
+  stream error.
 - Provider SDK/internal retry layers remain disabled where Dive owns the
   budget, so total transport attempts remain `maxRetries + 1`.
 
@@ -360,7 +368,8 @@ recoverable and persistent 429s, permanent 400s, cancellation during backoff,
 pre-header and post-`200 OK` transport failures, default attempt budgets,
 failed-stream cleanup, the no-retry-after-first-event commit point, full normal
 response accumulation, one-shot provider hooks, adapter names, retry-option
-passthrough, and structured retry fields without provider response bodies.
+passthrough without mutable package defaults, simultaneous stream/close error
+preservation, and structured retry fields without provider response bodies.
 
 The end-to-end agent regression runs two model generations around one tool
 call. The second generation receives `429 -> success`; both attempts carry the
@@ -382,10 +391,13 @@ rollout is:
 
 1. Release the root, Google, OpenAI, and Grok modules together. Anthropic,
    Chat Completions, Mistral, Ollama, and OpenRouter ship in the root module.
-2. Update Mobius Cloud's Dive provider pins.
-3. Exercise a synthetic `429 -> success` Grok turn in a non-production Mobius
+2. Confirm the root module containing `providers.NewRetryingStreamIterator` is
+   published before the nested Google, OpenAI, and Grok module tags.
+3. Update Mobius Cloud's root Dive pin first, then update its nested provider
+   pins only after that root version is available.
+4. Exercise a synthetic `429 -> success` Grok turn in a non-production Mobius
    environment.
-4. After production rollout, monitor terminal `generation_failed` turns whose
+5. After production rollout, monitor terminal `generation_failed` turns whose
    provider error is 429/5xx and confirm retry logs precede either success or
    retry exhaustion.
 

--- a/providers/anthropic/anthropic.go
+++ b/providers/anthropic/anthropic.go
@@ -32,6 +32,7 @@ var _ llm.StreamingLLM = &Provider{}
 
 // Provider implements the Anthropic LLM provider for Claude models.
 type Provider struct {
+	name          string
 	client        *http.Client
 	apiKey        string
 	endpoint      string
@@ -61,6 +62,9 @@ func New(opts ...Option) *Provider {
 }
 
 func (p *Provider) Name() string {
+	if p.name != "" {
+		return p.name
+	}
 	return ProviderName
 }
 
@@ -198,40 +202,33 @@ func (p *Provider) Stream(ctx context.Context, opts ...llm.Option) (llm.StreamIt
 		return nil, err
 	}
 
-	var stream *StreamIterator
-	err = retry.DoSimple(ctx, func() error {
+	stream := providers.NewRetryingStreamIterator(ctx, providers.StreamRetryConfig{
+		Provider:      p.Name(),
+		MaxRetries:    p.maxRetries,
+		RetryBaseWait: p.retryBaseWait,
+		Logger:        config.Logger,
+	}, func() (llm.StreamIterator, error) {
 		req, err := p.createRequest(ctx, body, config, true)
 		if err != nil {
-			return err
+			return nil, err
 		}
 		resp, err := p.client.Do(req)
 		if err != nil {
-			return fmt.Errorf("error making request: %w", err)
+			return nil, fmt.Errorf("error making request: %w", err)
 		}
 		if resp.StatusCode != http.StatusOK {
 			body, _ := io.ReadAll(resp.Body)
 			resp.Body.Close()
-			if resp.StatusCode == 429 {
-				if config.Logger != nil {
-					config.Logger.Warn("rate limit exceeded",
-						"status", resp.StatusCode, "body", string(body))
-				}
-			}
-			return providers.NewError(resp.StatusCode, string(body))
+			return nil, providers.NewError(resp.StatusCode, string(body))
 		}
-		stream = &StreamIterator{
+		return &StreamIterator{
 			body: resp.Body,
 			reader: llm.NewServerSentEventsReader[llm.Event](resp.Body).
 				WithSSECallback(config.SSECallback),
 			prefill:           config.Prefill,
 			prefillClosingTag: config.PrefillClosingTag,
-		}
-		return nil
-	}, retry.WithMaxAttempts(p.maxRetries+1), retry.WithBackoff(p.retryBaseWait, 5*time.Minute), retry.WithRetryIf(retry.SkipPermanent()))
-
-	if err != nil {
-		return nil, err
-	}
+		}, nil
+	})
 	return stream, nil
 }
 

--- a/providers/anthropic/options.go
+++ b/providers/anthropic/options.go
@@ -8,6 +8,14 @@ import (
 // Option configures the Anthropic provider.
 type Option func(*Provider)
 
+// WithName overrides the provider name used for logging and observability.
+// It is intended for providers that embed the Anthropic-compatible adapter.
+func WithName(name string) Option {
+	return func(p *Provider) {
+		p.name = name
+	}
+}
+
 // WithAPIKey sets the Anthropic API key.
 func WithAPIKey(apiKey string) Option {
 	return func(p *Provider) {

--- a/providers/anthropic/stream_retry_test.go
+++ b/providers/anthropic/stream_retry_test.go
@@ -1,0 +1,172 @@
+package anthropic
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/deepnoodle-ai/dive/llm"
+	"github.com/deepnoodle-ai/wonton/assert"
+)
+
+const successfulAnthropicStream = `data: {"type":"message_start","message":{"id":"msg_1","type":"message","role":"assistant","model":"test-model","content":[]}}
+
+data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}
+
+data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"ok"}}
+
+data: {"type":"content_block_stop","index":0}
+
+data: {"type":"message_delta","delta":{"stop_reason":"end_turn"}}
+
+data: {"type":"message_stop"}
+
+`
+
+type anthropicRoundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f anthropicRoundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+type failingAnthropicBody struct {
+	data   *strings.Reader
+	err    error
+	closed atomic.Bool
+}
+
+func (b *failingAnthropicBody) Read(p []byte) (int, error) {
+	if b.data.Len() == 0 {
+		return 0, b.err
+	}
+	return b.data.Read(p)
+}
+
+func (b *failingAnthropicBody) Close() error {
+	b.closed.Store(true)
+	return nil
+}
+
+func anthropicResponse(req *http.Request, body io.ReadCloser) *http.Response {
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Status:     http.StatusText(http.StatusOK),
+		Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+		Body:       body,
+		Request:    req,
+	}
+}
+
+func consumeAnthropicStream(t *testing.T, iterator llm.StreamIterator) *llm.ResponseAccumulator {
+	t.Helper()
+	accumulator := llm.NewResponseAccumulator()
+	for iterator.Next() {
+		assert.NoError(t, accumulator.AddEvent(iterator.Event()))
+	}
+	assert.NoError(t, iterator.Err())
+	return accumulator
+}
+
+func TestStreamRetriesBeforeFirstEvent(t *testing.T) {
+	var requests atomic.Int64
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if requests.Add(1) == 1 {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusTooManyRequests)
+			_, _ = io.WriteString(w, `{"error":{"message":"temporarily overloaded"}}`)
+			return
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = io.WriteString(w, successfulAnthropicStream)
+	}))
+	defer server.Close()
+
+	provider := New(
+		WithAPIKey("test-key"),
+		WithEndpoint(server.URL),
+		WithMaxRetries(1),
+		WithBaseWait(time.Millisecond),
+	)
+	var hooks atomic.Int64
+	iterator, err := provider.Stream(context.Background(),
+		llm.WithMessages(llm.NewUserTextMessage("hello")),
+		llm.WithHook(llm.BeforeGenerate, func(context.Context, *llm.HookContext) error {
+			hooks.Add(1)
+			return nil
+		}),
+	)
+	assert.NoError(t, err)
+	defer iterator.Close()
+
+	accumulator := consumeAnthropicStream(t, iterator)
+	assert.True(t, accumulator.IsComplete())
+	assert.Equal(t, "ok", accumulator.Response().Message().Text())
+	assert.Equal(t, int64(2), requests.Load())
+	assert.Equal(t, int64(1), hooks.Load())
+}
+
+func TestStreamRetriesBodyReadFailureBeforeFirstEvent(t *testing.T) {
+	sentinel := errors.New("connection reset before first event")
+	failedBody := &failingAnthropicBody{data: strings.NewReader(""), err: sentinel}
+	var requests atomic.Int64
+	client := &http.Client{Transport: anthropicRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if requests.Add(1) == 1 {
+			return anthropicResponse(req, failedBody), nil
+		}
+		return anthropicResponse(req, io.NopCloser(strings.NewReader(successfulAnthropicStream))), nil
+	})}
+	provider := New(
+		WithAPIKey("test-key"),
+		WithClient(client),
+		WithMaxRetries(1),
+		WithBaseWait(time.Millisecond),
+	)
+	iterator, err := provider.Stream(context.Background(),
+		llm.WithMessages(llm.NewUserTextMessage("hello")),
+	)
+	assert.NoError(t, err)
+	defer iterator.Close()
+
+	accumulator := consumeAnthropicStream(t, iterator)
+	assert.True(t, accumulator.IsComplete())
+	assert.Equal(t, "ok", accumulator.Response().Message().Text())
+	assert.Equal(t, int64(2), requests.Load())
+	assert.True(t, failedBody.closed.Load())
+}
+
+func TestStreamDoesNotRetryBodyFailureAfterFirstEvent(t *testing.T) {
+	sentinel := errors.New("connection reset after first event")
+	partialBody := &failingAnthropicBody{
+		data: strings.NewReader(`data: {"type":"message_start","message":{"id":"msg_1","type":"message","role":"assistant","model":"test-model","content":[]}}` + "\n"),
+		err:  sentinel,
+	}
+	var requests atomic.Int64
+	client := &http.Client{Transport: anthropicRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		requests.Add(1)
+		return anthropicResponse(req, partialBody), nil
+	})}
+	provider := New(
+		WithAPIKey("test-key"),
+		WithClient(client),
+		WithMaxRetries(2),
+		WithBaseWait(time.Millisecond),
+	)
+	iterator, err := provider.Stream(context.Background(),
+		llm.WithMessages(llm.NewUserTextMessage("hello")),
+	)
+	assert.NoError(t, err)
+	defer iterator.Close()
+
+	assert.True(t, iterator.Next())
+	assert.Equal(t, llm.EventTypeMessageStart, iterator.Event().Type)
+	assert.False(t, iterator.Next())
+	assert.True(t, errors.Is(iterator.Err(), sentinel))
+	assert.Equal(t, int64(1), requests.Load())
+	assert.True(t, partialBody.closed.Load())
+}

--- a/providers/google/google.go
+++ b/providers/google/google.go
@@ -226,11 +226,10 @@ func (p *Provider) Stream(ctx context.Context, opts ...llm.Option) (llm.StreamIt
 	}
 
 	stream := providers.NewRetryingStreamIterator(ctx, providers.StreamRetryConfig{
-		Provider:       p.Name(),
-		MaxRetries:     p.maxRetries,
-		RetryBaseWait:  p.retryBaseWait,
-		Logger:         config.Logger,
-		NormalizeError: wrapGoogleError,
+		Provider:      p.Name(),
+		MaxRetries:    p.maxRetries,
+		RetryBaseWait: p.retryBaseWait,
+		Logger:        config.Logger,
 	}, func() (llm.StreamIterator, error) {
 		// GenerateContentStream reports request failures through its lazy
 		// sequence. The shared iterator consumes the first result as part of

--- a/providers/google/google.go
+++ b/providers/google/google.go
@@ -215,10 +215,29 @@ func (p *Provider) Stream(ctx context.Context, opts ...llm.Option) (llm.StreamIt
 		return nil, err
 	}
 
-	// Note: GenerateContentStream returns an iterator; errors surface during
-	// iteration, not at creation time, so retry.DoSimple cannot help here.
-	streamSeq := p.client.Models.GenerateContentStream(ctx, request.Model, contents, genConfig)
-	stream := NewStreamIteratorFromSeq(ctx, streamSeq, request.Model)
+	if err := config.FireHooks(ctx, &llm.HookContext{
+		Type: llm.BeforeGenerate,
+		Request: &llm.HookRequestContext{
+			Messages: config.Messages,
+			Config:   config,
+		},
+	}); err != nil {
+		return nil, err
+	}
+
+	stream := providers.NewRetryingStreamIterator(ctx, providers.StreamRetryConfig{
+		Provider:       p.Name(),
+		MaxRetries:     p.maxRetries,
+		RetryBaseWait:  p.retryBaseWait,
+		Logger:         config.Logger,
+		NormalizeError: wrapGoogleError,
+	}, func() (llm.StreamIterator, error) {
+		// GenerateContentStream reports request failures through its lazy
+		// sequence. The shared iterator consumes the first result as part of
+		// the provider's pre-event retry boundary.
+		streamSeq := p.client.Models.GenerateContentStream(ctx, request.Model, contents, genConfig)
+		return NewStreamIteratorFromSeq(ctx, streamSeq, request.Model), nil
+	})
 
 	return stream, nil
 }
@@ -231,11 +250,17 @@ func renderReminderMessages(messages []*llm.Message) ([]*llm.Message, error) {
 
 // wrapGoogleError converts a Google API error to a providers.NewError so that
 // retry.SkipPermanent can detect non-retryable status codes. Falls back to the
-// original error if it's not a genai.APIError.
+// original error if it's not a genai.APIError. The SDK returns APIError as a
+// value today, while callers and wrappers may still expose a pointer, so both
+// forms must be handled.
 func wrapGoogleError(err error) error {
-	var apiErr *genai.APIError
+	var apiErr genai.APIError
 	if errors.As(err, &apiErr) {
 		return providers.NewError(apiErr.Code, apiErr.Message)
+	}
+	var apiErrPtr *genai.APIError
+	if errors.As(err, &apiErrPtr) {
+		return providers.NewError(apiErrPtr.Code, apiErrPtr.Message)
 	}
 	return err
 }

--- a/providers/google/stream_retry_test.go
+++ b/providers/google/stream_retry_test.go
@@ -1,0 +1,129 @@
+package google
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/deepnoodle-ai/dive/llm"
+	"github.com/deepnoodle-ai/wonton/assert"
+	"github.com/deepnoodle-ai/wonton/retry"
+	"google.golang.org/genai"
+)
+
+func newRetryTestProvider(t *testing.T, baseURL string, maxRetries int) *Provider {
+	t.Helper()
+	client, err := genai.NewClient(context.Background(), &genai.ClientConfig{
+		APIKey:      "test-key",
+		HTTPOptions: genai.HTTPOptions{BaseURL: baseURL},
+	})
+	assert.NoError(t, err)
+	provider := New(
+		WithModel("test-model"),
+		WithMaxRetries(maxRetries),
+		WithRetryBaseWait(time.Millisecond),
+	)
+	provider.client = client
+	return provider
+}
+
+func consumeGoogleProviderStream(t *testing.T, iterator llm.StreamIterator) *llm.ResponseAccumulator {
+	t.Helper()
+	accumulator := llm.NewResponseAccumulator()
+	for iterator.Next() {
+		assert.NoError(t, accumulator.AddEvent(iterator.Event()))
+	}
+	assert.NoError(t, iterator.Err())
+	return accumulator
+}
+
+func TestStreamRetriesBeforeFirstEvent(t *testing.T) {
+	var requests atomic.Int64
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if requests.Add(1) == 1 {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusTooManyRequests)
+			_, _ = io.WriteString(w, `{"error":{"code":429,"message":"temporarily overloaded","status":"RESOURCE_EXHAUSTED"}}`)
+			return
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = io.WriteString(w, "data: {\"responseId\":\"resp_1\",\"candidates\":[{\"content\":{\"role\":\"model\",\"parts\":[{\"text\":\"ok\"}]},\"finishReason\":\"STOP\"}],\"usageMetadata\":{}}\n\n")
+	}))
+	defer server.Close()
+
+	provider := newRetryTestProvider(t, server.URL, 1)
+
+	var hooks atomic.Int64
+	iterator, err := provider.Stream(context.Background(),
+		llm.WithMessages(llm.NewUserTextMessage("hello")),
+		llm.WithHook(llm.BeforeGenerate, func(context.Context, *llm.HookContext) error {
+			hooks.Add(1)
+			return nil
+		}),
+	)
+	assert.NoError(t, err)
+	defer iterator.Close()
+
+	accumulator := consumeGoogleProviderStream(t, iterator)
+	assert.True(t, accumulator.IsComplete())
+	assert.Equal(t, "ok", accumulator.Response().Message().Text())
+	assert.Equal(t, "stop", accumulator.Response().StopReason)
+	assert.Equal(t, int64(2), requests.Load())
+	assert.Equal(t, int64(1), hooks.Load())
+}
+
+func TestStreamDoesNotRetryPermanentLazyError(t *testing.T) {
+	var requests atomic.Int64
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = io.WriteString(w, `{"error":{"code":400,"message":"invalid request","status":"INVALID_ARGUMENT"}}`)
+	}))
+	defer server.Close()
+
+	provider := newRetryTestProvider(t, server.URL, 2)
+	iterator, err := provider.Stream(context.Background(),
+		llm.WithMessages(llm.NewUserTextMessage("hello")),
+	)
+	assert.NoError(t, err)
+	defer iterator.Close()
+
+	assert.False(t, iterator.Next())
+	assert.Error(t, iterator.Err())
+	assert.Equal(t, int64(1), requests.Load())
+}
+
+func TestStreamHookFailureDoesNotStartRequest(t *testing.T) {
+	var requests atomic.Int64
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests.Add(1)
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	provider := newRetryTestProvider(t, server.URL, 2)
+	sentinel := errors.New("hook rejected request")
+	iterator, err := provider.Stream(context.Background(),
+		llm.WithMessages(llm.NewUserTextMessage("hello")),
+		llm.WithHook(llm.BeforeGenerate, func(context.Context, *llm.HookContext) error {
+			return sentinel
+		}),
+	)
+	assert.True(t, errors.Is(err, sentinel))
+	assert.Nil(t, iterator)
+	assert.Equal(t, int64(0), requests.Load())
+}
+
+func TestWrapGoogleErrorHandlesValueAndPointerForms(t *testing.T) {
+	valueErr := genai.APIError{Code: http.StatusBadRequest, Message: "invalid request"}
+	pointerErr := &genai.APIError{Code: http.StatusTooManyRequests, Message: "overloaded"}
+
+	assert.True(t, retry.IsPermanent(wrapGoogleError(valueErr)))
+	assert.False(t, retry.IsPermanent(wrapGoogleError(pointerErr)))
+}

--- a/providers/grok/grok.go
+++ b/providers/grok/grok.go
@@ -8,9 +8,10 @@ import (
 )
 
 var (
-	DefaultModel     = ModelGrok45
-	DefaultEndpoint  = "https://api.x.ai/v1"
-	DefaultMaxTokens = 32768
+	DefaultModel      = ModelGrok45
+	DefaultEndpoint   = "https://api.x.ai/v1"
+	DefaultMaxTokens  = 32768
+	DefaultMaxRetries = openaiProvider.DefaultMaxRetries
 )
 
 var _ llm.StreamingLLM = &Provider{}
@@ -24,10 +25,11 @@ type Provider struct {
 // New creates a new Grok provider with the given options.
 func New(opts ...Option) *Provider {
 	cfg := &config{
-		apiKey:    getAPIKey(),
-		endpoint:  DefaultEndpoint,
-		model:     DefaultModel,
-		maxTokens: DefaultMaxTokens,
+		apiKey:     getAPIKey(),
+		endpoint:   DefaultEndpoint,
+		model:      DefaultModel,
+		maxTokens:  DefaultMaxTokens,
+		maxRetries: DefaultMaxRetries,
 	}
 	for _, opt := range opts {
 		opt(cfg)
@@ -38,6 +40,7 @@ func New(opts ...Option) *Provider {
 		openaiProvider.WithEndpoint(cfg.endpoint),
 		openaiProvider.WithModel(cfg.model),
 		openaiProvider.WithMaxTokens(cfg.maxTokens),
+		openaiProvider.WithMaxRetries(cfg.maxRetries),
 	}
 	if len(cfg.extraRequestOptions) > 0 {
 		openaiOpts = append(openaiOpts,

--- a/providers/grok/grok.go
+++ b/providers/grok/grok.go
@@ -8,10 +8,11 @@ import (
 )
 
 var (
-	DefaultModel      = ModelGrok45
-	DefaultEndpoint   = "https://api.x.ai/v1"
-	DefaultMaxTokens  = 32768
-	DefaultMaxRetries = openaiProvider.DefaultMaxRetries
+	DefaultModel         = ModelGrok45
+	DefaultEndpoint      = "https://api.x.ai/v1"
+	DefaultMaxTokens     = 32768
+	DefaultMaxRetries    = openaiProvider.DefaultMaxRetries
+	DefaultRetryBaseWait = openaiProvider.DefaultRetryBaseWait
 )
 
 var _ llm.StreamingLLM = &Provider{}
@@ -25,11 +26,12 @@ type Provider struct {
 // New creates a new Grok provider with the given options.
 func New(opts ...Option) *Provider {
 	cfg := &config{
-		apiKey:     getAPIKey(),
-		endpoint:   DefaultEndpoint,
-		model:      DefaultModel,
-		maxTokens:  DefaultMaxTokens,
-		maxRetries: DefaultMaxRetries,
+		apiKey:        getAPIKey(),
+		endpoint:      DefaultEndpoint,
+		model:         DefaultModel,
+		maxTokens:     DefaultMaxTokens,
+		maxRetries:    DefaultMaxRetries,
+		retryBaseWait: DefaultRetryBaseWait,
 	}
 	for _, opt := range opts {
 		opt(cfg)
@@ -41,6 +43,7 @@ func New(opts ...Option) *Provider {
 		openaiProvider.WithModel(cfg.model),
 		openaiProvider.WithMaxTokens(cfg.maxTokens),
 		openaiProvider.WithMaxRetries(cfg.maxRetries),
+		openaiProvider.WithRetryBaseWait(cfg.retryBaseWait),
 	}
 	if len(cfg.extraRequestOptions) > 0 {
 		openaiOpts = append(openaiOpts,

--- a/providers/grok/grok_test.go
+++ b/providers/grok/grok_test.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/deepnoodle-ai/dive/llm"
-	openaiProvider "github.com/deepnoodle-ai/dive/providers/openai"
 	"github.com/deepnoodle-ai/wonton/assert"
 )
 
@@ -65,16 +64,15 @@ func TestWithMaxRetriesControlsStreamingAttempts(t *testing.T) {
 	}))
 	defer server.Close()
 
-	oldRetryBaseWait := openaiProvider.DefaultRetryBaseWait
-	openaiProvider.DefaultRetryBaseWait = time.Millisecond
-	t.Cleanup(func() { openaiProvider.DefaultRetryBaseWait = oldRetryBaseWait })
-
 	provider := New(
 		WithAPIKey("test-key"),
 		WithEndpoint(server.URL),
 		WithMaxRetries(1),
+		WithRetryBaseWait(time.Millisecond),
 	)
-	iterator, err := provider.Stream(context.Background(),
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	iterator, err := provider.Stream(ctx,
 		llm.WithMessages(llm.NewUserTextMessage("hello")),
 	)
 	assert.NoError(t, err)

--- a/providers/grok/grok_test.go
+++ b/providers/grok/grok_test.go
@@ -1,9 +1,15 @@
 package grok
 
 import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/deepnoodle-ai/dive/llm"
+	openaiProvider "github.com/deepnoodle-ai/dive/providers/openai"
 	"github.com/deepnoodle-ai/wonton/assert"
 )
 
@@ -47,4 +53,35 @@ func TestProvider_GetAPIKey(t *testing.T) {
 	t.Setenv("XAI_API_KEY", "xai-key")
 	t.Setenv("GROK_API_KEY", "grok-key")
 	assert.Equal(t, "xai-key", getAPIKey())
+}
+
+func TestWithMaxRetriesControlsStreamingAttempts(t *testing.T) {
+	var requests atomic.Int64
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(`{"error":{"message":"temporarily at capacity","type":"rate_limit_error"}}`))
+	}))
+	defer server.Close()
+
+	oldRetryBaseWait := openaiProvider.DefaultRetryBaseWait
+	openaiProvider.DefaultRetryBaseWait = time.Millisecond
+	t.Cleanup(func() { openaiProvider.DefaultRetryBaseWait = oldRetryBaseWait })
+
+	provider := New(
+		WithAPIKey("test-key"),
+		WithEndpoint(server.URL),
+		WithMaxRetries(1),
+	)
+	iterator, err := provider.Stream(context.Background(),
+		llm.WithMessages(llm.NewUserTextMessage("hello")),
+	)
+	assert.NoError(t, err)
+	defer iterator.Close()
+
+	for iterator.Next() {
+	}
+	assert.Error(t, iterator.Err())
+	assert.Equal(t, int64(2), requests.Load())
 }

--- a/providers/grok/options.go
+++ b/providers/grok/options.go
@@ -1,6 +1,10 @@
 package grok
 
-import "github.com/openai/openai-go/v3/option"
+import (
+	"time"
+
+	"github.com/openai/openai-go/v3/option"
+)
 
 // config holds the Grok provider configuration before passing to the
 // embedded OpenAI Responses API provider.
@@ -10,6 +14,7 @@ type config struct {
 	model               string
 	maxTokens           int
 	maxRetries          int
+	retryBaseWait       time.Duration
 	extraRequestOptions []option.RequestOption
 }
 
@@ -42,6 +47,13 @@ func WithMaxTokens(maxTokens int) Option {
 func WithMaxRetries(maxRetries int) Option {
 	return func(c *config) {
 		c.maxRetries = maxRetries
+	}
+}
+
+// WithRetryBaseWait sets the base wait duration between retries.
+func WithRetryBaseWait(retryBaseWait time.Duration) Option {
+	return func(c *config) {
+		c.retryBaseWait = retryBaseWait
 	}
 }
 

--- a/providers/grok/options.go
+++ b/providers/grok/options.go
@@ -9,6 +9,7 @@ type config struct {
 	endpoint            string
 	model               string
 	maxTokens           int
+	maxRetries          int
 	extraRequestOptions []option.RequestOption
 }
 
@@ -33,6 +34,14 @@ func WithEndpoint(endpoint string) Option {
 func WithMaxTokens(maxTokens int) Option {
 	return func(c *config) {
 		c.maxTokens = maxTokens
+	}
+}
+
+// WithMaxRetries sets the maximum number of retry attempts performed by Dive
+// for transient generation failures (total attempts = maxRetries + 1).
+func WithMaxRetries(maxRetries int) Option {
+	return func(c *config) {
+		c.maxRetries = maxRetries
 	}
 }
 

--- a/providers/mistral/mistral.go
+++ b/providers/mistral/mistral.go
@@ -11,21 +11,23 @@ import (
 )
 
 var (
-	DefaultModel     = ModelMistralLarge3
-	DefaultEndpoint  = "https://api.mistral.ai/v1/chat/completions"
-	DefaultMaxTokens = 32768
-	DefaultClient    = &http.Client{Timeout: 300 * time.Second}
+	DefaultModel      = ModelMistralLarge3
+	DefaultEndpoint   = "https://api.mistral.ai/v1/chat/completions"
+	DefaultMaxTokens  = 32768
+	DefaultMaxRetries = openaic.DefaultMaxRetries
+	DefaultClient     = &http.Client{Timeout: 300 * time.Second}
 )
 
 var _ llm.StreamingLLM = &Provider{}
 
 // Provider implements the Mistral LLM provider.
 type Provider struct {
-	apiKey    string
-	endpoint  string
-	model     string
-	maxTokens int
-	client    *http.Client
+	apiKey     string
+	endpoint   string
+	model      string
+	maxTokens  int
+	maxRetries int
+	client     *http.Client
 
 	// Embedded OpenAI completions provider
 	*openaic.Provider
@@ -34,21 +36,24 @@ type Provider struct {
 // New creates a new Mistral provider with the given options.
 func New(opts ...Option) *Provider {
 	p := &Provider{
-		apiKey:    os.Getenv("MISTRAL_API_KEY"),
-		endpoint:  DefaultEndpoint,
-		client:    DefaultClient,
-		model:     DefaultModel,
-		maxTokens: DefaultMaxTokens,
+		apiKey:     os.Getenv("MISTRAL_API_KEY"),
+		endpoint:   DefaultEndpoint,
+		client:     DefaultClient,
+		model:      DefaultModel,
+		maxTokens:  DefaultMaxTokens,
+		maxRetries: DefaultMaxRetries,
 	}
 	for _, opt := range opts {
 		opt(p)
 	}
 	// Pass the options through to the wrapped OpenAI provider
 	p.Provider = openaic.New(
+		openaic.WithName(fmt.Sprintf("mistral-%s", p.model)),
 		openaic.WithAPIKey(p.apiKey),
 		openaic.WithClient(p.client),
 		openaic.WithEndpoint(p.endpoint),
 		openaic.WithMaxTokens(p.maxTokens),
+		openaic.WithMaxRetries(p.maxRetries),
 		openaic.WithModel(p.model),
 		openaic.WithSystemRole("system"),
 	)

--- a/providers/mistral/mistral.go
+++ b/providers/mistral/mistral.go
@@ -11,23 +11,25 @@ import (
 )
 
 var (
-	DefaultModel      = ModelMistralLarge3
-	DefaultEndpoint   = "https://api.mistral.ai/v1/chat/completions"
-	DefaultMaxTokens  = 32768
-	DefaultMaxRetries = openaic.DefaultMaxRetries
-	DefaultClient     = &http.Client{Timeout: 300 * time.Second}
+	DefaultModel         = ModelMistralLarge3
+	DefaultEndpoint      = "https://api.mistral.ai/v1/chat/completions"
+	DefaultMaxTokens     = 32768
+	DefaultMaxRetries    = openaic.DefaultMaxRetries
+	DefaultRetryBaseWait = openaic.DefaultRetryBaseWait
+	DefaultClient        = &http.Client{Timeout: 300 * time.Second}
 )
 
 var _ llm.StreamingLLM = &Provider{}
 
 // Provider implements the Mistral LLM provider.
 type Provider struct {
-	apiKey     string
-	endpoint   string
-	model      string
-	maxTokens  int
-	maxRetries int
-	client     *http.Client
+	apiKey        string
+	endpoint      string
+	model         string
+	maxTokens     int
+	maxRetries    int
+	retryBaseWait time.Duration
+	client        *http.Client
 
 	// Embedded OpenAI completions provider
 	*openaic.Provider
@@ -36,12 +38,13 @@ type Provider struct {
 // New creates a new Mistral provider with the given options.
 func New(opts ...Option) *Provider {
 	p := &Provider{
-		apiKey:     os.Getenv("MISTRAL_API_KEY"),
-		endpoint:   DefaultEndpoint,
-		client:     DefaultClient,
-		model:      DefaultModel,
-		maxTokens:  DefaultMaxTokens,
-		maxRetries: DefaultMaxRetries,
+		apiKey:        os.Getenv("MISTRAL_API_KEY"),
+		endpoint:      DefaultEndpoint,
+		client:        DefaultClient,
+		model:         DefaultModel,
+		maxTokens:     DefaultMaxTokens,
+		maxRetries:    DefaultMaxRetries,
+		retryBaseWait: DefaultRetryBaseWait,
 	}
 	for _, opt := range opts {
 		opt(p)
@@ -54,6 +57,7 @@ func New(opts ...Option) *Provider {
 		openaic.WithEndpoint(p.endpoint),
 		openaic.WithMaxTokens(p.maxTokens),
 		openaic.WithMaxRetries(p.maxRetries),
+		openaic.WithBaseWait(p.retryBaseWait),
 		openaic.WithModel(p.model),
 		openaic.WithSystemRole("system"),
 	)

--- a/providers/mistral/options.go
+++ b/providers/mistral/options.go
@@ -1,6 +1,9 @@
 package mistral
 
-import "net/http"
+import (
+	"net/http"
+	"time"
+)
 
 // Option is a function that configures the Provider
 type Option func(*Provider)
@@ -38,6 +41,13 @@ func WithMaxTokens(maxTokens int) Option {
 func WithMaxRetries(maxRetries int) Option {
 	return func(p *Provider) {
 		p.maxRetries = maxRetries
+	}
+}
+
+// WithBaseWait sets the base wait duration between retries.
+func WithBaseWait(baseWait time.Duration) Option {
+	return func(p *Provider) {
+		p.retryBaseWait = baseWait
 	}
 }
 

--- a/providers/mistral/options.go
+++ b/providers/mistral/options.go
@@ -33,6 +33,14 @@ func WithMaxTokens(maxTokens int) Option {
 	}
 }
 
+// WithMaxRetries sets the maximum number of retries for transient generation
+// failures (total attempts = maxRetries + 1).
+func WithMaxRetries(maxRetries int) Option {
+	return func(p *Provider) {
+		p.maxRetries = maxRetries
+	}
+}
+
 // WithModel sets the LLM model name to use for the provider
 func WithModel(model string) Option {
 	return func(p *Provider) {

--- a/providers/mistral/stream_retry_test.go
+++ b/providers/mistral/stream_retry_test.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/deepnoodle-ai/dive/llm"
-	openaic "github.com/deepnoodle-ai/dive/providers/openaicompletions"
 	"github.com/deepnoodle-ai/wonton/assert"
 )
 
@@ -23,16 +22,15 @@ func TestWithMaxRetriesControlsStreamingAttempts(t *testing.T) {
 	}))
 	defer server.Close()
 
-	oldRetryBaseWait := openaic.DefaultRetryBaseWait
-	openaic.DefaultRetryBaseWait = time.Millisecond
-	t.Cleanup(func() { openaic.DefaultRetryBaseWait = oldRetryBaseWait })
-
 	provider := New(
 		WithAPIKey("test-key"),
 		WithEndpoint(server.URL),
 		WithMaxRetries(1),
+		WithBaseWait(time.Millisecond),
 	)
-	iterator, err := provider.Stream(context.Background(),
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	iterator, err := provider.Stream(ctx,
 		llm.WithMessages(llm.NewUserTextMessage("hello")),
 	)
 	assert.NoError(t, err)

--- a/providers/mistral/stream_retry_test.go
+++ b/providers/mistral/stream_retry_test.go
@@ -1,0 +1,46 @@
+package mistral
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/deepnoodle-ai/dive/llm"
+	openaic "github.com/deepnoodle-ai/dive/providers/openaicompletions"
+	"github.com/deepnoodle-ai/wonton/assert"
+)
+
+func TestWithMaxRetriesControlsStreamingAttempts(t *testing.T) {
+	var requests atomic.Int64
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests.Add(1)
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = io.WriteString(w, `{"error":{"message":"rate limited"}}`)
+	}))
+	defer server.Close()
+
+	oldRetryBaseWait := openaic.DefaultRetryBaseWait
+	openaic.DefaultRetryBaseWait = time.Millisecond
+	t.Cleanup(func() { openaic.DefaultRetryBaseWait = oldRetryBaseWait })
+
+	provider := New(
+		WithAPIKey("test-key"),
+		WithEndpoint(server.URL),
+		WithMaxRetries(1),
+	)
+	iterator, err := provider.Stream(context.Background(),
+		llm.WithMessages(llm.NewUserTextMessage("hello")),
+	)
+	assert.NoError(t, err)
+	defer iterator.Close()
+	for iterator.Next() {
+	}
+
+	assert.Error(t, iterator.Err())
+	assert.Equal(t, int64(2), requests.Load())
+	assert.Equal(t, provider.Name(), provider.Provider.Name())
+}

--- a/providers/ollama/ollama.go
+++ b/providers/ollama/ollama.go
@@ -11,11 +11,12 @@ import (
 )
 
 var (
-	DefaultModel      = "llama3.2:3b"
-	DefaultEndpoint   = "http://localhost:11434/v1/messages"
-	DefaultMaxTokens  = 32768
-	DefaultMaxRetries = anthropic.DefaultMaxRetries
-	DefaultClient     = &http.Client{Timeout: 300 * time.Second}
+	DefaultModel         = "llama3.2:3b"
+	DefaultEndpoint      = "http://localhost:11434/v1/messages"
+	DefaultMaxTokens     = 32768
+	DefaultMaxRetries    = anthropic.DefaultMaxRetries
+	DefaultRetryBaseWait = anthropic.DefaultRetryBaseWait
+	DefaultClient        = &http.Client{Timeout: 300 * time.Second}
 )
 
 var _ llm.StreamingLLM = &Provider{}
@@ -23,12 +24,13 @@ var _ llm.StreamingLLM = &Provider{}
 // Provider implements the Ollama LLM provider for local model serving.
 // It uses Ollama's Anthropic-compatible Messages API endpoint.
 type Provider struct {
-	apiKey     string
-	endpoint   string
-	model      string
-	maxTokens  int
-	maxRetries int
-	client     *http.Client
+	apiKey        string
+	endpoint      string
+	model         string
+	maxTokens     int
+	maxRetries    int
+	retryBaseWait time.Duration
+	client        *http.Client
 
 	// Embedded Anthropic provider
 	*anthropic.Provider
@@ -37,12 +39,13 @@ type Provider struct {
 // New creates a new Ollama provider with the given options.
 func New(opts ...Option) *Provider {
 	p := &Provider{
-		apiKey:     getAPIKey(),
-		endpoint:   DefaultEndpoint,
-		client:     DefaultClient,
-		model:      DefaultModel,
-		maxTokens:  DefaultMaxTokens,
-		maxRetries: DefaultMaxRetries,
+		apiKey:        getAPIKey(),
+		endpoint:      DefaultEndpoint,
+		client:        DefaultClient,
+		model:         DefaultModel,
+		maxTokens:     DefaultMaxTokens,
+		maxRetries:    DefaultMaxRetries,
+		retryBaseWait: DefaultRetryBaseWait,
 	}
 	for _, opt := range opts {
 		opt(p)
@@ -55,6 +58,7 @@ func New(opts ...Option) *Provider {
 		anthropic.WithEndpoint(p.endpoint),
 		anthropic.WithMaxTokens(p.maxTokens),
 		anthropic.WithMaxRetries(p.maxRetries),
+		anthropic.WithBaseWait(p.retryBaseWait),
 		anthropic.WithModel(p.model),
 	)
 	return p

--- a/providers/ollama/ollama.go
+++ b/providers/ollama/ollama.go
@@ -11,10 +11,11 @@ import (
 )
 
 var (
-	DefaultModel     = "llama3.2:3b"
-	DefaultEndpoint  = "http://localhost:11434/v1/messages"
-	DefaultMaxTokens = 32768
-	DefaultClient    = &http.Client{Timeout: 300 * time.Second}
+	DefaultModel      = "llama3.2:3b"
+	DefaultEndpoint   = "http://localhost:11434/v1/messages"
+	DefaultMaxTokens  = 32768
+	DefaultMaxRetries = anthropic.DefaultMaxRetries
+	DefaultClient     = &http.Client{Timeout: 300 * time.Second}
 )
 
 var _ llm.StreamingLLM = &Provider{}
@@ -22,11 +23,12 @@ var _ llm.StreamingLLM = &Provider{}
 // Provider implements the Ollama LLM provider for local model serving.
 // It uses Ollama's Anthropic-compatible Messages API endpoint.
 type Provider struct {
-	apiKey    string
-	endpoint  string
-	model     string
-	maxTokens int
-	client    *http.Client
+	apiKey     string
+	endpoint   string
+	model      string
+	maxTokens  int
+	maxRetries int
+	client     *http.Client
 
 	// Embedded Anthropic provider
 	*anthropic.Provider
@@ -35,21 +37,24 @@ type Provider struct {
 // New creates a new Ollama provider with the given options.
 func New(opts ...Option) *Provider {
 	p := &Provider{
-		apiKey:    getAPIKey(),
-		endpoint:  DefaultEndpoint,
-		client:    DefaultClient,
-		model:     DefaultModel,
-		maxTokens: DefaultMaxTokens,
+		apiKey:     getAPIKey(),
+		endpoint:   DefaultEndpoint,
+		client:     DefaultClient,
+		model:      DefaultModel,
+		maxTokens:  DefaultMaxTokens,
+		maxRetries: DefaultMaxRetries,
 	}
 	for _, opt := range opts {
 		opt(p)
 	}
 	// Pass the options through to the wrapped Anthropic provider
 	p.Provider = anthropic.New(
+		anthropic.WithName(fmt.Sprintf("ollama-%s", p.model)),
 		anthropic.WithAPIKey(p.apiKey),
 		anthropic.WithClient(p.client),
 		anthropic.WithEndpoint(p.endpoint),
 		anthropic.WithMaxTokens(p.maxTokens),
+		anthropic.WithMaxRetries(p.maxRetries),
 		anthropic.WithModel(p.model),
 	)
 	return p

--- a/providers/ollama/options.go
+++ b/providers/ollama/options.go
@@ -33,6 +33,14 @@ func WithMaxTokens(maxTokens int) Option {
 	}
 }
 
+// WithMaxRetries sets the maximum number of retries for transient generation
+// failures (total attempts = maxRetries + 1).
+func WithMaxRetries(maxRetries int) Option {
+	return func(p *Provider) {
+		p.maxRetries = maxRetries
+	}
+}
+
 // WithModel sets the LLM model name to use for the provider
 func WithModel(model string) Option {
 	return func(p *Provider) {

--- a/providers/ollama/options.go
+++ b/providers/ollama/options.go
@@ -1,6 +1,9 @@
 package ollama
 
-import "net/http"
+import (
+	"net/http"
+	"time"
+)
 
 // Option is a function that configures the Provider
 type Option func(*Provider)
@@ -38,6 +41,13 @@ func WithMaxTokens(maxTokens int) Option {
 func WithMaxRetries(maxRetries int) Option {
 	return func(p *Provider) {
 		p.maxRetries = maxRetries
+	}
+}
+
+// WithBaseWait sets the base wait duration between retries.
+func WithBaseWait(baseWait time.Duration) Option {
+	return func(p *Provider) {
+		p.retryBaseWait = baseWait
 	}
 }
 

--- a/providers/ollama/stream_retry_test.go
+++ b/providers/ollama/stream_retry_test.go
@@ -1,0 +1,45 @@
+package ollama
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/deepnoodle-ai/dive/llm"
+	"github.com/deepnoodle-ai/dive/providers/anthropic"
+	"github.com/deepnoodle-ai/wonton/assert"
+)
+
+func TestWithMaxRetriesControlsStreamingAttempts(t *testing.T) {
+	var requests atomic.Int64
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests.Add(1)
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = io.WriteString(w, `{"error":{"message":"rate limited"}}`)
+	}))
+	defer server.Close()
+
+	oldRetryBaseWait := anthropic.DefaultRetryBaseWait
+	anthropic.DefaultRetryBaseWait = time.Millisecond
+	t.Cleanup(func() { anthropic.DefaultRetryBaseWait = oldRetryBaseWait })
+
+	provider := New(
+		WithEndpoint(server.URL),
+		WithMaxRetries(1),
+	)
+	iterator, err := provider.Stream(context.Background(),
+		llm.WithMessages(llm.NewUserTextMessage("hello")),
+	)
+	assert.NoError(t, err)
+	defer iterator.Close()
+	for iterator.Next() {
+	}
+
+	assert.Error(t, iterator.Err())
+	assert.Equal(t, int64(2), requests.Load())
+	assert.Equal(t, provider.Name(), provider.Provider.Name())
+}

--- a/providers/ollama/stream_retry_test.go
+++ b/providers/ollama/stream_retry_test.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/deepnoodle-ai/dive/llm"
-	"github.com/deepnoodle-ai/dive/providers/anthropic"
 	"github.com/deepnoodle-ai/wonton/assert"
 )
 
@@ -23,15 +22,14 @@ func TestWithMaxRetriesControlsStreamingAttempts(t *testing.T) {
 	}))
 	defer server.Close()
 
-	oldRetryBaseWait := anthropic.DefaultRetryBaseWait
-	anthropic.DefaultRetryBaseWait = time.Millisecond
-	t.Cleanup(func() { anthropic.DefaultRetryBaseWait = oldRetryBaseWait })
-
 	provider := New(
 		WithEndpoint(server.URL),
 		WithMaxRetries(1),
+		WithBaseWait(time.Millisecond),
 	)
-	iterator, err := provider.Stream(context.Background(),
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	iterator, err := provider.Stream(ctx,
 		llm.WithMessages(llm.NewUserTextMessage("hello")),
 	)
 	assert.NoError(t, err)

--- a/providers/openai/errors.go
+++ b/providers/openai/errors.go
@@ -1,0 +1,16 @@
+package openai
+
+import (
+	"errors"
+
+	"github.com/deepnoodle-ai/dive/providers"
+	openaisdk "github.com/openai/openai-go/v3"
+)
+
+func normalizeOpenAIError(err error) error {
+	var apiErr *openaisdk.Error
+	if errors.As(err, &apiErr) {
+		return providers.NewError(apiErr.StatusCode, apiErr.Message)
+	}
+	return err
+}

--- a/providers/openai/options.go
+++ b/providers/openai/options.go
@@ -2,6 +2,7 @@ package openai
 
 import (
 	"net/http"
+	"time"
 
 	"github.com/openai/openai-go/v3/option"
 )
@@ -55,6 +56,13 @@ func WithMaxTokens(maxTokens int) Option {
 func WithMaxRetries(maxRetries int) Option {
 	return func(p *Provider) {
 		p.maxRetries = maxRetries
+	}
+}
+
+// WithRetryBaseWait sets the base wait duration between retries.
+func WithRetryBaseWait(retryBaseWait time.Duration) Option {
+	return func(p *Provider) {
+		p.retryBaseWait = retryBaseWait
 	}
 }
 

--- a/providers/openai/provider.go
+++ b/providers/openai/provider.go
@@ -2,7 +2,6 @@ package openai
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net/http"
 	"os"
@@ -120,11 +119,7 @@ func (p *Provider) Generate(ctx context.Context, opts ...llm.Option) (*llm.Respo
 			reqOpts...,
 		)
 		if err != nil {
-			var apierr *openai.Error
-			if errors.As(err, &apierr) {
-				return providers.NewError(apierr.StatusCode, apierr.Message)
-			}
-			return err
+			return normalizeOpenAIError(err)
 		}
 		return nil
 	}, retry.WithMaxAttempts(p.maxRetries+1), retry.WithBackoff(p.retryBaseWait, 5*time.Minute), retry.WithRetryIf(retry.SkipPermanent()))
@@ -177,13 +172,22 @@ func (p *Provider) Stream(ctx context.Context, opts ...llm.Option) (llm.StreamIt
 	streamOpts := append([]option.RequestOption{
 		option.WithRequestTimeout(5 * time.Minute),
 	}, p.extraRequestOptions...)
-	streamSDK := p.client.Responses.NewStreaming(
+	stream := providers.NewRetryingStreamIterator(
 		ctx,
-		params,
-		streamOpts...,
+		providers.StreamRetryConfig{
+			Provider:       p.Name(),
+			MaxRetries:     p.maxRetries,
+			RetryBaseWait:  p.retryBaseWait,
+			Logger:         config.Logger,
+			NormalizeError: normalizeOpenAIError,
+		},
+		func() (llm.StreamIterator, error) {
+			streamSDK := p.client.Responses.NewStreaming(ctx, params, streamOpts...)
+			return newOpenAIStreamIterator(streamSDK, config), nil
+		},
 	)
 
-	return newOpenAIStreamIterator(streamSDK, config), nil
+	return stream, nil
 }
 
 // buildRequestParams converts llm.Config to responses.ResponseNewParams

--- a/providers/openai/stream_retry_agent_test.go
+++ b/providers/openai/stream_retry_agent_test.go
@@ -1,0 +1,127 @@
+package openai
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	dive "github.com/deepnoodle-ai/dive"
+	"github.com/deepnoodle-ai/wonton/assert"
+)
+
+const toolCallStream = `event: response.created
+data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_tool","status":"in_progress","model":"test-model","output":[]}}
+
+event: response.output_item.added
+data: {"type":"response.output_item.added","sequence_number":1,"output_index":0,"item":{"id":"fc_1","type":"function_call","status":"in_progress","arguments":"","call_id":"call_1","name":"record_effect"}}
+
+event: response.function_call_arguments.delta
+data: {"type":"response.function_call_arguments.delta","sequence_number":2,"output_index":0,"item_id":"fc_1","delta":"{}"}
+
+event: response.function_call_arguments.done
+data: {"type":"response.function_call_arguments.done","sequence_number":3,"output_index":0,"item_id":"fc_1","arguments":"{}"}
+
+event: response.output_item.done
+data: {"type":"response.output_item.done","sequence_number":4,"output_index":0,"item":{"id":"fc_1","type":"function_call","status":"completed","arguments":"{}","call_id":"call_1","name":"record_effect"}}
+
+event: response.completed
+data: {"type":"response.completed","sequence_number":5,"response":{"id":"resp_tool","status":"completed","model":"test-model","output":[{"id":"fc_1","type":"function_call","status":"completed","arguments":"{}","call_id":"call_1","name":"record_effect"}],"usage":{"input_tokens":1,"output_tokens":1,"input_tokens_details":{"cached_tokens":0},"output_tokens_details":{"reasoning_tokens":0}}}}
+
+`
+
+const finalAnswerStream = `event: response.created
+data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_final","status":"in_progress","model":"test-model","output":[]}}
+
+event: response.output_item.added
+data: {"type":"response.output_item.added","sequence_number":1,"output_index":0,"item":{"id":"msg_1","type":"message","status":"in_progress","content":[],"role":"assistant"}}
+
+event: response.content_part.added
+data: {"type":"response.content_part.added","sequence_number":2,"item_id":"msg_1","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"text":""}}
+
+event: response.output_text.delta
+data: {"type":"response.output_text.delta","sequence_number":3,"item_id":"msg_1","output_index":0,"content_index":0,"delta":"effect recorded once"}
+
+event: response.output_text.done
+data: {"type":"response.output_text.done","sequence_number":4,"item_id":"msg_1","output_index":0,"content_index":0,"text":"effect recorded once"}
+
+event: response.output_item.done
+data: {"type":"response.output_item.done","sequence_number":5,"output_index":0,"item":{"id":"msg_1","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"text":"effect recorded once"}],"role":"assistant"}}
+
+event: response.completed
+data: {"type":"response.completed","sequence_number":6,"response":{"id":"resp_final","status":"completed","model":"test-model","output":[{"id":"msg_1","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"text":"effect recorded once"}],"role":"assistant"}],"usage":{"input_tokens":2,"output_tokens":3,"input_tokens_details":{"cached_tokens":0},"output_tokens_details":{"reasoning_tokens":0}}}}
+
+`
+
+func TestAgentRetriesLaterStreamingGenerationWithoutReexecutingTool(t *testing.T) {
+	var requests atomic.Int64
+	var bodiesMu sync.Mutex
+	var requestBodies []string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		body, err := io.ReadAll(req.Body)
+		if err != nil {
+			t.Errorf("read request body: %v", err)
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		bodiesMu.Lock()
+		requestBodies = append(requestBodies, string(body))
+		bodiesMu.Unlock()
+
+		switch requests.Add(1) {
+		case 1:
+			w.Header().Set("Content-Type", "text/event-stream")
+			_, _ = io.WriteString(w, toolCallStream)
+		case 2:
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusTooManyRequests)
+			_, _ = io.WriteString(w, `{"error":{"message":"temporarily at capacity","type":"rate_limit_error"}}`)
+		case 3:
+			w.Header().Set("Content-Type", "text/event-stream")
+			_, _ = io.WriteString(w, finalAnswerStream)
+		default:
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+	}))
+	defer server.Close()
+
+	provider := New(
+		WithAPIKey("test-key"),
+		WithEndpoint(server.URL),
+		WithMaxRetries(1),
+	)
+	provider.retryBaseWait = time.Millisecond
+
+	var toolCalls atomic.Int64
+	tool := dive.FuncTool("record_effect", "Record one external effect",
+		func(context.Context, struct{}) (*dive.ToolResult, error) {
+			toolCalls.Add(1)
+			return dive.NewToolResultText("recorded"), nil
+		},
+	)
+	agent, err := dive.NewAgent(dive.AgentOptions{
+		Model: provider,
+		Tools: []dive.Tool{tool},
+	})
+	assert.NoError(t, err)
+
+	response, err := agent.CreateResponse(context.Background(), dive.WithInput("Record the effect"))
+	assert.NoError(t, err)
+	assert.Equal(t, "effect recorded once", response.OutputText())
+	assert.Equal(t, int64(1), toolCalls.Load())
+	assert.Equal(t, int64(3), requests.Load())
+
+	bodiesMu.Lock()
+	bodies := append([]string(nil), requestBodies...)
+	bodiesMu.Unlock()
+	assert.Len(t, bodies, 3)
+	assert.False(t, strings.Contains(bodies[0], "function_call_output"))
+	assert.Contains(t, bodies[1], "function_call_output")
+	assert.Equal(t, bodies[1], bodies[2])
+}

--- a/providers/openai/stream_retry_test.go
+++ b/providers/openai/stream_retry_test.go
@@ -1,0 +1,293 @@
+package openai
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/deepnoodle-ai/dive/llm"
+	"github.com/deepnoodle-ai/wonton/assert"
+)
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+type failingOpenAIStreamBody struct {
+	data   *strings.Reader
+	err    error
+	closed atomic.Bool
+}
+
+func (b *failingOpenAIStreamBody) Read(p []byte) (int, error) {
+	if b.data.Len() == 0 {
+		return 0, b.err
+	}
+	return b.data.Read(p)
+}
+
+func (b *failingOpenAIStreamBody) Close() error {
+	b.closed.Store(true)
+	return nil
+}
+
+func streamHTTPResponse(req *http.Request, status int, contentType, body string) *http.Response {
+	return &http.Response{
+		StatusCode: status,
+		Status:     http.StatusText(status),
+		Header:     http.Header{"Content-Type": []string{contentType}},
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Request:    req,
+	}
+}
+
+func consumeStream(t *testing.T, provider *Provider, opts ...llm.Option) (llm.StreamIterator, []*llm.Event) {
+	t.Helper()
+	iterator, err := provider.Stream(context.Background(), opts...)
+	assert.NoError(t, err)
+
+	var events []*llm.Event
+	for iterator.Next() {
+		events = append(events, iterator.Event())
+	}
+	return iterator, events
+}
+
+func TestStreamRetryPersistent429(t *testing.T) {
+	transport := &countingTransport{}
+	provider := New(
+		WithAPIKey("test-key"),
+		WithClient(&http.Client{Transport: transport}),
+		WithMaxRetries(2),
+	)
+	provider.retryBaseWait = time.Millisecond
+
+	iterator, _ := consumeStream(t, provider,
+		llm.WithMessages(llm.NewUserTextMessage("hello")),
+	)
+	defer iterator.Close()
+
+	assert.Error(t, iterator.Err())
+	assert.Equal(t, int64(3), transport.requests.Load())
+	var statusErr interface{ StatusCode() int }
+	assert.True(t, errors.As(iterator.Err(), &statusErr))
+	assert.Equal(t, http.StatusTooManyRequests, statusErr.StatusCode())
+}
+
+func TestStreamRetry429ThenSuccess(t *testing.T) {
+	fixture, err := os.ReadFile("fixtures/events-hello.txt")
+	assert.NoError(t, err)
+
+	var requests atomic.Int64
+	transport := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if requests.Add(1) == 1 {
+			return streamHTTPResponse(req, http.StatusTooManyRequests, "application/json",
+				`{"error":{"message":"temporarily at capacity","type":"rate_limit_error"}}`), nil
+		}
+		return streamHTTPResponse(req, http.StatusOK, "text/event-stream", string(fixture)), nil
+	})
+	provider := New(
+		WithAPIKey("test-key"),
+		WithClient(&http.Client{Transport: transport}),
+		WithMaxRetries(2),
+	)
+	provider.retryBaseWait = time.Millisecond
+	var hooks atomic.Int64
+
+	iterator, events := consumeStream(t, provider,
+		llm.WithMessages(llm.NewUserTextMessage("hello")),
+		llm.WithHook(llm.BeforeGenerate, func(context.Context, *llm.HookContext) error {
+			hooks.Add(1)
+			return nil
+		}),
+	)
+	defer iterator.Close()
+
+	assert.NoError(t, iterator.Err())
+	assert.Equal(t, int64(2), requests.Load())
+	assert.Equal(t, int64(1), hooks.Load())
+
+	accumulator := llm.NewResponseAccumulator()
+	messageStarts := 0
+	for _, event := range events {
+		if event.Type == llm.EventTypeMessageStart {
+			messageStarts++
+		}
+		assert.NoError(t, accumulator.AddEvent(event))
+	}
+	assert.Equal(t, 1, messageStarts)
+	assert.Equal(t, "Hello! How can I assist you today?", accumulator.Response().Message().Text())
+}
+
+func TestStreamRetryTransportErrorThenSuccess(t *testing.T) {
+	fixture, err := os.ReadFile("fixtures/events-hello.txt")
+	assert.NoError(t, err)
+
+	sentinel := errors.New("connection reset before response headers")
+	var requests atomic.Int64
+	transport := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if requests.Add(1) == 1 {
+			return nil, sentinel
+		}
+		return streamHTTPResponse(req, http.StatusOK, "text/event-stream", string(fixture)), nil
+	})
+	provider := New(
+		WithAPIKey("test-key"),
+		WithClient(&http.Client{Transport: transport}),
+		WithMaxRetries(1),
+	)
+	provider.retryBaseWait = time.Millisecond
+
+	iterator, events := consumeStream(t, provider,
+		llm.WithMessages(llm.NewUserTextMessage("hello")),
+	)
+	defer iterator.Close()
+
+	assert.NoError(t, iterator.Err())
+	assert.Equal(t, int64(2), requests.Load())
+	accumulator := llm.NewResponseAccumulator()
+	for _, event := range events {
+		assert.NoError(t, accumulator.AddEvent(event))
+	}
+	assert.True(t, accumulator.IsComplete())
+	assert.Equal(t, "Hello! How can I assist you today?", accumulator.Response().Message().Text())
+}
+
+func TestStreamDoesNotRetryTransportErrorAfterFirstEvent(t *testing.T) {
+	sentinel := errors.New("connection reset after first event")
+	partialStream := `event: response.created
+data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_partial","status":"in_progress","model":"test-model","output":[]}}
+
+`
+	body := &failingOpenAIStreamBody{data: strings.NewReader(partialStream), err: sentinel}
+	var requests atomic.Int64
+	transport := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		requests.Add(1)
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Status:     http.StatusText(http.StatusOK),
+			Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+			Body:       body,
+			Request:    req,
+		}, nil
+	})
+	provider := New(
+		WithAPIKey("test-key"),
+		WithClient(&http.Client{Transport: transport}),
+		WithMaxRetries(2),
+	)
+	provider.retryBaseWait = time.Millisecond
+	iterator, err := provider.Stream(context.Background(),
+		llm.WithMessages(llm.NewUserTextMessage("hello")),
+	)
+	assert.NoError(t, err)
+	defer iterator.Close()
+
+	assert.True(t, iterator.Next())
+	assert.Equal(t, llm.EventTypeMessageStart, iterator.Event().Type)
+	assert.False(t, iterator.Next())
+	assert.True(t, errors.Is(iterator.Err(), sentinel))
+	assert.Equal(t, int64(1), requests.Load())
+	assert.True(t, body.closed.Load())
+}
+
+func TestStreamRetryPermanent400(t *testing.T) {
+	var requests atomic.Int64
+	transport := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		requests.Add(1)
+		return streamHTTPResponse(req, http.StatusBadRequest, "application/json",
+			`{"error":{"message":"invalid request","type":"invalid_request_error"}}`), nil
+	})
+	provider := New(
+		WithAPIKey("test-key"),
+		WithClient(&http.Client{Transport: transport}),
+		WithMaxRetries(2),
+	)
+	provider.retryBaseWait = time.Millisecond
+
+	iterator, _ := consumeStream(t, provider,
+		llm.WithMessages(llm.NewUserTextMessage("hello")),
+	)
+	defer iterator.Close()
+
+	assert.Error(t, iterator.Err())
+	assert.Equal(t, int64(1), requests.Load())
+}
+
+type retrySignalLogger struct {
+	retry chan struct{}
+	once  sync.Once
+}
+
+func (l *retrySignalLogger) Debug(string, ...any)   {}
+func (l *retrySignalLogger) Info(string, ...any)    {}
+func (l *retrySignalLogger) Error(string, ...any)   {}
+func (l *retrySignalLogger) With(...any) llm.Logger { return l }
+func (l *retrySignalLogger) Warn(string, ...any) {
+	l.once.Do(func() { close(l.retry) })
+}
+
+func TestStreamRetryCancellationDuringBackoff(t *testing.T) {
+	transport := &countingTransport{}
+	provider := New(
+		WithAPIKey("test-key"),
+		WithClient(&http.Client{Transport: transport}),
+		WithMaxRetries(2),
+	)
+	provider.retryBaseWait = 10 * time.Second
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	logger := &retrySignalLogger{retry: make(chan struct{})}
+	iterator, err := provider.Stream(ctx,
+		llm.WithMessages(llm.NewUserTextMessage("hello")),
+		llm.WithLogger(logger),
+	)
+	assert.NoError(t, err)
+	defer iterator.Close()
+
+	next := make(chan bool, 1)
+	go func() { next <- iterator.Next() }()
+
+	select {
+	case <-logger.retry:
+		cancel()
+	case <-time.After(time.Second):
+		t.Fatal("retry did not enter backoff")
+	}
+
+	select {
+	case gotEvent := <-next:
+		assert.False(t, gotEvent)
+	case <-time.After(time.Second):
+		t.Fatal("stream did not stop promptly after cancellation")
+	}
+	assert.True(t, errors.Is(iterator.Err(), context.Canceled))
+	assert.Equal(t, int64(1), transport.requests.Load())
+}
+
+func TestStreamRetryDefaultBudget(t *testing.T) {
+	transport := &countingTransport{}
+	provider := New(
+		WithAPIKey("test-key"),
+		WithClient(&http.Client{Transport: transport}),
+	)
+	provider.retryBaseWait = time.Millisecond
+
+	iterator, _ := consumeStream(t, provider,
+		llm.WithMessages(llm.NewUserTextMessage("hello")),
+	)
+	defer iterator.Close()
+
+	assert.Error(t, iterator.Err())
+	assert.Equal(t, int64(DefaultMaxRetries+1), transport.requests.Load())
+}

--- a/providers/openaicompletions/openai.go
+++ b/providers/openaicompletions/openai.go
@@ -62,6 +62,7 @@ var _ llm.StreamingLLM = &Provider{}
 // This is used as the base for several providers including Grok, Groq, Mistral,
 // Ollama, and OpenRouter.
 type Provider struct {
+	name          string
 	client        *http.Client
 	apiKey        string
 	endpoint      string
@@ -91,6 +92,9 @@ func New(opts ...Option) *Provider {
 }
 
 func (p *Provider) Name() string {
+	if p.name != "" {
+		return p.name
+	}
 	return "openai-completions"
 }
 
@@ -267,29 +271,27 @@ func (p *Provider) Stream(ctx context.Context, opts ...llm.Option) (llm.StreamIt
 		return nil, err
 	}
 
-	var stream *StreamIterator
-	err = retry.DoSimple(ctx, func() error {
+	stream := providers.NewRetryingStreamIterator(ctx, providers.StreamRetryConfig{
+		Provider:      p.Name(),
+		MaxRetries:    p.maxRetries,
+		RetryBaseWait: p.retryBaseWait,
+		Logger:        config.Logger,
+	}, func() (llm.StreamIterator, error) {
 		req, err := p.createRequest(ctx, body, config, true)
 		if err != nil {
-			return err
+			return nil, err
 		}
 
 		resp, err := p.client.Do(req)
 		if err != nil {
-			return fmt.Errorf("error making request: %w", err)
+			return nil, fmt.Errorf("error making request: %w", err)
 		}
 		if resp.StatusCode != http.StatusOK {
 			body, _ := io.ReadAll(resp.Body)
 			resp.Body.Close()
-			if resp.StatusCode == 429 {
-				if config.Logger != nil {
-					config.Logger.Warn("rate limit exceeded",
-						"status", resp.StatusCode, "body", string(body))
-				}
-			}
-			return providers.NewError(resp.StatusCode, string(body))
+			return nil, providers.NewError(resp.StatusCode, string(body))
 		}
-		stream = &StreamIterator{
+		return &StreamIterator{
 			body:              resp.Body,
 			reader:            bufio.NewReader(resp.Body),
 			contentBlocks:     map[int]*ContentBlockAccumulator{},
@@ -299,13 +301,8 @@ func (p *Provider) Stream(ctx context.Context, opts ...llm.Option) (llm.StreamIt
 			prefillClosingTag: config.PrefillClosingTag,
 			thinkingIndex:     -1,
 			textIndex:         -1,
-		}
-		return nil
-	}, retry.WithMaxAttempts(p.maxRetries+1), retry.WithBackoff(p.retryBaseWait, 5*time.Minute), retry.WithRetryIf(retry.SkipPermanent()))
-
-	if err != nil {
-		return nil, err
-	}
+		}, nil
+	})
 	return stream, nil
 }
 

--- a/providers/openaicompletions/options.go
+++ b/providers/openaicompletions/options.go
@@ -8,6 +8,14 @@ import (
 // Option is a function that configures the Provider
 type Option func(*Provider)
 
+// WithName overrides the provider name used for logging and observability.
+// It is intended for providers that embed the Chat Completions adapter.
+func WithName(name string) Option {
+	return func(p *Provider) {
+		p.name = name
+	}
+}
+
 // WithAPIKey sets the API key for the provider
 func WithAPIKey(apiKey string) Option {
 	return func(p *Provider) {

--- a/providers/openaicompletions/stream_retry_test.go
+++ b/providers/openaicompletions/stream_retry_test.go
@@ -1,0 +1,170 @@
+package openaicompletions
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/deepnoodle-ai/dive/llm"
+	"github.com/deepnoodle-ai/wonton/assert"
+)
+
+const successfulChatCompletionsStream = `data: {"id":"chatcmpl_1","object":"chat.completion.chunk","model":"test-model","choices":[{"index":0,"delta":{"role":"assistant","content":"ok"}}]}
+
+data: {"id":"chatcmpl_1","object":"chat.completion.chunk","model":"test-model","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}
+
+data: {"id":"chatcmpl_1","object":"chat.completion.chunk","model":"test-model","choices":[],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}
+
+data: [DONE]
+
+`
+
+type completionsRoundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f completionsRoundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+type failingCompletionsBody struct {
+	data   *strings.Reader
+	err    error
+	closed atomic.Bool
+}
+
+func (b *failingCompletionsBody) Read(p []byte) (int, error) {
+	if b.data.Len() == 0 {
+		return 0, b.err
+	}
+	return b.data.Read(p)
+}
+
+func (b *failingCompletionsBody) Close() error {
+	b.closed.Store(true)
+	return nil
+}
+
+func completionsResponse(req *http.Request, body io.ReadCloser) *http.Response {
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Status:     http.StatusText(http.StatusOK),
+		Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+		Body:       body,
+		Request:    req,
+	}
+}
+
+func consumeCompletionsStream(t *testing.T, iterator llm.StreamIterator) *llm.ResponseAccumulator {
+	t.Helper()
+	accumulator := llm.NewResponseAccumulator()
+	for iterator.Next() {
+		assert.NoError(t, accumulator.AddEvent(iterator.Event()))
+	}
+	assert.NoError(t, iterator.Err())
+	return accumulator
+}
+
+func TestStreamRetriesBeforeFirstEvent(t *testing.T) {
+	var requests atomic.Int64
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if requests.Add(1) == 1 {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusTooManyRequests)
+			_, _ = io.WriteString(w, `{"error":{"message":"temporarily overloaded"}}`)
+			return
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = io.WriteString(w, successfulChatCompletionsStream)
+	}))
+	defer server.Close()
+
+	provider := New(
+		WithAPIKey("test-key"),
+		WithEndpoint(server.URL),
+		WithMaxRetries(1),
+		WithBaseWait(time.Millisecond),
+	)
+	var hooks atomic.Int64
+	iterator, err := provider.Stream(context.Background(),
+		llm.WithMessages(llm.NewUserTextMessage("hello")),
+		llm.WithHook(llm.BeforeGenerate, func(context.Context, *llm.HookContext) error {
+			hooks.Add(1)
+			return nil
+		}),
+	)
+	assert.NoError(t, err)
+	defer iterator.Close()
+
+	accumulator := consumeCompletionsStream(t, iterator)
+	assert.True(t, accumulator.IsComplete())
+	assert.Equal(t, "ok", accumulator.Response().Message().Text())
+	assert.Equal(t, int64(2), requests.Load())
+	assert.Equal(t, int64(1), hooks.Load())
+}
+
+func TestStreamRetriesBodyReadFailureBeforeFirstEvent(t *testing.T) {
+	sentinel := errors.New("connection reset before first event")
+	failedBody := &failingCompletionsBody{data: strings.NewReader(""), err: sentinel}
+	var requests atomic.Int64
+	client := &http.Client{Transport: completionsRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if requests.Add(1) == 1 {
+			return completionsResponse(req, failedBody), nil
+		}
+		return completionsResponse(req, io.NopCloser(strings.NewReader(successfulChatCompletionsStream))), nil
+	})}
+	provider := New(
+		WithAPIKey("test-key"),
+		WithClient(client),
+		WithMaxRetries(1),
+		WithBaseWait(time.Millisecond),
+	)
+	iterator, err := provider.Stream(context.Background(),
+		llm.WithMessages(llm.NewUserTextMessage("hello")),
+	)
+	assert.NoError(t, err)
+	defer iterator.Close()
+
+	accumulator := consumeCompletionsStream(t, iterator)
+	assert.True(t, accumulator.IsComplete())
+	assert.Equal(t, "ok", accumulator.Response().Message().Text())
+	assert.Equal(t, int64(2), requests.Load())
+	assert.True(t, failedBody.closed.Load())
+}
+
+func TestStreamDoesNotRetryBodyFailureAfterFirstEvent(t *testing.T) {
+	sentinel := errors.New("connection reset after first event")
+	partialBody := &failingCompletionsBody{
+		data: strings.NewReader(`data: {"id":"chatcmpl_1","object":"chat.completion.chunk","model":"test-model","choices":[{"index":0,"delta":{"role":"assistant","content":"partial"}}]}` + "\n"),
+		err:  sentinel,
+	}
+	var requests atomic.Int64
+	client := &http.Client{Transport: completionsRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		requests.Add(1)
+		return completionsResponse(req, partialBody), nil
+	})}
+	provider := New(
+		WithAPIKey("test-key"),
+		WithClient(client),
+		WithMaxRetries(2),
+		WithBaseWait(time.Millisecond),
+	)
+	iterator, err := provider.Stream(context.Background(),
+		llm.WithMessages(llm.NewUserTextMessage("hello")),
+	)
+	assert.NoError(t, err)
+	defer iterator.Close()
+
+	var events int
+	for iterator.Next() {
+		events++
+	}
+	assert.True(t, events > 0)
+	assert.True(t, errors.Is(iterator.Err(), sentinel))
+	assert.Equal(t, int64(1), requests.Load())
+	assert.True(t, partialBody.closed.Load())
+}

--- a/providers/openrouter/openrouter.go
+++ b/providers/openrouter/openrouter.go
@@ -10,23 +10,25 @@ import (
 )
 
 var (
-	DefaultModel     = ModelClaudeOpus48
-	DefaultEndpoint  = "https://openrouter.ai/api/v1/chat/completions"
-	DefaultMaxTokens = 32768
-	DefaultClient    = &http.Client{Timeout: 300 * time.Second}
+	DefaultModel      = ModelClaudeOpus48
+	DefaultEndpoint   = "https://openrouter.ai/api/v1/chat/completions"
+	DefaultMaxTokens  = 32768
+	DefaultMaxRetries = openaic.DefaultMaxRetries
+	DefaultClient     = &http.Client{Timeout: 300 * time.Second}
 )
 
 var _ llm.StreamingLLM = &Provider{}
 
 // Provider implements the OpenRouter multi-provider LLM proxy.
 type Provider struct {
-	apiKey    string
-	endpoint  string
-	model     string
-	maxTokens int
-	client    *http.Client
-	siteURL   string
-	siteName  string
+	apiKey     string
+	endpoint   string
+	model      string
+	maxTokens  int
+	maxRetries int
+	client     *http.Client
+	siteURL    string
+	siteName   string
 
 	// Embedded OpenAI completions provider
 	*openaic.Provider
@@ -35,11 +37,12 @@ type Provider struct {
 // New creates a new OpenRouter provider with the given options.
 func New(opts ...Option) *Provider {
 	p := &Provider{
-		apiKey:    getAPIKey(),
-		endpoint:  DefaultEndpoint,
-		client:    DefaultClient,
-		model:     DefaultModel,
-		maxTokens: DefaultMaxTokens,
+		apiKey:     getAPIKey(),
+		endpoint:   DefaultEndpoint,
+		client:     DefaultClient,
+		model:      DefaultModel,
+		maxTokens:  DefaultMaxTokens,
+		maxRetries: DefaultMaxRetries,
 	}
 	for _, opt := range opts {
 		opt(p)
@@ -64,10 +67,12 @@ func New(opts ...Option) *Provider {
 
 	// Pass the options through to the wrapped OpenAI provider
 	p.Provider = openaic.New(
+		openaic.WithName("openrouter"),
 		openaic.WithAPIKey(p.apiKey),
 		openaic.WithClient(customClient),
 		openaic.WithEndpoint(p.endpoint),
 		openaic.WithMaxTokens(p.maxTokens),
+		openaic.WithMaxRetries(p.maxRetries),
 		openaic.WithModel(p.model),
 		openaic.WithSystemRole("system"),
 	)

--- a/providers/openrouter/openrouter.go
+++ b/providers/openrouter/openrouter.go
@@ -10,25 +10,27 @@ import (
 )
 
 var (
-	DefaultModel      = ModelClaudeOpus48
-	DefaultEndpoint   = "https://openrouter.ai/api/v1/chat/completions"
-	DefaultMaxTokens  = 32768
-	DefaultMaxRetries = openaic.DefaultMaxRetries
-	DefaultClient     = &http.Client{Timeout: 300 * time.Second}
+	DefaultModel         = ModelClaudeOpus48
+	DefaultEndpoint      = "https://openrouter.ai/api/v1/chat/completions"
+	DefaultMaxTokens     = 32768
+	DefaultMaxRetries    = openaic.DefaultMaxRetries
+	DefaultRetryBaseWait = openaic.DefaultRetryBaseWait
+	DefaultClient        = &http.Client{Timeout: 300 * time.Second}
 )
 
 var _ llm.StreamingLLM = &Provider{}
 
 // Provider implements the OpenRouter multi-provider LLM proxy.
 type Provider struct {
-	apiKey     string
-	endpoint   string
-	model      string
-	maxTokens  int
-	maxRetries int
-	client     *http.Client
-	siteURL    string
-	siteName   string
+	apiKey        string
+	endpoint      string
+	model         string
+	maxTokens     int
+	maxRetries    int
+	retryBaseWait time.Duration
+	client        *http.Client
+	siteURL       string
+	siteName      string
 
 	// Embedded OpenAI completions provider
 	*openaic.Provider
@@ -37,12 +39,13 @@ type Provider struct {
 // New creates a new OpenRouter provider with the given options.
 func New(opts ...Option) *Provider {
 	p := &Provider{
-		apiKey:     getAPIKey(),
-		endpoint:   DefaultEndpoint,
-		client:     DefaultClient,
-		model:      DefaultModel,
-		maxTokens:  DefaultMaxTokens,
-		maxRetries: DefaultMaxRetries,
+		apiKey:        getAPIKey(),
+		endpoint:      DefaultEndpoint,
+		client:        DefaultClient,
+		model:         DefaultModel,
+		maxTokens:     DefaultMaxTokens,
+		maxRetries:    DefaultMaxRetries,
+		retryBaseWait: DefaultRetryBaseWait,
 	}
 	for _, opt := range opts {
 		opt(p)
@@ -73,6 +76,7 @@ func New(opts ...Option) *Provider {
 		openaic.WithEndpoint(p.endpoint),
 		openaic.WithMaxTokens(p.maxTokens),
 		openaic.WithMaxRetries(p.maxRetries),
+		openaic.WithBaseWait(p.retryBaseWait),
 		openaic.WithModel(p.model),
 		openaic.WithSystemRole("system"),
 	)

--- a/providers/openrouter/options.go
+++ b/providers/openrouter/options.go
@@ -33,6 +33,14 @@ func WithMaxTokens(maxTokens int) Option {
 	}
 }
 
+// WithMaxRetries sets the maximum number of retries for transient generation
+// failures (total attempts = maxRetries + 1).
+func WithMaxRetries(maxRetries int) Option {
+	return func(p *Provider) {
+		p.maxRetries = maxRetries
+	}
+}
+
 // WithModel sets the LLM model name to use for the provider
 func WithModel(model string) Option {
 	return func(p *Provider) {

--- a/providers/openrouter/options.go
+++ b/providers/openrouter/options.go
@@ -1,6 +1,9 @@
 package openrouter
 
-import "net/http"
+import (
+	"net/http"
+	"time"
+)
 
 // Option is a function that configures the Provider
 type Option func(*Provider)
@@ -38,6 +41,13 @@ func WithMaxTokens(maxTokens int) Option {
 func WithMaxRetries(maxRetries int) Option {
 	return func(p *Provider) {
 		p.maxRetries = maxRetries
+	}
+}
+
+// WithBaseWait sets the base wait duration between retries.
+func WithBaseWait(baseWait time.Duration) Option {
+	return func(p *Provider) {
+		p.retryBaseWait = baseWait
 	}
 }
 

--- a/providers/openrouter/stream_retry_test.go
+++ b/providers/openrouter/stream_retry_test.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/deepnoodle-ai/dive/llm"
-	openaic "github.com/deepnoodle-ai/dive/providers/openaicompletions"
 	"github.com/deepnoodle-ai/wonton/assert"
 )
 
@@ -23,16 +22,15 @@ func TestWithMaxRetriesControlsStreamingAttempts(t *testing.T) {
 	}))
 	defer server.Close()
 
-	oldRetryBaseWait := openaic.DefaultRetryBaseWait
-	openaic.DefaultRetryBaseWait = time.Millisecond
-	t.Cleanup(func() { openaic.DefaultRetryBaseWait = oldRetryBaseWait })
-
 	provider := New(
 		WithAPIKey("test-key"),
 		WithEndpoint(server.URL),
 		WithMaxRetries(1),
+		WithBaseWait(time.Millisecond),
 	)
-	iterator, err := provider.Stream(context.Background(),
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	iterator, err := provider.Stream(ctx,
 		llm.WithMessages(llm.NewUserTextMessage("hello")),
 	)
 	assert.NoError(t, err)

--- a/providers/openrouter/stream_retry_test.go
+++ b/providers/openrouter/stream_retry_test.go
@@ -1,0 +1,46 @@
+package openrouter
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/deepnoodle-ai/dive/llm"
+	openaic "github.com/deepnoodle-ai/dive/providers/openaicompletions"
+	"github.com/deepnoodle-ai/wonton/assert"
+)
+
+func TestWithMaxRetriesControlsStreamingAttempts(t *testing.T) {
+	var requests atomic.Int64
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests.Add(1)
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = io.WriteString(w, `{"error":{"message":"rate limited"}}`)
+	}))
+	defer server.Close()
+
+	oldRetryBaseWait := openaic.DefaultRetryBaseWait
+	openaic.DefaultRetryBaseWait = time.Millisecond
+	t.Cleanup(func() { openaic.DefaultRetryBaseWait = oldRetryBaseWait })
+
+	provider := New(
+		WithAPIKey("test-key"),
+		WithEndpoint(server.URL),
+		WithMaxRetries(1),
+	)
+	iterator, err := provider.Stream(context.Background(),
+		llm.WithMessages(llm.NewUserTextMessage("hello")),
+	)
+	assert.NoError(t, err)
+	defer iterator.Close()
+	for iterator.Next() {
+	}
+
+	assert.Error(t, iterator.Err())
+	assert.Equal(t, int64(2), requests.Load())
+	assert.Equal(t, provider.Name(), provider.Provider.Name())
+}

--- a/providers/retrying_stream.go
+++ b/providers/retrying_stream.go
@@ -107,14 +107,18 @@ func (s *retryingStreamIterator) Next() bool {
 		closeErr := s.current.Close()
 		s.current = nil // Close every failed attempt before creating a replacement.
 
-		if streamErr == nil || errors.Is(streamErr, io.EOF) {
+		normalizedStreamErr := s.normalizeError(streamErr)
+		if normalizedStreamErr == nil {
 			if closeErr != nil {
 				return s.normalizeError(closeErr)
 			}
 			s.ended = true
 			return nil
 		}
-		return s.normalizeError(streamErr)
+		if closeErr != nil {
+			return errors.Join(normalizedStreamErr, closeErr)
+		}
+		return normalizedStreamErr
 	},
 		retry.WithMaxAttempts(s.config.MaxRetries+1),
 		retry.WithBackoff(s.config.RetryBaseWait, maxStreamRetryBackoff),

--- a/providers/retrying_stream.go
+++ b/providers/retrying_stream.go
@@ -1,0 +1,197 @@
+package providers
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"sync"
+	"time"
+
+	"github.com/deepnoodle-ai/dive/llm"
+	"github.com/deepnoodle-ai/wonton/retry"
+)
+
+const maxStreamRetryBackoff = 5 * time.Minute
+
+// StreamFactory creates one transport-level streaming attempt for a logical
+// provider generation. It must not fire logical-generation hooks or mutate
+// caller-owned messages; retries may invoke it more than once.
+type StreamFactory func() (llm.StreamIterator, error)
+
+// StreamRetryConfig configures retries before the first event is exposed to a
+// stream consumer.
+type StreamRetryConfig struct {
+	Provider      string
+	MaxRetries    int
+	RetryBaseWait time.Duration
+	Logger        llm.Logger
+
+	// NormalizeError maps SDK-specific errors onto Dive's retryable/permanent
+	// error contract. A nil function leaves errors unchanged.
+	NormalizeError func(error) error
+}
+
+// NewRetryingStreamIterator returns one logical stream backed by fresh
+// transport attempts from factory. Factory errors and iterator errors share a
+// single retry budget. The first exposed llm.Event commits the current attempt;
+// after that point, errors are returned without retry to avoid duplicate output.
+func NewRetryingStreamIterator(
+	ctx context.Context,
+	config StreamRetryConfig,
+	factory StreamFactory,
+) llm.StreamIterator {
+	if config.MaxRetries < 0 {
+		config.MaxRetries = 0
+	}
+	return &retryingStreamIterator{
+		ctx:     ctx,
+		config:  config,
+		factory: factory,
+	}
+}
+
+type retryingStreamIterator struct {
+	ctx     context.Context
+	config  StreamRetryConfig
+	factory StreamFactory
+
+	current   llm.StreamIterator
+	committed bool
+	ended     bool
+	err       error
+	closeOnce sync.Once
+}
+
+func (s *retryingStreamIterator) Next() bool {
+	if s.ended || s.err != nil {
+		return false
+	}
+
+	if s.committed {
+		if s.current.Next() {
+			return true
+		}
+		s.err = s.normalizeError(s.current.Err())
+		s.ended = true
+		return false
+	}
+
+	var hasEvent bool
+	err := retry.DoSimple(s.ctx, func() error {
+		if s.factory == nil {
+			return retry.MarkPermanent(fmt.Errorf("providers: stream factory is nil"))
+		}
+
+		stream, err := s.factory()
+		if err != nil {
+			if stream != nil {
+				_ = stream.Close()
+			}
+			return s.normalizeError(err)
+		}
+		if stream == nil {
+			return retry.MarkPermanent(fmt.Errorf("providers: stream factory returned nil"))
+		}
+		s.current = stream
+
+		if s.current.Next() {
+			// The first exposed event is the commit point. A committed stream is
+			// never replaced, even if no content-bearing delta has arrived yet.
+			s.committed = true
+			hasEvent = true
+			return nil
+		}
+
+		streamErr := s.current.Err()
+		closeErr := s.current.Close()
+		s.current = nil // Close every failed attempt before creating a replacement.
+
+		if streamErr == nil || errors.Is(streamErr, io.EOF) {
+			if closeErr != nil {
+				return s.normalizeError(closeErr)
+			}
+			s.ended = true
+			return nil
+		}
+		return s.normalizeError(streamErr)
+	},
+		retry.WithMaxAttempts(s.config.MaxRetries+1),
+		retry.WithBackoff(s.config.RetryBaseWait, maxStreamRetryBackoff),
+		retry.WithRetryIf(func(err error) bool {
+			if s.ctx.Err() != nil || errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+				return false
+			}
+			return !retry.IsPermanent(err)
+		}),
+		retry.WithOnRetry(func(attempt int, err error, delay time.Duration) {
+			s.logRetry(attempt+1, s.config.MaxRetries+1, err, delay)
+		}),
+	)
+	if err != nil {
+		s.err = err
+		s.ended = true
+		return false
+	}
+	return hasEvent
+}
+
+func (s *retryingStreamIterator) Event() *llm.Event {
+	if s.current == nil {
+		return nil
+	}
+	return s.current.Event()
+}
+
+func (s *retryingStreamIterator) Err() error {
+	return s.err
+}
+
+func (s *retryingStreamIterator) Close() error {
+	var closeErr error
+	s.closeOnce.Do(func() {
+		s.ended = true
+		if s.current != nil {
+			closeErr = s.current.Close()
+		}
+	})
+	return closeErr
+}
+
+func (s *retryingStreamIterator) normalizeError(err error) error {
+	if err == nil || errors.Is(err, io.EOF) {
+		return nil
+	}
+	if s.ctx != nil && s.ctx.Err() != nil {
+		return s.ctx.Err()
+	}
+	if s.config.NormalizeError != nil {
+		return s.config.NormalizeError(err)
+	}
+	return err
+}
+
+func (s *retryingStreamIterator) logRetry(attempt, maxAttempts int, err error, delay time.Duration) {
+	if s.config.Logger == nil {
+		return
+	}
+	args := []any{
+		"provider", s.config.Provider,
+		"attempt", attempt,
+		"max_attempts", maxAttempts,
+		"before_first_event", true,
+		"backoff", delay,
+	}
+	if status := providerStatusCode(err); status != 0 {
+		args = append(args, "status", status)
+	}
+	s.config.Logger.Warn("retrying streaming generation", args...)
+}
+
+func providerStatusCode(err error) int {
+	var statusErr interface{ StatusCode() int }
+	if errors.As(err, &statusErr) {
+		return statusErr.StatusCode()
+	}
+	return 0
+}

--- a/providers/retrying_stream_test.go
+++ b/providers/retrying_stream_test.go
@@ -1,0 +1,466 @@
+package providers
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/deepnoodle-ai/dive/llm"
+	"github.com/deepnoodle-ai/wonton/assert"
+)
+
+type testStreamIterator struct {
+	events     []*llm.Event
+	err        error
+	pos        int
+	closed     bool
+	closeCount int
+	closeErr   error
+}
+
+func (s *testStreamIterator) Next() bool {
+	if s.pos >= len(s.events) {
+		return false
+	}
+	s.pos++
+	return true
+}
+
+func (s *testStreamIterator) Event() *llm.Event { return s.events[s.pos-1] }
+func (s *testStreamIterator) Err() error        { return s.err }
+func (s *testStreamIterator) Close() error {
+	s.closed = true
+	s.closeCount++
+	return s.closeErr
+}
+
+func TestRetryingStreamFirstAttemptSuccess(t *testing.T) {
+	stream := &testStreamIterator{events: []*llm.Event{
+		{Type: llm.EventTypeMessageStart},
+		{Type: llm.EventTypeMessageStop},
+	}}
+	var attempts atomic.Int64
+	iterator := NewRetryingStreamIterator(context.Background(), StreamRetryConfig{
+		Provider:      "test",
+		MaxRetries:    2,
+		RetryBaseWait: time.Millisecond,
+	}, func() (llm.StreamIterator, error) {
+		attempts.Add(1)
+		return stream, nil
+	})
+
+	assert.True(t, iterator.Next())
+	assert.Equal(t, llm.EventTypeMessageStart, iterator.Event().Type)
+	assert.True(t, iterator.Next())
+	assert.Equal(t, llm.EventTypeMessageStop, iterator.Event().Type)
+	assert.False(t, iterator.Next())
+	assert.NoError(t, iterator.Err())
+	assert.Equal(t, int64(1), attempts.Load())
+	assert.NoError(t, iterator.Close())
+	assert.Equal(t, 1, stream.closeCount)
+}
+
+func TestRetryingStreamSharesBudgetAcrossFactoryAndIteratorErrors(t *testing.T) {
+	preEventFailure := &testStreamIterator{err: errors.New("connection reset")}
+	success := &testStreamIterator{events: []*llm.Event{{Type: llm.EventTypeMessageStart}}}
+	var attempts atomic.Int64
+
+	iterator := NewRetryingStreamIterator(context.Background(), StreamRetryConfig{
+		Provider:      "test",
+		MaxRetries:    2,
+		RetryBaseWait: time.Millisecond,
+	}, func() (llm.StreamIterator, error) {
+		switch attempts.Add(1) {
+		case 1:
+			return nil, NewError(429, "rate limited")
+		case 2:
+			return preEventFailure, nil
+		default:
+			return success, nil
+		}
+	})
+	defer iterator.Close()
+
+	assert.True(t, iterator.Next())
+	assert.Equal(t, llm.EventTypeMessageStart, iterator.Event().Type)
+	assert.Equal(t, int64(3), attempts.Load())
+	assert.True(t, preEventFailure.closed)
+}
+
+func TestRetryingStreamClosesIteratorReturnedWithFactoryError(t *testing.T) {
+	failed := &testStreamIterator{}
+	success := &testStreamIterator{events: []*llm.Event{{Type: llm.EventTypeMessageStart}}}
+	var attempts atomic.Int64
+	iterator := NewRetryingStreamIterator(context.Background(), StreamRetryConfig{
+		Provider:      "test",
+		MaxRetries:    1,
+		RetryBaseWait: time.Millisecond,
+	}, func() (llm.StreamIterator, error) {
+		if attempts.Add(1) == 1 {
+			return failed, NewError(http.StatusTooManyRequests, "rate limited")
+		}
+		return success, nil
+	})
+	defer iterator.Close()
+
+	assert.True(t, iterator.Next())
+	assert.Equal(t, int64(2), attempts.Load())
+	assert.Equal(t, 1, failed.closeCount)
+}
+
+func TestRetryingStreamRetriesCloseErrorBeforeFirstEvent(t *testing.T) {
+	sentinel := errors.New("failed to close empty response body")
+	failed := &testStreamIterator{closeErr: sentinel}
+	success := &testStreamIterator{events: []*llm.Event{{Type: llm.EventTypeMessageStart}}}
+	var attempts atomic.Int64
+	iterator := NewRetryingStreamIterator(context.Background(), StreamRetryConfig{
+		Provider:      "test",
+		MaxRetries:    1,
+		RetryBaseWait: time.Millisecond,
+	}, func() (llm.StreamIterator, error) {
+		if attempts.Add(1) == 1 {
+			return failed, nil
+		}
+		return success, nil
+	})
+	defer iterator.Close()
+
+	assert.True(t, iterator.Next())
+	assert.Equal(t, int64(2), attempts.Load())
+	assert.Equal(t, 1, failed.closeCount)
+}
+
+func TestRetryingStreamStopsOnPermanentFactoryError(t *testing.T) {
+	var attempts atomic.Int64
+	iterator := NewRetryingStreamIterator(context.Background(), StreamRetryConfig{
+		Provider:      "test",
+		MaxRetries:    2,
+		RetryBaseWait: time.Millisecond,
+	}, func() (llm.StreamIterator, error) {
+		attempts.Add(1)
+		return nil, NewError(400, "bad request")
+	})
+	defer iterator.Close()
+
+	assert.False(t, iterator.Next())
+	assert.Error(t, iterator.Err())
+	assert.Equal(t, int64(1), attempts.Load())
+}
+
+func TestRetryingStreamExhaustsTransientIteratorErrors(t *testing.T) {
+	sentinel := errors.New("connection reset before first event")
+	var attempts atomic.Int64
+	var streams []*testStreamIterator
+	iterator := NewRetryingStreamIterator(context.Background(), StreamRetryConfig{
+		Provider:      "test",
+		MaxRetries:    2,
+		RetryBaseWait: time.Millisecond,
+	}, func() (llm.StreamIterator, error) {
+		attempts.Add(1)
+		stream := &testStreamIterator{err: sentinel}
+		streams = append(streams, stream)
+		return stream, nil
+	})
+	defer iterator.Close()
+
+	assert.False(t, iterator.Next())
+	assert.True(t, errors.Is(iterator.Err(), sentinel))
+	assert.Equal(t, int64(3), attempts.Load())
+	for _, stream := range streams {
+		assert.Equal(t, 1, stream.closeCount)
+	}
+	assert.False(t, iterator.Next())
+	assert.Equal(t, int64(3), attempts.Load())
+}
+
+func TestRetryingStreamStopsOnNormalizedPermanentIteratorError(t *testing.T) {
+	rawErr := errors.New("sdk authentication error")
+	var attempts atomic.Int64
+	var normalizations atomic.Int64
+	stream := &testStreamIterator{err: rawErr}
+	iterator := NewRetryingStreamIterator(context.Background(), StreamRetryConfig{
+		Provider:      "test",
+		MaxRetries:    2,
+		RetryBaseWait: time.Millisecond,
+		NormalizeError: func(err error) error {
+			normalizations.Add(1)
+			assert.True(t, errors.Is(err, rawErr))
+			return NewError(http.StatusUnauthorized, "unauthorized")
+		},
+	}, func() (llm.StreamIterator, error) {
+		attempts.Add(1)
+		return stream, nil
+	})
+	defer iterator.Close()
+
+	assert.False(t, iterator.Next())
+	assert.Error(t, iterator.Err())
+	assert.Equal(t, int64(1), attempts.Load())
+	assert.Equal(t, int64(1), normalizations.Load())
+	assert.Equal(t, 1, stream.closeCount)
+}
+
+func TestRetryingStreamEmptySuccessDoesNotRetry(t *testing.T) {
+	var attempts atomic.Int64
+	stream := &testStreamIterator{}
+	iterator := NewRetryingStreamIterator(context.Background(), StreamRetryConfig{
+		Provider:      "test",
+		MaxRetries:    2,
+		RetryBaseWait: time.Millisecond,
+	}, func() (llm.StreamIterator, error) {
+		attempts.Add(1)
+		return stream, nil
+	})
+	defer iterator.Close()
+
+	assert.False(t, iterator.Next())
+	assert.NoError(t, iterator.Err())
+	assert.Equal(t, int64(1), attempts.Load())
+	assert.Equal(t, 1, stream.closeCount)
+}
+
+func TestRetryingStreamRejectsNilFactoryAndNilStream(t *testing.T) {
+	t.Run("nil factory", func(t *testing.T) {
+		iterator := NewRetryingStreamIterator(context.Background(), StreamRetryConfig{
+			MaxRetries:    2,
+			RetryBaseWait: time.Millisecond,
+		}, nil)
+		defer iterator.Close()
+		assert.False(t, iterator.Next())
+		assert.Error(t, iterator.Err())
+	})
+
+	t.Run("nil stream", func(t *testing.T) {
+		var attempts atomic.Int64
+		iterator := NewRetryingStreamIterator(context.Background(), StreamRetryConfig{
+			MaxRetries:    2,
+			RetryBaseWait: time.Millisecond,
+		}, func() (llm.StreamIterator, error) {
+			attempts.Add(1)
+			return nil, nil
+		})
+		defer iterator.Close()
+		assert.False(t, iterator.Next())
+		assert.Error(t, iterator.Err())
+		assert.Equal(t, int64(1), attempts.Load())
+	})
+}
+
+func TestRetryingStreamClampsNegativeRetryBudget(t *testing.T) {
+	var attempts atomic.Int64
+	iterator := NewRetryingStreamIterator(context.Background(), StreamRetryConfig{
+		MaxRetries:    -1,
+		RetryBaseWait: time.Millisecond,
+	}, func() (llm.StreamIterator, error) {
+		attempts.Add(1)
+		return nil, NewError(http.StatusTooManyRequests, "rate limited")
+	})
+	defer iterator.Close()
+
+	assert.Nil(t, iterator.Event())
+	assert.False(t, iterator.Next())
+	assert.Error(t, iterator.Err())
+	assert.Equal(t, int64(1), attempts.Load())
+}
+
+func TestRetryingStreamDoesNotRetryAfterFirstEvent(t *testing.T) {
+	committed := &testStreamIterator{
+		events: []*llm.Event{{Type: llm.EventTypeMessageStart}},
+		err:    errors.New("connection reset after first event"),
+	}
+	var attempts atomic.Int64
+	iterator := NewRetryingStreamIterator(context.Background(), StreamRetryConfig{
+		Provider:      "test",
+		MaxRetries:    2,
+		RetryBaseWait: time.Millisecond,
+	}, func() (llm.StreamIterator, error) {
+		attempts.Add(1)
+		return committed, nil
+	})
+	defer iterator.Close()
+
+	assert.True(t, iterator.Next())
+	assert.False(t, iterator.Next())
+	assert.Error(t, iterator.Err())
+	assert.Equal(t, int64(1), attempts.Load())
+}
+
+func TestRetryingStreamCloseBeforeNextDoesNotStartAttempt(t *testing.T) {
+	var attempts atomic.Int64
+	iterator := NewRetryingStreamIterator(context.Background(), StreamRetryConfig{
+		Provider:      "test",
+		MaxRetries:    2,
+		RetryBaseWait: time.Millisecond,
+	}, func() (llm.StreamIterator, error) {
+		attempts.Add(1)
+		return &testStreamIterator{}, nil
+	})
+
+	assert.NoError(t, iterator.Close())
+	assert.NoError(t, iterator.Close())
+	assert.False(t, iterator.Next())
+	assert.NoError(t, iterator.Err())
+	assert.Equal(t, int64(0), attempts.Load())
+}
+
+func TestRetryingStreamCanceledBeforeNextDoesNotStartAttempt(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	var attempts atomic.Int64
+	iterator := NewRetryingStreamIterator(ctx, StreamRetryConfig{
+		Provider:      "test",
+		MaxRetries:    2,
+		RetryBaseWait: time.Millisecond,
+	}, func() (llm.StreamIterator, error) {
+		attempts.Add(1)
+		return &testStreamIterator{}, nil
+	})
+	defer iterator.Close()
+
+	assert.False(t, iterator.Next())
+	assert.True(t, errors.Is(iterator.Err(), context.Canceled))
+	assert.Equal(t, int64(0), attempts.Load())
+}
+
+func TestRetryingStreamCancellationFromAttemptStopsRetries(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	var attempts atomic.Int64
+	iterator := NewRetryingStreamIterator(ctx, StreamRetryConfig{
+		Provider:      "test",
+		MaxRetries:    2,
+		RetryBaseWait: time.Millisecond,
+	}, func() (llm.StreamIterator, error) {
+		attempts.Add(1)
+		cancel()
+		return nil, errors.New("transport stopped")
+	})
+	defer iterator.Close()
+
+	assert.False(t, iterator.Next())
+	assert.True(t, errors.Is(iterator.Err(), context.Canceled))
+	assert.Equal(t, int64(1), attempts.Load())
+}
+
+type retrySignalLogger struct {
+	retry chan struct{}
+	once  sync.Once
+}
+
+func (l *retrySignalLogger) Debug(string, ...any)   {}
+func (l *retrySignalLogger) Info(string, ...any)    {}
+func (l *retrySignalLogger) Error(string, ...any)   {}
+func (l *retrySignalLogger) With(...any) llm.Logger { return l }
+func (l *retrySignalLogger) Warn(string, ...any) {
+	l.once.Do(func() { close(l.retry) })
+}
+
+func TestRetryingStreamCancellationStopsBackoff(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	logger := &retrySignalLogger{retry: make(chan struct{})}
+	var attempts atomic.Int64
+	iterator := NewRetryingStreamIterator(ctx, StreamRetryConfig{
+		Provider:      "test",
+		MaxRetries:    2,
+		RetryBaseWait: 10 * time.Second,
+		Logger:        logger,
+	}, func() (llm.StreamIterator, error) {
+		attempts.Add(1)
+		return nil, NewError(429, "rate limited")
+	})
+	defer iterator.Close()
+
+	next := make(chan bool, 1)
+	go func() { next <- iterator.Next() }()
+	select {
+	case <-logger.retry:
+		cancel()
+	case <-time.After(time.Second):
+		t.Fatal("retry did not enter backoff")
+	}
+	select {
+	case gotEvent := <-next:
+		assert.False(t, gotEvent)
+	case <-time.After(time.Second):
+		t.Fatal("stream did not stop promptly after cancellation")
+	}
+	assert.True(t, errors.Is(iterator.Err(), context.Canceled))
+	assert.Equal(t, int64(1), attempts.Load())
+}
+
+type captureRetryLogger struct {
+	message string
+	args    []any
+}
+
+func (l *captureRetryLogger) Debug(string, ...any)   {}
+func (l *captureRetryLogger) Info(string, ...any)    {}
+func (l *captureRetryLogger) Error(string, ...any)   {}
+func (l *captureRetryLogger) With(...any) llm.Logger { return l }
+func (l *captureRetryLogger) Warn(message string, args ...any) {
+	l.message = message
+	l.args = append([]any(nil), args...)
+}
+
+func TestRetryingStreamLogsAttemptWithoutProviderBody(t *testing.T) {
+	logger := &captureRetryLogger{}
+	var attempts atomic.Int64
+	iterator := NewRetryingStreamIterator(context.Background(), StreamRetryConfig{
+		Provider:      "grok",
+		MaxRetries:    1,
+		RetryBaseWait: time.Millisecond,
+		Logger:        logger,
+	}, func() (llm.StreamIterator, error) {
+		if attempts.Add(1) == 1 {
+			return nil, NewError(429, "sensitive provider response")
+		}
+		return &testStreamIterator{events: []*llm.Event{{Type: llm.EventTypeMessageStart}}}, nil
+	})
+	defer iterator.Close()
+
+	assert.True(t, iterator.Next())
+	assert.Equal(t, "retrying streaming generation", logger.message)
+
+	fields := make(map[string]any, len(logger.args)/2)
+	for i := 0; i+1 < len(logger.args); i += 2 {
+		key, ok := logger.args[i].(string)
+		if ok {
+			fields[key] = logger.args[i+1]
+		}
+	}
+	assert.Equal(t, "grok", fields["provider"])
+	assert.Equal(t, 2, fields["attempt"])
+	assert.Equal(t, 2, fields["max_attempts"])
+	assert.Equal(t, true, fields["before_first_event"])
+	assert.Equal(t, http.StatusTooManyRequests, fields["status"])
+	assert.False(t, strings.Contains(fmt.Sprint(logger.args...), "sensitive provider response"))
+}
+
+func TestRetryingStreamLogsTransportErrorWithoutStatus(t *testing.T) {
+	logger := &captureRetryLogger{}
+	var attempts atomic.Int64
+	iterator := NewRetryingStreamIterator(context.Background(), StreamRetryConfig{
+		Provider:      "test",
+		MaxRetries:    1,
+		RetryBaseWait: time.Millisecond,
+		Logger:        logger,
+	}, func() (llm.StreamIterator, error) {
+		if attempts.Add(1) == 1 {
+			return nil, errors.New("connection reset")
+		}
+		return &testStreamIterator{events: []*llm.Event{{Type: llm.EventTypeMessageStart}}}, nil
+	})
+	defer iterator.Close()
+
+	assert.True(t, iterator.Next())
+	for i := 0; i+1 < len(logger.args); i += 2 {
+		assert.False(t, logger.args[i] == "status")
+	}
+}

--- a/providers/retrying_stream_test.go
+++ b/providers/retrying_stream_test.go
@@ -136,6 +136,25 @@ func TestRetryingStreamRetriesCloseErrorBeforeFirstEvent(t *testing.T) {
 	assert.Equal(t, 1, failed.closeCount)
 }
 
+func TestRetryingStreamPreservesStreamAndCloseErrors(t *testing.T) {
+	streamErr := errors.New("stream read failed")
+	closeErr := errors.New("stream close failed")
+	stream := &testStreamIterator{err: streamErr, closeErr: closeErr}
+	iterator := NewRetryingStreamIterator(context.Background(), StreamRetryConfig{
+		Provider:      "test",
+		MaxRetries:    0,
+		RetryBaseWait: time.Millisecond,
+	}, func() (llm.StreamIterator, error) {
+		return stream, nil
+	})
+	defer iterator.Close()
+
+	assert.False(t, iterator.Next())
+	assert.True(t, errors.Is(iterator.Err(), streamErr))
+	assert.True(t, errors.Is(iterator.Err(), closeErr))
+	assert.Equal(t, 1, stream.closeCount)
+}
+
 func TestRetryingStreamStopsOnPermanentFactoryError(t *testing.T) {
 	var attempts atomic.Int64
 	iterator := NewRetryingStreamIterator(context.Background(), StreamRetryConfig{


### PR DESCRIPTION
## Summary

- add a shared provider-layer iterator that retries transient stream creation and pre-first-event failures under one budget
- apply the same commit-point contract to Anthropic, Google, OpenAI Responses, and OpenAI-compatible Chat Completions
- expose retry budget and base-wait configuration through Grok, Mistral, Ollama, and OpenRouter while preserving provider-specific names in logs
- normalize Google SDK value- and pointer-form API errors so permanent failures stop immediately
- preserve both stream and close failures when cleanup also fails before commit
- document the design and rollout in Plan 09

## Why

Streaming retries were inconsistent by provider and failure phase. Lazy SDK failures and errors after a successful HTTP handshake could bypass `WithMaxRetries`, terminally failing a later model generation after earlier tools had already completed. Retrying the whole agent loop would risk replaying those side effects.

This keeps retries below `Agent.generateStreaming`: provider hooks and logical request setup run once, while only the underlying transport stream is recreated. The first exposed `llm.Event` commits the attempt, so failures after visible output are never retried.

## Impact

All Dive streaming providers now share the same pre-first-event behavior. Existing default budgets remain unchanged, SDK-internal retries remain disabled where Dive owns the budget, and adapter providers expose both retry-count and base-wait passthrough options without mutating package defaults in tests.

## Validation

- full `go test ./...` in the root, OpenAI, Google, and Grok modules
- `go test -race` across every provider package and nested provider module
- `go vet ./...` in the root and all nested provider modules
- 40 focused retry/regression tests with deterministic 429, permanent 400, transport, post-200 body, cancellation, cleanup, hook, adapter, and tool-replay fault injection
- 100% statement coverage for the shared retry iterator
- live streaming smoke tests for OpenAI Responses and Grok, plus available live Anthropic and Chat Completions coverage
- Prettier and diff checks for the changed files

## Release checklist

- [ ] Publish the root module first so `providers.NewRetryingStreamIterator` is available
- [ ] Publish the Google, OpenAI, and Grok module versions against that root release
- [ ] Update Mobius's root Dive pin before its provider-module pins
- [ ] Update the Mobius Google, OpenAI, and Grok pins only after the compatible root version is available
- [ ] Run the synthetic Grok mid-turn 429 smoke test against the pinned versions