### PR TITLE
Prepare v1.18.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,69 +11,42 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 ### Added
 
 - **Dragged-in files as CLI attachments** — dropping a file onto the terminal
-  pastes its path; the interactive CLI now recognizes those insertions and
-  turns them into attachments. Images, PDFs, and videos become native content
-  blocks and text files are inlined the way an `@reference` is. Detection is
-  deliberately narrow: an inserted run counts as a drop only when it consists
-  entirely of paths to files that exist, so typing and pasted logs that merely
-  mention absolute paths can't trigger it. Path parsing covers what terminals
-  actually emit (backslash-escaped spaces, quotes, `file://` URLs with
-  percent-encoding, `~`, multi-file drops). Each file is replaced with a
-  placeholder (`[Image #1]`) listed under the input divider; deleting the
-  placeholder releases the attachment, files are read at send time rather than
-  drop time, and unsupported or oversized files leave their path as text with a
-  one-line reason.
-- **Multimodal input support matrix** in the LLM guide, documenting which
-  content types each provider accepts.
+  pastes its path, and the interactive CLI now turns those insertions into
+  attachments: images, PDFs, and videos become native content blocks, text
+  files are inlined like an `@reference`. Each file is replaced with a
+  placeholder (`[Image #1]`) that releases the attachment when deleted.
+  Detection is narrow — an inserted run counts as a drop only when it is
+  entirely paths to files that exist — so typing and pasted logs can't trigger
+  it.
+- **Multimodal input support matrix** in the LLM guide.
 
 ### Fixed
 
 - **Caller-supplied media across providers** — images and documents were
-  failing or silently dropping in several provider encoders. Google now encodes
-  `DocumentContent` (base64 as inline bytes, URL as file URI, text inline)
-  instead of dropping it silently, and its content switch ends in a default
-  error so no future content type falls through unnoticed. OpenAI (Responses)
-  now passes URL-source documents through as `file_url` and inlines
-  text-source documents rather than erroring. The openaicompletions encoder —
-  and therefore Mistral and OpenRouter, which embed it — was text-only, so no
-  Chat Completions endpoint could receive images or PDFs; messages now support
-  a content-part array (still marshaled as a plain string when there are no
-  parts, so existing requests are byte-compatible), and assistant tool-call
-  messages keep all their text blocks instead of only the last one.
+  failing or silently dropping in several encoders. Google now encodes
+  `DocumentContent` instead of dropping it, and its content switch errors by
+  default so nothing falls through unnoticed. OpenAI (Responses) accepts
+  URL-source and text-source documents. The openaicompletions encoder was
+  text-only, so no Chat Completions endpoint could receive images or PDFs; it
+  now supports content parts, which also covers Mistral and OpenRouter.
 - **Typed blocks in tool results** (e.g. MCP tools returning screenshots) —
-  Anthropic marshaled image blocks in Dive's flat shape, which is not valid
-  Anthropic wire format; they are now converted to native image blocks with a
-  base64 source, with the media type auto-detected when missing. OpenAI
-  (Responses) JSON-marshaled typed text blocks into the output string; text is
-  now flattened and results containing images are emitted as a
-  `function_call_output` content-part list so the model can see them.
-  Google and openaicompletions dropped non-text blocks silently and now render
-  an explicit placeholder. A new shared `providers.ToolResultBlocks` helper
-  decodes typed blocks in both their in-memory and JSON-round-tripped shapes,
-  including hand-built blocks that carry no explicit type.
-- **Empty and nil tool results** — a tool that returned no output reached the
-  wire as `"content":[]` on Anthropic (which rejects it) or an empty output
-  string on OpenAI, telling the model nothing about whether the call ran. All
-  four providers now substitute a shared `providers.EmptyToolResultText`
-  placeholder, covering the typed-empty, zero-block, and post-round-trip
-  shapes. A nil `ToolResult` supplied on resume — previously `"content":null`
-  on Anthropic, the literal string `"null"` on Google, and a hard error on the
-  chat completions path — is treated the same way. Empty strings are left
+  Anthropic emitted image blocks in a shape it does not accept, and OpenAI
+  (Responses) JSON-marshaled typed text into the output string; both now encode
+  natively. Google and openaicompletions render an explicit placeholder instead
+  of dropping non-text blocks. Adds a shared `providers.ToolResultBlocks`
+  helper for decoding typed blocks in both in-memory and round-tripped shapes.
+- **Empty and nil tool results** — a tool returning no output reached the wire
+  as `"content":[]` on Anthropic (rejected), `"null"` on Google, or a hard
+  error on the chat completions path. All four providers now substitute a
+  shared `providers.EmptyToolResultText` placeholder. Empty strings are left
   alone, since a caller chose that value explicitly.
 - **Media sizing during compaction** (experimental) — `estimateTokens` sized
