### PR TITLE
Use JSON-aware unquoting for OpenAI-compatible error fallback

### DIFF
--- a/providers/openai/errors.go
+++ b/providers/openai/errors.go
@@ -1,8 +1,8 @@
 package openai
 
 import (
+	"encoding/json"
 	"errors"
-	"strconv"
 	"strings"
 
 	"github.com/deepnoodle-ai/dive/providers"
@@ -29,8 +29,9 @@ func apiErrorMessage(apiErr *openaisdk.Error) string {
 		return apiErr.Message
 	}
 	raw := strings.TrimSpace(apiErr.RawJSON())
-	if unquoted, err := strconv.Unquote(raw); err == nil {
-		raw = unquoted
+	var unquoted string
+	if err := json.Unmarshal([]byte(raw), &unquoted); err == nil {
+		return unquoted
 	}
 	return raw
 }

--- a/providers/openai/errors_test.go
+++ b/providers/openai/errors_test.go
@@ -35,7 +35,8 @@ func TestNormalizeOpenAIError_StandardMessage(t *testing.T) {
 func TestNormalizeOpenAIError_StringErrorFallback(t *testing.T) {
 	// xAI/Grok shape: {"code":"permission-denied","error":"<string>"}. The SDK
 	// hands UnmarshalJSON the bare "error" string, leaving Message empty. The
-	// message must still surface via the RawJSON fallback (unquoted).
+	// message must still surface via the RawJSON fallback, unquoted — not as
+	// the raw quoted JSON literal.
 	msg := "Your team has either used all available credits or reached its monthly spending limit."
 	apiErr := newAPIError(t, 403, `"`+msg+`"`)
 	assert.Equal(t, "", apiErr.Message) // precondition: Message really is empty
@@ -45,7 +46,21 @@ func TestNormalizeOpenAIError_StringErrorFallback(t *testing.T) {
 	var provErr *providers.ProviderError
 	assert.True(t, errors.As(got, &provErr))
 	assert.Equal(t, 403, provErr.StatusCode())
-	assert.Contains(t, provErr.Error(), msg)
+	assert.Equal(t, `provider api error (status 403): `+msg, provErr.Error())
+}
+
+func TestNormalizeOpenAIError_StringErrorFallback_JSONEscapes(t *testing.T) {
+	// The raw payload is JSON, not a Go string literal — escapes like \/ are
+	// valid JSON but not valid Go escape sequences, so the fallback must use
+	// a JSON-aware unquote rather than strconv.Unquote.
+	apiErr := newAPIError(t, 403, `"see https:\/\/example.com\/docs for details"`)
+	assert.Equal(t, "", apiErr.Message)
+
+	got := normalizeOpenAIError(apiErr)
+
+	var provErr *providers.ProviderError
+	assert.True(t, errors.As(got, &provErr))
+	assert.Equal(t, "provider api error (status 403): see https://example.com/docs for details", provErr.Error())
 }
 
 func TestNormalizeOpenAIError_NonAPIErrorPassthrough(t *testing.T) {


### PR DESCRIPTION
## Summary
- Follow-up to #238. The RawJSON fallback in `apiErrorMessage` used `strconv.Unquote`, which parses the body as a Go string literal. The body is JSON, not Go source, so valid JSON escapes it doesn't recognize (e.g. `\/`) fail to unquote and the raw quoted text leaks through instead of the clean message.
- Switch to `json.Unmarshal` into a `string`, which correctly handles JSON string escaping.

## Test plan
- [x] `go test ./...` in `providers/openai` (includes new `TestNormalizeOpenAIError_StringErrorFallback_JSONEscapes` regression test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of OpenAI error messages returned as JSON strings.
  - Correctly decodes escaped characters in provider error messages.
  - Ensures fallback error messages are displayed without unnecessary quotation marks.

- **Tests**
  - Added coverage for escaped characters and unquoted error-message formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->