### PR TITLE
Fix media input gaps across providers

### DIFF
--- a/docs/guides/llm-guide.md
+++ b/docs/guides/llm-guide.md
@@ -129,6 +129,8 @@ Anthropic and OpenAI (Responses) receive tool-result images natively; on
 providers whose tool messages are text-only (google, openaicompletions,
 mistral, openrouter), non-text blocks are replaced with a
 `[image content omitted]` placeholder so the model knows content was elided.
+A tool result with nothing to render is sent as `(no output)` rather than an
+empty block or empty array, which are variously rejected or ambiguous.
 
 ## Provider Options
 

--- a/docs/guides/llm-guide.md
+++ b/docs/guides/llm-guide.md
@@ -84,6 +84,52 @@ model := openrouter.New()
 **Env:** `OPENROUTER_API_KEY`
 **Features:** Access to 200+ models from multiple providers
 
+## Multimodal Input
+
+Messages can carry images and documents alongside text using
+`llm.ImageContent` and `llm.DocumentContent` blocks:
+
+```go
+message := llm.NewUserMessage(
+    &llm.TextContent{Text: "Summarize this report."},
+    &llm.DocumentContent{
+        Title: "report.pdf",
+        Source: &llm.ContentSource{
+            Type:      llm.ContentSourceTypeBase64,
+            MediaType: "application/pdf",
+            Data:      pdfBase64,
+        },
+    },
+)
+```
+
+Each provider encodes these blocks into its native request format. Supported
+content sources by provider:
+
+| Provider                                 | Images                | Documents                              |
+| ---------------------------------------- | --------------------- | -------------------------------------- |
+| anthropic                                | base64, URL, file ID  | base64, URL, file ID, text             |
+| openai (Responses)                       | base64, URL, file ID  | base64, URL, file ID, text             |
+| grok                                     | base64, URL, file ID  | same as openai (server support varies) |
+| google                                   | base64, URL/file URI  | base64, URL/file URI, text             |
+| openaicompletions, mistral, openrouter   | base64, URL           | base64, file ID, text (no URL)         |
+| ollama                                   | base64 (model-dependent) | model-dependent                     |
+
+Notes:
+
+- Base64 sources require `MediaType`. Providers convert to the wire format
+  they need (e.g. data URLs for OpenAI-style APIs, inline bytes for Gemini).
+- Text-source documents are sent natively on Anthropic and inlined as plain
+  text on providers without a text-document type.
+- A content block a provider cannot encode is a request-building error, never
+  a silent drop.
+
+Tool results can also carry media (e.g. an MCP tool returning a screenshot).
+Anthropic and OpenAI (Responses) receive tool-result images natively; on
+providers whose tool messages are text-only (google, openaicompletions,
+mistral, openrouter), non-text blocks are replaced with a
+`[image content omitted]` placeholder so the model knows content was elided.
+
 ## Provider Options
 
 All providers accept variadic options. For example, to specify a model:

--- a/providers/anthropic/anthropic.go
+++ b/providers/anthropic/anthropic.go
@@ -308,10 +308,15 @@ func convertMessages(messages []*llm.Message) ([]*llm.Message, error) {
 // {"type":"text","text":...} form, which happens to match Anthropic's text
 // block — but image blocks ({"type":"image","data":...,"mimeType":...}) do
 // not, so they are converted to native image blocks with a base64 source.
-// Content that is not block-shaped passes through unchanged.
+// Content that is not block-shaped passes through unchanged. A result with no
+// renderable blocks becomes a single placeholder text block, since Anthropic
+// accepts neither an empty text block nor an empty content array.
 func convertToolResultBlocks(c *llm.ToolResultContent) any {
 	blocks := providers.ToolResultBlocks(c)
 	if blocks == nil {
+		if providers.IsEmptyToolResultContent(c.Content) {
+			return []llm.Content{&llm.TextContent{Text: providers.EmptyToolResultText}}
+		}
 		return c.Content
 	}
 	content := make([]llm.Content, 0, len(blocks))
@@ -343,6 +348,9 @@ func convertToolResultBlocks(c *llm.ToolResultContent) any {
 		default:
 			content = append(content, &llm.TextContent{Text: fmt.Sprintf("[%s content omitted]", b.Type)})
 		}
+	}
+	if len(content) == 0 {
+		content = append(content, &llm.TextContent{Text: providers.EmptyToolResultText})
 	}
 	return content
 }

--- a/providers/anthropic/anthropic.go
+++ b/providers/anthropic/anthropic.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/deepnoodle-ai/dive"
 	"github.com/deepnoodle-ai/dive/llm"
 	"github.com/deepnoodle-ai/dive/providers"
 	"github.com/deepnoodle-ai/wonton/retry"
@@ -259,7 +260,7 @@ func convertMessages(messages []*llm.Message) ([]*llm.Message, error) {
 			switch c := content.(type) {
 			case *llm.ToolResultContent:
 				copiedContent = append(copiedContent, &llm.ToolResultContent{
-					Content:      c.Content,
+					Content:      convertToolResultBlocks(c),
 					ToolUseID:    c.ToolUseID,
 					IsError:      c.IsError,
 					CacheControl: c.CacheControl,
@@ -300,6 +301,50 @@ func convertMessages(messages []*llm.Message) ([]*llm.Message, error) {
 	// messages are not mutated.
 	reorderMessageContent(copied)
 	return copied, nil
+}
+
+// convertToolResultBlocks renders tool_result content in the Anthropic wire
+// shape. Typed tool result blocks (from toolkit and MCP tools) carry text in
+// {"type":"text","text":...} form, which happens to match Anthropic's text
+// block — but image blocks ({"type":"image","data":...,"mimeType":...}) do
+// not, so they are converted to native image blocks with a base64 source.
+// Content that is not block-shaped passes through unchanged.
+func convertToolResultBlocks(c *llm.ToolResultContent) any {
+	blocks := providers.ToolResultBlocks(c)
+	if blocks == nil {
+		return c.Content
+	}
+	content := make([]llm.Content, 0, len(blocks))
+	for _, b := range blocks {
+		switch b.Type {
+		case dive.ToolResultContentTypeImage:
+			mediaType := b.MimeType
+			if mediaType == "" {
+				if detected, err := llm.DetectImageType(b.Data); err == nil {
+					mediaType = string(detected)
+				}
+			}
+			if mediaType == "" || b.Data == "" {
+				content = append(content, &llm.TextContent{Text: "[image content omitted]"})
+				continue
+			}
+			content = append(content, &llm.ImageContent{
+				Source: &llm.ContentSource{
+					Type:      llm.ContentSourceTypeBase64,
+					MediaType: mediaType,
+					Data:      b.Data,
+				},
+			})
+		case dive.ToolResultContentTypeText, "":
+			// Anthropic rejects empty text blocks, so skip them.
+			if b.Text != "" {
+				content = append(content, &llm.TextContent{Text: b.Text})
+			}
+		default:
+			content = append(content, &llm.TextContent{Text: fmt.Sprintf("[%s content omitted]", b.Type)})
+		}
+	}
+	return content
 }
 
 const (

--- a/providers/anthropic/toolresult_test.go
+++ b/providers/anthropic/toolresult_test.go
@@ -110,6 +110,41 @@ func TestConvertToolResultStringContentUnchanged(t *testing.T) {
 	assert.Equal(t, "plain output", trc.Content)
 }
 
+// TestConvertToolResultEmptyBlocks verifies a tool result with nothing to
+// render becomes a placeholder text block. Anthropic rejects empty text
+// blocks, and an empty content array tells the model nothing about whether
+// the call ran.
+func TestConvertToolResultEmptyBlocks(t *testing.T) {
+	tests := []struct {
+		name    string
+		content any
+	}{
+		{"single empty text block", []*dive.ToolResultContent{{Type: dive.ToolResultContentTypeText, Text: ""}}},
+		{"no blocks at all", []*dive.ToolResultContent{}},
+		{"no blocks after round trip", []any{}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			trc := toolResultFromMessages(t, []*llm.Message{
+				llm.NewToolResultMessage(&llm.ToolResultContent{
+					ToolUseID: "toolu_1",
+					Content:   tt.content,
+				}),
+			})
+			content, ok := trc.Content.([]llm.Content)
+			assert.True(t, ok)
+			assert.Len(t, content, 1)
+			text, ok := content[0].(*llm.TextContent)
+			assert.True(t, ok)
+			assert.Equal(t, "(no output)", text.Text)
+
+			wire, err := json.Marshal(trc)
+			assert.NoError(t, err)
+			assert.Contains(t, string(wire), `"content":[{"type":"text","text":"(no output)"}]`)
+		})
+	}
+}
+
 // TestConvertToolResultAudioBlockPlaceholder verifies block types Anthropic
 // cannot accept are replaced with a text placeholder instead of producing an
 // invalid request.

--- a/providers/anthropic/toolresult_test.go
+++ b/providers/anthropic/toolresult_test.go
@@ -122,6 +122,7 @@ func TestConvertToolResultEmptyBlocks(t *testing.T) {
 		{"single empty text block", []*dive.ToolResultContent{{Type: dive.ToolResultContentTypeText, Text: ""}}},
 		{"no blocks at all", []*dive.ToolResultContent{}},
 		{"no blocks after round trip", []any{}},
+		{"nil content", nil},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/providers/anthropic/toolresult_test.go
+++ b/providers/anthropic/toolresult_test.go
@@ -1,0 +1,130 @@
+package anthropic
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/deepnoodle-ai/dive"
+	"github.com/deepnoodle-ai/dive/llm"
+	"github.com/deepnoodle-ai/wonton/assert"
+)
+
+func toolResultFromMessages(t *testing.T, messages []*llm.Message) *llm.ToolResultContent {
+	t.Helper()
+	converted, err := convertMessages(messages)
+	assert.NoError(t, err)
+	for _, msg := range converted {
+		for _, c := range msg.Content {
+			if trc, ok := c.(*llm.ToolResultContent); ok {
+				return trc
+			}
+		}
+	}
+	t.Fatal("no tool result found in converted messages")
+	return nil
+}
+
+// TestConvertToolResultImageBlocks verifies typed image blocks (e.g. from an
+// MCP tool returning a screenshot) are converted to Anthropic's native image
+// block shape, which requires a source object rather than flat data fields.
+func TestConvertToolResultImageBlocks(t *testing.T) {
+	trc := toolResultFromMessages(t, []*llm.Message{
+		llm.NewToolResultMessage(&llm.ToolResultContent{
+			ToolUseID: "toolu_1",
+			Content: []*dive.ToolResultContent{
+				{Type: dive.ToolResultContentTypeText, Text: "captured screenshot"},
+				{Type: dive.ToolResultContentTypeImage, Data: "aW1nZGF0YQ==", MimeType: "image/png"},
+			},
+		}),
+	})
+
+	content, ok := trc.Content.([]llm.Content)
+	assert.True(t, ok)
+	assert.Len(t, content, 2)
+
+	text, ok := content[0].(*llm.TextContent)
+	assert.True(t, ok)
+	assert.Equal(t, "captured screenshot", text.Text)
+
+	image, ok := content[1].(*llm.ImageContent)
+	assert.True(t, ok)
+	assert.Equal(t, llm.ContentSourceTypeBase64, image.Source.Type)
+	assert.Equal(t, "image/png", image.Source.MediaType)
+	assert.Equal(t, "aW1nZGF0YQ==", image.Source.Data)
+
+	// The converted result must marshal to Anthropic's wire shape.
+	wire, err := json.Marshal(trc)
+	assert.NoError(t, err)
+	assert.Contains(t, string(wire), `"source":{"type":"base64","media_type":"image/png","data":"aW1nZGF0YQ=="}`)
+}
+
+// TestConvertToolResultTextBlocksWire verifies text-only typed blocks keep
+// the same wire shape they had when marshaled directly.
+func TestConvertToolResultTextBlocksWire(t *testing.T) {
+	trc := toolResultFromMessages(t, []*llm.Message{
+		llm.NewToolResultMessage(&llm.ToolResultContent{
+			ToolUseID: "toolu_1",
+			Content: []*dive.ToolResultContent{
+				{Type: dive.ToolResultContentTypeText, Text: "line one"},
+			},
+		}),
+	})
+	wire, err := json.Marshal(trc)
+	assert.NoError(t, err)
+	assert.Contains(t, string(wire), `"content":[{"type":"text","text":"line one"}]`)
+}
+
+// TestConvertToolResultBlocksSurviveJSONRoundTrip verifies blocks that
+// round-tripped through session persistence (arriving as []any) are still
+// converted to native shapes.
+func TestConvertToolResultBlocksSurviveJSONRoundTrip(t *testing.T) {
+	original := llm.NewToolResultMessage(&llm.ToolResultContent{
+		ToolUseID: "toolu_1",
+		Content: []*dive.ToolResultContent{
+			{Type: dive.ToolResultContentTypeImage, Data: "aW1nZGF0YQ==", MimeType: "image/jpeg"},
+		},
+	})
+	body, err := json.Marshal(original)
+	assert.NoError(t, err)
+	var replayed llm.Message
+	assert.NoError(t, json.Unmarshal(body, &replayed))
+
+	trc := toolResultFromMessages(t, []*llm.Message{&replayed})
+	content, ok := trc.Content.([]llm.Content)
+	assert.True(t, ok)
+	assert.Len(t, content, 1)
+	image, ok := content[0].(*llm.ImageContent)
+	assert.True(t, ok)
+	assert.Equal(t, "image/jpeg", image.Source.MediaType)
+}
+
+// TestConvertToolResultStringContentUnchanged verifies plain string tool
+// results pass through untouched.
+func TestConvertToolResultStringContentUnchanged(t *testing.T) {
+	trc := toolResultFromMessages(t, []*llm.Message{
+		llm.NewToolResultMessage(&llm.ToolResultContent{
+			ToolUseID: "toolu_1",
+			Content:   "plain output",
+		}),
+	})
+	assert.Equal(t, "plain output", trc.Content)
+}
+
+// TestConvertToolResultAudioBlockPlaceholder verifies block types Anthropic
+// cannot accept are replaced with a text placeholder instead of producing an
+// invalid request.
+func TestConvertToolResultAudioBlockPlaceholder(t *testing.T) {
+	trc := toolResultFromMessages(t, []*llm.Message{
+		llm.NewToolResultMessage(&llm.ToolResultContent{
+			ToolUseID: "toolu_1",
+			Content: []*dive.ToolResultContent{
+				{Type: dive.ToolResultContentTypeAudio, Data: "YXVkaW8=", MimeType: "audio/wav"},
+			},
+		}),
+	})
+	content, ok := trc.Content.([]llm.Content)
+	assert.True(t, ok)
+	text, ok := content[0].(*llm.TextContent)
+	assert.True(t, ok)
+	assert.Equal(t, "[audio content omitted]", text.Text)
+}

--- a/providers/google/media_input_test.go
+++ b/providers/google/media_input_test.go
@@ -205,3 +205,14 @@ func TestJoinToolResultTextEmpty(t *testing.T) {
 		{Type: dive.ToolResultContentTypeText, Text: ""},
 	}))
 }
+
+// TestFunctionResponseNilContent verifies nil tool result content (reachable
+// when a caller supplies a nil result on resume) renders the placeholder
+// rather than the literal "null".
+func TestFunctionResponseNilContent(t *testing.T) {
+	part, err := convertToolResultToFunctionResponse(&llm.ToolResultContent{
+		ToolUseID: "call_1",
+	}, "my_tool")
+	assert.NoError(t, err)
+	assert.Equal(t, "(no output)", part.FunctionResponse.Response["output"])
+}

--- a/providers/google/media_input_test.go
+++ b/providers/google/media_input_test.go
@@ -196,3 +196,12 @@ func TestJoinToolResultTextPlaceholders(t *testing.T) {
 	})
 	assert.Equal(t, "captured screenshot\n\n[image content omitted]", joined)
 }
