### PR TITLE
Emit caller-supplied resume tool results

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -776,6 +776,24 @@ func (a *Agent) CreateResponse(ctx context.Context, opts ...CreateResponseOption
 		if err := a.fireResumePostHooks(ctx, hctx, rs, resumeToolsByName); err != nil {
 			return nil, err
 		}
+		// Caller-supplied resume results are part of the turn just like results
+		// produced by in-process tools. Emit them after post hooks so streaming
+		// observers see the final, hook-mutated value and can keep their
+		// transcript indexes aligned with rs.TurnMessages.
+		for _, toolUseID := range collectToolUseIDs(rs.AssistantToolUse) {
+			result := rs.CallerSupplied[toolUseID]
+			if result == nil {
+				continue
+			}
+			item := &ResponseItem{
+				Type:           ResponseItemTypeToolCallResult,
+				ToolCallResult: result,
+			}
+			resumeExtraItems = append(resumeExtraItems, item)
+			if err := eventCallback(ctx, item); err != nil {
+				return nil, fmt.Errorf("resume tool-result event callback: %w", err)
+			}
+		}
 		if len(rs.RemainingPending) > 0 {
 			// Partial resume: update session and return a new suspended response.
 			// This is not a fresh transition — the session was already suspended —
@@ -784,7 +802,7 @@ func (a *Agent) CreateResponse(ctx context.Context, opts ...CreateResponseOption
 				PendingToolCalls:   rs.RemainingPendingCalls,
 				CompletedToolCalls: rs.CompletedToolCalls(),
 			}
-			return a.finishSuspended(ctx, logger, hctx, response, inputMessages, snap, nil, eventCallback, sess, rs, true)
+			return a.finishSuspended(ctx, logger, hctx, response, inputMessages, snap, resumeExtraItems, eventCallback, sess, rs, true)
 		}
 		// Execute not-started tool calls, if any.
 		if len(rs.NotStartedToolCalls) > 0 {
@@ -815,7 +833,7 @@ func (a *Agent) CreateResponse(ctx context.Context, opts ...CreateResponseOption
 					Items: itemsSnapshot,
 				}
 			}
-			resumeExtraItems = resumeItems
+			resumeExtraItems = append(resumeExtraItems, resumeItems...)
 			// Merge completed outcomes into the tool_result message.
 			completed := batch.Completed()
 			if len(completed) > 0 {

--- a/agent.go
+++ b/agent.go
@@ -791,7 +791,14 @@ func (a *Agent) CreateResponse(ctx context.Context, opts ...CreateResponseOption
 			}
 			resumeExtraItems = append(resumeExtraItems, item)
 			if err := eventCallback(ctx, item); err != nil {
-				return nil, fmt.Errorf("resume tool-result event callback: %w", err)
+				// Mirror the not-started execution path below: expose the
+				// items already emitted via *GenerationError so callers can
+				// recover partial work (no LLM calls yet, so usage is zero).
+				return nil, &GenerationError{
+					Err:   fmt.Errorf("resume tool-result event callback: %w", err),
+					Usage: &llm.Usage{},
+					Items: slices.Clone(resumeExtraItems),
+				}
 			}
 		}
 		if len(rs.RemainingPending) > 0 {
@@ -830,7 +837,7 @@ func (a *Agent) CreateResponse(ctx context.Context, opts ...CreateResponseOption
 				return nil, &GenerationError{
 					Err:   err,
 					Usage: &llm.Usage{},
-					Items: itemsSnapshot,
+					Items: append(slices.Clone(resumeExtraItems), itemsSnapshot...),
 				}
 			}
 			resumeExtraItems = append(resumeExtraItems, resumeItems...)

--- a/agent_suspend_test.go
+++ b/agent_suspend_test.go
@@ -1044,6 +1044,79 @@ func TestPartialResumeTwice(t *testing.T) {
 	assert.Equal(t, sess.EventCount(), 1)
 }
 
+// Across multiple partial resumes, each caller-supplied result must be
+// emitted as a tool_call_result item exactly once — in the round it was
+// supplied — with no re-emission of earlier rounds' results. Transcript
+// consumers (which map items to history messages) depend on this.
+func TestPartialResumeEmitsEachResultOnce(t *testing.T) {
+	mock := &scriptedLLM{
+		script: []scriptedTurn{
+			toolUseAssistantTurn(
+				newScriptedToolUse("toolu_a", "tool_a", `{}`),
+				newScriptedToolUse("toolu_b", "tool_b", `{}`),
+				newScriptedToolUse("toolu_c", "tool_c", `{}`),
+			),
+			finalTextTurn("done"),
+		},
+	}
+	toolA := &scriptedTool{name: "tool_a", outcomes: []toolOutcome{{result: NewSuspendResult("wait a", nil)}}}
+	toolB := &scriptedTool{name: "tool_b", outcomes: []toolOutcome{{result: NewSuspendResult("wait b", nil)}}}
+	toolC := &scriptedTool{name: "tool_c", outcomes: []toolOutcome{{result: NewSuspendResult("wait c", nil)}}}
+	sess := session.New("partial-emit-once")
+	agent, err := NewAgent(AgentOptions{
+		Model:                 mock,
+		Tools:                 []Tool{toolA, toolB, toolC},
+		Session:               sess,
+		ParallelToolExecution: true,
+	})
+	assert.NoError(t, err)
+
+	resp, err := agent.CreateResponse(context.Background(), WithInput("start"))
+	assert.NoError(t, err)
+	assert.Equal(t, resp.Status, ResponseStatusSuspended)
+
+	collect := func() (*[]*ResponseItem, CreateResponseOption) {
+		var items []*ResponseItem
+		return &items, WithEventCallback(func(_ context.Context, item *ResponseItem) error {
+			items = append(items, item)
+			return nil
+		})
+	}
+
+	// Round 1: supply A only.
+	items1, cb1 := collect()
+	resp, err = agent.CreateResponse(context.Background(),
+		WithToolResults(map[string]*ToolResult{"toolu_a": NewToolResultText("A done")}), cb1)
+	assert.NoError(t, err)
+	assert.Equal(t, resp.Status, ResponseStatusSuspended)
+	assert.Equal(t, 1, countToolResultItems(*items1, "toolu_a"))
+	assert.Equal(t, 0, countToolResultItems(*items1, "toolu_b"))
+	assert.Equal(t, 0, countToolResultItems(*items1, "toolu_c"))
+
+	// Round 2: supply B only — A must NOT re-emit.
+	items2, cb2 := collect()
+	resp, err = agent.CreateResponse(context.Background(),
+		WithToolResults(map[string]*ToolResult{"toolu_b": NewToolResultText("B done")}), cb2)
+	assert.NoError(t, err)
+	assert.Equal(t, resp.Status, ResponseStatusSuspended)
+	assert.Equal(t, 0, countToolResultItems(*items2, "toolu_a"))
+	assert.Equal(t, 1, countToolResultItems(*items2, "toolu_b"))
+
+	// Round 3: supply C → completes. Only C emits, in both the stream and
+	// Response.Items.
+	items3, cb3 := collect()
+	resp, err = agent.CreateResponse(context.Background(),
+		WithToolResults(map[string]*ToolResult{"toolu_c": NewToolResultText("C done")}), cb3)
+	assert.NoError(t, err)
+	assert.Equal(t, resp.Status, ResponseStatusCompleted)
+	assert.Equal(t, 0, countToolResultItems(*items3, "toolu_a"))
+	assert.Equal(t, 0, countToolResultItems(*items3, "toolu_b"))
+	assert.Equal(t, 1, countToolResultItems(*items3, "toolu_c"))
+	assert.Equal(t, 0, countToolResultItems(resp.Items, "toolu_a"))
+	assert.Equal(t, 0, countToolResultItems(resp.Items, "toolu_b"))
+	assert.Equal(t, 1, countToolResultItems(resp.Items, "toolu_c"))
+}
+
 func TestResumePostHookAbortPropagates(t *testing.T) {
 	mock := &scriptedLLM{
 		script: []scriptedTurn{
@@ -2121,6 +2194,52 @@ func TestStatelessResumeEmitsCallerSuppliedToolResult(t *testing.T) {
 	assert.True(t, len(streamed) > 1)
 	assert.Equal(t, ResponseItemTypeToolCallResult, streamed[0].Type,
 		"resumed result must stream before the next model response")
+}
+
+// An event-callback failure while emitting a caller-supplied resume result
+// wraps the error in *GenerationError carrying the items emitted so far,
+// matching the contract of the generate loop and the not-started execution
+// path. Nothing is persisted: the session keeps its suspended turn, so the
+// caller can retry the resume.
+func TestResumeEmitCallbackErrorWrapsGenerationError(t *testing.T) {
+	mock := &scriptedLLM{
+		script: []scriptedTurn{
+			toolUseAssistantTurn(newScriptedToolUse("toolu_a", "tool_a", `{}`)),
+			finalTextTurn("done"),
+		},
+	}
+	tool := &scriptedTool{name: "tool_a", outcomes: []toolOutcome{{result: NewSuspendResult("wait", nil)}}}
+	sess := session.New("emit-cb-err")
+	agent, err := NewAgent(AgentOptions{Model: mock, Tools: []Tool{tool}, Session: sess})
+	assert.NoError(t, err)
+
+	resp, err := agent.CreateResponse(context.Background(), WithInput("start"))
+	assert.NoError(t, err)
+	assert.Equal(t, resp.Status, ResponseStatusSuspended)
+
+	callbackErr := errors.New("consumer failed")
+	_, err = agent.CreateResponse(context.Background(),
+		WithToolResults(map[string]*ToolResult{"toolu_a": NewToolResultText("A done")}),
+		WithEventCallback(func(_ context.Context, item *ResponseItem) error {
+			if item.Type == ResponseItemTypeToolCallResult {
+				return callbackErr
+			}
+			return nil
+		}),
+	)
+	assert.Error(t, err)
+	assert.True(t, errors.Is(err, callbackErr))
+	var genErr *GenerationError
+	assert.True(t, errors.As(err, &genErr))
+	assert.Equal(t, 1, countToolResultItems(genErr.Items, "toolu_a"))
+
+	// The session still holds the suspended turn — the resume is retryable.
+	assert.True(t, sessIsSuspended(sess))
+	resp, err = agent.CreateResponse(context.Background(),
+		WithToolResults(map[string]*ToolResult{"toolu_a": NewToolResultText("A done")}),
+	)
+	assert.NoError(t, err)
+	assert.Equal(t, resp.Status, ResponseStatusCompleted)
 }
 
 func countToolResultItems(items []*ResponseItem, id string) int {
@@ -3367,13 +3486,30 @@ func TestResumePostHookMutationsPropagate(t *testing.T) {
 	_, err = agent.CreateResponse(context.Background(), WithInput("start"))
 	assert.NoError(t, err)
 
+	var streamed []*ResponseItem
 	resp, err := agent.CreateResponse(context.Background(),
 		WithToolResults(map[string]*ToolResult{
 			"toolu_a": NewToolResultText("original content"),
 		}),
+		WithEventCallback(func(_ context.Context, item *ResponseItem) error {
+			streamed = append(streamed, item)
+			return nil
+		}),
 	)
 	assert.NoError(t, err)
 	assert.Equal(t, resp.Status, ResponseStatusCompleted)
+
+	// The emitted tool_call_result item must carry the hook-mutated result,
+	// not the original caller-supplied value.
+	assert.Equal(t, 1, countToolResultItems(streamed, "toolu_a"))
+	for _, item := range streamed {
+		if item.Type != ResponseItemTypeToolCallResult || item.ToolCallResult.ID != "toolu_a" {
+			continue
+		}
+		raw, _ := json.Marshal(item.ToolCallResult.Result)
+		assert.True(t, strings.Contains(string(raw), "REDACTED"),
+			"streamed resume result should reflect hook mutations")
+	}
 
 	// The LLM should have seen the hook-modified result, not the original.
 	// Check the second LLM call's messages for the tool_result content.

--- a/agent_suspend_test.go
+++ b/agent_suspend_test.go
@@ -2001,13 +2001,20 @@ func TestSuspendedOutputMessagesInvariant(t *testing.T) {
 
 	// Partial resume: provide A, B still pending → suspended without
 	// re-entering generate.
+	var partialStream []*ResponseItem
 	resp, err = agent2.CreateResponse(context.Background(),
 		WithToolResults(map[string]*ToolResult{"toolu_a": NewToolResultText("A")}),
+		WithEventCallback(func(_ context.Context, item *ResponseItem) error {
+			partialStream = append(partialStream, item)
+			return nil
+		}),
 	)
 	assert.NoError(t, err)
 	assert.Equal(t, resp.Status, ResponseStatusSuspended)
 	assert.Equal(t, len(resp.OutputMessages), 0,
 		"partial-resume-only suspend must not carry OutputMessages (caller should read from session)")
+	assert.Equal(t, 1, countToolResultItems(partialStream, "toolu_a"))
+	assert.Equal(t, 1, countToolResultItems(resp.Items, "toolu_a"))
 }
 
 // ---------------------------------------------------------------------------
@@ -2076,6 +2083,54 @@ func TestStatelessSuspendAndResume(t *testing.T) {
 	assert.True(t, len(resp.Suspension.TurnMessages) > len(savedState.TurnMessages),
 		"merged turn must include the final assistant message")
 	_ = append(preHistory, resp.Suspension.TurnMessages...)
+}
+
+func TestStatelessResumeEmitsCallerSuppliedToolResult(t *testing.T) {
+	mock := &scriptedLLM{
+		script: []scriptedTurn{
+			toolUseAssistantTurn(newScriptedToolUse("toolu_a", "approve", `{}`)),
+			finalTextTurn("done"),
+		},
+	}
+	tool := &scriptedTool{
+		name:     "approve",
+		outcomes: []toolOutcome{{result: NewSuspendResult("waiting", nil)}},
+	}
+	agent, err := NewAgent(AgentOptions{Model: mock, Tools: []Tool{tool}})
+	assert.NoError(t, err)
+
+	resp, err := agent.CreateResponse(context.Background(), WithMessages(llm.NewUserTextMessage("go")))
+	assert.NoError(t, err)
+	assert.Equal(t, ResponseStatusSuspended, resp.Status)
+
+	var streamed []*ResponseItem
+	resp, err = agent.CreateResponse(context.Background(),
+		WithResume(resp.Suspension, map[string]*ToolResult{
+			"toolu_a": NewToolResultText("approved"),
+		}),
+		WithEventCallback(func(_ context.Context, item *ResponseItem) error {
+			streamed = append(streamed, item)
+			return nil
+		}),
+	)
+	assert.NoError(t, err)
+	assert.Equal(t, ResponseStatusCompleted, resp.Status)
+
+	assert.Equal(t, 1, countToolResultItems(streamed, "toolu_a"))
+	assert.Equal(t, 1, countToolResultItems(resp.Items, "toolu_a"))
+	assert.True(t, len(streamed) > 1)
+	assert.Equal(t, ResponseItemTypeToolCallResult, streamed[0].Type,
+		"resumed result must stream before the next model response")
+}
+
+func countToolResultItems(items []*ResponseItem, id string) int {
+	count := 0
+	for _, item := range items {
+		if item != nil && item.Type == ResponseItemTypeToolCallResult && item.ToolCallResult != nil && item.ToolCallResult.ID == id {
+			count++
+		}
+	}
+	return count
 }
 
 // Stateless multi-pending resume: two parallel suspends, both resolved in

--- a/agent_suspend_test.go
+++ b/agent_suspend_test.go
@@ -843,6 +843,74 @@ func TestResumeNotStartedRunsInParallel(t *testing.T) {
 	assert.Equal(t, toolC.CallCount(), 1, "C should have run during resume")
 }
 
+// Combined resume path: one caller-supplied result AND not-started tools in
+// the same resume call. Both must land in the stream and Response.Items —
+// caller-supplied first, then not-started execution results, matching the
+// callback emission order. Regression test for the overwrite bug where
+// `resumeExtraItems = resumeItems` dropped the caller-supplied items.
+func TestResumeEmitsCallerSuppliedAndNotStartedItems(t *testing.T) {
+	mock := &scriptedLLM{
+		script: []scriptedTurn{
+			toolUseAssistantTurn(
+				newScriptedToolUse("toolu_a", "tool_a", `{}`),
+				newScriptedToolUse("toolu_b", "tool_b", `{}`),
+			),
+			finalTextTurn("done"),
+		},
+	}
+	toolA := &scriptedTool{name: "tool_a", outcomes: []toolOutcome{{result: NewSuspendResult("wait", nil)}}}
+	toolB := &scriptedTool{name: "tool_b", outcomes: []toolOutcome{{result: NewToolResultText("B done")}}}
+	sess := session.New("combined-emit")
+	agent, err := NewAgent(AgentOptions{
+		Model:   mock,
+		Tools:   []Tool{toolA, toolB},
+		Session: sess,
+	})
+	assert.NoError(t, err)
+
+	// Sequential: A suspends, B is left not-started.
+	resp, err := agent.CreateResponse(context.Background(), WithInput("start"))
+	assert.NoError(t, err)
+	assert.Equal(t, resp.Status, ResponseStatusSuspended)
+	assert.Equal(t, toolB.CallCount(), 0, "B should not have run (sequential, A suspended)")
+
+	// Resume with A's result: B executes as not-started during the resume.
+	var streamed []*ResponseItem
+	resp, err = agent.CreateResponse(context.Background(),
+		WithToolResults(map[string]*ToolResult{"toolu_a": NewToolResultText("A done")}),
+		WithEventCallback(func(_ context.Context, item *ResponseItem) error {
+			streamed = append(streamed, item)
+			return nil
+		}),
+	)
+	assert.NoError(t, err)
+	assert.Equal(t, resp.Status, ResponseStatusCompleted)
+	assert.Equal(t, toolB.CallCount(), 1, "B should have run during resume")
+
+	// Both results appear exactly once in the stream and in Response.Items.
+	assert.Equal(t, 1, countToolResultItems(streamed, "toolu_a"))
+	assert.Equal(t, 1, countToolResultItems(streamed, "toolu_b"))
+	assert.Equal(t, 1, countToolResultItems(resp.Items, "toolu_a"))
+	assert.Equal(t, 1, countToolResultItems(resp.Items, "toolu_b"))
+
+	// Caller-supplied result precedes the not-started execution result.
+	assert.True(t, toolResultItemIndex(streamed, "toolu_a") < toolResultItemIndex(streamed, "toolu_b"),
+		"caller-supplied result must stream before not-started execution results")
+	assert.True(t, toolResultItemIndex(resp.Items, "toolu_a") < toolResultItemIndex(resp.Items, "toolu_b"),
+		"Response.Items must preserve callback emission order")
+}
+
+// toolResultItemIndex returns the index of the first tool_call_result item
+// with the given tool_use ID, or -1 if absent.
+func toolResultItemIndex(items []*ResponseItem, id string) int {
+	for i, item := range items {
+		if item != nil && item.Type == ResponseItemTypeToolCallResult && item.ToolCallResult != nil && item.ToolCallResult.ID == id {
+			return i
+		}
+	}
+	return -1
+}
+
 func TestResumeNotStartedReSuspends(t *testing.T) {
 	// Sequential: A suspends, B and C are not-started. Resume with A's
 	// result causes B to run and suspend (re-suspend). C is not-started

--- a/docs/guides/suspend-resume.md
+++ b/docs/guides/suspend-resume.md
@@ -367,6 +367,45 @@ dive.WithEventCallback(func(ctx context.Context, item *dive.ResponseItem) error 
 Stream consumers should treat this item as end-of-stream and then
 observe `Response.Status` and `Response.Suspension` on the final return.
 
+### Resume streams
+
+A resume call (`WithToolResults` or `WithResume`) emits each
+caller-supplied result as a `ResponseItemTypeToolCallResult` item —
+the same event an in-process tool produces when it completes. These
+items are emitted:
+
+- after PostToolUse/PostToolUseFailure hooks, so observers receive the
+  final hook-mutated result;
+- in the original tool-call order, so multi-tool resumes are
+  deterministic;
+- before any model items from the continued generation;
+- on both complete and partial resumes, and in `Response.Items` as
+  well as through the event callback.
+
+Across multiple partial resumes, each result is emitted exactly once —
+in the round it was supplied. This gives transcript consumers one
+response item for every message-bearing event in the turn history.
+
+Note that a suspended tool call produces **two** `tool_call_result`
+items over the life of the conversation: one at suspend time whose
+`Result.Suspend` field is non-nil (the suspend signal — no
+`tool_result` exists in the turn history yet), and one at resume time
+carrying the real result. Consumers that map items to history messages
+must treat `Suspend != nil` items as non-message-bearing:
+
+```go
+dive.WithEventCallback(func(ctx context.Context, item *dive.ResponseItem) error {
+    if item.Type == dive.ResponseItemTypeToolCallResult {
+        r := item.ToolCallResult
+        if r.Result != nil && r.Result.Suspend != nil {
+            return nil // suspend signal — not part of the message history
+        }
+        // ... index the settled result
+    }
+    return nil
+})
+```
+
 ## Errors
 
 | Error                           | Cause |


### PR DESCRIPTION
## Summary

- emit caller-supplied resume results as `ResponseItemTypeToolCallResult` items
- emit after post-tool hooks so observers receive the final hook-mutated result
- include those items in completed and partial-resume responses
- preserve caller-supplied items when not-started tools also execute during resume
- add full- and partial-resume regressions

## Root cause

Resume results supplied through `WithResume` were merged into `SuspensionState.TurnMessages` and passed to the next model call, but were not sent through the event callback or returned in `Response.Items`. Transcript observers therefore counted fewer messages than the authoritative turn snapshot, allowing response indexes to drift after each suspension.

## Impact

Consumers such as Mobius Cloud can keep live transcript indexes aligned across human-input, job, and event resumes. This prevents the duplicate persistence shape repaired by the paired Mobius Cloud PR.

## Validation

- `go test ./...`
- full- and partial-resume streaming regressions
- `git diff --check`