### PR TITLE
Prepare v1.16.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,34 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [1.16.0] - 2026-07-16
+
+### Fixed
+
+- **Resumed tool results in the response stream** — caller-supplied results
+  delivered via `WithToolResults` or `WithResume` are now emitted as
+  `ResponseItemTypeToolCallResult` items through the event callback and in
+  `Response.Items`: after post-tool hooks (observers see the final
+  hook-mutated value), in the original tool-call order, exactly once per
+  result across partial resumes, and on both complete and partial resumes.
+  Previously a resumed result reached the model and the saved turn but was
+  invisible to streaming consumers, so transcripts built from response items
+  drifted one position behind the authoritative history on every resume.
+  Note that a suspended tool call now yields two `tool_call_result` items
+  over its lifetime — the suspend signal (`Result.Suspend != nil`) and the
+  later settlement; consumers that map items to history messages should skip
+  the suspend signal (see the suspend-resume guide's Streaming section).
+
+### Changed
+
+- **Resume-phase partial-work errors** — an event-callback failure while
+  emitting a caller-supplied resume result is now wrapped in
+  `*GenerationError` carrying the items emitted so far, and a failure during
+  not-started tool execution includes the already-emitted caller-supplied
+  items in `GenerationError.Items` — both matching the generate loop's
+  partial-work recovery contract. The session keeps its suspended turn in
+  these cases, so the resume can be retried.
+
 ## [1.15.1] - 2026-07-15
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,29 +10,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Fixed
 
-- **Resumed tool results in the response stream** — caller-supplied results
-  delivered via `WithToolResults` or `WithResume` are now emitted as
-  `ResponseItemTypeToolCallResult` items through the event callback and in
-  `Response.Items`: after post-tool hooks (observers see the final
-  hook-mutated value), in the original tool-call order, exactly once per
-  result across partial resumes, and on both complete and partial resumes.
-  Previously a resumed result reached the model and the saved turn but was
-  invisible to streaming consumers, so transcripts built from response items
-  drifted one position behind the authoritative history on every resume.
-  Note that a suspended tool call now yields two `tool_call_result` items
-  over its lifetime — the suspend signal (`Result.Suspend != nil`) and the
-  later settlement; consumers that map items to history messages should skip
-  the suspend signal (see the suspend-resume guide's Streaming section).
+- **Resumed tool results in the response stream** — results supplied via
+  `WithToolResults`/`WithResume` are now emitted as `tool_call_result`
+  response items (after post-tool hooks, in tool-call order, exactly once
+  per result). Previously they were invisible to stream consumers, so
+  transcripts built from response items drifted behind the authoritative
+  history. See the suspend-resume guide's Streaming section.
 
 ### Changed
 
-- **Resume-phase partial-work errors** — an event-callback failure while
-  emitting a caller-supplied resume result is now wrapped in
-  `*GenerationError` carrying the items emitted so far, and a failure during
-  not-started tool execution includes the already-emitted caller-supplied
-  items in `GenerationError.Items` — both matching the generate loop's
-  partial-work recovery contract. The session keeps its suspended turn in
-  these cases, so the resume can be retried.
+- **Resume-phase partial-work errors** — failures during resume emission or
+  not-started tool execution now carry all items emitted so far in
+  `*GenerationError`, matching the generate loop. The session keeps its
+  suspended turn, so the resume can be retried.
 
 ## [1.15.1] - 2026-07-15
 

--- a/a2a/go.mod
+++ b/a2a/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/a2aproject/a2a-go/v2 v2.2.0
-	github.com/deepnoodle-ai/dive v1.15.1
+	github.com/deepnoodle-ai/dive v1.16.0
 	github.com/deepnoodle-ai/wonton v0.0.36
 )
 

--- a/demos/colosseum/go.mod
+++ b/demos/colosseum/go.mod
@@ -3,11 +3,11 @@ module github.com/deepnoodle-ai/dive/demos/colosseum
 go 1.25.0
 
 require (
-	github.com/deepnoodle-ai/dive v1.15.1
-	github.com/deepnoodle-ai/dive/a2a v1.15.1
-	github.com/deepnoodle-ai/dive/providers/google v1.15.1
-	github.com/deepnoodle-ai/dive/providers/grok v1.15.1
-	github.com/deepnoodle-ai/dive/providers/openai v1.15.1
+	github.com/deepnoodle-ai/dive v1.16.0
+	github.com/deepnoodle-ai/dive/a2a v1.16.0
+	github.com/deepnoodle-ai/dive/providers/google v1.16.0
+	github.com/deepnoodle-ai/dive/providers/grok v1.16.0
+	github.com/deepnoodle-ai/dive/providers/openai v1.16.0
 	github.com/deepnoodle-ai/wonton v0.0.36
 )
 

--- a/demos/noodleville/go.mod
+++ b/demos/noodleville/go.mod
@@ -3,7 +3,7 @@ module github.com/deepnoodle-ai/dive/demos/noodleville
 go 1.25.0
 
 require (
-	github.com/deepnoodle-ai/dive v1.15.1
+	github.com/deepnoodle-ai/dive v1.16.0
 	github.com/deepnoodle-ai/wonton v0.0.36
 )
 

--- a/examples/go.mod
+++ b/examples/go.mod
@@ -3,13 +3,13 @@ module github.com/deepnoodle-ai/dive/examples
 go 1.25.0
 
 require (
-	github.com/deepnoodle-ai/dive v1.15.1
-	github.com/deepnoodle-ai/dive/a2a v1.15.1
-	github.com/deepnoodle-ai/dive/experimental/mcp v1.15.1
-	github.com/deepnoodle-ai/dive/otel v1.15.1
-	github.com/deepnoodle-ai/dive/providers/google v1.15.1
-	github.com/deepnoodle-ai/dive/providers/grok v1.15.1
-	github.com/deepnoodle-ai/dive/providers/openai v1.15.1
+	github.com/deepnoodle-ai/dive v1.16.0
+	github.com/deepnoodle-ai/dive/a2a v1.16.0
+	github.com/deepnoodle-ai/dive/experimental/mcp v1.16.0
+	github.com/deepnoodle-ai/dive/otel v1.16.0
+	github.com/deepnoodle-ai/dive/providers/google v1.16.0
+	github.com/deepnoodle-ai/dive/providers/grok v1.16.0
+	github.com/deepnoodle-ai/dive/providers/openai v1.16.0
 	github.com/deepnoodle-ai/wonton v0.0.36
 	github.com/fatih/color v1.18.0
 	github.com/mark3labs/mcp-go v0.45.0

--- a/experimental/cmd/dive/go.mod
+++ b/experimental/cmd/dive/go.mod
@@ -3,10 +3,10 @@ module github.com/deepnoodle-ai/dive/experimental/cmd/dive
 go 1.25.0
 
 require (
-	github.com/deepnoodle-ai/dive v1.15.1
-	github.com/deepnoodle-ai/dive/providers/google v1.15.1
-	github.com/deepnoodle-ai/dive/providers/grok v1.15.1
-	github.com/deepnoodle-ai/dive/providers/openai v1.15.1
+	github.com/deepnoodle-ai/dive v1.16.0
+	github.com/deepnoodle-ai/dive/providers/google v1.16.0
+	github.com/deepnoodle-ai/dive/providers/grok v1.16.0
+	github.com/deepnoodle-ai/dive/providers/openai v1.16.0
 	github.com/deepnoodle-ai/wonton v0.0.36
 	github.com/mattn/go-runewidth v0.0.21
 )

--- a/experimental/mcp/go.mod
+++ b/experimental/mcp/go.mod
@@ -3,7 +3,7 @@ module github.com/deepnoodle-ai/dive/experimental/mcp
 go 1.25.0
 
 require (
-	github.com/deepnoodle-ai/dive v1.15.1
+	github.com/deepnoodle-ai/dive v1.16.0
 	github.com/deepnoodle-ai/wonton v0.0.36
 	github.com/mark3labs/mcp-go v0.45.0
 )

--- a/otel/go.mod
+++ b/otel/go.mod
@@ -3,7 +3,7 @@ module github.com/deepnoodle-ai/dive/otel
 go 1.25.0
 
 require (
-	github.com/deepnoodle-ai/dive v1.15.1
+	github.com/deepnoodle-ai/dive v1.16.0
 	go.opentelemetry.io/otel v1.43.0
 	go.opentelemetry.io/otel/metric v1.43.0
 	go.opentelemetry.io/otel/sdk v1.43.0

--- a/providers/google/go.mod
+++ b/providers/google/go.mod
@@ -3,7 +3,7 @@ module github.com/deepnoodle-ai/dive/providers/google
 go 1.25.0
 
 require (
-	github.com/deepnoodle-ai/dive v1.15.1
+	github.com/deepnoodle-ai/dive v1.16.0
 	github.com/deepnoodle-ai/wonton v0.0.36
 	google.golang.org/genai v1.51.0
 )

--- a/providers/grok/go.mod
+++ b/providers/grok/go.mod
@@ -3,8 +3,8 @@ module github.com/deepnoodle-ai/dive/providers/grok
 go 1.25.0
 
 require (
-	github.com/deepnoodle-ai/dive v1.15.1
-	github.com/deepnoodle-ai/dive/providers/openai v1.15.1
+	github.com/deepnoodle-ai/dive v1.16.0
+	github.com/deepnoodle-ai/dive/providers/openai v1.16.0
 	github.com/deepnoodle-ai/wonton v0.0.36
 	github.com/openai/openai-go/v3 v3.41.2-0.20260709175524-86bbd3d91826
 	golang.org/x/image v0.41.0

--- a/providers/openai/go.mod
+++ b/providers/openai/go.mod
@@ -3,7 +3,7 @@ module github.com/deepnoodle-ai/dive/providers/openai
 go 1.25.0
 
 require (
-	github.com/deepnoodle-ai/dive v1.15.1
+	github.com/deepnoodle-ai/dive v1.16.0
 	github.com/deepnoodle-ai/wonton v0.0.36
 	github.com/openai/openai-go/v3 v3.41.2-0.20260709175524-86bbd3d91826
 	golang.org/x/image v0.41.0


### PR DESCRIPTION
## Summary

Release prep for v1.16.0, following the process from #230:

- **CHANGELOG**: cut the `1.16.0` heading. Entries cover #231 — resumed
  tool results are now emitted as `ResponseItemTypeToolCallResult` stream
  items / `Response.Items` entries, plus the `GenerationError`
  partial-work consistency changes on the resume paths.
- **Version bumps**: all internal `github.com/deepnoodle-ai/dive*`
  requires move from `v1.15.1` to `v1.16.0` across the submodules
  (a2a, otel, providers, experimental/mcp, experimental/cmd/dive,
  examples, demos). Local `replace` directives mean no go.sum changes.

Minor version (not patch) because the fix adds observable stream
behavior: a suspended tool call now yields two `tool_call_result` items
over its lifetime (suspend signal, then settlement), which consumers
with strict item-handling assumptions should get a minor-version signal
for.

## After merge

```
git tag v1.16.0 <merge-commit>
make tag-modules VERSION=v1.16.0
git push origin --tags
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)