### PR TITLE
Prepare v1.15.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [1.15.1] - 2026-07-15
+
 ### Fixed
 
+- **Streaming generation retries** — transient failures (rate limits,
+  overload, disconnects) that occur before a streaming generation's first
+  event are now retried across providers, so a multi-generation turn no
+  longer fails outright on a momentary capacity error.
 - **Same-name reminder interpretation** — the standing priming rule now keeps
   independent same-name facts and instructions cumulative, using later-wins
   ordering only where two blocks conflict.

--- a/a2a/go.mod
+++ b/a2a/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/a2aproject/a2a-go/v2 v2.2.0
-	github.com/deepnoodle-ai/dive v1.15.0
+	github.com/deepnoodle-ai/dive v1.15.1
 	github.com/deepnoodle-ai/wonton v0.0.36
 )
 

--- a/demos/colosseum/go.mod
+++ b/demos/colosseum/go.mod
@@ -3,11 +3,11 @@ module github.com/deepnoodle-ai/dive/demos/colosseum
 go 1.25.0
 
 require (
-	github.com/deepnoodle-ai/dive v1.15.0
-	github.com/deepnoodle-ai/dive/a2a v1.15.0
-	github.com/deepnoodle-ai/dive/providers/google v1.15.0
-	github.com/deepnoodle-ai/dive/providers/grok v1.15.0
-	github.com/deepnoodle-ai/dive/providers/openai v1.15.0
+	github.com/deepnoodle-ai/dive v1.15.1
+	github.com/deepnoodle-ai/dive/a2a v1.15.1
+	github.com/deepnoodle-ai/dive/providers/google v1.15.1
+	github.com/deepnoodle-ai/dive/providers/grok v1.15.1
+	github.com/deepnoodle-ai/dive/providers/openai v1.15.1
 	github.com/deepnoodle-ai/wonton v0.0.36
 )
 

--- a/demos/noodleville/go.mod
+++ b/demos/noodleville/go.mod
@@ -3,7 +3,7 @@ module github.com/deepnoodle-ai/dive/demos/noodleville
 go 1.25.0
 
 require (
-	github.com/deepnoodle-ai/dive v1.15.0
+	github.com/deepnoodle-ai/dive v1.15.1
 	github.com/deepnoodle-ai/wonton v0.0.36
 )
 

