### PR TITLE
Prepare v1.17.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [1.17.0] - 2026-07-21
+
 ### Added
 
 - **Gemini 3.6 Flash and 3.5 Flash-Lite** — added stable model constants,
@@ -13,6 +15,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
   defaults to Gemini 3.6 Flash when Google credentials are available, and the
   Google adapter omits deprecated temperature settings for the new request
   generation and logs a warning when a configured temperature is ignored.
+
+### Fixed
+
+- **Google tool results after session replay** — tool result content that
+  round-trips through JSON (session persistence, `Message.Copy`) arrives as
+  `[]any` rather than typed `[]*dive.ToolResultContent`, so the next turn of a
+  multi-turn conversation with tool calls failed with
+  `unknown content type: []interface {}`. The Google adapter now decodes the
+  round-tripped shape into typed blocks, matching the openaicompletions
+  provider.
 
 ## [1.16.0] - 2026-07-16
 

--- a/a2a/go.mod
+++ b/a2a/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/a2aproject/a2a-go/v2 v2.2.0
-	github.com/deepnoodle-ai/dive v1.16.0
+	github.com/deepnoodle-ai/dive v1.17.0
 	github.com/deepnoodle-ai/wonton v0.0.36
 )
 

--- a/demos/colosseum/go.mod
+++ b/demos/colosseum/go.mod
@@ -3,11 +3,11 @@ module github.com/deepnoodle-ai/dive/demos/colosseum
 go 1.25.0
 
 require (
-	github.com/deepnoodle-ai/dive v1.16.0
-	github.com/deepnoodle-ai/dive/a2a v1.16.0
-	github.com/deepnoodle-ai/dive/providers/google v1.16.0
-	github.com/deepnoodle-ai/dive/providers/grok v1.16.0
-	github.com/deepnoodle-ai/dive/providers/openai v1.16.0
+	github.com/deepnoodle-ai/dive v1.17.0
+	github.com/deepnoodle-ai/dive/a2a v1.17.0
+	github.com/deepnoodle-ai/dive/providers/google v1.17.0
+	github.com/deepnoodle-ai/dive/providers/grok v1.17.0
+	github.com/deepnoodle-ai/dive/providers/openai v1.17.0
 	github.com/deepnoodle-ai/wonton v0.0.36
 )
 

--- a/demos/noodleville/go.mod
+++ b/demos/noodleville/go.mod
@@ -3,7 +3,7 @@ module github.com/deepnoodle-ai/dive/demos/noodleville
 go 1.25.0
 
 require (
-	github.com/deepnoodle-ai/dive v1.16.0
+	github.com/deepnoodle-ai/dive v1.17.0
 	github.com/deepnoodle-ai/wonton v0.0.36
 )
 

