### PR TITLE
Add Gemini 3.6 Flash and 3.5 Flash-Lite support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Added
+
+- **Gemini 3.6 Flash and 3.5 Flash-Lite** — added stable model constants,
+  pricing, 1M-context CLI metadata, and model-picker entries. The CLI now
+  defaults to Gemini 3.6 Flash when Google credentials are available, and the
+  Google adapter omits deprecated sampling parameters for both new models.
+
 ## [1.16.0] - 2026-07-16
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - **Gemini 3.6 Flash and 3.5 Flash-Lite** — added stable model constants,
   pricing, 1M-context CLI metadata, and model-picker entries. The CLI now
   defaults to Gemini 3.6 Flash when Google credentials are available, and the
-  Google adapter omits deprecated sampling parameters for both new models.
+  Google adapter omits deprecated temperature settings for the new request
+  generation and logs a warning when a configured temperature is ignored.
 
 ## [1.16.0] - 2026-07-16
 

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ fmt.Println(response.OutputText())
 Use the LLM interface for direct model access without the agent loop:
 
 ```go
-model := google.New(google.WithModel("gemini-3-flash-preview"))
+model := google.New(google.WithModel(google.ModelGemini36Flash))
 response, err := model.Generate(ctx,
     llm.WithMessages(llm.NewUserMessage(
         llm.NewTextContent("What is in this image?"),

--- a/examples/google_example/main.go
+++ b/examples/google_example/main.go
@@ -11,7 +11,7 @@ import (
 
 func main() {
 	// Create the Google provider
-	provider := google.New(google.WithModel("gemini-2.0-flash-exp"))
+	provider := google.New(google.WithModel(google.ModelGemini36Flash))
 
 	ctx := context.Background()
 
@@ -47,14 +47,14 @@ func main() {
 	}
 	fmt.Println()
 
-	// Example 3: With system prompt and temperature
-	fmt.Println("=== With System Prompt and Temperature ===")
+	// Example 3: With system prompt. Gemini 3.6 Flash uses fixed sampling
+	// controls, so requests should not set a temperature.
+	fmt.Println("=== With System Prompt ===")
 	response, err = provider.Generate(ctx,
 		llm.WithMessages(
 			llm.NewUserTextMessage("Write a haiku about programming."),
 		),
 		llm.WithSystemPrompt("You are a poetic assistant who speaks in haikus."),
-		llm.WithTemperature(0.8),
 	)
 	if err != nil {
 		log.Fatalf("Error generating response: %v", err)

--- a/experimental/cmd/dive/main.go
+++ b/experimental/cmd/dive/main.go
@@ -1232,7 +1232,7 @@ func getDefaultModel() string {
 		return "claude-haiku-4-5"
 	}
 	if os.Getenv("GOOGLE_API_KEY") != "" || os.Getenv("GEMINI_API_KEY") != "" {
-		return "gemini-3-flash-preview"
+		return "gemini-3.6-flash"
 	}
 	if os.Getenv("OPENAI_API_KEY") != "" {
 		return "gpt-5.6-sol"

--- a/experimental/cmd/dive/main_test.go
+++ b/experimental/cmd/dive/main_test.go
@@ -46,7 +46,7 @@ func TestGetDefaultModel(t *testing.T) {
 			envVars: map[string]string{
 				"GOOGLE_API_KEY": "test",
 			},
-			expected: "gemini-3-flash-preview",
+			expected: "gemini-3.6-flash",
 		},
 		{
 			name: "openai key present",

--- a/experimental/cmd/dive/models.go
+++ b/experimental/cmd/dive/models.go
@@ -34,9 +34,11 @@ var modelCatalog = []modelInfo{
 	{"claude", "", 200_000},
 
 	// Google models
+	{"gemini-3.6-flash", "Gemini 3.6 Flash", 1_000_000},
 	{"gemini-3.1-pro-preview", "Gemini 3.1 Pro", 1_000_000},
 	{"gemini-3.1-pro", "Gemini 3.1 Pro", 1_000_000},
 	{"gemini-3.1-flash", "Gemini 3.1 Flash", 1_000_000},
+	{"gemini-3.5-flash-lite", "Gemini 3.5 Flash-Lite", 1_000_000},
 	{"gemini-3.5-flash", "Gemini 3.5 Flash", 1_000_000},
 	{"gemini-3-flash-preview", "Gemini 3 Flash", 1_000_000},
 	{"gemini-3-flash", "Gemini 3 Flash", 1_000_000},
@@ -152,9 +154,11 @@ var providerCatalog = []providerInfo{
 		Name:    "Google",
 		EnvVars: []string{"GOOGLE_API_KEY", "GEMINI_API_KEY"},
 		Models: []modelChoice{
-			{"gemini-3.1-pro-preview", "Gemini 3.1 Pro", "Google's latest flagship model"},
-			{"gemini-2.5-pro", "Gemini 2.5 Pro", "Strong all-around model"},
+			{"gemini-3.6-flash", "Gemini 3.6 Flash", "Fast agentic and multimodal model with strong coding performance"},
 			{"gemini-3.5-flash", "Gemini 3.5 Flash", "Frontier intelligence at high speed"},
+			{"gemini-3.5-flash-lite", "Gemini 3.5 Flash-Lite", "Lowest-cost model for high-throughput execution"},
+			{"gemini-3.1-pro-preview", "Gemini 3.1 Pro", "Flagship Pro model for complex reasoning"},
+			{"gemini-2.5-pro", "Gemini 2.5 Pro", "Strong all-around model"},
 		},
 	},
 	{

--- a/experimental/cmd/dive/models_test.go
+++ b/experimental/cmd/dive/models_test.go
@@ -6,6 +6,45 @@ import (
 	"github.com/deepnoodle-ai/wonton/assert"
 )
 
+func TestLatestGeminiFlashModels(t *testing.T) {
+	tests := []struct {
+		model string
+		label string
+	}{
+		{"gemini-3.6-flash", "Gemini 3.6 Flash"},
+		{"gemini-3.5-flash-lite", "Gemini 3.5 Flash-Lite"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.model, func(t *testing.T) {
+			info := lookupModel(tt.model)
+			assert.NotNil(t, info)
+			assert.Equal(t, tt.label, info.Label)
+			assert.Equal(t, 1_000_000, info.ContextWindow)
+		})
+	}
+}
+
+func TestGoogleProviderCatalogIncludesLatestFlashModels(t *testing.T) {
+	want := map[string]bool{
+		"gemini-3.6-flash":      false,
+		"gemini-3.5-flash-lite": false,
+	}
+	for _, provider := range providerCatalog {
+		if provider.Name != "Google" {
+			continue
+		}
+		for _, model := range provider.Models {
+			if _, ok := want[model.ModelID]; ok {
+				want[model.ModelID] = true
+			}
+		}
+	}
+	for model, found := range want {
+		assert.True(t, found, "Google model picker is missing %s", model)
+	}
+}
+
 func TestGrok45ContextWindow(t *testing.T) {
 	tests := []struct {
 		model string

--- a/llms.txt
+++ b/llms.txt
@@ -79,7 +79,7 @@ agent.CreateResponse(ctx,
 ## Direct LLM usage (no agent loop)
 
 ```go