-  every message as its serialized JSON over four, which over-counts embedded
-  media by two orders of magnitude: a 1.4 MB screenshot read as ~475k tokens
-  against a 100k default threshold, so attaching a single image tripped
-  mid-turn compaction on the first iteration of the first turn and summarized
-  the image away. Media is now sized by what it actually costs — a flat ~1600
-  tokens per base64 image and roughly a page per 50 KB for documents, both
-  erring high — while text, tool inputs, and tool results keep the
-  serialized-size estimate. This also corrects `reduceToSummaryBudget`, which
-  culled attached images from the summarizer transcript regardless of remaining
-  budget.
+  media by serialized JSON, over-counting by two orders of magnitude, so a
+  single attached image tripped mid-turn compaction on the first turn and
+  summarized itself away. Media is now sized by actual cost. Also fixes
+  `reduceToSummaryBudget` culling attached images regardless of budget.
 - **Video content labeling** — videos passed as `@references` were labeled
-  `[document: ...]` in the prompt; the media-block builder is now shared
-  between references and attachments and labels them correctly.
+  `[document: ...]` in the prompt.
 
 ## [1.17.0] - 2026-07-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,75 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [1.18.0] - 2026-07-22
+
+### Added
+
+- **Dragged-in files as CLI attachments** — dropping a file onto the terminal
+  pastes its path; the interactive CLI now recognizes those insertions and
+  turns them into attachments. Images, PDFs, and videos become native content
+  blocks and text files are inlined the way an `@reference` is. Detection is
+  deliberately narrow: an inserted run counts as a drop only when it consists
+  entirely of paths to files that exist, so typing and pasted logs that merely
+  mention absolute paths can't trigger it. Path parsing covers what terminals
+  actually emit (backslash-escaped spaces, quotes, `file://` URLs with
+  percent-encoding, `~`, multi-file drops). Each file is replaced with a
+  placeholder (`[Image #1]`) listed under the input divider; deleting the
+  placeholder releases the attachment, files are read at send time rather than
+  drop time, and unsupported or oversized files leave their path as text with a
+  one-line reason.
+- **Multimodal input support matrix** in the LLM guide, documenting which
+  content types each provider accepts.
+
+### Fixed
+
+- **Caller-supplied media across providers** — images and documents were
+  failing or silently dropping in several provider encoders. Google now encodes
+  `DocumentContent` (base64 as inline bytes, URL as file URI, text inline)
+  instead of dropping it silently, and its content switch ends in a default
+  error so no future content type falls through unnoticed. OpenAI (Responses)
+  now passes URL-source documents through as `file_url` and inlines
+  text-source documents rather than erroring. The openaicompletions encoder —
+  and therefore Mistral and OpenRouter, which embed it — was text-only, so no
+  Chat Completions endpoint could receive images or PDFs; messages now support
+  a content-part array (still marshaled as a plain string when there are no
+  parts, so existing requests are byte-compatible), and assistant tool-call
+  messages keep all their text blocks instead of only the last one.
+- **Typed blocks in tool results** (e.g. MCP tools returning screenshots) —
+  Anthropic marshaled image blocks in Dive's flat shape, which is not valid
+  Anthropic wire format; they are now converted to native image blocks with a
+  base64 source, with the media type auto-detected when missing. OpenAI
+  (Responses) JSON-marshaled typed text blocks into the output string; text is
+  now flattened and results containing images are emitted as a
+  `function_call_output` content-part list so the model can see them.
+  Google and openaicompletions dropped non-text blocks silently and now render
+  an explicit placeholder. A new shared `providers.ToolResultBlocks` helper
+  decodes typed blocks in both their in-memory and JSON-round-tripped shapes,
+  including hand-built blocks that carry no explicit type.
+- **Empty and nil tool results** — a tool that returned no output reached the
+  wire as `"content":[]` on Anthropic (which rejects it) or an empty output
+  string on OpenAI, telling the model nothing about whether the call ran. All
+  four providers now substitute a shared `providers.EmptyToolResultText`
+  placeholder, covering the typed-empty, zero-block, and post-round-trip
+  shapes. A nil `ToolResult` supplied on resume — previously `"content":null`
+  on Anthropic, the literal string `"null"` on Google, and a hard error on the
+  chat completions path — is treated the same way. Empty strings are left
+  alone, since a caller chose that value explicitly.
+- **Media sizing during compaction** (experimental) — `estimateTokens` sized
+  every message as its serialized JSON over four, which over-counts embedded
+  media by two orders of magnitude: a 1.4 MB screenshot read as ~475k tokens
+  against a 100k default threshold, so attaching a single image tripped
+  mid-turn compaction on the first iteration of the first turn and summarized
+  the image away. Media is now sized by what it actually costs — a flat ~1600
+  tokens per base64 image and roughly a page per 50 KB for documents, both
+  erring high — while text, tool inputs, and tool results keep the
+  serialized-size estimate. This also corrects `reduceToSummaryBudget`, which
+  culled attached images from the summarizer transcript regardless of remaining
+  budget.
+- **Video content labeling** — videos passed as `@references` were labeled
+  `[document: ...]` in the prompt; the media-block builder is now shared
+  between references and attachments and labels them correctly.
+
 ## [1.17.0] - 2026-07-21
 
 ### Added