+
+// TestJoinToolResultTextEmpty verifies a result with no renderable text says
+// so explicitly instead of producing an empty function response.
+func TestJoinToolResultTextEmpty(t *testing.T) {
+	assert.Equal(t, "(no output)", joinToolResultText(nil))
+	assert.Equal(t, "(no output)", joinToolResultText([]*dive.ToolResultContent{
+		{Type: dive.ToolResultContentTypeText, Text: ""},
+	}))
+}

--- a/providers/google/media_input_test.go
+++ b/providers/google/media_input_test.go
@@ -1,0 +1,198 @@
+package google
+
+import (
+	"encoding/base64"
+	"testing"
+
+	"github.com/deepnoodle-ai/dive"
+	"github.com/deepnoodle-ai/dive/llm"
+	"github.com/deepnoodle-ai/wonton/assert"
+)
+
+func userMessage(content ...llm.Content) *llm.Message {
+	return &llm.Message{Role: llm.User, Content: content}
+}
+
+func TestMessagesToContentsDocumentBase64(t *testing.T) {
+	pdfData := []byte("%PDF-1.4 fake")
+	contents, err := messagesToContents([]*llm.Message{
+		userMessage(
+			&llm.TextContent{Text: "Summarize this."},
+			&llm.DocumentContent{
+				Source: &llm.ContentSource{
+					Type:      llm.ContentSourceTypeBase64,
+					MediaType: "application/pdf",
+					Data:      base64.StdEncoding.EncodeToString(pdfData),
+				},
+			},
+		),
+	})
+	assert.NoError(t, err)
+	assert.Len(t, contents, 1)
+	assert.Len(t, contents[0].Parts, 2)
+	assert.Equal(t, "Summarize this.", contents[0].Parts[0].Text)
+	blob := contents[0].Parts[1].InlineData
+	assert.NotNil(t, blob)
+	assert.Equal(t, "application/pdf", blob.MIMEType)
+	assert.Equal(t, pdfData, blob.Data)
+}
+
+func TestMessagesToContentsDocumentURL(t *testing.T) {
+	contents, err := messagesToContents([]*llm.Message{
+		userMessage(&llm.DocumentContent{
+			Source: &llm.ContentSource{
+				Type:      llm.ContentSourceTypeURL,
+				MediaType: "application/pdf",
+				URL:       "https://example.com/report.pdf",
+			},
+		}),
+	})
+	assert.NoError(t, err)
+	fileData := contents[0].Parts[0].FileData
+	assert.NotNil(t, fileData)
+	assert.Equal(t, "https://example.com/report.pdf", fileData.FileURI)
+	assert.Equal(t, "application/pdf", fileData.MIMEType)
+}
+
+func TestMessagesToContentsDocumentTextSource(t *testing.T) {
+	contents, err := messagesToContents([]*llm.Message{
+		userMessage(&llm.DocumentContent{
+			Source: &llm.ContentSource{
+				Type:      llm.ContentSourceTypeText,
+				MediaType: "text/plain",
+				Data:      "The grass is green.",
+			},
+		}),
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, "The grass is green.", contents[0].Parts[0].Text)
+}
+
+func TestMessagesToContentsDocumentErrors(t *testing.T) {
+	tests := []struct {
+		name    string
+		content llm.Content
+		wantErr string
+	}{
+		{
+			name:    "nil source",
+			content: &llm.DocumentContent{},
+			wantErr: "document content has nil source",
+		},
+		{
+			name: "base64 without media type",
+			content: &llm.DocumentContent{
+				Source: &llm.ContentSource{
+					Type: llm.ContentSourceTypeBase64,
+					Data: "cGRm",
+				},
+			},
+			wantErr: "media type is required for base64 document content",
+		},
+		{
+			name: "URL source without URL",
+			content: &llm.DocumentContent{
+				Source: &llm.ContentSource{Type: llm.ContentSourceTypeURL},
+			},
+			wantErr: "URL is required for URL-based document content",
+		},
+		{
+			name: "text source without data",
+			content: &llm.DocumentContent{
+				Source: &llm.ContentSource{Type: llm.ContentSourceTypeText},
+			},
+			wantErr: "data is required for text document content",
+		},
+		{
+			name: "file source is unsupported",
+			content: &llm.DocumentContent{
+				Source: &llm.ContentSource{
+					Type:   llm.ContentSourceTypeFile,
+					FileID: "file_abc",
+				},
+			},
+			wantErr: "unsupported document source type: file",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := messagesToContents([]*llm.Message{userMessage(tt.content)})
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErr)
+		})
+	}
+}
+
+func TestMessagesToContentsImageErrors(t *testing.T) {
+	tests := []struct {
+		name    string
+		content llm.Content
+		wantErr string
+	}{
+		{
+			name: "base64 without media type",
+			content: &llm.ImageContent{
+				Source: &llm.ContentSource{
+					Type: llm.ContentSourceTypeBase64,
+					Data: "aW1n",
+				},
+			},
+			wantErr: "media type is required for base64 image content",
+		},
+		{
+			name: "URL source without URL",
+			content: &llm.ImageContent{
+				Source: &llm.ContentSource{Type: llm.ContentSourceTypeURL},
+			},
+			wantErr: "URL is required for URL-based image content",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := messagesToContents([]*llm.Message{userMessage(tt.content)})
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErr)
+		})
+	}
+}
+
+// TestMessagesToContentsSkipsThinking verifies that thinking blocks (e.g. from
+// a session started on another provider) are skipped rather than erroring or
+// being sent to Gemini.
+func TestMessagesToContentsSkipsThinking(t *testing.T) {
+	contents, err := messagesToContents([]*llm.Message{
+		{
+			Role: llm.Assistant,
+			Content: []llm.Content{
+				&llm.ThinkingContent{Thinking: "hmm..."},
+				&llm.RedactedThinkingContent{Data: "opaque"},
+				&llm.TextContent{Text: "The answer is 4."},
+			},
+		},
+	})
+	assert.NoError(t, err)
+	assert.Len(t, contents, 1)
+	assert.Len(t, contents[0].Parts, 1)
+	assert.Equal(t, "The answer is 4.", contents[0].Parts[0].Text)
+}
+
+// TestMessagesToContentsUnknownContentErrors verifies the switch has no silent
+// fall-through: content the provider cannot encode is a visible error, not a
+// dropped block.
+func TestMessagesToContentsUnknownContentErrors(t *testing.T) {
+	_, err := messagesToContents([]*llm.Message{
+		userMessage(&llm.ServerToolUseContent{ID: "srv_1", Name: "web_search"}),
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported content type for google provider: server_tool_use")
+}
+
+// TestJoinToolResultTextPlaceholders verifies non-text tool result blocks are
+// represented with a placeholder rather than dropped silently.
+func TestJoinToolResultTextPlaceholders(t *testing.T) {
+	joined := joinToolResultText([]*dive.ToolResultContent{
+		{Type: dive.ToolResultContentTypeText, Text: "captured screenshot"},
+		{Type: dive.ToolResultContentTypeImage, Data: "aW1n", MimeType: "image/png"},
+	})
+	assert.Equal(t, "captured screenshot\n\n[image content omitted]", joined)
+}

--- a/providers/google/util.go
+++ b/providers/google/util.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/deepnoodle-ai/dive"
 	"github.com/deepnoodle-ai/dive/llm"
+	"github.com/deepnoodle-ai/dive/providers"
 	"github.com/deepnoodle-ai/wonton/schema"
 	"google.golang.org/genai"
 )
@@ -148,16 +149,21 @@ func convertToolUseToFunctionCall(toolUse *llm.ToolUseContent) (*genai.Part, err
 // joinToolResultText flattens tool result content blocks to a single string.
 // Gemini function responses are JSON-only, so non-text blocks (e.g. images
 // from an MCP tool) are represented with a placeholder rather than being
-// dropped silently.
+// dropped silently, as is a result with no renderable text at all.
 func joinToolResultText(blocks []*dive.ToolResultContent) string {
 	var parts []string
 	for _, b := range blocks {
 		switch b.Type {
 		case dive.ToolResultContentTypeText, "":
-			parts = append(parts, b.Text)
+			if b.Text != "" {
+				parts = append(parts, b.Text)
+			}
 		default:
 			parts = append(parts, fmt.Sprintf("[%s content omitted]", b.Type))
 		}
+	}
+	if len(parts) == 0 {
+		return providers.EmptyToolResultText
 	}
 	return strings.Join(parts, "\n\n")
 }

--- a/providers/google/util.go
+++ b/providers/google/util.go
@@ -146,10 +146,18 @@ func convertToolUseToFunctionCall(toolUse *llm.ToolUseContent) (*genai.Part, err
 }
 
 // joinToolResultText flattens tool result content blocks to a single string.
+// Gemini function responses are JSON-only, so non-text blocks (e.g. images
+// from an MCP tool) are represented with a placeholder rather than being
+// dropped silently.
 func joinToolResultText(blocks []*dive.ToolResultContent) string {
 	var parts []string
 	for _, b := range blocks {
-		parts = append(parts, b.Text)
+		switch b.Type {
+		case dive.ToolResultContentTypeText, "":
+			parts = append(parts, b.Text)
+		default:
+			parts = append(parts, fmt.Sprintf("[%s content omitted]", b.Type))
+		}
 	}
 	return strings.Join(parts, "\n\n")
 }
@@ -254,8 +262,14 @@ func messagesToContents(messages []*llm.Message) ([]*genai.Content, error) {
 				}
 				switch ct.Source.Type {
 				case llm.ContentSourceTypeURL:
+					if ct.Source.URL == "" {
+						return nil, fmt.Errorf("URL is required for URL-based image content")
+					}
 					content.Parts = append(content.Parts, genai.NewPartFromURI(ct.Source.URL, ct.Source.MediaType))
 				case llm.ContentSourceTypeBase64:
+					if ct.Source.MediaType == "" {
+						return nil, fmt.Errorf("media type is required for base64 image content")
+					}
 					data, err := ct.Source.DecodedData()
 					if err != nil {
 						return nil, fmt.Errorf("failed to decode image data: %w", err)
@@ -263,6 +277,33 @@ func messagesToContents(messages []*llm.Message) ([]*genai.Content, error) {
 					content.Parts = append(content.Parts, genai.NewPartFromBytes(data, ct.Source.MediaType))
 				default:
 					return nil, fmt.Errorf("unsupported image source type: %s", ct.Source.Type)
+				}
+			case *llm.DocumentContent:
+				if ct.Source == nil {
+					return nil, fmt.Errorf("document content has nil source")
+				}
+				switch ct.Source.Type {
+				case llm.ContentSourceTypeURL:
+					if ct.Source.URL == "" {
+						return nil, fmt.Errorf("URL is required for URL-based document content")
+					}
+					content.Parts = append(content.Parts, genai.NewPartFromURI(ct.Source.URL, ct.Source.MediaType))
+				case llm.ContentSourceTypeBase64:
+					if ct.Source.MediaType == "" {
+						return nil, fmt.Errorf("media type is required for base64 document content")
+					}
+					data, err := ct.Source.DecodedData()
+					if err != nil {
+						return nil, fmt.Errorf("failed to decode document data: %w", err)
+					}
+					content.Parts = append(content.Parts, genai.NewPartFromBytes(data, ct.Source.MediaType))
+				case llm.ContentSourceTypeText:
+					if ct.Source.Data == "" {
+						return nil, fmt.Errorf("data is required for text document content")
+					}
+					content.Parts = append(content.Parts, genai.NewPartFromText(ct.Source.Data))
+				default:
+					return nil, fmt.Errorf("unsupported document source type: %s", ct.Source.Type)
 				}
 			case *llm.ToolUseContent:
 				// Track tool use for later matching
@@ -285,6 +326,12 @@ func messagesToContents(messages []*llm.Message) ([]*genai.Content, error) {
 					return nil, err
 				}
 				content.Parts = append(content.Parts, part)
+			case *llm.ThinkingContent, *llm.RedactedThinkingContent:
+				// Gemini has no field for replaying another model's reasoning,
+				// so thinking blocks (e.g. from a session started on Anthropic)
+				// are skipped on encode rather than erroring.
+			default:
+				return nil, fmt.Errorf("unsupported content type for google provider: %s", c.Type())
 			}
 		}
 		contents = append(contents, content)

--- a/providers/google/util.go
+++ b/providers/google/util.go
@@ -175,6 +175,8 @@ func convertToolResultToFunctionResponse(content *llm.ToolResultContent, functio
 	}
 	var outputValue any
 	switch c := content.Content.(type) {
+	case nil:
+		outputValue = providers.EmptyToolResultText
 	case string:
 		outputValue = c
 	case []byte:

--- a/providers/openai/encode.go
+++ b/providers/openai/encode.go
@@ -344,6 +344,11 @@ func toolResultOutputText(c *llm.ToolResultContent) (string, error) {
 	var output string
 	if blocks := providers.ToolResultBlocks(c); blocks != nil {
 		output = joinToolResultBlockText(blocks)
+		if output == "" {
+			output = providers.EmptyToolResultText
+		}
+	} else if providers.IsEmptyToolResultContent(c.Content) {
+		output = providers.EmptyToolResultText
 	} else {
 		switch content := c.Content.(type) {
 		case string:

--- a/providers/openai/encode.go
+++ b/providers/openai/encode.go
@@ -6,7 +6,9 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/deepnoodle-ai/dive"
 	"github.com/deepnoodle-ai/dive/llm"
+	"github.com/deepnoodle-ai/dive/providers"
 	"github.com/openai/openai-go/v3"
 	"github.com/openai/openai-go/v3/responses"
 )
@@ -269,37 +271,115 @@ func encodeAssistantRefusalContent() (responses.ResponseInputItemUnionParam, err
 }
 
 func encodeAssistantToolResultContent(c *llm.ToolResultContent) (responses.ResponseInputItemUnionParam, error) {
-	output, err := toolResultOutputText(c)
-	if err != nil {
-		return responses.ResponseInputItemUnionParam{}, err
+	return encodeFunctionCallOutput(c)
+}
+
+// encodeFunctionCallOutput renders a tool result as a Responses API
+// function_call_output item. Typed tool result blocks are flattened to plain
+// text rather than JSON-marshaled; results carrying images are emitted as a
+// content-part list so the model can actually see them.
+func encodeFunctionCallOutput(c *llm.ToolResultContent) (responses.ResponseInputItemUnionParam, error) {
+	blocks := providers.ToolResultBlocks(c)
+	if blocks == nil || c.IsError || !blocksContainImage(blocks) {
+		output, err := toolResultOutputText(c)
+		if err != nil {
+			return responses.ResponseInputItemUnionParam{}, err
+		}
+		return responses.ResponseInputItemParamOfFunctionCallOutput(c.ToolUseID, output), nil
 	}
-	param := responses.ResponseInputItemParamOfFunctionCallOutput(c.ToolUseID, output)
-	return param, nil
+	items := make(responses.ResponseFunctionCallOutputItemListParam, 0, len(blocks))
+	for _, b := range blocks {
+		switch b.Type {
+		case dive.ToolResultContentTypeImage:
+			mediaType := b.MimeType
+			if mediaType == "" {
+				if detected, err := llm.DetectImageType(b.Data); err == nil {
+					mediaType = string(detected)
+				}
+			}
+			if mediaType == "" || b.Data == "" {
+				items = append(items, responses.ResponseFunctionCallOutputItemUnionParam{
+					OfInputText: &responses.ResponseInputTextContentParam{Text: "[image content omitted]"},
+				})
+				continue
+			}
+			dataURL := fmt.Sprintf("data:%s;base64,%s", mediaType, b.Data)
+			items = append(items, responses.ResponseFunctionCallOutputItemUnionParam{
+				OfInputImage: &responses.ResponseInputImageContentParam{
+					ImageURL: openai.String(dataURL),
+				},
+			})
+		case dive.ToolResultContentTypeText, "":
+			if b.Text != "" {
+				items = append(items, responses.ResponseFunctionCallOutputItemUnionParam{
+					OfInputText: &responses.ResponseInputTextContentParam{Text: b.Text},
+				})
+			}
+		default:
+			items = append(items, responses.ResponseFunctionCallOutputItemUnionParam{
+				OfInputText: &responses.ResponseInputTextContentParam{Text: fmt.Sprintf("[%s content omitted]", b.Type)},
+			})
+		}
+	}
+	return responses.ResponseInputItemParamOfFunctionCallOutput(c.ToolUseID, items), nil
+}
+
+func blocksContainImage(blocks []*dive.ToolResultContent) bool {
+	for _, b := range blocks {
+		if b.Type == dive.ToolResultContentTypeImage {
+			return true
+		}
+	}
+	return false
 }
 
 // toolResultOutputText renders a tool result as the output string for a
-// Responses API function_call_output item. The Responses API has no
+// Responses API function_call_output item. Typed tool result blocks are
+// flattened to their joined text (with placeholders for non-text blocks);
+// other structured content is JSON-marshaled. The Responses API has no
 // equivalent of Anthropic's is_error flag on tool results, so when IsError is
 // set the output text is prefixed with "Error: " so the model can tell the
 // call failed rather than the flag being silently dropped.
 func toolResultOutputText(c *llm.ToolResultContent) (string, error) {
 	var output string
-	switch content := c.Content.(type) {
-	case string:
-		output = content
-	case []byte:
-		output = string(content)
-	default:
-		resultJSON, err := json.Marshal(c.Content)
-		if err != nil {
-			return "", fmt.Errorf("failed to marshal tool result: %v", err)
+	if blocks := providers.ToolResultBlocks(c); blocks != nil {
+		output = joinToolResultBlockText(blocks)
+	} else {
+		switch content := c.Content.(type) {
+		case string:
+			output = content
+		case []byte:
+			output = string(content)
+		default:
+			resultJSON, err := json.Marshal(c.Content)
+			if err != nil {
+				return "", fmt.Errorf("failed to marshal tool result: %v", err)
+			}
+			output = string(resultJSON)
 		}
-		output = string(resultJSON)
 	}
 	if c.IsError && !strings.HasPrefix(output, "Error:") {
 		output = "Error: " + output
 	}
 	return output, nil
+}
+
+// joinToolResultBlockText flattens typed tool result blocks to a single
+// string, representing non-text blocks with a placeholder rather than
+// dropping them silently.
+func joinToolResultBlockText(blocks []*dive.ToolResultContent) string {
+	var parts []string
+	for _, b := range blocks {
+		switch b.Type {
+		case dive.ToolResultContentTypeText, "":
+			if b.Text != "" {
+				parts = append(parts, b.Text)
+			}
+		default:
+			parts = append(parts, fmt.Sprintf("[%s content omitted]", b.Type))
+		}
+	}
+	return strings.Join(parts, "\n\n")
 }
 
 func encodeAssistantServerToolUseContent(c *llm.ServerToolUseContent) (responses.ResponseInputItemUnionParam, error) {
@@ -491,7 +571,19 @@ func encodeInputDocumentContent(c *llm.DocumentContent) (*responses.ResponseInpu
 		fileParam.FileID = openai.String(c.Source.FileID)
 
 	case llm.ContentSourceTypeURL:
-		return nil, fmt.Errorf("url-based document content is not supported by openai")
+		if c.Source.URL == "" {
+			return nil, fmt.Errorf("URL is required for URL-based document content")
+		}
+		fileParam.FileURL = openai.String(c.Source.URL)
+
+	case llm.ContentSourceTypeText:
+		// The Responses API has no plain-text document shape, so inline the
+		// document text as an input_text part.
+		if c.Source.Data == "" {
+			return nil, fmt.Errorf("data is required for text document content")
+		}
+		param := responses.ResponseInputContentParamOfInputText(c.Source.Data)
+		return &param, nil
 
 	default:
 		return nil, fmt.Errorf("unsupported content source type for document: %v", c.Source.Type)
@@ -503,10 +595,9 @@ func encodeToolResultContent(c *llm.ToolResultContent) (*responses.ResponseInput
 	if c.ToolUseID == "" {
 		return nil, fmt.Errorf("tool use id is not set")
 	}
-	output, err := toolResultOutputText(c)
+	param, err := encodeFunctionCallOutput(c)
 	if err != nil {
 		return nil, err
 	}
-	param := responses.ResponseInputItemParamOfFunctionCallOutput(c.ToolUseID, output)
 	return &param, nil
 }

--- a/providers/openai/provider_test.go
+++ b/providers/openai/provider_test.go
@@ -95,6 +95,77 @@ func TestEncodeMessages(t *testing.T) {
 			want: `[{"content":[{"detail":"auto","image_url":"data:image/jpeg;base64,base64data","type":"input_image"}],"role":"user"}]`,
 		},
 		{
+			name: "document content via URL",
+			messages: []*llm.Message{
+				{
+					Role: llm.User,
+					Content: []llm.Content{
+						&llm.DocumentContent{
+							Title: "report.pdf",
+							Source: &llm.ContentSource{
+								Type: llm.ContentSourceTypeURL,
+								URL:  "https://example.com/doc.pdf",
+							},
+						},
+					},
+				},
+			},
+			want: `[{"content":[{"file_url":"https://example.com/doc.pdf","filename":"report.pdf","type":"input_file"}],"role":"user"}]`,
+		},
+		{
+			name: "document content via base64",
+			messages: []*llm.Message{
+				{
+					Role: llm.User,
+					Content: []llm.Content{
+						&llm.DocumentContent{
+							Source: &llm.ContentSource{
+								Type:      llm.ContentSourceTypeBase64,
+								MediaType: "application/pdf",
+								Data:      "cGRmZGF0YQ==",
+							},
+						},
+					},
+				},
+			},
+			want: `[{"content":[{"file_data":"data:application/pdf;base64,cGRmZGF0YQ==","filename":"document","type":"input_file"}],"role":"user"}]`,
+		},
+		{
+			name: "document content via file ID",
+			messages: []*llm.Message{
+				{
+					Role: llm.User,
+					Content: []llm.Content{
+						&llm.DocumentContent{
+							Source: &llm.ContentSource{
+								Type:   llm.ContentSourceTypeFile,
+								FileID: "file_abc123",
+							},
+						},
+					},
+				},
+			},
+			want: `[{"content":[{"file_id":"file_abc123","filename":"document","type":"input_file"}],"role":"user"}]`,
+		},
+		{
+			name: "document content via text source",
+			messages: []*llm.Message{
+				{
+					Role: llm.User,
+					Content: []llm.Content{
+						&llm.DocumentContent{
+							Source: &llm.ContentSource{
+								Type:      llm.ContentSourceTypeText,
+								MediaType: "text/plain",
+								Data:      "The grass is green.",
+							},
+						},
+					},
+				},
+			},
+			want: `[{"content":[{"text":"The grass is green.","type":"input_text"}],"role":"user"}]`,
+		},
+		{
 			name: "tool use content",
 			messages: []*llm.Message{
 				{
@@ -242,7 +313,7 @@ func TestEncodeMessagesErrors(t *testing.T) {
 			wantErr: "media type and data are required for base64 image content",
 		},
 		{
-			name: "document with URL source",
+			name: "document with empty URL",
 			messages: []*llm.Message{
 				{
 					Role: llm.User,
@@ -250,13 +321,28 @@ func TestEncodeMessagesErrors(t *testing.T) {
 						&llm.DocumentContent{
 							Source: &llm.ContentSource{
 								Type: llm.ContentSourceTypeURL,
-								URL:  "https://example.com/doc.pdf",
 							},
 						},
 					},
 				},
 			},
-			wantErr: "url-based document content is not supported by openai",
+			wantErr: "URL is required for URL-based document content",
+		},
+		{
+			name: "text document without data",
+			messages: []*llm.Message{
+				{
+					Role: llm.User,
+					Content: []llm.Content{
+						&llm.DocumentContent{
+							Source: &llm.ContentSource{
+								Type: llm.ContentSourceTypeText,
+							},
+						},
+					},
+				},
+			},
+			wantErr: "data is required for text document content",
 		},
 	}
 

--- a/providers/openai/toolresult_test.go
+++ b/providers/openai/toolresult_test.go
@@ -77,6 +77,7 @@ func TestEncodeToolResultEmptyOutput(t *testing.T) {
 	}{
 		{"single empty text block", []*dive.ToolResultContent{{Type: dive.ToolResultContentTypeText, Text: ""}}},
 		{"no blocks at all", []*dive.ToolResultContent{}},
+		{"nil content", nil},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/providers/openai/toolresult_test.go
+++ b/providers/openai/toolresult_test.go
@@ -1,0 +1,90 @@
+package openai
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/deepnoodle-ai/dive"
+	"github.com/deepnoodle-ai/dive/llm"
+	"github.com/deepnoodle-ai/wonton/assert"
+)
+
+// TestEncodeToolResultTextBlocksFlattened verifies typed tool result blocks
+// are flattened to plain text rather than JSON-marshaled into the output
+// string.
+func TestEncodeToolResultTextBlocksFlattened(t *testing.T) {
+	items, err := encodeMessages([]*llm.Message{
+		llm.NewToolResultMessage(&llm.ToolResultContent{
+			ToolUseID: "call_1",
+			Content: []*dive.ToolResultContent{
+				{Type: dive.ToolResultContentTypeText, Text: "line one"},
+				{Type: dive.ToolResultContentTypeText, Text: "line two"},
+			},
+		}),
+	})
+	assert.NoError(t, err)
+	data, err := json.Marshal(items)
+	assert.NoError(t, err)
+	assert.Equal(t, `[{"call_id":"call_1","output":"line one\n\nline two","type":"function_call_output"}]`, string(data))
+}
+
+// TestEncodeToolResultWithImageBlocks verifies a tool result carrying an
+// image is emitted as a content-part list so the model can see the image.
+func TestEncodeToolResultWithImageBlocks(t *testing.T) {
+	items, err := encodeMessages([]*llm.Message{
+		llm.NewToolResultMessage(&llm.ToolResultContent{
+			ToolUseID: "call_1",
+			Content: []*dive.ToolResultContent{
+				{Type: dive.ToolResultContentTypeText, Text: "captured screenshot"},
+				{Type: dive.ToolResultContentTypeImage, Data: "aW1nZGF0YQ==", MimeType: "image/png"},
+			},
+		}),
+	})
+	assert.NoError(t, err)
+	data, err := json.Marshal(items)
+	assert.NoError(t, err)
+	assert.Contains(t, string(data), `"type":"input_text"`)
+	assert.Contains(t, string(data), `"text":"captured screenshot"`)
+	assert.Contains(t, string(data), `"type":"input_image"`)
+	assert.Contains(t, string(data), `"image_url":"data:image/png;base64,aW1nZGF0YQ=="`)
+}
+
+// TestEncodeToolResultErrorKeepsTextForm verifies error results keep the
+// string output form with the "Error: " prefix, even when images are present.
+func TestEncodeToolResultErrorKeepsTextForm(t *testing.T) {
+	items, err := encodeMessages([]*llm.Message{
+		llm.NewToolResultMessage(&llm.ToolResultContent{
+			ToolUseID: "call_1",
+			IsError:   true,
+			Content: []*dive.ToolResultContent{
+				{Type: dive.ToolResultContentTypeText, Text: "boom"},
+				{Type: dive.ToolResultContentTypeImage, Data: "aW1n", MimeType: "image/png"},
+			},
+		}),
+	})
+	assert.NoError(t, err)
+	data, err := json.Marshal(items)
+	assert.NoError(t, err)
+	assert.Contains(t, string(data), `"output":"Error: boom\n\n[image content omitted]"`)
+}
+
+// TestEncodeToolResultBlocksSurviveJSONRoundTrip verifies session-replayed
+// tool results (blocks arriving as []any) get the same flattening.
+func TestEncodeToolResultBlocksSurviveJSONRoundTrip(t *testing.T) {
+	original := llm.NewToolResultMessage(&llm.ToolResultContent{
+		ToolUseID: "call_1",
+		Content: []*dive.ToolResultContent{
+			{Type: dive.ToolResultContentTypeText, Text: "replayed"},
+		},
+	})
+	body, err := json.Marshal(original)
+	assert.NoError(t, err)
+	var replayed llm.Message
+	assert.NoError(t, json.Unmarshal(body, &replayed))
+
+	items, err := encodeMessages([]*llm.Message{&replayed})
+	assert.NoError(t, err)
+	data, err := json.Marshal(items)
+	assert.NoError(t, err)
+	assert.Equal(t, `[{"call_id":"call_1","output":"replayed","type":"function_call_output"}]`, string(data))
+}

--- a/providers/openai/toolresult_test.go
+++ b/providers/openai/toolresult_test.go
@@ -68,6 +68,32 @@ func TestEncodeToolResultErrorKeepsTextForm(t *testing.T) {
 	assert.Contains(t, string(data), `"output":"Error: boom\n\n[image content omitted]"`)
 }
 
+// TestEncodeToolResultEmptyOutput verifies a tool result with nothing to
+// render produces an explicit placeholder rather than an empty output string.
+func TestEncodeToolResultEmptyOutput(t *testing.T) {
+	tests := []struct {
+		name    string
+		content any
+	}{
+		{"single empty text block", []*dive.ToolResultContent{{Type: dive.ToolResultContentTypeText, Text: ""}}},
+		{"no blocks at all", []*dive.ToolResultContent{}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			items, err := encodeMessages([]*llm.Message{
+				llm.NewToolResultMessage(&llm.ToolResultContent{
+					ToolUseID: "call_1",
+					Content:   tt.content,
+				}),
+			})
+			assert.NoError(t, err)
+			data, err := json.Marshal(items)
+			assert.NoError(t, err)
+			assert.Equal(t, `[{"call_id":"call_1","output":"(no output)","type":"function_call_output"}]`, string(data))
+		})
+	}
+}
+
 // TestEncodeToolResultBlocksSurviveJSONRoundTrip verifies session-replayed
 // tool results (blocks arriving as []any) get the same flattening.
 func TestEncodeToolResultBlocksSurviveJSONRoundTrip(t *testing.T) {

--- a/providers/openai/toolresult_test.go
+++ b/providers/openai/toolresult_test.go
@@ -77,6 +77,7 @@ func TestEncodeToolResultEmptyOutput(t *testing.T) {
 	}{
 		{"single empty text block", []*dive.ToolResultContent{{Type: dive.ToolResultContentTypeText, Text: ""}}},
 		{"no blocks at all", []*dive.ToolResultContent{}},
+		{"no blocks after JSON round trip", []any{}},
 		{"nil content", nil},
 	}
 	for _, tt := range tests {

--- a/providers/openaicompletions/media_input_test.go
+++ b/providers/openaicompletions/media_input_test.go
@@ -57,6 +57,8 @@ func TestMessageUnmarshalContentShapes(t *testing.T) {
 	assert.Len(t, m3.ContentParts, 2)
 	assert.Equal(t, "hi", m3.ContentParts[0].Text)
 	assert.Equal(t, "https://example.com/a.png", m3.ContentParts[1].ImageURL.URL)
+	// Text is mirrored into Content so string-only readers see the text.
+	assert.Equal(t, "hi", m3.Content)
 }
 
 func TestConvertMessagesImageBase64(t *testing.T) {
@@ -268,6 +270,20 @@ func TestToolResultImageBlockPlaceholder(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Len(t, converted, 1)
 	assert.Equal(t, "captured screenshot\n[image content omitted]", converted[0].Content)
+}
+
+// TestToolResultEmptyPlaceholder verifies a tool result with no renderable
+// text produces an explicit placeholder rather than an empty tool message.
+func TestToolResultEmptyPlaceholder(t *testing.T) {
+	converted, err := convertMessages([]*llm.Message{
+		llm.NewToolResultMessage(&llm.ToolResultContent{
+			ToolUseID: "call_1",
+			Content:   []*dive.ToolResultContent{{Type: dive.ToolResultContentTypeText, Text: ""}},
+		}),
+	})
+	assert.NoError(t, err)
+	assert.Len(t, converted, 1)
+	assert.Equal(t, "(no output)", converted[0].Content)
 }
 
 // TestRequestMarshalMultimodal verifies the full request wire shape for a

--- a/providers/openaicompletions/media_input_test.go
+++ b/providers/openaicompletions/media_input_test.go
@@ -1,0 +1,294 @@
+package openaicompletions
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/deepnoodle-ai/dive"
+	"github.com/deepnoodle-ai/dive/llm"
+	"github.com/deepnoodle-ai/wonton/assert"
+)
+
+// TestMessageMarshalStringContent verifies text-only messages keep the exact
+// wire shape they had before content-part support was added.
+func TestMessageMarshalStringContent(t *testing.T) {
+	data, err := json.Marshal(Message{Role: "user", Content: "hi"})
+	assert.NoError(t, err)
+	assert.Equal(t, `{"role":"user","content":"hi"}`, string(data))
+
+	data, err = json.Marshal(Message{
+		Role:       "tool",
+		Content:    "4",
+		ToolCallID: "call_123",
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, `{"role":"tool","content":"4","tool_call_id":"call_123"}`, string(data))
+}
+
+func TestMessageMarshalContentParts(t *testing.T) {
+	data, err := json.Marshal(Message{
+		Role: "user",
+		ContentParts: []ContentPart{
+			{Type: "text", Text: "What is in this image?"},
+			{Type: "image_url", ImageURL: &ImageURLPart{URL: "data:image/png;base64,aW1n"}},
+		},
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, `{"role":"user","content":[{"type":"text","text":"What is in this image?"},{"type":"image_url","image_url":{"url":"data:image/png;base64,aW1n"}}]}`, string(data))
+}
+
+func TestMessageUnmarshalContentShapes(t *testing.T) {
+	// String content (the usual response shape)
+	var m Message
+	assert.NoError(t, json.Unmarshal([]byte(`{"role":"assistant","content":"hello"}`), &m))
+	assert.Equal(t, "assistant", m.Role)
+	assert.Equal(t, "hello", m.Content)
+	assert.Len(t, m.ContentParts, 0)
+
+	// Null content with tool calls
+	var m2 Message
+	assert.NoError(t, json.Unmarshal([]byte(`{"role":"assistant","content":null,"tool_calls":[{"id":"call_1","type":"function","function":{"name":"f","arguments":"{}"}}]}`), &m2))
+	assert.Equal(t, "", m2.Content)
+	assert.Len(t, m2.ToolCalls, 1)
+
+	// Content-part array round-trips
+	var m3 Message
+	assert.NoError(t, json.Unmarshal([]byte(`{"role":"user","content":[{"type":"text","text":"hi"},{"type":"image_url","image_url":{"url":"https://example.com/a.png"}}]}`), &m3))
+	assert.Len(t, m3.ContentParts, 2)
+	assert.Equal(t, "hi", m3.ContentParts[0].Text)
+	assert.Equal(t, "https://example.com/a.png", m3.ContentParts[1].ImageURL.URL)
+}
+
+func TestConvertMessagesImageBase64(t *testing.T) {
+	converted, err := convertMessages([]*llm.Message{
+		{
+			Role: llm.User,
+			Content: []llm.Content{
+				&llm.TextContent{Text: "What is in this image?"},
+				&llm.ImageContent{
+					Source: &llm.ContentSource{
+						Type:      llm.ContentSourceTypeBase64,
+						MediaType: "image/png",
+						Data:      "aW1nZGF0YQ==",
+					},
+				},
+			},
+		},
+	})
+	assert.NoError(t, err)
+	assert.Len(t, converted, 1)
+	assert.Equal(t, "user", converted[0].Role)
+	assert.Len(t, converted[0].ContentParts, 2)
+	assert.Equal(t, "text", converted[0].ContentParts[0].Type)
+	assert.Equal(t, "What is in this image?", converted[0].ContentParts[0].Text)
+	assert.Equal(t, "image_url", converted[0].ContentParts[1].Type)
+	assert.Equal(t, "data:image/png;base64,aW1nZGF0YQ==", converted[0].ContentParts[1].ImageURL.URL)
+}
+
+func TestConvertMessagesImageURL(t *testing.T) {
+	converted, err := convertMessages([]*llm.Message{
+		{
+			Role: llm.User,
+			Content: []llm.Content{
+				&llm.ImageContent{
+					Source: &llm.ContentSource{
+						Type: llm.ContentSourceTypeURL,
+						URL:  "https://example.com/photo.jpg",
+					},
+				},
+			},
+		},
+	})
+	assert.NoError(t, err)
+	assert.Len(t, converted, 1)
+	assert.Len(t, converted[0].ContentParts, 1)
+	assert.Equal(t, "https://example.com/photo.jpg", converted[0].ContentParts[0].ImageURL.URL)
+}
+
+func TestConvertMessagesDocumentBase64(t *testing.T) {
+	converted, err := convertMessages([]*llm.Message{
+		{
+			Role: llm.User,
+			Content: []llm.Content{
+				&llm.DocumentContent{
+					Title: "report.pdf",
+					Source: &llm.ContentSource{
+						Type:      llm.ContentSourceTypeBase64,
+						MediaType: "application/pdf",
+						Data:      "cGRmZGF0YQ==",
+					},
+				},
+			},
+		},
+	})
+	assert.NoError(t, err)
+	assert.Len(t, converted, 1)
+	part := converted[0].ContentParts[0]
+	assert.Equal(t, "file", part.Type)
+	assert.Equal(t, "report.pdf", part.File.Filename)
+	assert.Equal(t, "data:application/pdf;base64,cGRmZGF0YQ==", part.File.FileData)
+}
+
+func TestConvertMessagesDocumentFileID(t *testing.T) {
+	converted, err := convertMessages([]*llm.Message{
+		{
+			Role: llm.User,
+			Content: []llm.Content{
+				&llm.DocumentContent{
+					Source: &llm.ContentSource{
+						Type:   llm.ContentSourceTypeFile,
+						FileID: "file_abc123",
+					},
+				},
+			},
+		},
+	})
+	assert.NoError(t, err)
+	part := converted[0].ContentParts[0]
+	assert.Equal(t, "file", part.Type)
+	assert.Equal(t, "file_abc123", part.File.FileID)
+}
+
+func TestConvertMessagesDocumentTextSource(t *testing.T) {
+	converted, err := convertMessages([]*llm.Message{
+		{
+			Role: llm.User,
+			Content: []llm.Content{
+				&llm.DocumentContent{
+					Source: &llm.ContentSource{
+						Type:      llm.ContentSourceTypeText,
+						MediaType: "text/plain",
+						Data:      "The grass is green.",
+					},
+				},
+			},
+		},
+	})
+	assert.NoError(t, err)
+	part := converted[0].ContentParts[0]
+	assert.Equal(t, "text", part.Type)
+	assert.Equal(t, "The grass is green.", part.Text)
+}
+
+func TestConvertMessagesDocumentURLErrors(t *testing.T) {
+	_, err := convertMessages([]*llm.Message{
+		{
+			Role: llm.User,
+			Content: []llm.Content{
+				&llm.DocumentContent{
+					Source: &llm.ContentSource{
+						Type: llm.ContentSourceTypeURL,
+						URL:  "https://example.com/doc.pdf",
+					},
+				},
+			},
+		},
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "url-based document content is not supported")
+}
+
+func TestConvertMessagesAssistantImageErrors(t *testing.T) {
+	_, err := convertMessages([]*llm.Message{
+		{
+			Role: llm.Assistant,
+			Content: []llm.Content{
+				&llm.ImageContent{
+					Source: &llm.ContentSource{
+						Type: llm.ContentSourceTypeURL,
+						URL:  "https://example.com/generated.png",
+					},
+				},
+			},
+		},
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "not supported in assistant messages")
+}
+
+// TestConvertMessagesAuxImageWithToolResults verifies media content alongside
+// tool results (e.g. a screenshot injected by a PostToolUse hook) is emitted
+// as a trailing multimodal user message after the tool outputs.
+func TestConvertMessagesAuxImageWithToolResults(t *testing.T) {
+	converted, err := convertMessages([]*llm.Message{
+		{
+			Role: llm.User,
+			Content: []llm.Content{
+				&llm.ToolResultContent{ToolUseID: "call_1", Content: "done"},
+				&llm.ImageContent{
+					Source: &llm.ContentSource{
+						Type: llm.ContentSourceTypeURL,
+						URL:  "https://example.com/screenshot.png",
+					},
+				},
+			},
+		},
+	})
+	assert.NoError(t, err)
+	assert.Len(t, converted, 2)
+	assert.Equal(t, "tool", converted[0].Role)
+	assert.Equal(t, "call_1", converted[0].ToolCallID)
+	assert.Equal(t, "user", converted[1].Role)
+	assert.Len(t, converted[1].ContentParts, 1)
+	assert.Equal(t, "image_url", converted[1].ContentParts[0].Type)
+}
+
+// TestConvertMessagesJoinsToolCallText verifies that all text blocks in an
+// assistant tool-call message are kept (the previous encoding kept only the
+// last one).
+func TestConvertMessagesJoinsToolCallText(t *testing.T) {
+	converted, err := convertMessages([]*llm.Message{
+		{
+			Role: llm.Assistant,
+			Content: []llm.Content{
+				&llm.TextContent{Text: "First thought."},
+				&llm.TextContent{Text: "Second thought."},
+				&llm.ToolUseContent{ID: "call_1", Name: "calc", Input: []byte(`{}`)},
+			},
+		},
+	})
+	assert.NoError(t, err)
+	assert.Len(t, converted, 1)
+	assert.Equal(t, "First thought.\n\nSecond thought.", converted[0].Content)
+	assert.Len(t, converted[0].ToolCalls, 1)
+}
+
+// TestToolResultImageBlockPlaceholder verifies non-text tool result blocks
+// are represented with a placeholder rather than dropped silently.
+func TestToolResultImageBlockPlaceholder(t *testing.T) {
+	converted, err := convertMessages([]*llm.Message{
+		llm.NewToolResultMessage(&llm.ToolResultContent{
+			ToolUseID: "call_1",
+			Content: []*dive.ToolResultContent{
+				{Type: dive.ToolResultContentTypeText, Text: "captured screenshot"},
+				{Type: dive.ToolResultContentTypeImage, Data: "aW1n", MimeType: "image/png"},
+			},
+		}),
+	})
+	assert.NoError(t, err)
+	assert.Len(t, converted, 1)
+	assert.Equal(t, "captured screenshot\n[image content omitted]", converted[0].Content)
+}
+
+// TestRequestMarshalMultimodal verifies the full request wire shape for a
+// multimodal message.
+func TestRequestMarshalMultimodal(t *testing.T) {
+	msgs, err := convertMessages([]*llm.Message{
+		{
+			Role: llm.User,
+			Content: []llm.Content{
+				&llm.TextContent{Text: "Describe:"},
+				&llm.ImageContent{
+					Source: &llm.ContentSource{
+						Type: llm.ContentSourceTypeURL,
+						URL:  "https://example.com/a.png",
+					},
+				},
+			},
+		},
+	})
+	assert.NoError(t, err)
+	data, err := json.Marshal(Request{Model: "gpt-test", Messages: msgs})
+	assert.NoError(t, err)
+	assert.Equal(t, `{"model":"gpt-test","messages":[{"role":"user","content":[{"type":"text","text":"Describe:"},{"type":"image_url","image_url":{"url":"https://example.com/a.png"}}]}]}`, string(data))
+}

--- a/providers/openaicompletions/media_input_test.go
+++ b/providers/openaicompletions/media_input_test.go
@@ -273,17 +273,30 @@ func TestToolResultImageBlockPlaceholder(t *testing.T) {
 }
 
 // TestToolResultEmptyPlaceholder verifies a tool result with no renderable
-// text produces an explicit placeholder rather than an empty tool message.
+// text produces an explicit placeholder rather than an empty tool message or,
+// for nil content, a request-building error.
 func TestToolResultEmptyPlaceholder(t *testing.T) {
-	converted, err := convertMessages([]*llm.Message{
-		llm.NewToolResultMessage(&llm.ToolResultContent{
-			ToolUseID: "call_1",
-			Content:   []*dive.ToolResultContent{{Type: dive.ToolResultContentTypeText, Text: ""}},
-		}),
-	})
-	assert.NoError(t, err)
-	assert.Len(t, converted, 1)
-	assert.Equal(t, "(no output)", converted[0].Content)
+	tests := []struct {
+		name    string
+		content any
+	}{
+		{"single empty text block", []*dive.ToolResultContent{{Type: dive.ToolResultContentTypeText, Text: ""}}},
+		{"no blocks at all", []*dive.ToolResultContent{}},
+		{"nil content", nil},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			converted, err := convertMessages([]*llm.Message{
+				llm.NewToolResultMessage(&llm.ToolResultContent{
+					ToolUseID: "call_1",
+					Content:   tt.content,
+				}),
+			})
+			assert.NoError(t, err)
+			assert.Len(t, converted, 1)
+			assert.Equal(t, "(no output)", converted[0].Content)
+		})
+	}
 }
 
 // TestRequestMarshalMultimodal verifies the full request wire shape for a

--- a/providers/openaicompletions/openai.go
+++ b/providers/openaicompletions/openai.go
@@ -497,6 +497,9 @@ func convertToolResultContent(c *llm.ToolResultContent) (Message, error) {
 }
 
 func toolResultContentString(c *llm.ToolResultContent) (string, error) {
+	if providers.IsEmptyToolResultContent(c.Content) {
+		return providers.EmptyToolResultText, nil
+	}
 	switch content := c.Content.(type) {
 	case string:
 		return content, nil

--- a/providers/openaicompletions/openai.go
+++ b/providers/openaicompletions/openai.go
@@ -330,17 +330,15 @@ func convertMessages(messages []*llm.Message) ([]Message, error) {
 		}
 		role := strings.ToLower(string(msg.Role))
 
-		// Group all tool use content blocks into a single message
+		// Partition the content blocks: tool calls, tool results, and the
+		// remaining text/media content parts (order preserved).
 		var toolCalls []ToolCall
-		var textContent string
-		var hasToolUse bool
-		var hasToolResult bool
-
-		// First pass: collect all tool use content blocks and check for tool results
+		var toolResults []*llm.ToolResultContent
+		var parts []ContentPart
+		var hasMedia bool
 		for _, c := range msg.Content {
 			switch c := c.(type) {
 			case *llm.ToolUseContent:
-				hasToolUse = true
 				toolCalls = append(toolCalls, ToolCall{
 					ID:   c.ID,
 					Type: "function",
@@ -349,76 +347,141 @@ func convertMessages(messages []*llm.Message) ([]Message, error) {
 						Arguments: string(c.Input),
 					},
 				})
-			case *llm.TextContent:
-				textContent = c.Text
 			case *llm.ToolResultContent:
-				hasToolResult = true
-			}
-		}
-
-		// Create a single message for all tool use content blocks
-		if hasToolUse {
-			result = append(result, Message{
-				Role:      role,
-				Content:   textContent,
-				ToolCalls: toolCalls,
-			})
-		}
-
-		if hasToolResult {
-			for _, c := range msg.Content {
-				trc, ok := c.(*llm.ToolResultContent)
-				if !ok {
-					continue
-				}
-				toolMessage, err := convertToolResultContent(trc)
+				toolResults = append(toolResults, c)
+			case *llm.TextContent:
+				parts = append(parts, ContentPart{Type: "text", Text: c.Text})
+			case *llm.ImageContent:
+				part, err := encodeImageContentPart(c)
 				if err != nil {
 					return nil, err
 				}
-				result = append(result, toolMessage)
-			}
-			for _, c := range msg.Content {
-				switch c := c.(type) {
-				case *llm.TextContent:
-					if !hasToolUse {
-						result = append(result, Message{Role: role, Content: c.Text})
-					}
-				case *llm.ToolResultContent, *llm.ToolUseContent:
-					// Already handled above
-				case *llm.ThinkingContent, *llm.RedactedThinkingContent:
-					// The Chat Completions API has no standard field for
-					// replaying assistant reasoning back to the server, so
-					// thinking content (which this provider's own stream
-					// iterator can produce from "reasoning" deltas) is
-					// skipped on encode rather than erroring.
-				default:
-					return nil, fmt.Errorf("unsupported content type: %s", c.Type())
+				parts = append(parts, part)
+				hasMedia = true
+			case *llm.DocumentContent:
+				part, err := encodeDocumentContentPart(c)
+				if err != nil {
+					return nil, err
 				}
+				parts = append(parts, part)
+				hasMedia = true
+			case *llm.ThinkingContent, *llm.RedactedThinkingContent:
+				// The Chat Completions API has no standard field for
+				// replaying assistant reasoning back to the server, so
+				// thinking content (which this provider's own stream
+				// iterator can produce from "reasoning" deltas) is
+				// skipped on encode rather than erroring.
+			default:
+				return nil, fmt.Errorf("unsupported content type: %s", c.Type())
 			}
-			continue
+		}
+		if hasMedia && role == "assistant" {
+			return nil, fmt.Errorf("image and document content is not supported in assistant messages by the chat completions API")
 		}
 
-		// Process non-tool-use content blocks
-		if !hasToolUse {
-			for _, c := range msg.Content {
-				switch c := c.(type) {
-				case *llm.TextContent:
-					result = append(result, Message{Role: role, Content: c.Text})
-				case *llm.ToolUseContent:
-					// Already handled above
-				case *llm.ThinkingContent, *llm.RedactedThinkingContent:
-					// The Chat Completions API has no standard field for
-					// replaying assistant reasoning back to the server, so
-					// thinking content (which this provider's own stream
-					// iterator can produce from "reasoning" deltas) is
-					// skipped on encode rather than erroring.
-				default:
-					return nil, fmt.Errorf("unsupported content type: %s", c.Type())
+		// A single message carries all tool calls, plus any accompanying text.
+		if len(toolCalls) > 0 {
+			result = append(result, Message{
+				Role:      role,
+				Content:   joinTextParts(parts),
+				ToolCalls: toolCalls,
+			})
+			parts = nil
+		}
+
+		// One "tool" message per tool result.
+		for _, trc := range toolResults {
+			toolMessage, err := convertToolResultContent(trc)
+			if err != nil {
+				return nil, err
+			}
+			result = append(result, toolMessage)
+		}
+
+		// Remaining content: messages with media carry a content-part array;
+		// text-only messages keep the plain-string content shape.
+		if len(parts) > 0 {
+			if hasMedia {
+				result = append(result, Message{Role: role, ContentParts: parts})
+			} else {
+				for _, p := range parts {
+					result = append(result, Message{Role: role, Content: p.Text})
 				}
 			}
 		}
 	}
 	return result, nil
+}
+
+// joinTextParts flattens text content parts into a single string for message
+// shapes that only accept plain-string content.
+func joinTextParts(parts []ContentPart) string {
+	var texts []string
+	for _, p := range parts {
+		if p.Type == "text" && p.Text != "" {
+			texts = append(texts, p.Text)
+		}
+	}
+	return strings.Join(texts, "\n\n")
+}
+
+// encodeImageContentPart converts an ImageContent block to an image_url
+// content part. Base64 sources are inlined as data URLs; URL sources pass
+// through. The Chat Completions API has no file-ID image reference.
+func encodeImageContentPart(c *llm.ImageContent) (ContentPart, error) {
+	if c.Source == nil {
+		return ContentPart{}, fmt.Errorf("image content has nil source")
+	}
+	switch c.Source.Type {
+	case llm.ContentSourceTypeBase64:
+		if c.Source.MediaType == "" || c.Source.Data == "" {
+			return ContentPart{}, fmt.Errorf("media type and data are required for base64 image content")
+		}
+		dataURL := fmt.Sprintf("data:%s;base64,%s", c.Source.MediaType, c.Source.Data)
+		return ContentPart{Type: "image_url", ImageURL: &ImageURLPart{URL: dataURL}}, nil
+	case llm.ContentSourceTypeURL:
+		if c.Source.URL == "" {
+			return ContentPart{}, fmt.Errorf("URL is required for URL-based image content")
+		}
+		return ContentPart{Type: "image_url", ImageURL: &ImageURLPart{URL: c.Source.URL}}, nil
+	default:
+		return ContentPart{}, fmt.Errorf("unsupported image source type for the chat completions API: %s", c.Source.Type)
+	}
+}
+
+// encodeDocumentContentPart converts a DocumentContent block to a file
+// content part (base64 and file-ID sources) or a text part (text sources).
+// The Chat Completions API has no URL-based file reference.
+func encodeDocumentContentPart(c *llm.DocumentContent) (ContentPart, error) {
+	if c.Source == nil {
+		return ContentPart{}, fmt.Errorf("document content has nil source")
+	}
+	switch c.Source.Type {
+	case llm.ContentSourceTypeBase64:
+		if c.Source.MediaType == "" || c.Source.Data == "" {
+			return ContentPart{}, fmt.Errorf("media type and data are required for base64 document content")
+		}
+		filename := c.Title
+		if filename == "" {
+			filename = "document"
+		}
+		dataURL := fmt.Sprintf("data:%s;base64,%s", c.Source.MediaType, c.Source.Data)
+		return ContentPart{Type: "file", File: &FilePart{Filename: filename, FileData: dataURL}}, nil
+	case llm.ContentSourceTypeFile:
+		if c.Source.FileID == "" {
+			return ContentPart{}, fmt.Errorf("file ID is required for file-based document content")
+		}
+		return ContentPart{Type: "file", File: &FilePart{FileID: c.Source.FileID}}, nil
+	case llm.ContentSourceTypeText:
+		if c.Source.Data == "" {
+			return ContentPart{}, fmt.Errorf("data is required for text document content")
+		}
+		return ContentPart{Type: "text", Text: c.Source.Data}, nil
+	case llm.ContentSourceTypeURL:
+		return ContentPart{}, fmt.Errorf("url-based document content is not supported by the chat completions API; use a base64 or file source")
+	default:
+		return ContentPart{}, fmt.Errorf("unsupported document source type: %s", c.Source.Type)
+	}
 }
 
 func convertToolResultContent(c *llm.ToolResultContent) (Message, error) {
@@ -448,11 +511,20 @@ func toolResultContentString(c *llm.ToolResultContent) (string, error) {
 	}
 }
 
+// toolResultTextBlocks flattens tool result content blocks to a single
+// string. Chat Completions tool messages are text-only, so non-text blocks
+// (e.g. images from an MCP tool) are represented with a placeholder rather
+// than being dropped silently.
 func toolResultTextBlocks(content []*dive.ToolResultContent) string {
 	var texts []string
 	for _, c := range content {
-		if c.Text != "" {
-			texts = append(texts, c.Text)
+		switch c.Type {
+		case dive.ToolResultContentTypeText, "":
+			if c.Text != "" {
+				texts = append(texts, c.Text)
+			}
+		default:
+			texts = append(texts, fmt.Sprintf("[%s content omitted]", c.Type))
 		}
 	}
 	return strings.Join(texts, "\n")

--- a/providers/openaicompletions/openai.go
+++ b/providers/openaicompletions/openai.go
@@ -514,7 +514,7 @@ func toolResultContentString(c *llm.ToolResultContent) (string, error) {
 // toolResultTextBlocks flattens tool result content blocks to a single
 // string. Chat Completions tool messages are text-only, so non-text blocks
 // (e.g. images from an MCP tool) are represented with a placeholder rather
-// than being dropped silently.
+// than being dropped silently, as is a result with no renderable text at all.
 func toolResultTextBlocks(content []*dive.ToolResultContent) string {
 	var texts []string
 	for _, c := range content {
@@ -526,6 +526,9 @@ func toolResultTextBlocks(content []*dive.ToolResultContent) string {
 		default:
 			texts = append(texts, fmt.Sprintf("[%s content omitted]", c.Type))
 		}
+	}
+	if len(texts) == 0 {
+		return providers.EmptyToolResultText
 	}
 	return strings.Join(texts, "\n")
 }

--- a/providers/openaicompletions/types.go
+++ b/providers/openaicompletions/types.go
@@ -1,6 +1,10 @@
 package openaicompletions
 
 import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+
 	"github.com/deepnoodle-ai/dive/llm"
 	"github.com/deepnoodle-ai/wonton/schema"
 )
@@ -38,11 +42,86 @@ type Request struct {
 }
 
 type Message struct {
-	Role       string     `json:"role"`
-	Content    string     `json:"content"`
-	Name       string     `json:"name,omitempty"`
-	ToolCallID string     `json:"tool_call_id,omitempty"`
-	ToolCalls  []ToolCall `json:"tool_calls,omitempty"`
+	Role    string `json:"role"`
+	Content string `json:"content"`
+	// ContentParts, when non-empty, replaces Content in the marshaled JSON
+	// with a content-part array (multimodal messages). Set at most one of
+	// Content and ContentParts.
+	ContentParts []ContentPart `json:"-"`
+	Name         string        `json:"name,omitempty"`
+	ToolCallID   string        `json:"tool_call_id,omitempty"`
+	ToolCalls    []ToolCall    `json:"tool_calls,omitempty"`
+}
+
+func (m Message) MarshalJSON() ([]byte, error) {
+	if len(m.ContentParts) == 0 {
+		type alias Message
+		return json.Marshal(alias(m))
+	}
+	return json.Marshal(struct {
+		Role       string        `json:"role"`
+		Content    []ContentPart `json:"content"`
+		Name       string        `json:"name,omitempty"`
+		ToolCallID string        `json:"tool_call_id,omitempty"`
+		ToolCalls  []ToolCall    `json:"tool_calls,omitempty"`
+	}{m.Role, m.ContentParts, m.Name, m.ToolCallID, m.ToolCalls})
+}
+
+// UnmarshalJSON accepts both content shapes: a plain string (the usual
+// response form) or a content-part array.
+func (m *Message) UnmarshalJSON(data []byte) error {
+	var aux struct {
+		Role       string          `json:"role"`
+		Content    json.RawMessage `json:"content"`
+		Name       string          `json:"name"`
+		ToolCallID string          `json:"tool_call_id"`
+		ToolCalls  []ToolCall      `json:"tool_calls"`
+	}
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+	m.Role = aux.Role
+	m.Name = aux.Name
+	m.ToolCallID = aux.ToolCallID
+	m.ToolCalls = aux.ToolCalls
+	m.Content = ""
+	m.ContentParts = nil
+	content := bytes.TrimSpace(aux.Content)
+	if len(content) == 0 || bytes.Equal(content, []byte("null")) {
+		return nil
+	}
+	switch content[0] {
+	case '"':
+		return json.Unmarshal(content, &m.Content)
+	case '[':
+		return json.Unmarshal(content, &m.ContentParts)
+	default:
+		return fmt.Errorf("unexpected message content shape: %s", content)
+	}
+}
+
+// ContentPart is one element of a multimodal content array in a Chat
+// Completions message.
+type ContentPart struct {
+	Type     string        `json:"type"` // "text", "image_url", or "file"
+	Text     string        `json:"text,omitempty"`
+	ImageURL *ImageURLPart `json:"image_url,omitempty"`
+	File     *FilePart     `json:"file,omitempty"`
+}
+
+// ImageURLPart carries an image in a content-part array, referenced by
+// public URL or data URL.
+type ImageURLPart struct {
+	URL    string `json:"url"`
+	Detail string `json:"detail,omitempty"`
+}
+
+// FilePart carries a file (typically a PDF) in a content-part array, either
+// inline as a data URL or by Files API ID.
+type FilePart struct {
+	Filename string `json:"filename,omitempty"`
+	FileData string `json:"file_data,omitempty"`
+	FileID   string `json:"file_id,omitempty"`
 }
 
 type ToolFunction struct {

--- a/providers/openaicompletions/types.go
+++ b/providers/openaicompletions/types.go
@@ -45,8 +45,11 @@ type Message struct {
 	Role    string `json:"role"`
 	Content string `json:"content"`
 	// ContentParts, when non-empty, replaces Content in the marshaled JSON
-	// with a content-part array (multimodal messages). Set at most one of
-	// Content and ContentParts.
+	// with a content-part array (multimodal messages). When building a
+	// request, set at most one of Content and ContentParts. When decoding a
+	// response that used the array shape, both are populated: ContentParts
+	// holds the parts and Content holds their joined text, so callers that
+	// only read Content never silently see an empty message.
 	ContentParts []ContentPart `json:"-"`
 	Name         string        `json:"name,omitempty"`
 	ToolCallID   string        `json:"tool_call_id,omitempty"`
@@ -94,7 +97,13 @@ func (m *Message) UnmarshalJSON(data []byte) error {
 	case '"':
 		return json.Unmarshal(content, &m.Content)
 	case '[':
-		return json.Unmarshal(content, &m.ContentParts)
+		if err := json.Unmarshal(content, &m.ContentParts); err != nil {
+			return err
+		}
+		// Mirror the text into Content so consumers reading only the string
+		// field don't silently observe an empty message.
+		m.Content = joinTextParts(m.ContentParts)
+		return nil
 	default:
 		return fmt.Errorf("unexpected message content shape: %s", content)
 	}

--- a/providers/toolresult.go
+++ b/providers/toolresult.go
@@ -12,11 +12,15 @@ import (
 // neither of which tells the model the call actually produced nothing.
 const EmptyToolResultText = "(no output)"
 
-// IsEmptyToolResultContent reports whether tool result content is an empty
-// list of blocks, in either the typed in-memory shape or the generic shape it
-// takes after a JSON round-trip.
+// IsEmptyToolResultContent reports whether tool result content carries
+// nothing: nil (reachable when a caller supplies a nil ToolResult on resume)
+// or an empty list of blocks, in either the typed in-memory shape or the
+// generic shape it takes after a JSON round-trip. An empty string is not
+// treated as empty, since a caller chose it explicitly.
 func IsEmptyToolResultContent(content any) bool {
 	switch v := content.(type) {
+	case nil:
+		return true
 	case []*dive.ToolResultContent:
 		return len(v) == 0
 	case []any:

--- a/providers/toolresult.go
+++ b/providers/toolresult.go
@@ -1,0 +1,40 @@
+package providers
+
+import (
+	"github.com/deepnoodle-ai/dive"
+	"github.com/deepnoodle-ai/dive/llm"
+)
+
+// ToolResultBlocks extracts typed tool result content blocks from a
+// tool_result content block, handling both the in-memory shape
+// ([]*dive.ToolResultContent) and the generic shape the same data takes after
+// a JSON round-trip (session persistence, Message.Copy). Returns nil when the
+// content is not block-shaped, in which case callers should fall back to
+// their string/JSON rendering.
+func ToolResultBlocks(c *llm.ToolResultContent) []*dive.ToolResultContent {
+	if blocks, ok := c.Content.([]*dive.ToolResultContent); ok {
+		if len(blocks) == 0 {
+			return nil
+		}
+		return blocks
+	}
+	var blocks []*dive.ToolResultContent
+	if err := c.DecodeContent(&blocks); err != nil || len(blocks) == 0 {
+		return nil
+	}
+	// Guard against arbitrary JSON arrays decoding into zero-valued blocks:
+	// every element must carry a known content block type.
+	for _, b := range blocks {
+		if b == nil {
+			return nil
+		}
+		switch b.Type {
+		case dive.ToolResultContentTypeText,
+			dive.ToolResultContentTypeImage,
+			dive.ToolResultContentTypeAudio:
+		default:
+			return nil
+		}
+	}
+	return blocks
+}

--- a/providers/toolresult.go
+++ b/providers/toolresult.go
@@ -48,7 +48,10 @@ func ToolResultBlocks(c *llm.ToolResultContent) []*dive.ToolResultContent {
 		return nil
 	}
 	// Guard against arbitrary JSON arrays decoding into zero-valued blocks:
-	// every element must carry a known content block type.
+	// every element must carry a known content block type. An absent type is
+	// accepted when the element still carries a block payload, since providers
+	// render an untyped block as text; that keeps a hand-built untyped block
+	// rendering the same before and after a JSON round-trip.
 	for _, b := range blocks {
 		if b == nil {
 			return nil
@@ -57,6 +60,10 @@ func ToolResultBlocks(c *llm.ToolResultContent) []*dive.ToolResultContent {
 		case dive.ToolResultContentTypeText,
 			dive.ToolResultContentTypeImage,
 			dive.ToolResultContentTypeAudio:
+		case "":
+			if b.Text == "" && b.Data == "" {
+				return nil
+			}
 		default:
 			return nil
 		}

--- a/providers/toolresult.go
+++ b/providers/toolresult.go
@@ -5,6 +5,27 @@ import (
 	"github.com/deepnoodle-ai/dive/llm"
 )
 
+// EmptyToolResultText stands in for a tool result that carries no renderable
+// text (a tool that returned no output, or only empty text blocks). Providers
+// substitute it rather than emitting an empty content block or an empty
+// content array, both of which are rejected or ambiguous on some APIs, and
+// neither of which tells the model the call actually produced nothing.
+const EmptyToolResultText = "(no output)"
+
+// IsEmptyToolResultContent reports whether tool result content is an empty
+// list of blocks, in either the typed in-memory shape or the generic shape it
+// takes after a JSON round-trip.
+func IsEmptyToolResultContent(content any) bool {
+	switch v := content.(type) {
+	case []*dive.ToolResultContent:
+		return len(v) == 0
+	case []any:
+		return len(v) == 0
+	default:
+		return false
+	}
+}
+
 // ToolResultBlocks extracts typed tool result content blocks from a
 // tool_result content block, handling both the in-memory shape
 // ([]*dive.ToolResultContent) and the generic shape the same data takes after

--- a/providers/toolresult_test.go
+++ b/providers/toolresult_test.go
@@ -1,0 +1,48 @@
+package providers
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/deepnoodle-ai/dive"
+	"github.com/deepnoodle-ai/dive/llm"
+	"github.com/deepnoodle-ai/wonton/assert"
+)
+
+func TestToolResultBlocksTyped(t *testing.T) {
+	blocks := ToolResultBlocks(&llm.ToolResultContent{
+		ToolUseID: "call_1",
+		Content: []*dive.ToolResultContent{
+			{Type: dive.ToolResultContentTypeText, Text: "hello"},
+			{Type: dive.ToolResultContentTypeImage, Data: "aW1n", MimeType: "image/png"},
+		},
+	})
+	assert.Len(t, blocks, 2)
+	assert.Equal(t, "hello", blocks[0].Text)
+	assert.Equal(t, dive.ToolResultContentTypeImage, blocks[1].Type)
+}
+
+func TestToolResultBlocksJSONRoundTrip(t *testing.T) {
+	original := &llm.ToolResultContent{
+		ToolUseID: "call_1",
+		Content: []*dive.ToolResultContent{
+			{Type: dive.ToolResultContentTypeText, Text: "hello"},
+		},
+	}
+	body, err := json.Marshal(original)
+	assert.NoError(t, err)
+	var replayed llm.ToolResultContent
+	assert.NoError(t, json.Unmarshal(body, &replayed))
+
+	blocks := ToolResultBlocks(&replayed)
+	assert.Len(t, blocks, 1)
+	assert.Equal(t, "hello", blocks[0].Text)
+}
+
+func TestToolResultBlocksNonBlockContent(t *testing.T) {
+	assert.Nil(t, ToolResultBlocks(&llm.ToolResultContent{Content: "plain string"}))
+	assert.Nil(t, ToolResultBlocks(&llm.ToolResultContent{Content: nil}))
+	assert.Nil(t, ToolResultBlocks(&llm.ToolResultContent{Content: []*dive.ToolResultContent{}}))
+	assert.Nil(t, ToolResultBlocks(&llm.ToolResultContent{Content: []any{map[string]any{"foo": "bar"}}}))
+	assert.Nil(t, ToolResultBlocks(&llm.ToolResultContent{Content: []any{1, 2, 3}}))
+}

--- a/providers/toolresult_test.go
+++ b/providers/toolresult_test.go
@@ -39,6 +39,17 @@ func TestToolResultBlocksJSONRoundTrip(t *testing.T) {
 	assert.Equal(t, "hello", blocks[0].Text)
 }
 
+// TestToolResultBlocksUntypedText verifies a block with no explicit type but
+// real text survives the round-trip guard, matching how the typed in-memory
+// path treats it.
+func TestToolResultBlocksUntypedText(t *testing.T) {
+	blocks := ToolResultBlocks(&llm.ToolResultContent{
+		Content: []any{map[string]any{"text": "hello"}},
+	})
+	assert.Len(t, blocks, 1)
+	assert.Equal(t, "hello", blocks[0].Text)
+}
+
 func TestToolResultBlocksNonBlockContent(t *testing.T) {
 	assert.Nil(t, ToolResultBlocks(&llm.ToolResultContent{Content: "plain string"}))
 	assert.Nil(t, ToolResultBlocks(&llm.ToolResultContent{Content: nil}))


### PR DESCRIPTION
## Summary

Closes the media input gaps identified in the Mobius audit of v1.17.0 (`2026-07-22-dive-media-input-gaps.md`), plus adjacent tool-result media issues found while reviewing the same code paths. The goal: a caller-supplied `ImageContent`/`DocumentContent` block either reaches the model correctly or fails loudly — never a silent drop.

### Gap 1 — google silently dropped `DocumentContent` (highest severity)

The content switch in `messagesToContents` had no `DocumentContent` case and no `default`, so documents vanished from the request and the model hallucinated an answer (the Sage incident failure class). Now:

- base64 → inline bytes, URL → file URI, text source → inline text
- `ThinkingContent`/`RedactedThinkingContent` explicitly skipped (cross-provider session handoff)
- trailing `default` error, so no future content type can fall through silently
- base64 sources validate `MediaType`, URL sources validate `URL`

### Gap 2 — openai (Responses) rejected URL-source documents

The pinned SDK exposes `ResponseInputFileParam.FileURL`, and the API accepts it. URL sources now pass through (grok inherits this; whether xAI's endpoint accepts `input_file` remains a server-side question — a clear 4xx if not, vs. never leaving Dive before). Text-source documents are now inlined as `input_text` instead of erroring.

### Gap 3 — Chat Completions path was text-only (entire OpenRouter catalog)

`openaicompletions.Message` now supports a content-part array: marshaled as a plain string when there are no parts (**byte-compatible** with existing requests — covered by an exact-bytes test), as `[{type:text|image_url|file}, …]` when media is present. `ImageContent` → `image_url` (base64 → data URL, URL passthrough); `DocumentContent` → `file` (base64 → `file_data`, file ID) or inline text. This unlocks multimodal input for **mistral and openrouter** at once. Also fixes assistant tool-call messages keeping only the *last* text block.

### Adjacent: tool results carrying typed media blocks (e.g. MCP screenshot tools)

Found while reviewing the same encoders — same silent-loss failure class:

| Provider | Before | After |
|---|---|---|
| anthropic | image blocks sent in Dive's flat JSON shape → invalid wire format (400) | converted to native image blocks with base64 source; media type auto-detected when missing; stray `annotations` no longer leak |
| openai (Responses) | typed text blocks JSON-marshaled into the output string (`[{"type":"text",...}]` noise); images inlined as base64 *text* | text flattened to plain text; image-bearing results emitted as a `function_call_output` content-part list so the model can actually see them |
| google / openaicompletions | non-text blocks silently dropped | explicit `[image content omitted]` placeholder |

New shared helper `providers.ToolResultBlocks` decodes typed blocks in both their in-memory and JSON-round-tripped (session replay) shapes.

### Docs

`docs/guides/llm-guide.md` gains a Multimodal Input section with the per-provider source-support matrix.

## Notes for release

`providers/openai` and `providers/google` now use new symbols from the root `providers` package (`ToolResultBlocks`, `EmptyToolResultText`, `IsEmptyToolResultContent`) via their `replace` directives — the next release needs the usual lockstep tag bump of the root module before the provider modules.

## Empty tool results

Follow-up commit after self-review. Filtering empty text blocks out of typed tool results left a degenerate wire shape: Anthropic got `"content":[]` for a tool that returned no output (rejected the same way an empty text block is), and the Responses API got an empty `output` string. All providers now substitute a shared `(no output)` placeholder, which also fixes the pre-existing zero-block case reachable whenever a tool returns a nil `ToolResult`. The chat completions decoder additionally mirrors content-part text into `Message.Content` so an array-shaped response never reads as an empty message.

## Testing

- New unit tests for every encode path: google document/image encoding + default-error behavior, openai document sources + function-call-output shapes, openaicompletions content parts (incl. exact byte-compat assertions for text-only messages), anthropic tool-result block conversion (incl. JSON round-trip), and the shared block decoder.
- Full suites pass in all touched modules (root, `providers/google`, `providers/openai`, `providers/grok`). The five pre-existing anthropic live-API tests fail locally with 401s (invalid key in the environment) — unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added multimodal input support for images and documents, including URLs, base64 data, file IDs, and inline text.
* **Bug Fixes**
  * Improved tool-result handling across providers: image and other non-text blocks are preserved via clear placeholders, and empty tool results now consistently show “(no output)”.
  * Strengthened validation for missing/unsupported media fields and corrected mixed text+media tool outputs.
* **Documentation**
  * Expanded the multimodal input guide with examples, provider capability notes, and detailed encoding/omission behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