-model := google.New(google.WithModel("gemini-3-flash-preview"))
+model := google.New(google.WithModel(google.ModelGemini36Flash))
 response, _ := model.Generate(ctx,
     llm.WithMessages(llm.NewUserMessage(
         llm.NewTextContent("What is in this image?"),

--- a/providers/google/google.go
+++ b/providers/google/google.go
@@ -292,7 +292,9 @@ func (p *Provider) applyRequestConfig(req *Request, config *llm.Config) error {
 		req.Tools = tools
 	}
 
-	req.Temperature = config.Temperature
+	if !omitsSamplingParameters(req.Model) {
+		req.Temperature = config.Temperature
+	}
 	req.System = config.SystemPrompt
 
 	return nil

--- a/providers/google/google.go
+++ b/providers/google/google.go
@@ -292,9 +292,14 @@ func (p *Provider) applyRequestConfig(req *Request, config *llm.Config) error {
 		req.Tools = tools
 	}
 
-	if !omitsSamplingParameters(req.Model) {
+	if !shouldOmitTemperature(req.Model) {
 		req.Temperature = config.Temperature
+	} else if config.Temperature != nil && config.Logger != nil {
+		config.Logger.Warn("temperature is not supported by this Google model and will be ignored",
+			"model", req.Model)
 	}
+	// Dive does not currently expose top_p or top_k. If those controls are
+	// added, apply the same Gemini request-generation cutoff used above.
 	req.System = config.SystemPrompt
 
 	return nil

--- a/providers/google/models.go
+++ b/providers/google/models.go
@@ -1,5 +1,10 @@
 package google
 
+import (
+	"strconv"
+	"strings"
+)
+
 const (
 	// Gemini 3.6 models (stable)
 	ModelGemini36Flash = "gemini-3.6-flash"
@@ -47,15 +52,31 @@ const (
 	ModelGemini15Flash = "gemini-1.5-flash"
 )
 
-// omitsSamplingParameters reports whether a model rejects the legacy Gemini
-// sampling controls. Gemini 3.6 Flash and Gemini 3.5 Flash-Lite ignore these
-// controls today and future model generations return an error when they are
-// supplied, so Dive leaves them off the wire for these model families.
-func omitsSamplingParameters(model string) bool {
-	switch model {
-	case ModelGemini36Flash, ModelGemini35FlashLite:
+// shouldOmitTemperature reports whether a model belongs to the Gemini request
+// generation that deprecated temperature. The cutover starts with Gemini 3.5
+// Flash-Lite and all Gemini 3.6+ models.
+func shouldOmitTemperature(model string) bool {
+	model = strings.TrimPrefix(model, "models/")
+	if model == ModelGemini35FlashLite || strings.HasPrefix(model, ModelGemini35FlashLite+"-") {
 		return true
-	default:
+	}
+
+	version, ok := strings.CutPrefix(model, "gemini-")
+	if !ok {
 		return false
 	}
+	version, _, _ = strings.Cut(version, "-")
+	majorText, minorText, hasMinor := strings.Cut(version, ".")
+	major, err := strconv.Atoi(majorText)
+	if err != nil {
+		return false
+	}
+	minor := 0
+	if hasMinor {
+		minor, err = strconv.Atoi(minorText)
+		if err != nil {
+			return false
+		}
+	}
+	return major > 3 || (major == 3 && minor >= 6)
 }

--- a/providers/google/models.go
+++ b/providers/google/models.go
@@ -1,8 +1,12 @@
 package google
 
 const (
+	// Gemini 3.6 models (stable)
+	ModelGemini36Flash = "gemini-3.6-flash"
+
 	// Gemini 3.5 models (stable)
-	ModelGemini35Flash = "gemini-3.5-flash"
+	ModelGemini35Flash     = "gemini-3.5-flash"
+	ModelGemini35FlashLite = "gemini-3.5-flash-lite"
 
 	// Gemini 3.1 models
 	ModelGemini31ProPreview            = "gemini-3.1-pro-preview"
@@ -42,3 +46,16 @@ const (
 	ModelGemini15Pro   = "gemini-1.5-pro"
 	ModelGemini15Flash = "gemini-1.5-flash"
 )
+
+// omitsSamplingParameters reports whether a model rejects the legacy Gemini
+// sampling controls. Gemini 3.6 Flash and Gemini 3.5 Flash-Lite ignore these
+// controls today and future model generations return an error when they are
+// supplied, so Dive leaves them off the wire for these model families.
+func omitsSamplingParameters(model string) bool {
+	switch model {
+	case ModelGemini36Flash, ModelGemini35FlashLite:
+		return true
+	default:
+		return false
+	}
+}

--- a/providers/google/models_test.go
+++ b/providers/google/models_test.go
@@ -1,0 +1,64 @@
+package google
+
+import (
+	"testing"
+
+	"github.com/deepnoodle-ai/dive/llm"
+	"github.com/deepnoodle-ai/wonton/assert"
+)
+
+func TestLatestGeminiFlashModels(t *testing.T) {
+	tests := []struct {
+		model       string
+		wantID      string
+		inputPrice  float64
+		outputPrice float64
+	}{
+		{ModelGemini36Flash, "gemini-3.6-flash", 1.50, 7.50},
+		{ModelGemini35FlashLite, "gemini-3.5-flash-lite", 0.30, 2.50},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.model, func(t *testing.T) {
+			assert.Equal(t, tt.wantID, tt.model)
+			pricing, ok := TextModelPricing[tt.model]
+			assert.True(t, ok)
+			assert.Equal(t, tt.inputPrice, pricing.InputPrice)
+			assert.Equal(t, tt.outputPrice, pricing.OutputPrice)
+		})
+	}
+}
+
+func TestLatestGeminiFlashModelsOmitTemperature(t *testing.T) {
+	temperature := 0.8
+	provider := New()
+
+	for _, model := range []string{ModelGemini36Flash, ModelGemini35FlashLite} {
+		t.Run(model, func(t *testing.T) {
+			var request Request
+			err := provider.applyRequestConfig(&request, &llm.Config{
+				Model:       model,
+				Temperature: &temperature,
+			})
+			assert.NoError(t, err)
+			assert.Nil(t, request.Temperature)
+
+			generateConfig, err := buildGenAIGenerateConfig(&request)
+			assert.NoError(t, err)
+			assert.Nil(t, generateConfig.Temperature)
+		})
+	}
+}
+
+func TestGemini35FlashKeepsTemperature(t *testing.T) {
+	temperature := 0.8
+	provider := New()
+	var request Request
+	err := provider.applyRequestConfig(&request, &llm.Config{
+		Model:       ModelGemini35Flash,
+		Temperature: &temperature,
+	})
+	assert.NoError(t, err)
+	assert.NotNil(t, request.Temperature)
+	assert.Equal(t, temperature, *request.Temperature)
+}

--- a/providers/google/models_test.go
+++ b/providers/google/models_test.go
@@ -35,17 +35,43 @@ func TestLatestGeminiFlashModelsOmitTemperature(t *testing.T) {
 
 	for _, model := range []string{ModelGemini36Flash, ModelGemini35FlashLite} {
 		t.Run(model, func(t *testing.T) {
+			logger := &recordingWarningLogger{}
 			var request Request
 			err := provider.applyRequestConfig(&request, &llm.Config{
 				Model:       model,
 				Temperature: &temperature,
+				Logger:      logger,
 			})
 			assert.NoError(t, err)
 			assert.Nil(t, request.Temperature)
+			assert.Len(t, logger.warnings, 1)
 
 			generateConfig, err := buildGenAIGenerateConfig(&request)
 			assert.NoError(t, err)
 			assert.Nil(t, generateConfig.Temperature)
+		})
+	}
+}
+
+func TestShouldOmitTemperatureCoversFutureGeminiModels(t *testing.T) {
+	tests := []struct {
+		model string
+		want  bool
+	}{
+		{ModelGemini35FlashLite, true},
+		{"gemini-3.5-flash-lite-001", true},
+		{ModelGemini36Flash, true},
+		{"gemini-3.7-pro", true},
+		{"gemini-4-pro", true},
+		{"models/gemini-4.1-flash", true},
+		{ModelGemini35Flash, false},
+		{ModelGemini31ProPreview, false},
+		{"not-a-gemini-model", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.model, func(t *testing.T) {
+			assert.Equal(t, tt.want, shouldOmitTemperature(tt.model))
 		})
 	}
 }
@@ -62,3 +88,15 @@ func TestGemini35FlashKeepsTemperature(t *testing.T) {
 	assert.NotNil(t, request.Temperature)
 	assert.Equal(t, temperature, *request.Temperature)
 }
+
+type recordingWarningLogger struct {
+	warnings []string
+}
+
+func (l *recordingWarningLogger) Debug(string, ...any) {}
+func (l *recordingWarningLogger) Info(string, ...any)  {}
+func (l *recordingWarningLogger) Warn(message string, _ ...any) {
+	l.warnings = append(l.warnings, message)
+}
+func (l *recordingWarningLogger) Error(string, ...any)   {}
+func (l *recordingWarningLogger) With(...any) llm.Logger { return l }

--- a/providers/google/pricing.go
+++ b/providers/google/pricing.go
@@ -4,12 +4,26 @@ import "github.com/deepnoodle-ai/dive/llm"
 
 // TextModelPricing contains pricing for all text generation models
 var TextModelPricing = map[string]llm.PricingInfo{
+	ModelGemini36Flash: {
+		Model:       ModelGemini36Flash,
+		InputPrice:  1.50,
+		OutputPrice: 7.50,
+		Currency:    "USD",
+		UpdatedAt:   "2026-07-21",
+	},
 	ModelGemini35Flash: {
 		Model:       ModelGemini35Flash,
 		InputPrice:  1.50,
 		OutputPrice: 9.00,
 		Currency:    "USD",
 		UpdatedAt:   "2026-05-28",
+	},
+	ModelGemini35FlashLite: {
+		Model:       ModelGemini35FlashLite,
+		InputPrice:  0.30,
+		OutputPrice: 2.50,
+		Currency:    "USD",
+		UpdatedAt:   "2026-07-21",
 	},
 	ModelGemini31ProPreview: {
 		Model:       ModelGemini31ProPreview,

--- a/providers/google/util.go
+++ b/providers/google/util.go
@@ -4,7 +4,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"reflect"
 	"strings"
 	"sync/atomic"
 
@@ -146,6 +145,15 @@ func convertToolUseToFunctionCall(toolUse *llm.ToolUseContent) (*genai.Part, err
 	return part, nil
 }
 
+// joinToolResultText flattens tool result content blocks to a single string.
+func joinToolResultText(blocks []*dive.ToolResultContent) string {
+	var parts []string
+	for _, b := range blocks {
+		parts = append(parts, b.Text)
+	}
+	return strings.Join(parts, "\n\n")
+}
+
 // convertToolResultToFunctionResponse converts a generic llm.ToolResultContent to a genai.FunctionResponse part
 func convertToolResultToFunctionResponse(content *llm.ToolResultContent, functionName string) (*genai.Part, error) {
 	if content == nil {
@@ -158,13 +166,20 @@ func convertToolResultToFunctionResponse(content *llm.ToolResultContent, functio
 	case []byte:
 		outputValue = string(c)
 	case []*dive.ToolResultContent:
-		var parts []string
-		for _, ch := range c {
-			parts = append(parts, ch.Text)
-		}
-		outputValue = strings.Join(parts, "\n\n")
+		outputValue = joinToolResultText(c)
 	default:
-		return nil, fmt.Errorf("unknown content type: %v", reflect.TypeOf(c))
+		// Content that round-tripped through JSON (session persistence,
+		// Message.Copy) arrives as generic []any rather than typed blocks.
+		var blocks []*dive.ToolResultContent
+		if err := content.DecodeContent(&blocks); err == nil && blocks != nil {
+			outputValue = joinToolResultText(blocks)
+		} else {
+			data, err := json.Marshal(content.Content)
+			if err != nil {
+				return nil, fmt.Errorf("error marshaling tool result content: %w", err)
+			}
+			outputValue = string(data)
+		}
 	}
 	responseData := map[string]any{}
 	if content.IsError {

--- a/providers/google/util_test.go
+++ b/providers/google/util_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/deepnoodle-ai/dive"
 	"github.com/deepnoodle-ai/dive/llm"
 	"github.com/deepnoodle-ai/wonton/assert"
 	"google.golang.org/genai"
@@ -55,6 +56,40 @@ func TestMessagesToContentsToolRoundTrip(t *testing.T) {
 	assert.NotNil(t, contents[2].Parts[0].FunctionResponse)
 	assert.Equal(t, contents[2].Parts[0].FunctionResponse.ID, id)
 	assert.Equal(t, contents[2].Parts[0].FunctionResponse.Name, "calculator")
+}
+
+func TestToolResultSurvivesJSONRoundTrip(t *testing.T) {
+	// Session persistence and Message.Copy round-trip messages through JSON,
+	// which turns typed []*dive.ToolResultContent tool result content into
+	// generic []any. The converter must decode that shape rather than fail
+	// with "unknown content type: []interface {}".
+	id := generateToolCallID("bash")
+	original := llm.NewToolResultMessage(&llm.ToolResultContent{
+		ToolUseID: id,
+		Content: []*dive.ToolResultContent{
+			{Type: dive.ToolResultContentTypeText, Text: "line one"},
+			{Type: dive.ToolResultContentTypeText, Text: "line two"},
+		},
+	})
+	body, err := json.Marshal(original)
+	assert.NoError(t, err)
+	var replayed llm.Message
+	assert.NoError(t, json.Unmarshal(body, &replayed))
+
+	contents, err := messagesToContents([]*llm.Message{
+		{
+			Role: llm.Assistant,
+			Content: []llm.Content{
+				&llm.ToolUseContent{ID: id, Name: "bash", Input: []byte(`{"command":"ls"}`)},
+			},
+		},
+		&replayed,
+	})
+	assert.NoError(t, err)
+	assert.Len(t, contents, 2)
+	response := contents[1].Parts[0].FunctionResponse
+	assert.NotNil(t, response)
+	assert.Equal(t, response.Response["output"], "line one\n\nline two")
 }
 
 func TestGoogleThoughtSignatureSurvivesMessageRoundTrip(t *testing.T) {


### PR DESCRIPTION
## Summary

- add Gemini 3.6 Flash and Gemini 3.5 Flash-Lite constants, pricing, and 1M-context CLI catalog metadata
- omit the deprecated temperature parameter for both new request shapes
- make Gemini 3.6 Flash the experimental CLI Google default and refresh examples

## Validation

- root: go test ./... with provider API keys unset
- providers/google: go test ./..., go test -race ./..., go vet ./...
- experimental/cmd/dive: go test ./..., go test -race ./..., go vet ./...
- examples: go test ./..., go vet ./...
- git diff --check

A live Gemini smoke was not run because no Google credentials are available in this environment.

Docs: https://ai.google.dev/gemini-api/docs/latest-model

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for **Gemini 3.6 Flash** and **Gemini 3.5 Flash-Lite**, including pricing and **model-picker** entries with **1M-context** metadata.
  - Updated the interactive CLI to default to **Gemini 3.6 Flash** when Google credentials are available.
- **Documentation**
  - Updated README and examples to use **Gemini 3.6 Flash** in Google model configuration.
- **Bug Fixes**
  - For supported Gemini flash models, temperature is now automatically omitted when not applicable (with a warning when ignored).
- **Tests**
  - Added coverage for model selection, temperature-handling, and tool-result JSON round-trip behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->