--- a/a2a/go.mod
+++ b/a2a/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/a2aproject/a2a-go/v2 v2.2.0
-	github.com/deepnoodle-ai/dive v1.17.0
+	github.com/deepnoodle-ai/dive v1.18.0
 	github.com/deepnoodle-ai/wonton v0.0.36
 )
 

--- a/demos/colosseum/go.mod
+++ b/demos/colosseum/go.mod
@@ -3,11 +3,11 @@ module github.com/deepnoodle-ai/dive/demos/colosseum
 go 1.25.0
 
 require (
-	github.com/deepnoodle-ai/dive v1.17.0
-	github.com/deepnoodle-ai/dive/a2a v1.17.0
-	github.com/deepnoodle-ai/dive/providers/google v1.17.0
-	github.com/deepnoodle-ai/dive/providers/grok v1.17.0
-	github.com/deepnoodle-ai/dive/providers/openai v1.17.0
+	github.com/deepnoodle-ai/dive v1.18.0
+	github.com/deepnoodle-ai/dive/a2a v1.18.0
+	github.com/deepnoodle-ai/dive/providers/google v1.18.0
+	github.com/deepnoodle-ai/dive/providers/grok v1.18.0
+	github.com/deepnoodle-ai/dive/providers/openai v1.18.0
 	github.com/deepnoodle-ai/wonton v0.0.36
 )
 

--- a/demos/noodleville/go.mod
+++ b/demos/noodleville/go.mod
@@ -3,7 +3,7 @@ module github.com/deepnoodle-ai/dive/demos/noodleville
 go 1.25.0
 
 require (
-	github.com/deepnoodle-ai/dive v1.17.0
+	github.com/deepnoodle-ai/dive v1.18.0
 	github.com/deepnoodle-ai/wonton v0.0.36
 )
 