--- a/examples/go.mod
+++ b/examples/go.mod
@@ -3,13 +3,13 @@ module github.com/deepnoodle-ai/dive/examples
 go 1.25.0
 
 require (
-	github.com/deepnoodle-ai/dive v1.15.0
-	github.com/deepnoodle-ai/dive/a2a v1.15.0
-	github.com/deepnoodle-ai/dive/experimental/mcp v1.15.0
-	github.com/deepnoodle-ai/dive/otel v1.15.0
-	github.com/deepnoodle-ai/dive/providers/google v1.15.0
-	github.com/deepnoodle-ai/dive/providers/grok v1.15.0
-	github.com/deepnoodle-ai/dive/providers/openai v1.15.0
+	github.com/deepnoodle-ai/dive v1.15.1
+	github.com/deepnoodle-ai/dive/a2a v1.15.1
+	github.com/deepnoodle-ai/dive/experimental/mcp v1.15.1
+	github.com/deepnoodle-ai/dive/otel v1.15.1
+	github.com/deepnoodle-ai/dive/providers/google v1.15.1
+	github.com/deepnoodle-ai/dive/providers/grok v1.15.1
+	github.com/deepnoodle-ai/dive/providers/openai v1.15.1
 	github.com/deepnoodle-ai/wonton v0.0.36
 	github.com/fatih/color v1.18.0
 	github.com/mark3labs/mcp-go v0.45.0

--- a/experimental/cmd/dive/go.mod
+++ b/experimental/cmd/dive/go.mod
@@ -3,10 +3,10 @@ module github.com/deepnoodle-ai/dive/experimental/cmd/dive
 go 1.25.0
 
 require (
-	github.com/deepnoodle-ai/dive v1.15.0
-	github.com/deepnoodle-ai/dive/providers/google v1.15.0
-	github.com/deepnoodle-ai/dive/providers/grok v1.15.0
-	github.com/deepnoodle-ai/dive/providers/openai v1.15.0
+	github.com/deepnoodle-ai/dive v1.15.1
+	github.com/deepnoodle-ai/dive/providers/google v1.15.1
+	github.com/deepnoodle-ai/dive/providers/grok v1.15.1
+	github.com/deepnoodle-ai/dive/providers/openai v1.15.1
 	github.com/deepnoodle-ai/wonton v0.0.36
 	github.com/mattn/go-runewidth v0.0.21
 )

--- a/experimental/mcp/go.mod
+++ b/experimental/mcp/go.mod
@@ -3,7 +3,7 @@ module github.com/deepnoodle-ai/dive/experimental/mcp
 go 1.25.0
 
 require (
-	github.com/deepnoodle-ai/dive v1.15.0
+	github.com/deepnoodle-ai/dive v1.15.1
 	github.com/deepnoodle-ai/wonton v0.0.36
 	github.com/mark3labs/mcp-go v0.45.0
 )

--- a/otel/go.mod
+++ b/otel/go.mod
@@ -3,7 +3,7 @@ module github.com/deepnoodle-ai/dive/otel
 go 1.25.0
 
 require (
-	github.com/deepnoodle-ai/dive v1.15.0
+	github.com/deepnoodle-ai/dive v1.15.1
 	go.opentelemetry.io/otel v1.43.0
 	go.opentelemetry.io/otel/metric v1.43.0
 	go.opentelemetry.io/otel/sdk v1.43.0

--- a/providers/google/go.mod
+++ b/providers/google/go.mod
@@ -3,7 +3,7 @@ module github.com/deepnoodle-ai/dive/providers/google
 go 1.25.0
 
 require (
-	github.com/deepnoodle-ai/dive v1.15.0
+	github.com/deepnoodle-ai/dive v1.15.1
 	github.com/deepnoodle-ai/wonton v0.0.36
 	google.golang.org/genai v1.51.0
 )

--- a/providers/grok/go.mod
+++ b/providers/grok/go.mod
@@ -3,8 +3,8 @@ module github.com/deepnoodle-ai/dive/providers/grok
 go 1.25.0
 
 require (
-	github.com/deepnoodle-ai/dive v1.15.0
-	github.com/deepnoodle-ai/dive/providers/openai v1.15.0
+	github.com/deepnoodle-ai/dive v1.15.1
+	github.com/deepnoodle-ai/dive/providers/openai v1.15.1
 	github.com/deepnoodle-ai/wonton v0.0.36
 	github.com/openai/openai-go/v3 v3.41.2-0.20260709175524-86bbd3d91826
 	golang.org/x/image v0.41.0

--- a/providers/openai/go.mod
+++ b/providers/openai/go.mod
@@ -3,7 +3,7 @@ module github.com/deepnoodle-ai/dive/providers/openai
 go 1.25.0
 
 require (
-	github.com/deepnoodle-ai/dive v1.15.0
+	github.com/deepnoodle-ai/dive v1.15.1
 	github.com/deepnoodle-ai/wonton v0.0.36
 	github.com/openai/openai-go/v3 v3.41.2-0.20260709175524-86bbd3d91826
 	golang.org/x/image v0.41.0


### PR DESCRIPTION
Patch release prep. Since v1.15.0, main carries two fixes:

- **Streaming generation retries** (#229) — transient pre-first-event failures retried across providers. This PR also adds its missing CHANGELOG entry.
- **Same-name reminder semantics** (#226) — cumulative-unless-conflict priming rule, plus the skill-catalog completeness/eviction fixes that make catalog replacement actually work under it.

(#227 was reverted by #228 — net zero.)

Prep changes, matching the v1.15.0 procedure (#225):

- CHANGELOG: cut the `[1.15.1] - 2026-07-15` heading
- Bump internal `github.com/deepnoodle-ai/dive*` requires v1.15.0 → v1.15.1 in all 10 submodule `go.mod` files (safe pre-tag; all submodules use local `replace` directives)

Verified: root `go build`/`go test` pass; all 10 submodules build.

After merge, tag the merge commit with the 9 release tags (same layout as v1.15.0): `v1.15.1`, `a2a/v1.15.1`, `examples/v1.15.1`, `experimental/cmd/dive/v1.15.1`, `experimental/mcp/v1.15.1`, `otel/v1.15.1`, `providers/google/v1.15.1`, `providers/grok/v1.15.1`, `providers/openai/v1.15.1`. Then repin `mobius-cloud` from the PR-226 pseudo-version to `v1.15.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)