### PR TITLE
Prepare v1.19.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [1.19.0] - 2026-08-09
+
 ### Added
 
 - **Provider catalogs** — each provider's models, pricing, feature flags, and
@@ -34,6 +36,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Fixed
 
+- **Blank error messages from OpenAI-compatible providers** — xAI/Grok returns
+  `{"code":…,"error":"<message>"}`, a shape the OpenAI SDK does not parse, so
+  failures surfaced as `provider api error (status 403):` with no reason. The
+  message now falls back to the raw JSON body.
 - **Nine OpenRouter ids used the wrong separator** — OpenRouter serves
   `anthropic/claude-opus-4.7`, not `anthropic/claude-opus-4-7`. Same for Opus
   4.8/4.6/4.5/4.1, Sonnet 4.6/4.5, Haiku 4.5, and one pricing row.
@@ -57,6 +63,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Changed
 
+- **Every module pins `toolchain go1.26.5`** and refreshes its dependencies
+  (openai-go v3.50.0, mcp-go v0.57.0, a2a-go v2.4.0, otel v1.45.0). The minimum
+  `go` directive stays at 1.25.0; the pin closes standard-library CVEs.
 - **`mistral.DefaultModel` is now `ModelMistralLarge`** (`mistral-large-latest`)
   rather than a pinned dated snapshot, matching the model the CLI recommends.
   Pass `WithModel` explicitly to pin a dated snapshot.

--- a/a2a/go.mod
+++ b/a2a/go.mod
@@ -6,7 +6,7 @@ toolchain go1.26.5
 
 require (
 	github.com/a2aproject/a2a-go/v2 v2.4.0
-	github.com/deepnoodle-ai/dive v1.18.0
+	github.com/deepnoodle-ai/dive v1.19.0
 	github.com/deepnoodle-ai/wonton v0.0.37
 )
 

--- a/demos/colosseum/go.mod
+++ b/demos/colosseum/go.mod
@@ -5,11 +5,11 @@ go 1.25.0
 toolchain go1.26.5
 
 require (
-	github.com/deepnoodle-ai/dive v1.18.0
-	github.com/deepnoodle-ai/dive/a2a v1.18.0
-	github.com/deepnoodle-ai/dive/providers/google v1.18.0
-	github.com/deepnoodle-ai/dive/providers/grok v1.18.0
-	github.com/deepnoodle-ai/dive/providers/openai v1.18.0
+	github.com/deepnoodle-ai/dive v1.19.0
+	github.com/deepnoodle-ai/dive/a2a v1.19.0
+	github.com/deepnoodle-ai/dive/providers/google v1.19.0
+	github.com/deepnoodle-ai/dive/providers/grok v1.19.0
+	github.com/deepnoodle-ai/dive/providers/openai v1.19.0
 	github.com/deepnoodle-ai/wonton v0.0.37
 )
 

--- a/demos/noodleville/go.mod
+++ b/demos/noodleville/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 toolchain go1.26.5
 
 require (
-	github.com/deepnoodle-ai/dive v1.18.0
+	github.com/deepnoodle-ai/dive v1.19.0
 	github.com/deepnoodle-ai/wonton v0.0.37
 )
 