--- a/examples/go.mod
+++ b/examples/go.mod
@@ -3,13 +3,13 @@ module github.com/deepnoodle-ai/dive/examples
 go 1.25.0
 
 require (
-	github.com/deepnoodle-ai/dive v1.17.0
-	github.com/deepnoodle-ai/dive/a2a v1.17.0
-	github.com/deepnoodle-ai/dive/experimental/mcp v1.17.0
-	github.com/deepnoodle-ai/dive/otel v1.17.0
-	github.com/deepnoodle-ai/dive/providers/google v1.17.0
-	github.com/deepnoodle-ai/dive/providers/grok v1.17.0
-	github.com/deepnoodle-ai/dive/providers/openai v1.17.0
+	github.com/deepnoodle-ai/dive v1.18.0
+	github.com/deepnoodle-ai/dive/a2a v1.18.0
+	github.com/deepnoodle-ai/dive/experimental/mcp v1.18.0
+	github.com/deepnoodle-ai/dive/otel v1.18.0
+	github.com/deepnoodle-ai/dive/providers/google v1.18.0
+	github.com/deepnoodle-ai/dive/providers/grok v1.18.0
+	github.com/deepnoodle-ai/dive/providers/openai v1.18.0
 	github.com/deepnoodle-ai/wonton v0.0.36
 	github.com/fatih/color v1.18.0
 	github.com/mark3labs/mcp-go v0.45.0

--- a/experimental/cmd/dive/go.mod
+++ b/experimental/cmd/dive/go.mod
@@ -3,10 +3,10 @@ module github.com/deepnoodle-ai/dive/experimental/cmd/dive
 go 1.25.0
 
 require (
-	github.com/deepnoodle-ai/dive v1.17.0
-	github.com/deepnoodle-ai/dive/providers/google v1.17.0
-	github.com/deepnoodle-ai/dive/providers/grok v1.17.0
-	github.com/deepnoodle-ai/dive/providers/openai v1.17.0
+	github.com/deepnoodle-ai/dive v1.18.0
+	github.com/deepnoodle-ai/dive/providers/google v1.18.0
+	github.com/deepnoodle-ai/dive/providers/grok v1.18.0
+	github.com/deepnoodle-ai/dive/providers/openai v1.18.0
 	github.com/deepnoodle-ai/wonton v0.0.36
 	github.com/mattn/go-runewidth v0.0.21
 )

--- a/experimental/mcp/go.mod
+++ b/experimental/mcp/go.mod
@@ -3,7 +3,7 @@ module github.com/deepnoodle-ai/dive/experimental/mcp
 go 1.25.0
 
 require (
-	github.com/deepnoodle-ai/dive v1.17.0
+	github.com/deepnoodle-ai/dive v1.18.0
 	github.com/deepnoodle-ai/wonton v0.0.36
 	github.com/mark3labs/mcp-go v0.45.0
 )

--- a/otel/go.mod
+++ b/otel/go.mod
@@ -3,7 +3,7 @@ module github.com/deepnoodle-ai/dive/otel
 go 1.25.0
 
 require (
-	github.com/deepnoodle-ai/dive v1.17.0
+	github.com/deepnoodle-ai/dive v1.18.0
 	go.opentelemetry.io/otel v1.43.0
 	go.opentelemetry.io/otel/metric v1.43.0
 	go.opentelemetry.io/otel/sdk v1.43.0

--- a/providers/google/go.mod
+++ b/providers/google/go.mod
@@ -3,7 +3,7 @@ module github.com/deepnoodle-ai/dive/providers/google
 go 1.25.0
 
 require (
-	github.com/deepnoodle-ai/dive v1.17.0
+	github.com/deepnoodle-ai/dive v1.18.0
 	github.com/deepnoodle-ai/wonton v0.0.36
 	google.golang.org/genai v1.51.0
 )

--- a/providers/grok/go.mod
+++ b/providers/grok/go.mod
@@ -3,8 +3,8 @@ module github.com/deepnoodle-ai/dive/providers/grok
 go 1.25.0
 
 require (
-	github.com/deepnoodle-ai/dive v1.17.0
-	github.com/deepnoodle-ai/dive/providers/openai v1.17.0
+	github.com/deepnoodle-ai/dive v1.18.0
+	github.com/deepnoodle-ai/dive/providers/openai v1.18.0
 	github.com/deepnoodle-ai/wonton v0.0.36
 	github.com/openai/openai-go/v3 v3.41.2-0.20260709175524-86bbd3d91826
 	golang.org/x/image v0.41.0

--- a/providers/openai/go.mod
+++ b/providers/openai/go.mod
@@ -3,7 +3,7 @@ module github.com/deepnoodle-ai/dive/providers/openai
 go 1.25.0
 
 require (
-	github.com/deepnoodle-ai/dive v1.17.0
+	github.com/deepnoodle-ai/dive v1.18.0
 	github.com/deepnoodle-ai/wonton v0.0.36
 	github.com/openai/openai-go/v3 v3.41.2-0.20260709175524-86bbd3d91826
 	golang.org/x/image v0.41.0


### PR DESCRIPTION
Release prep for v1.18.0.

## Changes

- **CHANGELOG**: cut the `1.18.0` heading covering everything merged since v1.17.0:
  - Dragged-in files as CLI attachments (#236) — plus the multimodal support matrix added in #235
  - Caller-supplied media gaps across the Google, OpenAI Responses, and openaicompletions encoders (#235)
  - Typed blocks and empty/nil tool results across all four providers (#235)
  - Media token sizing during compaction, and the video-labeling fix, both from #236
- **Module versions**: bump internal `github.com/deepnoodle-ai/dive*` requires from `v1.17.0` to `v1.18.0` across all submodules.

## Verification

- `go build ./...` and `go vet ./...` clean
- `go test ./...` passes except the live `providers/anthropic` tests, which fail on a 401 (no valid API key in this environment) — unrelated to these changes
- `prettier --check CHANGELOG.md` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Drag files into the CLI terminal to create attachments, with clear placeholders and send-time file loading.
  * Added a multimodal input support matrix to the language model guide.

* **Bug Fixes**
  * Improved media and document handling across providers.
  * Corrected typed tool results, including image content and serialization.
  * Standardized empty tool-result behavior.
  * Improved token estimates during message compaction.
  * Corrected video labels for referenced media.

* **Documentation**
  * Added release notes for version 1.18.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->