### PR TITLE
Default to Sonnet 5 across Anthropic/OpenRouter/CLI, and fix per-model reasoning capability gaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Changed
+
+- **`anthropic.DefaultModel` is now `ModelClaudeSonnet5`** (`claude-sonnet-5`,
+  1M context, $3/$15 per MTok), replacing `claude-opus-5`. Callers that relied on
+  the default now get a cheaper, faster model; pass `WithModel(ModelClaudeOpus5)`
+  to keep Opus 5. The CLI's own default (`claude-haiku-4-5`) is unchanged.
+
 ### Fixed
 
 - **Anthropic per-model capability gaps.** `claude-opus-5` was absent from every

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **Anthropic per-model capability gaps.** `claude-opus-5` was absent from every
+  reasoning/thinking classification in `providers/anthropic`, so effort requests
+  fell through to the legacy thinking-budget path and `max`/`xhigh` were silently
+  downgraded to `high`. Opus 5 now uses native `output_config.effort`, the full
+  effort ladder, adaptive-only thinking, and thinking-on-by-default.
+- **Temperature is now dropped on Opus 4.7/4.8.** These models reject sampling
+  parameters with a 400; because thinking is off by default on them, a
+  caller-supplied `Temperature` was forwarded and rejected by the API.
+- **`xhigh` effort is no longer downgraded on Sonnet 5**, which supports the full
+  `low`–`max` ladder.
+- **Forced `tool_choice` no longer fails client-side on thinking-by-default
+  models** that accept an explicit thinking disable (Opus 5, Sonnet 5). An
+  explicit thinking config still takes precedence.
+
 ## [1.19.0] - 2026-08-09
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,26 +8,24 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Changed
 
-- **`anthropic.DefaultModel` is now `ModelClaudeSonnet5`** (`claude-sonnet-5`,
-  1M context, $3/$15 per MTok), replacing `claude-opus-5`. Callers that relied on
-  the default now get a cheaper, faster model; pass `WithModel(ModelClaudeOpus5)`
-  to keep Opus 5. The CLI's own default (`claude-haiku-4-5`) is unchanged.
+- **`anthropic.DefaultModel` is now `ModelClaudeSonnet5`** (`claude-sonnet-5`),
+  replacing `claude-opus-5`. Pass `WithModel(ModelClaudeOpus5)` to keep Opus 5.
+- **`openrouter.DefaultModel` is now `ModelClaudeSonnet5`**
+  (`anthropic/claude-sonnet-5`), matching the Anthropic provider default.
+- **The CLI's Anthropic default follows `anthropic.DefaultModel`** rather than a
+  separate hardcoded `claude-haiku-4-5`.
+- **The CLI defaults `--thinking-effort` to `medium`.** Pass an empty value to
+  omit the parameter on models that reject it.
 
 ### Fixed
 
-- **Anthropic per-model capability gaps.** `claude-opus-5` was absent from every
-  reasoning/thinking classification in `providers/anthropic`, so effort requests
-  fell through to the legacy thinking-budget path and `max`/`xhigh` were silently
-  downgraded to `high`. Opus 5 now uses native `output_config.effort`, the full
-  effort ladder, adaptive-only thinking, and thinking-on-by-default.
-- **Temperature is now dropped on Opus 4.7/4.8.** These models reject sampling
-  parameters with a 400; because thinking is off by default on them, a
-  caller-supplied `Temperature` was forwarded and rejected by the API.
-- **`xhigh` effort is no longer downgraded on Sonnet 5**, which supports the full
-  `low`–`max` ladder.
-- **Forced `tool_choice` no longer fails client-side on thinking-by-default
-  models** that accept an explicit thinking disable (Opus 5, Sonnet 5). An
-  explicit thinking config still takes precedence.
+- **`claude-opus-5` was missing from every Anthropic reasoning classification**,
+  so effort fell through to the legacy thinking-budget path and `max`/`xhigh`
+  silently became `high`. It now uses native `output_config.effort`.
+- **`temperature` is now dropped on Opus 4.7/4.8**, which reject it with a 400.
+- **`xhigh` is no longer downgraded on Sonnet 5**, which supports the full ladder.
+- **Forced `tool_choice` no longer fails client-side on Opus 5 and Sonnet 5**,
+  which default thinking on but accept an explicit disable.
 
 ## [1.19.0] - 2026-08-09
 