--- a/examples/go.mod
+++ b/examples/go.mod
@@ -5,13 +5,13 @@ go 1.25.5
 toolchain go1.26.5
 
 require (
-	github.com/deepnoodle-ai/dive v1.18.0
-	github.com/deepnoodle-ai/dive/a2a v1.18.0
-	github.com/deepnoodle-ai/dive/experimental/mcp v1.18.0
-	github.com/deepnoodle-ai/dive/otel v1.18.0
-	github.com/deepnoodle-ai/dive/providers/google v1.18.0
-	github.com/deepnoodle-ai/dive/providers/grok v1.18.0
-	github.com/deepnoodle-ai/dive/providers/openai v1.18.0
+	github.com/deepnoodle-ai/dive v1.19.0
+	github.com/deepnoodle-ai/dive/a2a v1.19.0
+	github.com/deepnoodle-ai/dive/experimental/mcp v1.19.0
+	github.com/deepnoodle-ai/dive/otel v1.19.0
+	github.com/deepnoodle-ai/dive/providers/google v1.19.0
+	github.com/deepnoodle-ai/dive/providers/grok v1.19.0
+	github.com/deepnoodle-ai/dive/providers/openai v1.19.0
 	github.com/deepnoodle-ai/wonton v0.0.37
 	github.com/fatih/color v1.19.0
 	github.com/mark3labs/mcp-go v0.57.0

--- a/experimental/cmd/dive/go.mod
+++ b/experimental/cmd/dive/go.mod
@@ -5,10 +5,10 @@ go 1.25.0
 toolchain go1.26.5
 
 require (
-	github.com/deepnoodle-ai/dive v1.18.0
-	github.com/deepnoodle-ai/dive/providers/google v1.18.0
-	github.com/deepnoodle-ai/dive/providers/grok v1.18.0
-	github.com/deepnoodle-ai/dive/providers/openai v1.18.0
+	github.com/deepnoodle-ai/dive v1.19.0
+	github.com/deepnoodle-ai/dive/providers/google v1.19.0
+	github.com/deepnoodle-ai/dive/providers/grok v1.19.0
+	github.com/deepnoodle-ai/dive/providers/openai v1.19.0
 	github.com/deepnoodle-ai/wonton v0.0.37
 	github.com/mattn/go-runewidth v0.0.27
 )

--- a/experimental/mcp/go.mod
+++ b/experimental/mcp/go.mod
@@ -5,7 +5,7 @@ go 1.25.5
 toolchain go1.26.5
 
 require (
-	github.com/deepnoodle-ai/dive v1.18.0
+	github.com/deepnoodle-ai/dive v1.19.0
 	github.com/deepnoodle-ai/wonton v0.0.37
 	github.com/mark3labs/mcp-go v0.57.0
 )

--- a/otel/go.mod
+++ b/otel/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 toolchain go1.26.5
 
 require (
-	github.com/deepnoodle-ai/dive v1.18.0
+	github.com/deepnoodle-ai/dive v1.19.0
 	go.opentelemetry.io/otel v1.45.0
 	go.opentelemetry.io/otel/metric v1.45.0
 	go.opentelemetry.io/otel/sdk v1.45.0

--- a/providers/google/go.mod
+++ b/providers/google/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 toolchain go1.26.5
 
 require (
-	github.com/deepnoodle-ai/dive v1.18.0
+	github.com/deepnoodle-ai/dive v1.19.0
 	github.com/deepnoodle-ai/wonton v0.0.37
 	google.golang.org/genai v1.67.0
 )

--- a/providers/grok/go.mod
+++ b/providers/grok/go.mod
@@ -5,8 +5,8 @@ go 1.25.0
 toolchain go1.26.5
 
 require (
-	github.com/deepnoodle-ai/dive v1.18.0
-	github.com/deepnoodle-ai/dive/providers/openai v1.18.0
+	github.com/deepnoodle-ai/dive v1.19.0
+	github.com/deepnoodle-ai/dive/providers/openai v1.19.0
 	github.com/deepnoodle-ai/wonton v0.0.37
 	github.com/openai/openai-go/v3 v3.50.0
 	golang.org/x/image v0.44.0

--- a/providers/openai/go.mod
+++ b/providers/openai/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 toolchain go1.26.5
 
 require (
-	github.com/deepnoodle-ai/dive v1.18.0
+	github.com/deepnoodle-ai/dive v1.19.0
 	github.com/deepnoodle-ai/wonton v0.0.37
 	github.com/openai/openai-go/v3 v3.50.0
 	golang.org/x/image v0.44.0


### PR DESCRIPTION
Cuts the `v1.19.0` changelog heading and points every intra-repo module
requirement at the version being released.

## Changelog

- Cut `[1.19.0] - 2026-08-09`, covering the provider catalogs and provider
  watch work (#240), the `make release-prep` tooling, and the model
  constant/pricing corrections across Grok, OpenRouter, Mistral, Google, and
  Ollama.
- Added the two entries that had no `Unreleased` coverage:
  - **Fixed** — blank error messages from OpenAI-compatible providers
    (#238, #243).
  - **Changed** — the `toolchain go1.26.5` pin and refreshed dependencies
    (#242).

## Module requirements

`make release-prep VERSION=v1.19.0` bumped every sub-module from `v1.18.0` to
`v1.19.0`. `demos/colosseum` and `demos/noodleville` were bumped by hand:
`scripts/sync_module_versions.py` does not list them, but the v1.18.0 release
commit (d68cbcc) bumped them, so the touched-file list here matches it exactly.

Worth deciding separately whether demos belong in the script's `SUB_MODULES` or
whether the exclusion should be recorded as deliberate — they are never tagged,
so the script's stated downstream-breakage rationale does not apply to them.

## Verification

- `make check` — catalog check, watcher tests, `fmt-check`, and `vet` pass.
- `go test ./...` green across the root module and all seven sub-modules, plus
  `go build` on `demos/` and `examples/`.
- `python3 scripts/sync_module_versions.py v1.19.0 --check` passes, so
  `make tag-modules` will not refuse.

After this merges: `make tag-modules VERSION=v1.19.0 && git push origin --tags`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added provider catalogs to support catalog-driven command-line workflows.
  * Added watch workflows for supported provider operations.
  * Added support for a new Grok video model.
* **Bug Fixes**
  * Improved provider error handling with clearer fallback messages.
* **Documentation**
  * Added release notes for version 1.19.0, including model updates and retired functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->