--- a/examples/go.mod
+++ b/examples/go.mod
@@ -3,13 +3,13 @@ module github.com/deepnoodle-ai/dive/examples
 go 1.25.0
 
 require (
-	github.com/deepnoodle-ai/dive v1.16.0
-	github.com/deepnoodle-ai/dive/a2a v1.16.0
-	github.com/deepnoodle-ai/dive/experimental/mcp v1.16.0
-	github.com/deepnoodle-ai/dive/otel v1.16.0
-	github.com/deepnoodle-ai/dive/providers/google v1.16.0
-	github.com/deepnoodle-ai/dive/providers/grok v1.16.0
-	github.com/deepnoodle-ai/dive/providers/openai v1.16.0
+	github.com/deepnoodle-ai/dive v1.17.0
+	github.com/deepnoodle-ai/dive/a2a v1.17.0
+	github.com/deepnoodle-ai/dive/experimental/mcp v1.17.0
+	github.com/deepnoodle-ai/dive/otel v1.17.0
+	github.com/deepnoodle-ai/dive/providers/google v1.17.0
+	github.com/deepnoodle-ai/dive/providers/grok v1.17.0
+	github.com/deepnoodle-ai/dive/providers/openai v1.17.0
 	github.com/deepnoodle-ai/wonton v0.0.36
 	github.com/fatih/color v1.18.0
 	github.com/mark3labs/mcp-go v0.45.0

--- a/experimental/cmd/dive/go.mod
+++ b/experimental/cmd/dive/go.mod
@@ -3,10 +3,10 @@ module github.com/deepnoodle-ai/dive/experimental/cmd/dive
 go 1.25.0
 
 require (
-	github.com/deepnoodle-ai/dive v1.16.0
-	github.com/deepnoodle-ai/dive/providers/google v1.16.0
-	github.com/deepnoodle-ai/dive/providers/grok v1.16.0
-	github.com/deepnoodle-ai/dive/providers/openai v1.16.0
+	github.com/deepnoodle-ai/dive v1.17.0
+	github.com/deepnoodle-ai/dive/providers/google v1.17.0
+	github.com/deepnoodle-ai/dive/providers/grok v1.17.0
+	github.com/deepnoodle-ai/dive/providers/openai v1.17.0
 	github.com/deepnoodle-ai/wonton v0.0.36
 	github.com/mattn/go-runewidth v0.0.21
 )

--- a/experimental/mcp/go.mod
+++ b/experimental/mcp/go.mod
@@ -3,7 +3,7 @@ module github.com/deepnoodle-ai/dive/experimental/mcp
 go 1.25.0
 
 require (
-	github.com/deepnoodle-ai/dive v1.16.0
+	github.com/deepnoodle-ai/dive v1.17.0
 	github.com/deepnoodle-ai/wonton v0.0.36
 	github.com/mark3labs/mcp-go v0.45.0
 )

--- a/otel/go.mod
+++ b/otel/go.mod
@@ -3,7 +3,7 @@ module github.com/deepnoodle-ai/dive/otel
 go 1.25.0
 
 require (
-	github.com/deepnoodle-ai/dive v1.16.0
+	github.com/deepnoodle-ai/dive v1.17.0
 	go.opentelemetry.io/otel v1.43.0
 	go.opentelemetry.io/otel/metric v1.43.0
 	go.opentelemetry.io/otel/sdk v1.43.0

--- a/providers/google/go.mod
+++ b/providers/google/go.mod
@@ -3,7 +3,7 @@ module github.com/deepnoodle-ai/dive/providers/google
 go 1.25.0
 
 require (
-	github.com/deepnoodle-ai/dive v1.16.0
+	github.com/deepnoodle-ai/dive v1.17.0
 	github.com/deepnoodle-ai/wonton v0.0.36
 	google.golang.org/genai v1.51.0
 )

--- a/providers/grok/go.mod
+++ b/providers/grok/go.mod
@@ -3,8 +3,8 @@ module github.com/deepnoodle-ai/dive/providers/grok
 go 1.25.0
 
 require (
-	github.com/deepnoodle-ai/dive v1.16.0
-	github.com/deepnoodle-ai/dive/providers/openai v1.16.0
+	github.com/deepnoodle-ai/dive v1.17.0
+	github.com/deepnoodle-ai/dive/providers/openai v1.17.0
 	github.com/deepnoodle-ai/wonton v0.0.36
 	github.com/openai/openai-go/v3 v3.41.2-0.20260709175524-86bbd3d91826
 	golang.org/x/image v0.41.0

--- a/providers/openai/go.mod
+++ b/providers/openai/go.mod
@@ -3,7 +3,7 @@ module github.com/deepnoodle-ai/dive/providers/openai
 go 1.25.0
 
 require (
-	github.com/deepnoodle-ai/dive v1.16.0
+	github.com/deepnoodle-ai/dive v1.17.0
 	github.com/deepnoodle-ai/wonton v0.0.36
 	github.com/openai/openai-go/v3 v3.41.2-0.20260709175524-86bbd3d91826
 	golang.org/x/image v0.41.0


### PR DESCRIPTION
## Summary

Release prep for v1.17.0, following the process from #232:

- **CHANGELOG**: cut the `1.17.0` heading. Entries cover #233 — Gemini 3.6
  Flash and 3.5 Flash-Lite model constants, pricing, CLI metadata and
  model-picker entries, plus the temperature-omission behavior for the new
  Gemini request generation. Also adds a `Fixed` entry for the Google
  tool-result decode fix that shipped in the same PR without a changelog line
  (round-tripped `[]any` tool result content failed multi-turn conversations
  with `unknown content type: []interface {}`).
- **Version bumps**: all internal `github.com/deepnoodle-ai/dive*` requires
  move from `v1.16.0` to `v1.17.0` across the submodules (a2a, otel,
  providers, experimental/mcp, experimental/cmd/dive, examples, demos).
  Local `replace` directives mean no go.sum changes.

Minor version (not patch) because the release adds new public model
constants (`ModelGemini36Flash`, `ModelGemini35FlashLite`) and changes the
CLI's default Google model.

## Verification

- `go vet ./...` clean; `go test ./...` passes except the 5 live-API tests in
  `providers/anthropic`, which fail with a 401 in this environment (no valid
  `ANTHROPIC_API_KEY`) — unrelated to this change.
- All 10 submodules build.
- `make fmt-check` fails on 36 pre-existing Markdown files unrelated to this
  change; `CHANGELOG.md` is prettier-clean.

## After merge

```
git tag v1.17.0 <merge-commit>
make tag-modules VERSION=v1.17.0
git push origin --tags
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)