### PR TITLE
Surface raw error body for OpenAI-compatible provider errors

### DIFF
--- a/providers/openai/errors.go
+++ b/providers/openai/errors.go
@@ -2,6 +2,8 @@ package openai
 
 import (
 	"errors"
+	"strconv"
+	"strings"
 
 	"github.com/deepnoodle-ai/dive/providers"
 	openaisdk "github.com/openai/openai-go/v3"
@@ -10,7 +12,25 @@ import (
 func normalizeOpenAIError(err error) error {
 	var apiErr *openaisdk.Error
 	if errors.As(err, &apiErr) {
-		return providers.NewError(apiErr.StatusCode, apiErr.Message)
+		return providers.NewError(apiErr.StatusCode, apiErrorMessage(apiErr))
 	}
 	return err
+}
+
+// apiErrorMessage extracts a human-readable message from an SDK API error. The
+// SDK parses Message out of the standard OpenAI shape {"error":{"message":...}},
+// but OpenAI-compatible providers (e.g. xAI/Grok) return other shapes — such as
+// {"code":"permission-denied","error":"<message>"} where "error" is a bare
+// string. In those cases Message is empty, so fall back to the raw error payload
+// the SDK captured, unquoting it when it is a JSON string, so the underlying
+// reason (auth, credits, rate limits) is still surfaced instead of a blank body.
+func apiErrorMessage(apiErr *openaisdk.Error) string {
+	if apiErr.Message != "" {
+		return apiErr.Message
+	}
+	raw := strings.TrimSpace(apiErr.RawJSON())
+	if unquoted, err := strconv.Unquote(raw); err == nil {
+		raw = unquoted
+	}
+	return raw
 }

--- a/providers/openai/errors_test.go
+++ b/providers/openai/errors_test.go
@@ -1,0 +1,54 @@
+package openai
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/deepnoodle-ai/dive/providers"
+	"github.com/deepnoodle-ai/wonton/assert"
+	openaisdk "github.com/openai/openai-go/v3"
+)
+
+// newAPIError builds an SDK error the way the SDK does: it extracts the "error"
+// subtree from the response body and unmarshals that into the Error type.
+func newAPIError(t *testing.T, statusCode int, errSubtree string) *openaisdk.Error {
+	t.Helper()
+	var e openaisdk.Error
+	err := e.UnmarshalJSON([]byte(errSubtree))
+	assert.NoError(t, err)
+	e.StatusCode = statusCode
+	return &e
+}
+
+func TestNormalizeOpenAIError_StandardMessage(t *testing.T) {
+	// Standard OpenAI shape: {"error":{"message":"...","type":"..."}}.
+	apiErr := newAPIError(t, 400, `{"message":"invalid model","type":"invalid_request_error"}`)
+
+	got := normalizeOpenAIError(apiErr)
+
+	var provErr *providers.ProviderError
+	assert.True(t, errors.As(got, &provErr))
+	assert.Equal(t, 400, provErr.StatusCode())
+	assert.Contains(t, provErr.Error(), "invalid model")
+}
+
+func TestNormalizeOpenAIError_StringErrorFallback(t *testing.T) {
+	// xAI/Grok shape: {"code":"permission-denied","error":"<string>"}. The SDK
+	// hands UnmarshalJSON the bare "error" string, leaving Message empty. The
+	// message must still surface via the RawJSON fallback (unquoted).
+	msg := "Your team has either used all available credits or reached its monthly spending limit."
+	apiErr := newAPIError(t, 403, `"`+msg+`"`)
+	assert.Equal(t, "", apiErr.Message) // precondition: Message really is empty
+
+	got := normalizeOpenAIError(apiErr)
+
+	var provErr *providers.ProviderError
+	assert.True(t, errors.As(got, &provErr))
+	assert.Equal(t, 403, provErr.StatusCode())
+	assert.Contains(t, provErr.Error(), msg)
+}
+
+func TestNormalizeOpenAIError_NonAPIErrorPassthrough(t *testing.T) {
+	orig := errors.New("connection refused")
+	assert.Equal(t, orig, normalizeOpenAIError(orig))
+}


### PR DESCRIPTION
## Problem

Running a Grok model with an xAI account that's out of credits produced an
opaque error:

```
Error: agent error: retry failed after 1 attempts: provider api error (status 403):
```

The status code was there, but the body was blank — so the real reason was invisible.

## Root cause

Grok (and other OpenAI-compatible providers) route through the OpenAI SDK's
error path. The SDK extracts only the `error` subtree from the response body and
maps it onto the standard OpenAI shape `{"error":{"message":...}}`, populating
`apiErr.Message`.

xAI/Grok instead returns:

```json
{"code":"permission-denied","error":"Your team … has either used all available credits or reached its monthly spending limit."}
```

Here `error` is a bare **string**, so there's no `.message` to parse — `apiErr.Message`
comes back empty, and `normalizeOpenAIError` handed that empty string straight to
`ProviderError`, yielding `status 403:` with nothing after it.

## Fix

Add `apiErrorMessage()` in `providers/openai/errors.go`. When `Message` is empty,
fall back to `apiErr.RawJSON()` (the raw payload the SDK captured), unquoting it
when it's a JSON string. Standard OpenAI errors are unaffected — they still use
`Message`.

This benefits every OpenAI-compatible provider on this code path (Grok,
OpenRouter, Mistral, Ollama, …), not just xAI.

After the fix the same failure reads:

```
provider api error (status 403): Your team … has either used all available credits or reached its monthly spending limit.
```

## Tests

`providers/openai/errors_test.go` covers three cases:
- standard `{"error":{"message":…}}` shape → uses `Message`
- xAI string-body shape → empty `Message`, message surfaces via the `RawJSON` fallback
- non-API error → passed through unchanged

All pass; the openai module and the CLI both build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messages shown when OpenAI returns string-based or otherwise incomplete error details.
  * Preserved HTTP status codes and provider messages for standard OpenAI errors.
  * Ensured unrelated connection errors continue to pass through unchanged.

* **Tests**
  * Added coverage for standard, fallback, and non-provider error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->