--- a/experimental/cmd/dive/main.go
+++ b/experimental/cmd/dive/main.go
@@ -22,6 +22,7 @@ import (
 	"github.com/deepnoodle-ai/dive/experimental/toolkit/kagi"
 	"github.com/deepnoodle-ai/dive/llm"
 	"github.com/deepnoodle-ai/dive/permission"
+	"github.com/deepnoodle-ai/dive/providers/anthropic"
 	"github.com/deepnoodle-ai/dive/session"
 	"github.com/deepnoodle-ai/dive/skill"
 	"github.com/deepnoodle-ai/dive/subagent"
@@ -126,9 +127,9 @@ func main() {
 				Env("DIVE_SHOW_THINKING").
 				Help("Request and show summarized model thinking when supported"),
 			cli.String("thinking-effort").
-				Default("").
+				Default(string(llm.ReasoningEffortMedium)).
 				Env("DIVE_THINKING_EFFORT").
-				Help("Thinking effort: none, minimal, low, medium, high, xhigh, max, or provider-specific value"),
+				Help("Thinking effort: none, minimal, low, medium, high, xhigh, max, or provider-specific value. Pass an empty value to omit the parameter entirely"),
 			cli.String("system-prompt").
 				Default("").
 				Help("System prompt to use for the session"),
@@ -1229,7 +1230,7 @@ func getDefaultVideoModel() string {
 
 func getDefaultModel() string {
 	if os.Getenv("ANTHROPIC_API_KEY") != "" {
-		return "claude-haiku-4-5"
+		return anthropic.DefaultModel
 	}
 	if os.Getenv("GOOGLE_API_KEY") != "" || os.Getenv("GEMINI_API_KEY") != "" {
 		return "gemini-3.6-flash"
@@ -1243,5 +1244,5 @@ func getDefaultModel() string {
 	if os.Getenv("MISTRAL_API_KEY") != "" {
 		return "mistral-small-latest"
 	}
-	return "claude-haiku-4-5"
+	return anthropic.DefaultModel
 }

--- a/experimental/cmd/dive/main_test.go
+++ b/experimental/cmd/dive/main_test.go
@@ -30,16 +30,19 @@ func TestGetDefaultModel(t *testing.T) {
 		expected string
 	}{
 		{
+			// Both Anthropic cases track anthropic.DefaultModel rather than a
+			// separate CLI-only pin; the literal is spelled out so a change to
+			// the library default has to be acknowledged here too.
 			name:     "no api keys defaults to claude",
 			envVars:  map[string]string{},
-			expected: "claude-haiku-4-5",
+			expected: "claude-sonnet-5",
 		},
 		{
 			name: "anthropic key present",
 			envVars: map[string]string{
 				"ANTHROPIC_API_KEY": "test",
 			},
-			expected: "claude-haiku-4-5",
+			expected: "claude-sonnet-5",
 		},
 		{
 			name: "google key present",
@@ -187,6 +190,48 @@ func TestNewCLIModelSettingsThinkingEffortEnv(t *testing.T) {
 	assert.Equal(t, settings.ReasoningEffort, llm.ReasoningEffortXHigh)
 	assert.Equal(t, settings.Thinking, llm.ThinkingType(""))
 	assert.Equal(t, settings.ThinkingDisplay, llm.ThinkingDisplay(""))
+}
+
+func TestNewCLIModelSettingsThinkingEffortDefaultsToMedium(t *testing.T) {
+	// Mirrors the real flag definition in main(): unset means medium, and an
+	// explicitly empty value omits the parameter so non-reasoning models can
+	// still be driven from the CLI.
+	for _, tt := range []struct {
+		name     string
+		args     []string
+		expected llm.ReasoningEffort
+	}{
+		{"unset defaults to medium", nil, llm.ReasoningEffortMedium},
+		{"explicit empty omits effort", []string{"--thinking-effort", ""}, llm.ReasoningEffort("")},
+		{"explicit value wins", []string{"--thinking-effort", "low"}, llm.ReasoningEffortLow},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			app := cli.New("test")
+			var settings *dive.ModelSettings
+			app.Main().
+				Flags(
+					cli.Int("max-tokens").
+						Default(16000).
+						Env("DIVE_MAX_TOKENS"),
+					cli.Bool("show-thinking").
+						Default(false).
+						Env("DIVE_SHOW_THINKING"),
+					cli.String("thinking-effort").
+						Default(string(llm.ReasoningEffortMedium)).
+						Env("DIVE_THINKING_EFFORT"),
+				).
+				Run(func(ctx *cli.Context) error {
+					settings, _ = newCLIModelSettings(ctx)
+					return nil
+				})
+
+			result := app.Test(t, cli.TestArgs(tt.args...))
+			assert.True(t, result.Success(), result.Stderr)
+			assert.Equal(t, settings.ReasoningEffort, tt.expected)
+			// The default must not imply thinking; --show-thinking owns that.
+			assert.Equal(t, settings.Thinking, llm.ThinkingType(""))
+		})
+	}
 }
 
 func TestParseThinkingEffortAllowsProviderSpecificValues(t *testing.T) {

--- a/providers/anthropic/anthropic.go
+++ b/providers/anthropic/anthropic.go
@@ -658,7 +658,7 @@ func (p *Provider) applyRequestConfig(req *Request, config *llm.Config) error {
 	}
 
 	if config.ToolChoice != nil && len(config.Tools) > 0 {
-		if requestHasThinkingEnabled(req.Model, req.Thinking) && forcedToolChoice(config.ToolChoice.Type) {
+		if requestThinkingBlocksForcedToolChoice(req.Model, req.Thinking) && forcedToolChoice(config.ToolChoice.Type) {
 			return fmt.Errorf("anthropic extended thinking only supports tool_choice auto or none; got %q", config.ToolChoice.Type)
 		}
 		req.ToolChoice = &ToolChoice{
@@ -692,12 +692,13 @@ func (p *Provider) applyRequestConfig(req *Request, config *llm.Config) error {
 
 // applyReasoningConfig maps Dive's reasoning/thinking options onto the Anthropic
 // request, accounting for per-model differences:
-//   - Opus 4.5+, Sonnet 4.6, and the Claude 5 models (Fable 5, Mythos 5) take
-//     the native effort parameter via output_config; older models emulate
-//     effort with a thinking budget.
+//   - Opus 4.5+, Sonnet 4.6, and the Claude 5 models (Opus 5, Fable 5, Mythos 5,
+//     Sonnet 5) take the native effort parameter via output_config; older models
+//     emulate effort with a thinking budget.
 //   - Opus 4.6/4.7/4.8, Sonnet 4.6, and the Claude 5 models support adaptive
 //     thinking. Opus 4.7/4.8 and the Claude 5 models reject manual budgets, so
 //     a budget set against them transparently falls back to adaptive thinking.
+//   - Opus 5 accepts an explicit thinking disable only at effort high or below.
 func applyReasoningConfig(req *Request, config *llm.Config) error {
 	model := req.Model
 
@@ -710,6 +711,11 @@ func applyReasoningConfig(req *Request, config *llm.Config) error {
 		effort, err := normalizeReasoningEffort(model, config.ReasoningEffort)
 		if err != nil {
 			return err
+		}
+		if config.Thinking == llm.ThinkingTypeDisabled &&
+			modelRejectsDisabledThinkingAboveHighEffort(model) &&
+			(effort == llm.ReasoningEffortXHigh || effort == llm.ReasoningEffortMax) {
+			return fmt.Errorf("cannot set reasoning effort %s with thinking disabled on model %s: it accepts an explicit thinking disable only at effort high or below", effort, model)
 		}
 		if modelSupportsEffortParam(model) {
 			req.OutputConfig = &OutputConfig{Effort: string(effort)}
@@ -851,18 +857,33 @@ func requestHasThinkingEnabled(model string, thinking *Thinking) bool {
 	return modelRunsThinkingByDefault(model)
 }
 
+// requestThinkingBlocksForcedToolChoice reports whether the request's thinking
+// configuration rules out a forced tool_choice. An explicit thinking config is
+// authoritative. When the request omits it, only models that always run thinking
+// and reject an explicit disable (Fable 5, Mythos 5) block forced tool choice:
+// Opus 5 and Sonnet 5 default thinking on but the caller can still turn it off,
+// so Dive leaves that request to the API rather than rejecting it here.
+func requestThinkingBlocksForcedToolChoice(model string, thinking *Thinking) bool {
+	if thinking != nil {
+		return thinking.Type != "disabled"
+	}
+	return modelRunsThinkingByDefault(model) && !modelDefaultsThinkingOn(model)
+}
+
 func forcedToolChoice(choice llm.ToolChoiceType) bool {
 	return choice == llm.ToolChoiceTypeAny || choice == llm.ToolChoiceTypeTool
 }
 
 // modelSupportsEffortParam reports whether the model accepts the native
-// output_config.effort parameter (Opus 4.5+, Sonnet 4.6, Fable 5, Mythos 5).
+// output_config.effort parameter (Opus 4.5+, Opus 5, Sonnet 4.6, Sonnet 5,
+// Fable 5, Mythos 5).
 func modelSupportsEffortParam(model string) bool {
 	switch {
 	case strings.HasPrefix(model, "claude-opus-4-5"),
 		strings.HasPrefix(model, "claude-opus-4-6"),
 		strings.HasPrefix(model, "claude-opus-4-7"),
 		strings.HasPrefix(model, "claude-opus-4-8"),
+		strings.HasPrefix(model, "claude-opus-5"),
 		strings.HasPrefix(model, "claude-sonnet-4-6"),
 		strings.HasPrefix(model, "claude-sonnet-5"),
 		strings.HasPrefix(model, "claude-fable-5"),
@@ -875,6 +896,8 @@ func modelSupportsEffortParam(model string) bool {
 func modelSupportsXHighEffort(model string) bool {
 	return strings.HasPrefix(model, "claude-opus-4-7") ||
 		strings.HasPrefix(model, "claude-opus-4-8") ||
+		strings.HasPrefix(model, "claude-opus-5") ||
+		strings.HasPrefix(model, "claude-sonnet-5") ||
 		strings.HasPrefix(model, "claude-fable-5") ||
 		strings.HasPrefix(model, "claude-mythos-5")
 }
@@ -883,6 +906,7 @@ func modelSupportsMaxEffort(model string) bool {
 	return strings.HasPrefix(model, "claude-opus-4-6") ||
 		strings.HasPrefix(model, "claude-opus-4-7") ||
 		strings.HasPrefix(model, "claude-opus-4-8") ||
+		strings.HasPrefix(model, "claude-opus-5") ||
 		strings.HasPrefix(model, "claude-sonnet-4-6") ||
 		strings.HasPrefix(model, "claude-sonnet-5") ||
 		strings.HasPrefix(model, "claude-fable-5") ||
@@ -890,23 +914,28 @@ func modelSupportsMaxEffort(model string) bool {
 }
 
 // modelRejectsTemperature reports whether the model rejects the temperature
-// parameter (Claude 5 models: Fable 5, Mythos 5, Sonnet 5).
+// parameter (Opus 4.7/4.8, Opus 5, and the rest of the Claude 5 family: Fable 5,
+// Mythos 5, Sonnet 5). Opus 4.6 and Sonnet 4.6 still accept it.
 func modelRejectsTemperature(model string) bool {
-	return strings.HasPrefix(model, "claude-fable-5") ||
+	return strings.HasPrefix(model, "claude-opus-4-7") ||
+		strings.HasPrefix(model, "claude-opus-4-8") ||
+		strings.HasPrefix(model, "claude-opus-5") ||
+		strings.HasPrefix(model, "claude-fable-5") ||
 		strings.HasPrefix(model, "claude-mythos-5") ||
 		strings.HasPrefix(model, "claude-sonnet-5")
 }
 
 // modelRejectsManualThinking reports whether the model rejects manual extended
-// thinking budgets and supports only adaptive thinking (Opus 4.7/4.8, Fable 5,
-// Mythos 5, Sonnet 5). On Fable 5 and Mythos 5 adaptive thinking is always on
-// and an explicit thinking disable is also rejected by the API; Dive omits the
-// thinking parameter entirely when thinking is disabled, which is the accepted
-// form. Sonnet 5 also defaults thinking on but, unlike Fable/Mythos, accepts an
-// explicit disable — see modelDefaultsThinkingOn.
+// thinking budgets and supports only adaptive thinking (Opus 4.7/4.8, Opus 5,
+// Fable 5, Mythos 5, Sonnet 5). On Fable 5 and Mythos 5 adaptive thinking is
+// always on and an explicit thinking disable is also rejected by the API; Dive
+// omits the thinking parameter entirely when thinking is disabled, which is the
+// accepted form. Opus 5 and Sonnet 5 also default thinking on but, unlike
+// Fable/Mythos, accept an explicit disable — see modelDefaultsThinkingOn.
 func modelRejectsManualThinking(model string) bool {
 	return strings.HasPrefix(model, "claude-opus-4-7") ||
 		strings.HasPrefix(model, "claude-opus-4-8") ||
+		strings.HasPrefix(model, "claude-opus-5") ||
 		strings.HasPrefix(model, "claude-fable-5") ||
 		strings.HasPrefix(model, "claude-mythos-5") ||
 		strings.HasPrefix(model, "claude-sonnet-5")
@@ -915,11 +944,22 @@ func modelRejectsManualThinking(model string) bool {
 // modelDefaultsThinkingOn reports whether the model runs with adaptive thinking
 // when the request omits the thinking parameter. For these models a caller that
 // asks to disable thinking must send an explicit thinking:{type:"disabled"} —
-// omitting the field would leave thinking on. Currently only Sonnet 5 both
-// defaults thinking on and accepts an explicit disable (Fable 5 and Mythos 5
-// default on but reject the explicit disable, so Dive omits the field for them).
+// omitting the field would leave thinking on. Opus 5 and Sonnet 5 both default
+// thinking on and accept an explicit disable (Fable 5 and Mythos 5 default on
+// but reject the explicit disable, so Dive omits the field for them). On Opus 5
+// the explicit disable is only accepted at effort high or below — see
+// modelRejectsDisabledThinkingAboveHighEffort.
 func modelDefaultsThinkingOn(model string) bool {
-	return strings.HasPrefix(model, "claude-sonnet-5")
+	return strings.HasPrefix(model, "claude-opus-5") ||
+		strings.HasPrefix(model, "claude-sonnet-5")
+}
+
+// modelRejectsDisabledThinkingAboveHighEffort reports whether the model rejects
+// an explicit thinking disable combined with an effort level above high. Opus 5
+// accepts thinking:{type:"disabled"} only at effort high or below and returns a
+// 400 when it is paired with xhigh or max.
+func modelRejectsDisabledThinkingAboveHighEffort(model string) bool {
+	return strings.HasPrefix(model, "claude-opus-5")
 }
 
 // modelRunsThinkingByDefault reports whether omitting the thinking parameter

--- a/providers/anthropic/anthropic_test.go
+++ b/providers/anthropic/anthropic_test.go
@@ -359,6 +359,13 @@ func countMessageBreakpoints(messages []*llm.Message) int {
 	return n
 }
 
+func TestProvider_DefaultModel(t *testing.T) {
+	// Generated from the catalog's default model; pinned here so a catalog
+	// regeneration cannot move the default without an explicit test change.
+	assert.Equal(t, ModelClaudeSonnet5, DefaultModel)
+	assert.Equal(t, DefaultModel, New().model)
+}
+
 func TestApplyCachingDoesNotMutateOriginal(t *testing.T) {
 	// convertMessages clones content, so applyCaching must not touch the original.
 	original := &llm.TextContent{Text: "hello"}

--- a/providers/anthropic/catalog.json
+++ b/providers/anthropic/catalog.json
@@ -144,7 +144,6 @@
     {
       "go_name": "ModelClaudeOpus5",
       "id": "claude-opus-5",
-      "default": true,
       "kind": "text",
       "context_window": 1000000,
       "display_name": "Opus 5",
@@ -172,6 +171,7 @@
     {
       "go_name": "ModelClaudeSonnet5",
       "id": "claude-sonnet-5",
+      "default": true,
       "kind": "text",
       "context_window": 1000000,
       "display_name": "Sonnet 5",

--- a/providers/anthropic/models_gen.go
+++ b/providers/anthropic/models_gen.go
@@ -26,4 +26,4 @@ const (
 )
 
 // DefaultModel is generated from the catalog's default model.
-var DefaultModel = ModelClaudeOpus5
+var DefaultModel = ModelClaudeSonnet5

--- a/providers/anthropic/reasoning_test.go
+++ b/providers/anthropic/reasoning_test.go
@@ -188,6 +188,36 @@ func TestDefaultThinkingWithForcedToolChoiceErrors(t *testing.T) {
 	assert.Contains(t, err.Error(), "tool_choice auto or none")
 }
 
+func TestDefaultThinkingAllowsForcedToolChoiceWhenDisableIsAccepted(t *testing.T) {
+	// Opus 5 and Sonnet 5 default thinking on but accept an explicit disable, so
+	// Dive must not reject a forced tool choice client-side — the API accepts it.
+	for _, model := range []string{ModelClaudeOpus5, ModelClaudeSonnet5} {
+		req := buildReq(t, model,
+			llm.WithTools(reasoningTestTool()),
+			llm.WithToolChoice(&llm.ToolChoice{
+				Type: llm.ToolChoiceTypeTool,
+				Name: "lookup",
+			}))
+		assert.NotNil(t, req.ToolChoice)
+		assert.Equal(t, ToolChoiceType(llm.ToolChoiceTypeTool), req.ToolChoice.Type)
+	}
+}
+
+func TestExplicitThinkingWithForcedToolChoiceStillErrors(t *testing.T) {
+	// An explicit thinking config remains authoritative on the default-on models.
+	cfg := &llm.Config{}
+	cfg.Apply(
+		llm.WithModel(ModelClaudeOpus5),
+		llm.WithAdaptiveThinking(),
+		llm.WithTools(reasoningTestTool()),
+		llm.WithToolChoice(llm.ToolChoiceAny),
+	)
+	var req Request
+	err := New().applyRequestConfig(&req, cfg)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "tool_choice auto or none")
+}
+
 func TestThinkingAllowsToolChoiceAutoAndNone(t *testing.T) {
 	for _, choice := range []*llm.ToolChoice{llm.ToolChoiceAuto, llm.ToolChoiceNone} {
 		req := buildReq(t, ModelClaudeOpus46,
@@ -267,10 +297,12 @@ func TestModelCapabilityHelpers(t *testing.T) {
 	assert.True(t, modelSupportsEffortParam(ModelClaudeFable5))
 	assert.True(t, modelSupportsEffortParam(ModelClaudeMythos5))
 	assert.True(t, modelSupportsEffortParam(ModelClaudeSonnet5))
+	assert.True(t, modelSupportsEffortParam(ModelClaudeOpus5))
 	assert.False(t, modelSupportsEffortParam(ModelClaude37Sonnet20250219))
 
 	assert.True(t, modelRejectsManualThinking(ModelClaudeOpus47))
 	assert.True(t, modelRejectsManualThinking(ModelClaudeOpus48))
+	assert.True(t, modelRejectsManualThinking(ModelClaudeOpus5))
 	assert.True(t, modelRejectsManualThinking(ModelClaudeFable5))
 	assert.True(t, modelRejectsManualThinking(ModelClaudeMythos5))
 	assert.True(t, modelRejectsManualThinking(ModelClaudeSonnet5))
@@ -282,19 +314,40 @@ func TestModelCapabilityHelpers(t *testing.T) {
 	assert.True(t, modelSupportsXHighEffort(ModelClaudeMythos5))
 	assert.True(t, modelSupportsMaxEffort(ModelClaudeMythos5))
 
-	// Sonnet 5 supports max effort (like Sonnet 4.6) but not xhigh.
-	assert.False(t, modelSupportsXHighEffort(ModelClaudeSonnet5))
+	// Sonnet 5 is the first Sonnet-tier model with the full effort ladder.
+	assert.True(t, modelSupportsXHighEffort(ModelClaudeSonnet5))
 	assert.True(t, modelSupportsMaxEffort(ModelClaudeSonnet5))
+	assert.False(t, modelSupportsXHighEffort(ModelClaudeSonnet46))
+	assert.True(t, modelSupportsMaxEffort(ModelClaudeSonnet46))
 
-	// Sonnet 5 rejects sampling params and defaults thinking on.
+	// Opus 5 supports the full effort ladder.
+	assert.True(t, modelSupportsXHighEffort(ModelClaudeOpus5))
+	assert.True(t, modelSupportsMaxEffort(ModelClaudeOpus5))
+
+	// Opus 4.7/4.8 and the Claude 5 family reject sampling params; Opus 4.6 and
+	// Sonnet 4.6 still accept them.
+	assert.True(t, modelRejectsTemperature(ModelClaudeOpus47))
+	assert.True(t, modelRejectsTemperature(ModelClaudeOpus48))
+	assert.True(t, modelRejectsTemperature(ModelClaudeOpus5))
 	assert.True(t, modelRejectsTemperature(ModelClaudeSonnet5))
+	assert.False(t, modelRejectsTemperature(ModelClaudeOpus46))
+	assert.False(t, modelRejectsTemperature(ModelClaudeSonnet46))
+
+	// Opus 5 and Sonnet 5 default thinking on and accept an explicit disable.
+	assert.True(t, modelDefaultsThinkingOn(ModelClaudeOpus5))
 	assert.True(t, modelDefaultsThinkingOn(ModelClaudeSonnet5))
 	assert.True(t, modelRunsThinkingByDefault(ModelClaudeFable5))
 	assert.True(t, modelRunsThinkingByDefault(ModelClaudeMythos5))
 	assert.True(t, modelRunsThinkingByDefault(ModelClaudeSonnet5))
+	assert.True(t, modelRunsThinkingByDefault(ModelClaudeOpus5))
 	assert.False(t, modelRunsThinkingByDefault(ModelClaudeOpus48))
 	assert.False(t, modelDefaultsThinkingOn(ModelClaudeFable5))
 	assert.False(t, modelDefaultsThinkingOn(ModelClaudeSonnet46))
+
+	// Only Opus 5 caps an explicit thinking disable at effort high.
+	assert.True(t, modelRejectsDisabledThinkingAboveHighEffort(ModelClaudeOpus5))
+	assert.False(t, modelRejectsDisabledThinkingAboveHighEffort(ModelClaudeOpus48))
+	assert.False(t, modelRejectsDisabledThinkingAboveHighEffort(ModelClaudeSonnet5))
 }
 
 func TestReasoningEffortFable5UsesOutputConfig(t *testing.T) {
@@ -322,11 +375,10 @@ func TestThinkingDisabledFable5OmitsThinkingParam(t *testing.T) {
 }
 
 func TestReasoningEffortSonnet5UsesOutputConfig(t *testing.T) {
-	// Sonnet 5 takes the native effort parameter. It does not support xhigh, so
-	// that request degrades to high rather than erroring.
+	// Sonnet 5 takes the native effort parameter, including xhigh.
 	req := buildReq(t, ModelClaudeSonnet5, llm.WithReasoningEffort(llm.ReasoningEffortXHigh))
 	assert.NotNil(t, req.OutputConfig)
-	assert.Equal(t, "high", req.OutputConfig.Effort)
+	assert.Equal(t, "xhigh", req.OutputConfig.Effort)
 	assert.Nil(t, req.Thinking)
 }
 
@@ -351,4 +403,86 @@ func TestSonnet5RejectsTemperature(t *testing.T) {
 	// Sampling parameters return a 400 on Sonnet 5; Dive drops temperature.
 	req := buildReq(t, ModelClaudeSonnet5, llm.WithTemperature(0.7))
 	assert.Nil(t, req.Temperature)
+}
+
+func TestSonnet5SupportsXHighEffort(t *testing.T) {
+	// Sonnet 5 takes xhigh natively rather than being downgraded to high.
+	req := buildReq(t, ModelClaudeSonnet5, llm.WithReasoningEffort(llm.ReasoningEffortXHigh))
+	assert.NotNil(t, req.OutputConfig)
+	assert.Equal(t, "xhigh", req.OutputConfig.Effort)
+}
+
+func TestOpus47And48RejectTemperature(t *testing.T) {
+	// Sampling parameters return a 400 on Opus 4.7/4.8. Thinking is off by
+	// default on these models, so the temperature drop cannot rely on the
+	// thinking-enabled path.
+	for _, model := range []string{ModelClaudeOpus47, ModelClaudeOpus48} {
+		req := buildReq(t, model, llm.WithTemperature(0.7))
+		assert.Nil(t, req.Temperature)
+		assert.Nil(t, req.Thinking)
+	}
+}
+
+func TestReasoningEffortOpus5UsesOutputConfig(t *testing.T) {
+	// Opus 5 takes the native effort parameter across the full ladder.
+	for _, effort := range []llm.ReasoningEffort{
+		llm.ReasoningEffortLow,
+		llm.ReasoningEffortHigh,
+		llm.ReasoningEffortXHigh,
+		llm.ReasoningEffortMax,
+	} {
+		req := buildReq(t, ModelClaudeOpus5, llm.WithReasoningEffort(effort))
+		assert.NotNil(t, req.OutputConfig)
+		assert.Equal(t, string(effort), req.OutputConfig.Effort)
+	}
+}
+
+func TestReasoningBudgetOpus5FallsBackToAdaptive(t *testing.T) {
+	// Manual budget_tokens returns a 400 on Opus 5; Dive uses adaptive thinking.
+	req := buildReq(t, ModelClaudeOpus5, llm.WithReasoningBudget(8000))
+	assert.NotNil(t, req.Thinking)
+	assert.Equal(t, "adaptive", req.Thinking.Type)
+	assert.Equal(t, 0, req.Thinking.BudgetTokens)
+}
+
+func TestOpus5RejectsTemperature(t *testing.T) {
+	req := buildReq(t, ModelClaudeOpus5, llm.WithTemperature(0.7))
+	assert.Nil(t, req.Temperature)
+}
+
+func TestThinkingDisabledOpus5EmitsExplicitDisable(t *testing.T) {
+	// Opus 5 defaults thinking on, so a disable must be sent explicitly —
+	// omitting the parameter would leave adaptive thinking enabled.
+	req := buildReq(t, ModelClaudeOpus5, llm.WithThinking(llm.ThinkingTypeDisabled))
+	assert.NotNil(t, req.Thinking)
+	assert.Equal(t, "disabled", req.Thinking.Type)
+}
+
+func TestThinkingDisabledOpus5AboveHighEffortErrors(t *testing.T) {
+	// Opus 5 accepts an explicit thinking disable only at effort high or below.
+	for _, effort := range []llm.ReasoningEffort{
+		llm.ReasoningEffortXHigh,
+		llm.ReasoningEffortMax,
+	} {
+		cfg := &llm.Config{}
+		cfg.Apply(
+			llm.WithModel(ModelClaudeOpus5),
+			llm.WithReasoningEffort(effort),
+			llm.WithThinking(llm.ThinkingTypeDisabled),
+		)
+		var req Request
+		err := New().applyRequestConfig(&req, cfg)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "effort high or below")
+	}
+}
+
+func TestThinkingDisabledOpus5AtHighEffortOK(t *testing.T) {
+	req := buildReq(t, ModelClaudeOpus5,
+		llm.WithReasoningEffort(llm.ReasoningEffortHigh),
+		llm.WithThinking(llm.ThinkingTypeDisabled))
+	assert.NotNil(t, req.Thinking)
+	assert.Equal(t, "disabled", req.Thinking.Type)
+	assert.NotNil(t, req.OutputConfig)
+	assert.Equal(t, "high", req.OutputConfig.Effort)
 }

--- a/providers/openrouter/catalog.json
+++ b/providers/openrouter/catalog.json
@@ -25,6 +25,7 @@
     {
       "go_name": "ModelClaudeSonnet5",
       "id": "anthropic/claude-sonnet-5",
+      "default": true,
       "kind": "text",
       "context_window": 1000000,
       "display_name": "Sonnet 5"
@@ -32,7 +33,6 @@
     {
       "go_name": "ModelClaudeOpus5",
       "id": "anthropic/claude-opus-5",
-      "default": true,
       "kind": "text",
       "context_window": 1000000,
       "display_name": "Opus 5"

--- a/providers/openrouter/models_gen.go
+++ b/providers/openrouter/models_gen.go
@@ -42,4 +42,4 @@ const (
 )
 
 // DefaultModel is generated from the catalog's default model.
-var DefaultModel = ModelClaudeOpus5
+var DefaultModel = ModelClaudeSonnet5


### PR DESCRIPTION
## Summary

1. **Sonnet 5 is the default** for `anthropic`, `openrouter`, and the CLI.
2. **The CLI defaults `--thinking-effort` to `medium`.**
3. **Six per-model reasoning/thinking classifications were wrong or incomplete**, including for the model that was the default.

## 1. Sonnet 5 as the default

- `anthropic.DefaultModel` → `claude-sonnet-5` (was `claude-opus-5`). Near-Opus quality on coding and agentic work at $3/$15 per MTok vs $5/$25. `ModelClaudeOpus5` stays available via `WithModel`.
- `openrouter.DefaultModel` → `anthropic/claude-sonnet-5`.
- The CLI's `getDefaultModel()` hardcoded `claude-haiku-4-5` for both the Anthropic branch and the no-key fallback, so the library and CLI defaults could drift apart silently. Both now read `anthropic.DefaultModel`, matching how the Grok branch already reads `grok.DefaultModel`. Other providers stay hardcoded.

Both catalog changes are the `"default"` flag in `catalog.json` plus `make provider-catalog-generate`; `make provider-catalog-check` is clean. `TestProvider_DefaultModel` pins the Anthropic default so a regeneration can't move it silently.

`cli_order`/`recommended` are untouched — Opus 5 remains `cli_order: 1` in the CLI's model list. Separate fields from the default; say the word if you want them aligned.

## 2. CLI reasoning effort defaults to `medium`

`--thinking-effort` now defaults to `medium` (was unset), overridable via the flag or `DIVE_THINKING_EFFORT`. Every model the CLI picks on its own handles it: Anthropic and OpenAI map it natively, Grok clamps it, Mistral omits it with a warning, and Google ignores the field.

⚠️ **One behavior change worth your call.** The flag applies to whatever model the user names, and both OpenAI normalizers pass an unrecognized model's effort through untouched (`default: return effort, nil`); `openaicompletions.resolveReasoningEffort` does the same for custom endpoints. So an explicitly requested **non-reasoning** model — `gpt-4o`, plain Ollama models, a custom OpenAI-compatible endpoint — now sends an effort value it didn't before and may reject it. Passing an empty `--thinking-effort` omits the parameter, and the help text says so. Gating the default on a real per-model capability lookup needs the capability table in the follow-up below; happy to drop the default or add a guard instead.

## 3. Per-model reasoning capability gaps

`claude-opus-5` became `anthropic.DefaultModel` in v1.19.0 via the generated-catalog work, but the hand-maintained prefix-match functions in `anthropic.go` were never updated — all six classifications recognized the rest of the Claude 5 family and missed Opus 5 entirely.

On what was then the default model: `normalizeReasoningEffort` silently downgraded `max`/`xhigh` to `high`, then `modelSupportsEffortParam` returned false and effort was emulated via `legacyEffortBudget` — sending `thinking: {type: "enabled", budget_tokens: 16384}`, a value hand-tuned for models several generations older, on a code path no other current model uses.

Auditing the same functions surfaced two further gaps unrelated to Opus 5:

**`modelRejectsTemperature` omitted Opus 4.7/4.8.** Both reject sampling parameters with a 400. Since thinking is *off* by default on them, the drop couldn't fall back to the thinking-enabled path at `anthropic.go:681`, so a caller-supplied `Temperature` was forwarded and rejected by the API. The test asserts both the drop and that thinking stays nil, so it can't pass for the wrong reason.

**`modelSupportsXHighEffort` omitted Sonnet 5,** which supports the full `low`–`max` ladder. This was asserted rather than merely missing — two tests pinned the incorrect belief that Sonnet 5 has no `xhigh`. Both corrected. This now applies to the default model.

**New `modelRejectsDisabledThinkingAboveHighEffort`.** Opus 5 accepts an explicit thinking disable only at effort `high` or below, so `applyReasoningConfig` rejects it paired with `xhigh`/`max` rather than letting the API 400.

Doc comments on `applyReasoningConfig` and the classification functions are updated — the `applyReasoningConfig` comment was already stale before Opus 5 landed (it never mentioned Sonnet 5).

## The other judgment call — please review

Marking Opus 5 thinking-on-by-default made `modelRunsThinkingByDefault` true for it, which tripped the "extended thinking only supports tool_choice auto or none" guard. Opus 5 was the default model at the time, so **every caller doing forced tool choice would have started getting a client-side error.** `TestToolUse`/`TestToolCallStream` caught it — they went from failing at the network to failing before it.

The guard is now `requestThinkingBlocksForcedToolChoice`: an explicit thinking config stays authoritative, but when the request omits one it fires only for models that always run thinking *and* reject an explicit disable (Fable 5, Mythos 5). Opus 5 and Sonnet 5 default thinking on yet accept a disable, so Dive leaves that request to the API. Anthropic documents this restriction as Bedrock-only for this generation — the first-party API accepts forced tool choice with adaptive thinking — so this also lifts the same over-restriction that already applied to Sonnet 5, now the default.

**Deliberately out of scope:** explicit adaptive thinking + forced tool choice still errors on Opus 4.6/4.7/4.8 and the Claude 5 family (`TestExplicitThinkingWithForcedToolChoiceStillErrors` pins current behavior). Changing it touches every thinking-capable model.

## Follow-up worth considering

These six functions are a hand-maintained compatibility matrix that must stay in sync with the model catalog by hand, and this is the second time a model shipped with pricing and a `DefaultModel` flag but no capability classification. Collapsing them into a single table keyed by model prefix would make disagreement between the lists unrepresentable; a test requiring an explicit entry for every constant in `models_gen.go` would catch the next omission at build time. That table is also what the CLI would need to gate the effort default on real per-model capability.

## Test plan

- `make provider-catalog-check` clean; only the two `catalog.json` files and their `models_gen.go` changed.
- `go build ./...`, `go vet ./...`, `gofmt`, and `prettier --check CHANGELOG.md` clean, in both the root and `experimental/cmd/dive` modules.
- Root `go test ./...` passes except five live-API tests that fail with 401 for lack of a key; verified identical failures on `main` via `git stash`. CLI module tests pass.
- Verified the real binary reports `--thinking-effort … (default: medium)` rather than only asserting against the mirrored flag set in tests.
- New coverage: default-model pins for the library and CLI; effort default unset/empty/explicit; Opus 5 effort ladder, budget→adaptive fallback, temperature drop, explicit thinking disable, and the disabled-thinking/effort-cap error in both directions; Sonnet 5 `xhigh`; Opus 4.7/4.8 temperature; both sides of the forced-tool-choice guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
