### PR TITLE
Accept dragged-in files as CLI attachments

### DIFF
--- a/experimental/cmd/dive/app.go
+++ b/experimental/cmd/dive/app.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -12,6 +11,7 @@ import (
 	"sort"
 	"strings"
 	"time"
+	"unicode"
 	"unicode/utf8"
 
 	"github.com/deepnoodle-ai/dive"
@@ -260,6 +260,13 @@ type App struct {
 	inputText    string
 	historyIndex int // -1 when not navigating history
 
+	// Dropped-file attachments pending on the current draft. lastInput is the
+	// previous value of inputText, used to isolate the run of text a paste (or
+	// a terminal file drop) inserted.
+	lastInput   string
+	attachments []attachment
+	attachSeq   int
+
 	// Chat state
 	messages              []Message
 	streamingMessageIndex int
@@ -429,18 +436,22 @@ func (a *App) LiveView() tui.View {
 
 	// Input area
 	views = append(views, tui.Divider())
+	if attachmentsView := a.attachmentsView(); attachmentsView != nil {
+		views = append(views, attachmentsView)
+	}
 	views = append(views,
 		tui.InputField(&a.inputText).
 			ID("main-input").
 			Prompt(" ❯ ").
 			PromptStyle(tui.NewStyle().WithFgRGB(tui.RGB{R: 100, G: 100, B: 110})).
-			Placeholder("Type a message... (@filename for autocomplete)").
+			Placeholder("Type a message... (@filename, or drop a file to attach)").
 			Multiline(true).
 			MaxHeight(10).
-			OnChange(func(string) {
+			OnChange(func(value string) {
 				// A focused input consumes its own keystrokes (wonton
-				// >= v0.0.35), so refresh autocomplete on edits here
-				// rather than from HandleEvent.
+				// >= v0.0.35), so capture dropped files and refresh
+				// autocomplete on edits here rather than from HandleEvent.
+				a.handleInputChange(value)
 				a.updateAutocomplete()
 			}).
 			OnKey(func(e tui.KeyEvent) bool {
@@ -512,6 +523,23 @@ func (a *App) LiveView() tui.View {
 	}
 
 	return tui.Stack(views...).Gap(0)
+}
+
+// attachmentsView names the files attached to the draft message, rendered just
+// inside the input box. The rows are listed in placeholder order, so the "#N" in
+// the text is not repeated here. Returns nil when nothing is attached.
+func (a *App) attachmentsView() tui.View {
+	if len(a.attachments) == 0 {
+		return nil
+	}
+	rows := make([]tui.View, 0, len(a.attachments))
+	for _, att := range a.attachments {
+		rows = append(rows, tui.Group(
+			tui.Text(" ⏺ ").Fg(tui.ColorCyan),
+			tui.Text("%s (%s)", att.Name, formatBytes(int(att.Size))).Hint(),
+		))
+	}
+	return tui.Stack(rows...).Gap(0)
 }
 
 // Purple color for Claude Code style UI elements
@@ -924,6 +952,132 @@ func (a *App) updateAutocomplete() {
 	}
 }
 
+// setInputText replaces the input buffer from application code (history recall,
+// autocomplete, clearing on submit). Keeping the drop-detection baseline in sync
+// here means a programmatic change is never mistaken for a paste.
+func (a *App) setInputText(value string) {
+	a.inputText = value
+	a.lastInput = value
+}
+
+// handleInputChange watches the input for terminal file drops. A drop arrives as
+// a paste — one contiguous insertion of the dropped file's path — so the newly
+// inserted run is the only text worth scanning, and a single typed character
+// never triggers a filesystem lookup.
+func (a *App) handleInputChange(value string) {
+	prev := a.lastInput
+	a.lastInput = value
+	a.pruneAttachments(value)
+
+	start, end, ok := insertedRange(prev, value)
+	if !ok {
+		return
+	}
+	inserted := value[start:end]
+	replaced := a.captureDroppedFiles(inserted)
+	if replaced == inserted {
+		return
+	}
+
+	// Space the placeholders off from whatever surrounds them. Terminals pad a
+	// drop with their own whitespace — a trailing space, sometimes a leading
+	// newline — which would otherwise strand the placeholder on its own line.
+	before, after := value[:start], value[end:]
+	if before != "" && !endsWithSpace(before) {
+		replaced = " " + replaced
+	}
+	if after == "" || !startsWithSpace(after) {
+		replaced += " "
+	}
+
+	a.inputText = before + replaced + after
+	a.lastInput = a.inputText
+}
+
+func endsWithSpace(s string) bool {
+	r, _ := utf8.DecodeLastRuneInString(s)
+	return unicode.IsSpace(r)
+}
+
+func startsWithSpace(s string) bool {
+	r, _ := utf8.DecodeRuneInString(s)
+	return unicode.IsSpace(r)
+}
+
+// captureDroppedFiles turns a run of inserted text into placeholders such as
+// "[Image #1]", registering each file as an attachment on the current draft. The
+// run is left untouched unless it is a file drop — nothing but paths to files
+// that exist — in which case it is rebuilt from the placeholders alone, since
+// the whitespace a terminal wraps a drop in carries no meaning. A path that
+// can't be attached is kept as text. Returns the rewritten run.
+func (a *App) captureDroppedFiles(inserted string) string {
+	tokens := scanPathTokens(inserted)
+	paths, ok := isFileDrop(tokens)
+	if !ok {
+		return inserted
+	}
+
+	parts := make([]string, 0, len(paths))
+	found := 0
+	for i, path := range paths {
+		kind, size, err := classifyAttachment(path)
+		if err != nil {
+			// The drop was deliberate, so say why nothing was attached and
+			// leave the path in the message as text.
+			if a.runner != nil {
+				a.runner.Printf("Did not attach %s: %s.", filepath.Base(path), err)
+			}
+			parts = append(parts, tokens[i].value)
+			continue
+		}
+		a.attachSeq++
+		att := attachment{
+			Placeholder: fmt.Sprintf("[%s #%d]", kind.label(), a.attachSeq),
+			Path:        path,
+			Name:        filepath.Base(path),
+			Kind:        kind,
+			Size:        size,
+		}
+		a.attachments = append(a.attachments, att)
+		parts = append(parts, att.Placeholder)
+		found++
+	}
+	if found == 0 {
+		return inserted
+	}
+	return strings.Join(parts, " ")
+}
+
+// pruneAttachments drops attachments whose placeholder the user has deleted from
+// the input, so the attachment list and the outbound message stay in sync with
+// what is actually on screen.
+func (a *App) pruneAttachments(value string) {
+	if len(a.attachments) == 0 {
+		return
+	}
+	kept := a.attachments[:0]
+	for _, att := range a.attachments {
+		if strings.Contains(value, att.Placeholder) {
+			kept = append(kept, att)
+		}
+	}
+	a.attachments = kept
+	if len(a.attachments) == 0 {
+		a.attachments = nil
+		a.attachSeq = 0
+	}
+}
+
+// takeAttachments returns the attachments still referenced by the submitted text
+// and clears the pending set.
+func (a *App) takeAttachments(value string) []attachment {
+	a.pruneAttachments(value)
+	taken := a.attachments
+	a.attachments = nil
+	a.attachSeq = 0
+	return taken
+}
+
 // clearAutocomplete resets autocomplete state
 func (a *App) clearAutocomplete() {
 	a.autocompleteMatches = nil
@@ -942,12 +1096,12 @@ func (a *App) selectAutocomplete() bool {
 
 	if a.autocompleteType == "command" {
 		// Replace entire input with selected command (add space for args)
-		a.inputText = "/" + selected + " "
+		a.setInputText("/" + selected + " ")
 	} else {
 		// Find the last @ and replace prefix with selected match
 		lastAt := strings.LastIndex(a.inputText, "@")
 		if lastAt >= 0 {
-			a.inputText = a.inputText[:lastAt+1] + selected + " "
+			a.setInputText(a.inputText[:lastAt+1] + selected + " ")
 		}
 	}
 
@@ -1035,7 +1189,7 @@ func (a *App) handleInputNavKey(e tui.KeyEvent) bool {
 				a.historyIndex--
 			}
 			if a.historyIndex >= 0 && a.historyIndex < len(a.history) {
-				a.inputText = a.history[a.historyIndex]
+				a.setInputText(a.history[a.historyIndex])
 			}
 			return true
 		}
@@ -1045,9 +1199,9 @@ func (a *App) handleInputNavKey(e tui.KeyEvent) bool {
 			a.historyIndex++
 			if a.historyIndex >= len(a.history) {
 				a.historyIndex = -1
-				a.inputText = ""
+				a.setInputText("")
 			} else {
-				a.inputText = a.history[a.historyIndex]
+				a.setInputText(a.history[a.historyIndex])
 			}
 			return true
 		}
@@ -1064,18 +1218,30 @@ func (a *App) submitInput(value string) {
 		return
 	}
 
-	trimmed := strings.TrimSpace(value)
+	// The input reports its own value, which a drop landing in the same event
+	// batch as Enter may not yet have been through the change hook. Fold it in
+	// so the submitted text is the placeholder form, not a raw path.
+	if value != a.lastInput {
+		a.inputText = value
+		a.handleInputChange(value)
+	}
+
+	trimmed := strings.TrimSpace(a.inputText)
 	if trimmed == "" || a.processing {
 		return
 	}
 
-	a.inputText = "" // Clear input
+	// Claim the attachments the submitted text still refers to; any whose
+	// placeholder the user deleted are dropped along with the draft.
+	attachments := a.takeAttachments(trimmed)
+
+	a.setInputText("") // Clear input
 	a.historyIndex = -1
 	a.history = append(a.history, trimmed)
 
 	// Handle commands
 	if strings.HasPrefix(trimmed, "/") {
-		if a.handleCommand(trimmed) {
+		if a.handleCommand(trimmed, attachments) {
 			return
 		}
 	}
@@ -1083,17 +1249,22 @@ func (a *App) submitInput(value string) {
 	// Process message asynchronously
 	includeStartupAttachment := !a.firstUserSent
 	a.firstUserSent = true
-	go a.processMessageAsync(trimmed, includeStartupAttachment)
+	go a.processMessageAsync(trimmed, attachments, includeStartupAttachment)
 }
 
 // processMessageAsync handles message processing in background.
 // Sends events to the main event loop instead of modifying state directly.
-func (a *App) processMessageAsync(input string, includeStartupAttachment bool) {
+func (a *App) processMessageAsync(input string, attachments []attachment, includeStartupAttachment bool) {
 	// Expand file references (uses only immutable workspaceDir)
 	expanded, extraContent, err := a.expandFileReferences(input)
 	if err != nil {
 		a.runner.Printf("Warning: %s", err.Error())
 	}
+	expanded, attachedContent, err := expandAttachments(expanded, attachments)
+	if err != nil {
+		a.runner.Printf("Warning: %s", err.Error())
+	}
+	extraContent = append(extraContent, attachedContent...)
 	if includeStartupAttachment {
 		expanded = appendAttachedContent(expanded, a.startupAttachment)
 	}
@@ -1106,12 +1277,17 @@ func (a *App) processMessageAsync(input string, includeStartupAttachment bool) {
 // processCommandAsync handles slash command processing in background.
 // displayText is what the user typed (e.g., "/explain go.mod")
 // expanded is the full prompt to send to the agent
-func (a *App) processCommandAsync(displayText, expanded string, includeStartupAttachment bool) {
+func (a *App) processCommandAsync(displayText, expanded string, attachments []attachment, includeStartupAttachment bool) {
 	// Expand file references in the expanded text
 	expandedWithFiles, extraContent, err := a.expandFileReferences(expanded)
 	if err != nil {
 		a.runner.Printf("Warning: %s", err.Error())
 	}
+	expandedWithFiles, attachedContent, err := expandAttachments(expandedWithFiles, attachments)
+	if err != nil {
+		a.runner.Printf("Warning: %s", err.Error())
+	}
+	extraContent = append(extraContent, attachedContent...)
 	if includeStartupAttachment {
 		expandedWithFiles = appendAttachedContent(expandedWithFiles, a.startupAttachment)
 	}
@@ -2052,7 +2228,10 @@ func extractToolResultText(result *llm.ToolResultContent) string {
 	}
 }
 
-func (a *App) handleCommand(input string) bool {
+// handleCommand runs a built-in or custom slash command, returning true when it
+// handled the input. Attachments pending on the draft are forwarded to custom
+// commands and skills; built-ins take no input beyond their arguments.
+func (a *App) handleCommand(input string, attachments []attachment) bool {
 	// Parse command name and arguments
 	parts := strings.SplitN(strings.TrimPrefix(input, "/"), " ", 2)
 	cmdName := parts[0]
@@ -2160,7 +2339,7 @@ func (a *App) handleCommand(input string) bool {
 			// Send the expanded instructions to the agent (async like regular messages)
 			includeStartupAttachment := !a.firstUserSent
 			a.firstUserSent = true
-			go a.processCommandAsync(displayCmd, expanded, includeStartupAttachment)
+			go a.processCommandAsync(displayCmd, expanded, attachments, includeStartupAttachment)
 			return true
 		}
 	}
@@ -2273,6 +2452,7 @@ func (a *App) printHelp() {
 		tui.Text(""),
 		tui.Text("Input:").Bold(),
 		tui.Text("  @filename      Include file contents"),
+		tui.Text("  drag & drop    Attach an image, PDF, video, or text file"),
 		tui.Text("  Enter          Send message"),
 		tui.Text("  Shift+Enter    New line"),
 		tui.Text("  Ctrl+C twice   Exit"),
@@ -2606,45 +2786,10 @@ func (a *App) expandFileReferences(input string) (string, []llm.Content, error) 
 			return match
 		}
 
-		ext := strings.ToLower(filepath.Ext(path))
-		filename := filepath.Base(path)
-
-		// Images → ImageContent
-		if mediaType, ok := fileMediaTypes[ext]; ok && strings.HasPrefix(mediaType, "image/") {
-			contentBlocks = append(contentBlocks, &llm.ImageContent{
-				Source: &llm.ContentSource{
-					Type:      llm.ContentSourceTypeBase64,
-					MediaType: mediaType,
-					Data:      base64.StdEncoding.EncodeToString(data),
-				},
-			})
-			return fmt.Sprintf("[image: %s]%s", path, trailing)
-		}
-
-		// PDFs and videos → DocumentContent (base64)
-		if mediaType, ok := fileMediaTypes[ext]; ok {
-			contentBlocks = append(contentBlocks, &llm.DocumentContent{
-				Source: &llm.ContentSource{
-					Type:      llm.ContentSourceTypeBase64,
-					MediaType: mediaType,
-					Data:      base64.StdEncoding.EncodeToString(data),
-				},
-				Title: filename,
-			})
-			return fmt.Sprintf("[document: %s]%s", path, trailing)
-		}
-
-		// Structured text files → DocumentContent (text source)
-		if textDocExtensions[ext] {
-			contentBlocks = append(contentBlocks, &llm.DocumentContent{
-				Source: &llm.ContentSource{
-					Type:      llm.ContentSourceTypeText,
-					MediaType: "text/plain",
-					Data:      string(data),
-				},
-				Title: filename,
-			})
-			return fmt.Sprintf("[document: %s]%s", path, trailing)
+		// Images, PDFs, videos, and structured text → native content blocks
+		if content, kind, ok := mediaContentFor(filepath.Base(path), data); ok {
+			contentBlocks = append(contentBlocks, content)
+			return fmt.Sprintf("[%s: %s]%s", kind, path, trailing)
 		}
 
 		// Default: inline as XML-style tag

--- a/experimental/cmd/dive/attachments.go
+++ b/experimental/cmd/dive/attachments.go
@@ -1,0 +1,378 @@
+package main
+
+import (
+	"bytes"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"io"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/deepnoodle-ai/dive/llm"
+)
+
+// Dropping a file onto a terminal makes it insert that file's path as if it had
+// been pasted. The input watches for those insertions, resolves them to local
+// files, and replaces each one with a placeholder such as "[Image #1]". The file
+// itself is read when the message is sent, at which point images, PDFs, and
+// videos become native content blocks and text files are inlined into the
+// prompt.
+//
+// Unlike an @reference, a dropped file may live anywhere on disk: dragging it
+// onto the input is the user pointing at that exact file, so the workspace
+// boundary that guards @references doesn't apply.
+
+const (
+	// maxAttachmentBytes caps a dropped file that is sent as a native content
+	// block. Providers reject requests well below this, but the limit keeps a
+	// stray multi-gigabyte drop from being base64-encoded into memory.
+	maxAttachmentBytes = 32 << 20
+
+	// maxInlineTextBytes caps a dropped file with no native media type, which
+	// is inlined into the prompt as text.
+	maxInlineTextBytes = 256 << 10
+)
+
+// mediaKind describes how an attachment is sent to the model.
+type mediaKind string
+
+const (
+	mediaKindImage    mediaKind = "image"
+	mediaKindDocument mediaKind = "document"
+	mediaKindVideo    mediaKind = "video"
+	mediaKindFile     mediaKind = "file"
+)
+
+// label returns the form used in input placeholders, e.g. "[Image #1]".
+func (k mediaKind) label() string {
+	switch k {
+	case mediaKindImage:
+		return "Image"
+	case mediaKindDocument:
+		return "Document"
+	case mediaKindVideo:
+		return "Video"
+	default:
+		return "File"
+	}
+}
+
+// attachment is a file the user dropped onto the input. It is referenced from
+// the input text by Placeholder until the message is sent; the contents are not
+// read until then, so a large drop never blocks the event loop.
+type attachment struct {
+	Placeholder string
+	Path        string
+	Name        string
+	Kind        mediaKind
+	Size        int64
+}
+
+// mediaKindForExt reports how a file extension is sent to the model, without
+// reading the file. Returns false for extensions with no native handling.
+func mediaKindForExt(ext string) (mediaKind, bool) {
+	ext = strings.ToLower(ext)
+	if mediaType, ok := fileMediaTypes[ext]; ok {
+		switch {
+		case strings.HasPrefix(mediaType, "image/"):
+			return mediaKindImage, true
+		case strings.HasPrefix(mediaType, "video/"):
+			return mediaKindVideo, true
+		default:
+			return mediaKindDocument, true
+		}
+	}
+	if textDocExtensions[ext] {
+		return mediaKindDocument, true
+	}
+	return "", false
+}
+
+// mediaContentFor builds the native content block for a file whose extension has
+// known media handling, reporting false for anything that should be sent as
+// plain text instead. Shared by @references and dropped attachments.
+func mediaContentFor(filename string, data []byte) (llm.Content, mediaKind, bool) {
+	ext := strings.ToLower(filepath.Ext(filename))
+
+	if mediaType, ok := fileMediaTypes[ext]; ok {
+		source := &llm.ContentSource{
+			Type:      llm.ContentSourceTypeBase64,
+			MediaType: mediaType,
+			Data:      base64.StdEncoding.EncodeToString(data),
+		}
+		if strings.HasPrefix(mediaType, "image/") {
+			return &llm.ImageContent{Source: source}, mediaKindImage, true
+		}
+		kind := mediaKindDocument
+		if strings.HasPrefix(mediaType, "video/") {
+			kind = mediaKindVideo
+		}
+		return &llm.DocumentContent{Source: source, Title: filename}, kind, true
+	}
+
+	if textDocExtensions[ext] {
+		return &llm.DocumentContent{
+			Source: &llm.ContentSource{
+				Type:      llm.ContentSourceTypeText,
+				MediaType: "text/plain",
+				Data:      string(data),
+			},
+			Title: filename,
+		}, mediaKindDocument, true
+	}
+
+	return nil, "", false
+}
+
+// pathToken is a whitespace-delimited token from a run of inserted text, along
+// with its byte range within that run.
+type pathToken struct {
+	start int
+	end   int
+	value string
+}
+
+// scanPathTokens splits text the way a shell would: on unquoted whitespace,
+// honoring single quotes, double quotes, and backslash escapes. Terminals use
+// exactly these forms when they insert the path of a dropped file, so a path
+// containing spaces survives the round trip.
+func scanPathTokens(text string) []pathToken {
+	var (
+		tokens []pathToken
+		value  strings.Builder
+		start  = -1
+		quote  = byte(0)
+	)
+	flush := func(end int) {
+		if start >= 0 {
+			tokens = append(tokens, pathToken{start: start, end: end, value: value.String()})
+			value.Reset()
+			start = -1
+		}
+	}
+	for i := 0; i < len(text); i++ {
+		c := text[i]
+		switch {
+		case quote == 0 && (c == ' ' || c == '\t' || c == '\n' || c == '\r'):
+			flush(i)
+		case quote == 0 && (c == '\'' || c == '"'):
+			if start < 0 {
+				start = i
+			}
+			quote = c
+		case quote != 0 && c == quote:
+			quote = 0
+		// A backslash escapes only the characters a terminal actually escapes
+		// when it inserts a path, so a Windows separator stays literal.
+		case c == '\\' && quote != '\'' && i+1 < len(text) && isEscapable(text[i+1]):
+			if start < 0 {
+				start = i
+			}
+			i++
+			value.WriteByte(text[i])
+		default:
+			if start < 0 {
+				start = i
+			}
+			value.WriteByte(c)
+		}
+	}
+	flush(len(text))
+	return tokens
+}
+
+// isEscapable reports whether a backslash before c should be read as an escape.
+func isEscapable(c byte) bool {
+	switch c {
+	case ' ', '\t', '\'', '"', '\\', '(', ')', '[', ']', '&', ';', '$', '`', '!', '*', '?', '#':
+		return true
+	}
+	return false
+}
+
+// resolveDroppedPath turns an inserted token into an absolute filesystem path,
+// reporting false when it doesn't look like one. Terminals emit either a plain
+// (possibly escaped) path or a file:// URL when a file is dropped; both are
+// accepted, as is a leading ~. Relative tokens are rejected so an ordinary word
+// in a pasted sentence is never mistaken for an attachment.
+func resolveDroppedPath(token string) (string, bool) {
+	path := token
+
+	if strings.HasPrefix(strings.ToLower(path), "file://") {
+		u, err := url.Parse(path)
+		if err != nil || (u.Host != "" && u.Host != "localhost") {
+			return "", false
+		}
+		decoded, err := url.PathUnescape(u.Path)
+		if err != nil {
+			return "", false
+		}
+		path = decoded
+	}
+
+	if strings.HasPrefix(path, "~") {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", false
+		}
+		switch {
+		case path == "~":
+			path = home
+		case path[1] == '/' || path[1] == '\\':
+			path = filepath.Join(home, path[2:])
+		}
+	}
+
+	if path == "" || !filepath.IsAbs(path) {
+		return "", false
+	}
+	return filepath.Clean(path), true
+}
+
+// isFileDrop reports whether every token in a run of inserted text resolves to
+// something that exists on disk, which is exactly what a terminal inserts for a
+// file drop. Requiring the whole run keeps a pasted log or stack trace that
+// merely mentions absolute paths from being turned into attachments.
+func isFileDrop(tokens []pathToken) ([]string, bool) {
+	if len(tokens) == 0 {
+		return nil, false
+	}
+	paths := make([]string, 0, len(tokens))
+	for _, token := range tokens {
+		path, ok := resolveDroppedPath(token.value)
+		if !ok {
+			return nil, false
+		}
+		if _, err := os.Lstat(path); err != nil {
+			return nil, false
+		}
+		paths = append(paths, path)
+	}
+	return paths, true
+}
+
+// classifyAttachment decides how a dropped file will be sent, returning an error
+// phrase describing why it can't be attached at all.
+func classifyAttachment(path string) (mediaKind, int64, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return "", 0, errors.New("it cannot be read")
+	}
+	if info.IsDir() {
+		return "", 0, errors.New("it is a directory")
+	}
+	if !info.Mode().IsRegular() {
+		return "", 0, errors.New("it is not a regular file")
+	}
+
+	if kind, ok := mediaKindForExt(filepath.Ext(path)); ok {
+		if info.Size() > maxAttachmentBytes {
+			return "", 0, fmt.Errorf("it is larger than %s", formatBytes(maxAttachmentBytes))
+		}
+		return kind, info.Size(), nil
+	}
+
+	// No native media type. Attach it only if it reads as text, in which case
+	// it is inlined into the prompt exactly like an @reference.
+	if !looksLikeText(path) {
+		return "", 0, errors.New("its file type is not supported")
+	}
+	if info.Size() > maxInlineTextBytes {
+		return "", 0, fmt.Errorf("it is larger than %s", formatBytes(maxInlineTextBytes))
+	}
+	return mediaKindFile, info.Size(), nil
+}
+
+// looksLikeText reports whether the head of a file decodes as UTF-8 with no NUL
+// bytes, the same cheap test editors use to avoid opening binaries.
+func looksLikeText(path string) bool {
+	f, err := os.Open(path)
+	if err != nil {
+		return false
+	}
+	defer f.Close()
+
+	buf := make([]byte, 4096)
+	n, err := f.Read(buf)
+	if n == 0 {
+		// An empty file counts as text; anything else means it can't be read.
+		return errors.Is(err, io.EOF)
+	}
+	buf = buf[:n]
+	if bytes.IndexByte(buf, 0) >= 0 {
+		return false
+	}
+	// The read may have stopped mid-rune, so allow trimming a truncated tail.
+	for i := 0; i < 4; i++ {
+		if utf8.Valid(buf) {
+			return true
+		}
+		if len(buf) == 0 {
+			return false
+		}
+		buf = buf[:len(buf)-1]
+	}
+	return false
+}
+
+// insertedRange locates the single contiguous run of text present in next but
+// not in prev, returning its byte range in next. It reports false unless more
+// than one character was inserted, which is what separates a paste (or a
+// terminal file drop) from ordinary typing.
+func insertedRange(prev, next string) (int, int, bool) {
+	if len(next) <= len(prev) {
+		return 0, 0, false
+	}
+	prevRunes := []rune(prev)
+	nextRunes := []rune(next)
+	if len(nextRunes)-len(prevRunes) < 2 {
+		return 0, 0, false
+	}
+
+	head := 0
+	for head < len(prevRunes) && prevRunes[head] == nextRunes[head] {
+		head++
+	}
+	tail := 0
+	for tail < len(prevRunes)-head && prevRunes[len(prevRunes)-1-tail] == nextRunes[len(nextRunes)-1-tail] {
+		tail++
+	}
+
+	start := len(string(nextRunes[:head]))
+	end := len(next) - len(string(nextRunes[len(nextRunes)-tail:]))
+	return start, end, true
+}
+
+// expandAttachments reads each attachment and returns the message text with
+// text-only files inlined, plus the native content blocks for images, documents,
+// and videos. Placeholders for native blocks become a short "[image: path]"
+// marker so the model can tell where each attachment belongs. Runs off the event
+// loop, so it must not touch App state.
+func expandAttachments(text string, attachments []attachment) (string, []llm.Content, error) {
+	var (
+		blocks   []llm.Content
+		firstErr error
+	)
+	for _, att := range attachments {
+		data, err := os.ReadFile(att.Path)
+		if err != nil {
+			if firstErr == nil {
+				firstErr = fmt.Errorf("cannot read %s: %w", att.Name, err)
+			}
+			text = strings.ReplaceAll(text, att.Placeholder, att.Path)
+			continue
+		}
+		if content, kind, ok := mediaContentFor(att.Name, data); ok {
+			blocks = append(blocks, content)
+			text = strings.ReplaceAll(text, att.Placeholder, fmt.Sprintf("[%s: %s]", kind, att.Path))
+			continue
+		}
+		text = strings.ReplaceAll(text, att.Placeholder,
+			fmt.Sprintf("\n<file path=%q>\n%s\n</file>\n", att.Path, string(data)))
+	}
+	return text, blocks, firstErr
+}

--- a/experimental/cmd/dive/attachments_test.go
+++ b/experimental/cmd/dive/attachments_test.go
@@ -1,0 +1,386 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/deepnoodle-ai/dive/llm"
+	"github.com/deepnoodle-ai/wonton/assert"
+	"github.com/deepnoodle-ai/wonton/tui"
+)
+
+// These tests cover terminal drag and drop: a dropped file arrives as a pasted
+// run of text holding its path, which the input turns into an attachment.
+
+// simulateInput mimics an edit from the input widget, which writes the new
+// value into the bound field before firing the change hook.
+func simulateInput(a *App, value string) {
+	a.inputText = value
+	a.handleInputChange(value)
+}
+
+func writeTempFile(t *testing.T, name string, data []byte) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), name)
+	assert.NoError(t, os.WriteFile(path, data, 0o644))
+	return path
+}
+
+// pngBytes is a 1x1 PNG. Only the header matters here; nothing decodes it.
+var pngBytes = []byte("\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR")
+
+func TestScanPathTokens(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  []string
+	}{
+		{"plain", "/tmp/a.png", []string{"/tmp/a.png"}},
+		{"trailing space", "/tmp/a.png ", []string{"/tmp/a.png"}},
+		{"multiple", "/tmp/a.png /tmp/b.pdf", []string{"/tmp/a.png", "/tmp/b.pdf"}},
+		{"newline separated", "/tmp/a.png\n/tmp/b.pdf", []string{"/tmp/a.png", "/tmp/b.pdf"}},
+		// macOS Terminal and iTerm2 backslash-escape spaces on drop.
+		{"escaped spaces", `/tmp/my\ shot.png`, []string{"/tmp/my shot.png"}},
+		{"single quoted", `'/tmp/my shot.png'`, []string{"/tmp/my shot.png"}},
+		{"double quoted", `"/tmp/my shot.png"`, []string{"/tmp/my shot.png"}},
+		{"sentence", "look at /tmp/a.png please", []string{"look", "at", "/tmp/a.png", "please"}},
+		{"empty", "   ", nil},
+		// A backslash is a separator, not an escape, unless what follows is
+		// something a terminal would actually escape.
+		{"windows separator", `C:\Users\me\a.png`, []string{`C:\Users\me\a.png`}},
+		{"escaped backslash", `/tmp/a\\b.png`, []string{`/tmp/a\b.png`}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tokens := scanPathTokens(tt.input)
+			got := make([]string, 0, len(tokens))
+			for _, token := range tokens {
+				got = append(got, token.value)
+				// Ranges must index back into the original text.
+				assert.True(t, token.start >= 0 && token.end <= len(tt.input) && token.start < token.end)
+			}
+			if len(tt.want) == 0 {
+				assert.Empty(t, got)
+				return
+			}
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestResolveDroppedPath(t *testing.T) {
+	home, err := os.UserHomeDir()
+	assert.NoError(t, err)
+
+	tests := []struct {
+		name  string
+		token string
+		want  string
+		ok    bool
+	}{
+		{"absolute", "/tmp/a.png", "/tmp/a.png", true},
+		{"cleaned", "/tmp//sub/../a.png", "/tmp/a.png", true},
+		{"file url", "file:///tmp/a.png", "/tmp/a.png", true},
+		{"file url percent encoded", "file:///tmp/my%20shot.png", "/tmp/my shot.png", true},
+		{"file url localhost", "file://localhost/tmp/a.png", "/tmp/a.png", true},
+		{"home relative", "~/a.png", filepath.Join(home, "a.png"), true},
+		// A bare word in a pasted sentence must never look like a path.
+		{"relative rejected", "a.png", "", false},
+		{"word rejected", "please", "", false},
+		{"remote url rejected", "file://example.com/a.png", "", false},
+		{"empty rejected", "", "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := resolveDroppedPath(tt.token)
+			assert.Equal(t, tt.ok, ok)
+			if tt.ok {
+				assert.Equal(t, tt.want, got)
+			}
+		})
+	}
+}
+
+func TestInsertedRange(t *testing.T) {
+	// Typing one character at a time is never treated as an insertion.
+	_, _, ok := insertedRange("hello", "hello!")
+	assert.False(t, ok, "a single typed character is not a paste")
+
+	// Deletions and no-ops are ignored.
+	_, _, ok = insertedRange("hello", "hell")
+	assert.False(t, ok)
+	_, _, ok = insertedRange("hello", "hello")
+	assert.False(t, ok)
+
+	// A paste into an empty input covers the whole value.
+	start, end, ok := insertedRange("", "/tmp/a.png")
+	assert.True(t, ok)
+	assert.Equal(t, "/tmp/a.png", "/tmp/a.png"[start:end])
+
+	// A paste at the end of a draft isolates just the new run.
+	next := "look at /tmp/a.png"
+	start, end, ok = insertedRange("look at ", next)
+	assert.True(t, ok)
+	assert.Equal(t, "/tmp/a.png", next[start:end])
+
+	// A paste in the middle isolates just the new run.
+	next = "look at /tmp/a.png now"
+	start, end, ok = insertedRange("look at  now", next)
+	assert.True(t, ok)
+	assert.Equal(t, "/tmp/a.png", next[start:end])
+
+	// Multi-byte text on either side must not split a rune.
+	next = "héllo /tmp/a.png wörld"
+	start, end, ok = insertedRange("héllo  wörld", next)
+	assert.True(t, ok)
+	assert.Equal(t, "/tmp/a.png", next[start:end])
+}
+
+func TestHandleInputChange_CapturesDroppedImage(t *testing.T) {
+	a := newTestApp()
+	path := writeTempFile(t, "shot.png", pngBytes)
+
+	// A drop after some typed text: the terminal pastes the path.
+	a.setInputText("what is this ")
+	simulateInput(a, "what is this "+path)
+
+	assert.Equal(t, "what is this [Image #1] ", a.inputText)
+	assert.Len(t, a.attachments, 1)
+	assert.Equal(t, path, a.attachments[0].Path)
+	assert.Equal(t, "shot.png", a.attachments[0].Name)
+	assert.Equal(t, mediaKindImage, a.attachments[0].Kind)
+	assert.Equal(t, int64(len(pngBytes)), a.attachments[0].Size)
+}
+
+func TestHandleInputChange_CapturesEscapedAndQuotedPaths(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "my shot.png")
+	assert.NoError(t, os.WriteFile(path, pngBytes, 0o644))
+
+	for _, dropped := range []string{
+		strings.ReplaceAll(path, " ", `\ `),              // macOS Terminal / iTerm2
+		`'` + path + `'`,                                 // shells that quote instead
+		"file://" + strings.ReplaceAll(path, " ", "%20"), // file URL
+	} {
+		a := newTestApp()
+		simulateInput(a, dropped)
+		assert.Equal(t, "[Image #1] ", a.inputText, dropped)
+		assert.Len(t, a.attachments, 1, dropped)
+		assert.Equal(t, path, a.attachments[0].Path, dropped)
+	}
+}
+
+func TestHandleInputChange_MultipleFilesNumberedInOrder(t *testing.T) {
+	a := newTestApp()
+	dir := t.TempDir()
+	image := filepath.Join(dir, "shot.png")
+	doc := filepath.Join(dir, "paper.pdf")
+	assert.NoError(t, os.WriteFile(image, pngBytes, 0o644))
+	assert.NoError(t, os.WriteFile(doc, []byte("%PDF-1.4"), 0o644))
+
+	simulateInput(a, image+" "+doc+" ")
+
+	assert.Equal(t, "[Image #1] [Document #2] ", a.inputText)
+	assert.Len(t, a.attachments, 2)
+	assert.Equal(t, mediaKindImage, a.attachments[0].Kind)
+	assert.Equal(t, mediaKindDocument, a.attachments[1].Kind)
+}
+
+func TestHandleInputChange_NormalizesTerminalWhitespace(t *testing.T) {
+	path := writeTempFile(t, "shot.png", pngBytes)
+
+	// Terminals pad a drop with their own whitespace. Whatever they add, the
+	// placeholder ends up inline with the text and separated by single spaces
+	// rather than stranded on a line of its own.
+	for _, dropped := range []string{
+		"\n" + path,        // a leading newline
+		path + " ",         // a trailing space
+		"\n" + path + "\n", // both
+		"  " + path + "  ",
+	} {
+		a := newTestApp()
+		a.setInputText("what is this?")
+		simulateInput(a, "what is this?"+dropped)
+		assert.Equal(t, "what is this? [Image #1] ", a.inputText, dropped)
+	}
+
+	// A newline the user typed themselves is not part of the drop, so it stays.
+	a := newTestApp()
+	a.setInputText("what is this?\n")
+	simulateInput(a, "what is this?\n"+path)
+	assert.Equal(t, "what is this?\n[Image #1] ", a.inputText)
+}
+
+func TestHandleInputChange_TypingIsNotADrop(t *testing.T) {
+	a := newTestApp()
+	path := writeTempFile(t, "shot.png", pngBytes)
+
+	// Typing the same path character by character leaves it as text: only a
+	// contiguous multi-character insertion is treated as a paste.
+	for i := 1; i <= len(path); i++ {
+		simulateInput(a, path[:i])
+	}
+	assert.Equal(t, path, a.inputText)
+	assert.Empty(t, a.attachments)
+}
+
+func TestHandleInputChange_PastedProseIsNotADrop(t *testing.T) {
+	a := newTestApp()
+	path := writeTempFile(t, "shot.png", pngBytes)
+
+	// A pasted log or stack trace mentioning a real path must not become an
+	// attachment: only a run made up entirely of paths counts as a drop.
+	pasted := "panic: boom\n\tat " + path + ":42"
+	simulateInput(a, pasted)
+
+	assert.Equal(t, pasted, a.inputText)
+	assert.Empty(t, a.attachments)
+}
+
+func TestHandleInputChange_UnsupportedBinaryIsNotAttached(t *testing.T) {
+	a := newTestApp()
+	path := writeTempFile(t, "archive.bin", []byte{0x00, 0x01, 0x02, 0x00})
+
+	simulateInput(a, path)
+
+	assert.Equal(t, path, a.inputText, "the path stays in the message as text")
+	assert.Empty(t, a.attachments)
+}
+
+func TestHandleInputChange_TextFileIsAttached(t *testing.T) {
+	a := newTestApp()
+	path := writeTempFile(t, "notes.md", []byte("# Notes\n"))
+
+	simulateInput(a, path)
+
+	assert.Equal(t, "[File #1] ", a.inputText)
+	assert.Len(t, a.attachments, 1)
+	assert.Equal(t, mediaKindFile, a.attachments[0].Kind)
+}
+
+func TestPruneAttachments_DropsDeletedPlaceholders(t *testing.T) {
+	a := newTestApp()
+	path := writeTempFile(t, "shot.png", pngBytes)
+
+	simulateInput(a, path)
+	assert.Len(t, a.attachments, 1)
+
+	// Deleting the placeholder from the draft releases the attachment, and the
+	// numbering restarts so the next drop is "#1" again.
+	simulateInput(a, "")
+	assert.Empty(t, a.attachments)
+	assert.Equal(t, 0, a.attachSeq)
+}
+
+func TestTakeAttachments(t *testing.T) {
+	a := newTestApp()
+	dir := t.TempDir()
+	kept := filepath.Join(dir, "kept.png")
+	gone := filepath.Join(dir, "gone.png")
+	assert.NoError(t, os.WriteFile(kept, pngBytes, 0o644))
+	assert.NoError(t, os.WriteFile(gone, pngBytes, 0o644))
+
+	simulateInput(a, kept+" "+gone)
+	assert.Len(t, a.attachments, 2)
+
+	// Only the attachments the submitted text still refers to are sent.
+	taken := a.takeAttachments("[Image #1]")
+	assert.Len(t, taken, 1)
+	assert.Equal(t, kept, taken[0].Path)
+	assert.Empty(t, a.attachments)
+	assert.Equal(t, 0, a.attachSeq)
+}
+
+func TestSubmitInput_CapturesADropDeliveredWithEnter(t *testing.T) {
+	a := newTestApp()
+	path := writeTempFile(t, "shot.png", pngBytes)
+
+	// The input hands submitInput its own value. If the drop and Enter arrive
+	// in one batch the change hook hasn't run yet, so submit must fold it in
+	// rather than sending a raw path with no attachment. processing keeps the
+	// agent out of it; the draft is what's under test.
+	a.processing = true
+	a.submitInput(path)
+
+	assert.Equal(t, "[Image #1] ", a.inputText)
+	assert.Len(t, a.attachments, 1)
+	assert.Equal(t, path, a.attachments[0].Path)
+}
+
+func TestExpandAttachments_Image(t *testing.T) {
+	path := writeTempFile(t, "shot.png", pngBytes)
+	attachments := []attachment{{
+		Placeholder: "[Image #1]",
+		Path:        path,
+		Name:        "shot.png",
+		Kind:        mediaKindImage,
+	}}
+
+	text, blocks, err := expandAttachments("what is this [Image #1]", attachments)
+	assert.NoError(t, err)
+	assert.Equal(t, "what is this [image: "+path+"]", text)
+	assert.Len(t, blocks, 1)
+
+	image, ok := blocks[0].(*llm.ImageContent)
+	assert.True(t, ok, "expected an image content block")
+	assert.Equal(t, "image/png", image.Source.MediaType)
+	assert.Equal(t, llm.ContentSourceTypeBase64, image.Source.Type)
+	assert.NotEmpty(t, image.Source.Data)
+}
+
+func TestExpandAttachments_TextFileIsInlined(t *testing.T) {
+	path := writeTempFile(t, "notes.md", []byte("# Notes"))
+	attachments := []attachment{{
+		Placeholder: "[File #1]",
+		Path:        path,
+		Name:        "notes.md",
+		Kind:        mediaKindFile,
+	}}
+
+	text, blocks, err := expandAttachments("summarize [File #1]", attachments)
+	assert.NoError(t, err)
+	assert.Empty(t, blocks, "text files are inlined rather than sent as blocks")
+	assert.Contains(t, text, `<file path="`+path+`">`)
+	assert.Contains(t, text, "# Notes")
+}
+
+func TestExpandAttachments_MissingFileReportsError(t *testing.T) {
+	attachments := []attachment{{
+		Placeholder: "[Image #1]",
+		Path:        filepath.Join(t.TempDir(), "deleted.png"),
+		Name:        "deleted.png",
+		Kind:        mediaKindImage,
+	}}
+
+	// A file removed between the drop and the send leaves the path in the text
+	// rather than a dangling placeholder.
+	text, blocks, err := expandAttachments("look [Image #1]", attachments)
+	assert.Error(t, err)
+	assert.Empty(t, blocks)
+	assert.Contains(t, text, "deleted.png")
+	assert.NotContains(t, text, "[Image #1]")
+}
+
+func TestAttachmentsView(t *testing.T) {
+	a := newTestApp()
+	assert.Nil(t, a.attachmentsView(), "no view when nothing is attached")
+
+	path := writeTempFile(t, "shot.png", pngBytes)
+	simulateInput(a, path)
+
+	// The name and size, but not the placeholder, which is already in the input.
+	rendered := tui.Sprint(a.attachmentsView())
+	assert.Contains(t, rendered, "shot.png")
+	assert.Contains(t, rendered, formatBytes(len(pngBytes)))
+	assert.NotContains(t, rendered, "[Image #1]")
+}
+
+func TestLooksLikeText(t *testing.T) {
+	assert.True(t, looksLikeText(writeTempFile(t, "a.txt", []byte("hello"))))
+	assert.True(t, looksLikeText(writeTempFile(t, "empty.txt", nil)))
+	assert.True(t, looksLikeText(writeTempFile(t, "utf8.txt", []byte("héllo wörld"))))
+	assert.False(t, looksLikeText(writeTempFile(t, "bin", []byte{0x7f, 0x45, 0x00, 0x01})))
+	assert.False(t, looksLikeText(filepath.Join(t.TempDir(), "missing")))
+}

--- a/experimental/compaction/compaction.go
+++ b/experimental/compaction/compaction.go
@@ -21,6 +21,7 @@ package compaction
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -345,12 +346,63 @@ func filterPendingToolUse(messages []*llm.Message) []*llm.Message {
 	return result
 }
 
-// estimateTokens approximates a message's token footprint from its serialized
-// JSON size (~4 bytes per token). Marshaling the whole message counts tool
-// inputs and results — often the largest payloads — which Message.Text (text
-// content only) would miss. Best effort: a marshal error yields 0.
+// Token cost of embedded media, which is not proportional to its byte size.
+const (
+	// base64ImageTokens is roughly what one image costs on the major providers
+	// — on the order of a thousand tokens however many megabytes the base64
+	// encoding runs to (Anthropic tops out near 1600 for a full-size image,
+	// OpenAI near 1100, Gemini lower still). This is the high end, so the
+	// estimate errs toward compacting early rather than overflowing.
+	base64ImageTokens = 1600
+
+	// base64DocumentBytesPerToken approximates a PDF or video from its decoded
+	// size. Providers bill a document per page — its text plus a rendered image
+	// of the page — which lands near 2k tokens for every ~50 KB of PDF. Crude,
+	// but within an order of magnitude, which byte-count sizing is not.
+	base64DocumentBytesPerToken = 25
+)
+
+// estimateTokens approximates a message's token footprint. Text, tool inputs,
+// and tool results are sized from their serialized JSON (~4 bytes per token);
+// counting the serialization rather than Message.Text is what catches tool
+// payloads, often the largest part of a turn.
+//
+// Base64 media is sized separately, because its token cost has almost nothing
+// to do with its encoded length: a 1.4 MB screenshot serializes to ~1.9 MB of
+// base64 but costs ~1.6k tokens. Charging it 4 bytes per token would call that
+// half a million, enough for a single attached image to look like a full
+// context window and trigger a compaction that summarizes the conversation away.
+//
+// Best effort throughout: a marshal error yields 0.
 func estimateTokens(m *llm.Message) int {
-	return messageBytes(m) / 4
+	total := 0
+	for _, content := range m.Content {
+		total += estimateContentTokens(content)
+	}
+	return total
+}
+
+// estimateContentTokens approximates one content block's token footprint.
+func estimateContentTokens(c llm.Content) int {
+	switch cc := c.(type) {
+	case *llm.ImageContent:
+		if isBase64Source(cc.Source) {
+			return base64ImageTokens
+		}
+	case *llm.DocumentContent:
+		if isBase64Source(cc.Source) {
+			decoded := base64.StdEncoding.DecodedLen(len(cc.Source.Data))
+			if tokens := decoded / base64DocumentBytesPerToken; tokens > base64ImageTokens {
+				return tokens
+			}
+			return base64ImageTokens
+		}
+	}
+	return contentBytes(c) / 4
+}
+
+func isBase64Source(s *llm.ContentSource) bool {
+	return s != nil && s.Type == llm.ContentSourceTypeBase64 && s.Data != ""
 }
 
 func messageBytes(m *llm.Message) int {

--- a/experimental/compaction/compaction_test.go
+++ b/experimental/compaction/compaction_test.go
@@ -317,6 +317,58 @@ func totalTokens(msgs []*llm.Message) int {
 	return total
 }
 
+func TestEstimateTokensSizesMediaByCostNotBytes(t *testing.T) {
+	// A 1.4 MB screenshot, the size a drag-and-drop attachment routinely is.
+	screenshot := &llm.Message{Role: llm.User, Content: []llm.Content{
+		&llm.TextContent{Text: "what does this image say?"},
+		&llm.ImageContent{Source: &llm.ContentSource{
+			Type:      llm.ContentSourceTypeBase64,
+			MediaType: "image/png",
+			Data:      strings.Repeat("A", 1_900_000),
+		}},
+	}}
+
+	got := estimateTokens(screenshot)
+
+	// Sizing the base64 at 4 bytes per token would call this ~475k — enough to
+	// blow past any compaction threshold and summarize the conversation away
+	// the moment an image is attached.
+	assert.True(t, got < 2_500, "one image should not read as a full context window, got %d", got)
+	assert.True(t, got >= base64ImageTokens, "the image still has to be counted, got %d", got)
+
+	// A URL source carries no payload, so it stays on the serialized-size path.
+	linked := &llm.Message{Role: llm.User, Content: []llm.Content{
+		&llm.ImageContent{Source: &llm.ContentSource{
+			Type: llm.ContentSourceTypeURL,
+			URL:  "https://example.com/a.png",
+		}},
+	}}
+	assert.True(t, estimateTokens(linked) < base64ImageTokens)
+
+	// Text and tool payloads keep their serialized-size estimate.
+	text := llm.NewUserTextMessage(strings.Repeat("x", 4_000))
+	assert.True(t, estimateTokens(text) >= 1_000, "text is still ~4 bytes per token")
+}
+
+func TestEstimateTokensSizesDocumentsByDecodedLength(t *testing.T) {
+	doc := func(base64Len int) *llm.Message {
+		return &llm.Message{Role: llm.User, Content: []llm.Content{
+			&llm.DocumentContent{Source: &llm.ContentSource{
+				Type:      llm.ContentSourceTypeBase64,
+				MediaType: "application/pdf",
+				Data:      strings.Repeat("A", base64Len),
+			}},
+		}}
+	}
+
+	// A big PDF costs more than a small one, but nothing like its byte count.
+	small := estimateTokens(doc(20_000))
+	large := estimateTokens(doc(2_000_000))
+	assert.True(t, large > small, "a longer document should cost more")
+	assert.True(t, small >= base64ImageTokens, "a short document still costs at least a page")
+	assert.True(t, large < 2_000_000/4, "a document must not be sized as if it were text")
+}
+
 func TestReduceToSummaryBudget(t *testing.T) {
 	bigText := strings.Repeat("x", 200_000) // ~50k tokens
 
@@ -367,21 +419,41 @@ func TestReduceToSummaryBudget(t *testing.T) {
 }
 
 func TestReduceToSummaryBudgetCullsUntruncatableContent(t *testing.T) {
-	t.Run("culls a large image to a placeholder", func(t *testing.T) {
+	t.Run("culls an image that does not fit the budget", func(t *testing.T) {
 		image := &llm.Message{Role: llm.User, Content: []llm.Content{
 			&llm.ImageContent{Source: &llm.ContentSource{
 				Type:      llm.ContentSourceTypeBase64,
 				MediaType: "image/png",
-				Data:      strings.Repeat("A", 400_000), // ~100k tokens of base64
+				Data:      strings.Repeat("A", 400_000),
 			}},
 		}}
-		out := reduceToSummaryBudget([]*llm.Message{image}, 2_000)
+		// An image costs base64ImageTokens however long its encoding is, so the
+		// budget has to be under that for culling to be the right call.
+		out := reduceToSummaryBudget([]*llm.Message{image}, base64ImageTokens/2)
 
 		assert.Equal(t, 1, len(out)) // not dropped
 		txt, isText := out[0].Content[0].(*llm.TextContent)
 		assert.True(t, isText) // image culled to a text placeholder
 		assert.True(t, strings.Contains(txt.Text, "image content omitted"))
-		assert.True(t, totalTokens(out) <= 2_000)
+		assert.True(t, totalTokens(out) <= base64ImageTokens/2)
+	})
+
+	t.Run("keeps an image that fits the budget", func(t *testing.T) {
+		// The same megabytes of base64, but a budget that accommodates what the
+		// image actually costs: it must survive intact. Sizing media by encoded
+		// bytes instead would read as ~100k tokens and cull it every time.
+		image := &llm.Message{Role: llm.User, Content: []llm.Content{
+			&llm.ImageContent{Source: &llm.ContentSource{
+				Type:      llm.ContentSourceTypeBase64,
+				MediaType: "image/png",
+				Data:      strings.Repeat("A", 400_000),
+			}},
+		}}
+		out := reduceToSummaryBudget([]*llm.Message{image}, 10_000)
+
+		assert.Equal(t, 1, len(out))
+		_, isImage := out[0].Content[0].(*llm.ImageContent)
+		assert.True(t, isImage, "an image within budget should not be culled")
 	})
 
 	t.Run("culls an oversized tool_use input but keeps the block paired", func(t *testing.T) {

--- a/experimental/compaction/mid_turn_test.go
+++ b/experimental/compaction/mid_turn_test.go
@@ -66,3 +66,27 @@ func TestMidTurnCompactionHook(t *testing.T) {
 		assert.Equal(t, 0, stub.sawMessages)
 	})
 }
+
+func TestMidTurnCompactionIgnoresAttachedImageBytes(t *testing.T) {
+	// The regression: attaching an image used to push the working set past the
+	// threshold on the first iteration, compacting a two-message conversation.
+	stub := &stubLLM{}
+	hook := MidTurnCompactionHook(stub, DefaultContextTokenThreshold)
+
+	hctx := dive.NewHookContext()
+	hctx.Messages = []*llm.Message{
+		{Role: llm.User, Content: []llm.Content{
+			&llm.TextContent{Text: "what does this image say?"},
+			&llm.ImageContent{Source: &llm.ContentSource{
+				Type:      llm.ContentSourceTypeBase64,
+				MediaType: "image/png",
+				Data:      strings.Repeat("A", 1_900_000),
+			}},
+		}},
+		llm.NewAssistantTextMessage("It says: Early Warning Signs of Fascism"),
+	}
+
+	assert.NoError(t, hook(context.Background(), hctx))
+	assert.Equal(t, 2, len(hctx.Messages), "an attached image must not trigger compaction")
+	assert.Equal(t, 0, stub.sawMessages, "the summarizer should never have been called")
+}


### PR DESCRIPTION
Dropping a file onto a terminal makes it paste that file's path. The interactive CLI now recognizes those insertions and turns them into attachments — images, PDFs, and videos as native content blocks, text files inlined the way an `@reference` is.

```
 ⏺ my shot.png (1.4 MB)
 ❯  what does this image say? [Image #1]
```

## Detecting a drop without eating prose

The input is also where people paste logs and stack traces, so detection is deliberately narrow. The change hook diffs the previous draft against the new one to isolate the single contiguous run an edit inserted, and treats that run as a drop **only when it consists of nothing but paths to files that exist**. Two consequences worth stating:

- Typing a path character by character never attaches it — a single character is not an insertion.
- Pasting a panic trace that mentions absolute `.go` paths never attaches them — the run has non-path tokens in it.

Path parsing covers what terminals actually emit: backslash-escaped spaces (macOS Terminal, iTerm2), single and double quotes, `file://` URLs with percent-encoding, `~`, and multi-file drops. A backslash escapes only what a terminal would actually escape, so a Windows separator stays literal.

## Behavior

Each recognized file becomes a placeholder (`[Image #1]`) listed under the input divider. Deleting the placeholder releases the attachment, and only the ones the submitted text still refers to are sent. Files are read at send time rather than drop time, so a large attachment never blocks the event loop.

Unlike an `@reference`, a dropped file may live anywhere on disk — dragging it onto the input is the user pointing at that exact file, so the workspace boundary doesn't apply. Unsupported or oversized files leave their path in the message as text with a one-line reason.

Whitespace a terminal wraps a drop in is discarded: a recognized run is rebuilt from the placeholders alone with single spaces bridging to the surrounding text. Without this, a terminal's leading newline strands the placeholder on its own line. A newline the user typed isn't part of the inserted run and survives.

## The compaction bug this surfaced

Second commit, and the more consequential half. `compaction.estimateTokens` sized every message as `json.Marshal(msg) / 4` — right for text and tool payloads, wrong by two orders of magnitude for embedded media. A 1.4 MB screenshot serializes to ~1.9 MB of base64 and so read as **~475k tokens** against a 100k default threshold:

```
⚡ Context compacted mid-turn: ~491256 → ~474 tokens (3 messages summarized)
```

Attaching one image tripped mid-turn compaction on the first iteration of the first turn, summarizing a two-message conversation — and the image itself — away. This is pre-existing; `@image.png` hit it too. Drag-and-drop just made it trivially reachable.

Media is now sized by what it costs: a flat ~1600 tokens per base64 image (the high end across providers) and documents from their decoded length at roughly a page per 50 KB. Both err high, so the estimate compacts early rather than overflowing. Text and tool payloads keep the serialized-size estimate.

This also corrects `reduceToSummaryBudget`, which was culling any attached image out of the summarizer transcript regardless of remaining budget.

**One test changed meaning, not just numbers.** `culls a large image to a placeholder` asserted a 400 KB base64 image gets culled at a 2000-token budget; under correct accounting that image fits. It's split into the two cases that are now distinguishable — culled when the budget is genuinely below what an image costs, kept when it isn't.

`HookWithModel` is left alone: it estimates from `Message.Text`, ignoring media and tool payloads alike, which under-counts rather than over-counts and so fails safe. Changing it would make compaction fire earlier for existing callers — worth doing deliberately, not as a side effect.

## Verification

- 18 new tests across tokenizing, path resolution, insertion diffing (including multi-byte), capture, pruning, expansion, whitespace normalization, and the estimator.
- Smoke-tested in a real pty by emitting bracketed-paste sequences. The pre-fix binary reproduced the stranded-placeholder bug; the post-fix binary produces the output at the top.
- `go build ./...`, `go vet`, and `go test ./...` clean for both modules. Each commit builds and tests standalone.
- Pre-existing `providers/anthropic` live tests fail on HTTP 401 without a valid key; untouched by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added terminal drag-and-drop and paste support for file attachments.
  * Displays attached file previews, names, and sizes in the input area.
  * Supports images, documents, videos, and text files in messages and commands.
  * Added guidance for attaching files in the help text.

* **Bug Fixes**
  * Improved context-size estimation for images and documents.
  * Prevents attached image data from triggering unnecessary mid-turn compaction.

* **Tests**
  * Added comprehensive coverage for attachment handling, file expansion, rendering, and media-aware compaction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->