### PR TITLE
Gate reasoning and sampling parameters on verified per-model capability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,10 +14,36 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
   (`anthropic/claude-sonnet-5`), matching the Anthropic provider default.
 - **The CLI's Anthropic default follows `anthropic.DefaultModel`** rather than a
   separate hardcoded `claude-haiku-4-5`.
-- **The CLI defaults `--thinking-effort` to `medium`.** Pass an empty value to
-  omit the parameter on models that reject it.
+- **The CLI defaults `--thinking-effort` to `medium`.** Providers now drop the
+  parameter on models that have none, so this is safe on every model.
+- **Unsupported reasoning and sampling settings are clamped or dropped with a
+  warning instead of returning an error.** One `ModelSettings` now survives
+  being pointed at a model with a narrower range.
+- **New `providers/modelcaps` package** holds the verified per-model capability
+  tables shared by the Responses and Chat Completions providers, replacing three
+  separate copies of the same prefix switches.
+- **New `llm.ClampReasoningEffort`** maps a requested effort onto the closest
+  level a model accepts.
 
 ### Fixed
+
+- **Reasoning effort was sent to models that have no reasoning parameter**,
+  producing a 400 on every request. Affects `gpt-4o` and `gpt-4.1`, plus
+  `grok-build`, `grok-code-fast`, and both `grok-4.20-0309` models. The CLI's new
+  `medium` default made this fire on every call.
+- **`temperature` was sent to models that reject it** on the OpenAI providers:
+  `gpt-5`/`-mini`/`-nano`, `gpt-5.5`, `gpt-5.6`, `o3`, and `o4-mini`.
+- **Adaptive thinking was sent to models that do not support it.** Haiku 4.5,
+  Sonnet 4.5, and Opus 4.5 answer "adaptive thinking is not supported on this
+  model"; the request now falls back to a manual thinking budget.
+- **Codex models bypassed effort clamping entirely**, so `minimal` and `max`
+  reached `gpt-5.3-codex`, which rejects both.
+- **A reasoning budget and an effort together were rejected client-side** on
+  Opus 4.5 and Sonnet 4.6, which accept the combination.
+- **Effort ranges corrected against the live API:** `grok-4.5` accepts `xhigh`
+  (was downgraded to `high`) and rejects `none`; the Grok multi-agent model
+  accepts `max` and `none`; `gpt-5.2-pro` accepts only `medium`/`high`/`xhigh`;
+  `gpt-5.3-chat-latest` accepts only `medium`.
 
 - **`claude-opus-5` was missing from every Anthropic reasoning classification**,
   so effort fell through to the legacy thinking-budget path and `max`/`xhigh`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,8 +25,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - **New `llm.ClampReasoningEffort`** maps a requested effort onto the closest
   level a model accepts.
 
+- **Gemini thinking control is now wired up.** `WithReasoningEffort` maps to
+  `thinkingConfig.thinkingLevel`, `WithReasoningBudget` to `thinkingBudget`,
+  `WithAdaptiveThinking` to a dynamic budget, and `WithThinkingDisplay` to
+  `includeThoughts`. All four were previously discarded before the request.
+
 ### Fixed
 
+- **Gemini thought summaries were emitted as answer text.** With thoughts
+  enabled, the non-streaming path spliced the model's reasoning into its reply;
+  the streaming path dropped it. Both now produce `llm.ThinkingContent`.
 - **Reasoning effort was sent to models that have no reasoning parameter**,
   producing a 400 on every request. Affects `gpt-4o` and `gpt-4.1`, plus
   `grok-build`, `grok-code-fast`, and both `grok-4.20-0309` models. The CLI's new

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,11 +24,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
   separate copies of the same prefix switches.
 - **New `llm.ClampReasoningEffort`** maps a requested effort onto the closest
   level a model accepts.
-
 - **Gemini thinking control is now wired up.** `WithReasoningEffort` maps to
-  `thinkingConfig.thinkingLevel`, `WithReasoningBudget` to `thinkingBudget`,
-  `WithAdaptiveThinking` to a dynamic budget, and `WithThinkingDisplay` to
-  `includeThoughts`. All four were previously discarded before the request.
+  `thinkingConfig.thinkingLevel`, or to a clamped `thinkingBudget` on models
+  with no thinking level (the 2.5 generation); `WithReasoningBudget` maps to
+  `thinkingBudget`, `WithAdaptiveThinking` to a dynamic budget, and
+  `WithThinkingDisplay` to `includeThoughts`. All four were previously
+  discarded before the request was built.
 
 ### Fixed
 
@@ -52,7 +53,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
   (was downgraded to `high`) and rejects `none`; the Grok multi-agent model
   accepts `max` and `none`; `gpt-5.2-pro` accepts only `medium`/`high`/`xhigh`;
   `gpt-5.3-chat-latest` accepts only `medium`.
-
 - **`claude-opus-5` was missing from every Anthropic reasoning classification**,
   so effort fell through to the legacy thinking-budget path and `max`/`xhigh`
   silently became `high`. It now uses native `output_config.effort`.

--- a/llm/options.go
+++ b/llm/options.go
@@ -236,6 +236,77 @@ func (r ReasoningEffort) IsValid() bool {
 		r == ReasoningEffortMax
 }
 
+// reasoningEffortLadder orders the graduated effort levels from least to most
+// eager. ReasoningEffortNone is deliberately absent: it asks for no reasoning at
+// all rather than a little, so it is never selected as the neighbour of a
+// graduated level. A caller that wants it must have it explicitly supported.
+var reasoningEffortLadder = []ReasoningEffort{
+	ReasoningEffortMinimal,
+	ReasoningEffortLow,
+	ReasoningEffortMedium,
+	ReasoningEffortHigh,
+	ReasoningEffortXHigh,
+	ReasoningEffortMax,
+}
+
+func ladderIndex(effort ReasoningEffort) int {
+	for i, level := range reasoningEffortLadder {
+		if level == effort {
+			return i
+		}
+	}
+	return -1
+}
+
+// ClampReasoningEffort maps a requested effort onto the closest level a model
+// actually accepts, reporting whether it had to move. Providers use it so that
+// a portable ModelSettings survives being pointed at a model with a narrower
+// range, instead of failing the request.
+//
+// The requested level is clamped down to the most eager supported level that
+// does not exceed it — xhigh becomes high on a model that stops at high. When
+// the request sits below everything supported, it clamps up to the least eager
+// supported level, so minimal becomes low rather than none.
+//
+// An empty supported set, an unrecognized effort, or a supported set holding no
+// graduated levels all return the input unchanged with false; the caller owns
+// those cases.
+func ClampReasoningEffort(requested ReasoningEffort, supported []ReasoningEffort) (ReasoningEffort, bool) {
+	if len(supported) == 0 || !requested.IsValid() {
+		return requested, false
+	}
+	for _, level := range supported {
+		if level == requested {
+			return requested, false
+		}
+	}
+
+	best, bestIdx := ReasoningEffort(""), -1
+	lowest, lowestIdx := ReasoningEffort(""), len(reasoningEffortLadder)
+	requestedIdx := ladderIndex(requested)
+	for _, level := range supported {
+		idx := ladderIndex(level)
+		if idx < 0 {
+			continue // ReasoningEffortNone, only reachable by exact match above
+		}
+		if idx < lowestIdx {
+			lowest, lowestIdx = level, idx
+		}
+		// requestedIdx is -1 for ReasoningEffortNone, so no level qualifies and
+		// the clamp falls through to the least eager supported level.
+		if idx <= requestedIdx && idx > bestIdx {
+			best, bestIdx = level, idx
+		}
+	}
+	if bestIdx >= 0 {
+		return best, true
+	}
+	if lowestIdx < len(reasoningEffortLadder) {
+		return lowest, true
+	}
+	return requested, false
+}
+
 // WithReasoningEffort sets the reasoning effort for the interaction.
 func WithReasoningEffort(reasoningEffort ReasoningEffort) Option {
 	return func(config *Config) {

--- a/providers/anthropic/anthropic.go
+++ b/providers/anthropic/anthropic.go
@@ -766,7 +766,7 @@ func applyEffort(
 		// Opus 5 rejects an effort above high while thinking is explicitly
 		// disabled, so the cap applies only to that combination.
 		if config.Thinking == llm.ThinkingTypeDisabled && caps.disabledEffortCap != "" {
-			capped, ok := llm.ClampReasoningEffort(effort, []llm.ReasoningEffort{caps.disabledEffortCap})
+			capped, ok := llm.ClampReasoningEffort(effort, effortsUpTo(caps.efforts, caps.disabledEffortCap))
 			if ok && capped != effort {
 				warnf(config, "model caps reasoning effort while thinking is disabled; clamping",
 					"model", model, "requested", effort, "using", capped)
@@ -1002,13 +1002,6 @@ func modelAcceptsTemperature(model string) bool {
 func modelRejectsManualThinking(model string) bool {
 	caps, known := lookupCapabilities(model)
 	return known && !caps.manualBudget && caps.adaptive
-}
-
-// modelSupportsAdaptiveThinking reports whether thinking:{type:"adaptive"} is
-// accepted. The 4.5 generation predates it and answers 400.
-func modelSupportsAdaptiveThinking(model string) bool {
-	caps, known := lookupCapabilities(model)
-	return !known || caps.adaptive
 }
 
 // modelDefaultsThinkingOn reports whether the model runs with adaptive thinking

--- a/providers/anthropic/anthropic.go
+++ b/providers/anthropic/anthropic.go
@@ -678,7 +678,7 @@ func (p *Provider) applyRequestConfig(req *Request, config *llm.Config) error {
 		req.ContextManagement = config.ContextManagement
 	}
 
-	if !modelRejectsTemperature(req.Model) && !requestHasThinkingEnabled(req.Model, req.Thinking) {
+	if modelAcceptsTemperature(req.Model) && !requestHasThinkingEnabled(req.Model, req.Thinking) {
 		req.Temperature = config.Temperature
 	} else if config.Temperature != nil && config.Logger != nil {
 		config.Logger.Warn("temperature is not supported by this Anthropic request and will be ignored",
@@ -690,58 +690,41 @@ func (p *Provider) applyRequestConfig(req *Request, config *llm.Config) error {
 	return nil
 }
 
+// defaultThinkingBudget is the budget used when a caller asks for thinking
+// without saying how much — it matches the budget medium effort maps to.
+const defaultThinkingBudget = 4096
+
+// minThinkingBudget is the smallest budget the API accepts.
+const minThinkingBudget = 1024
+
+func warnf(config *llm.Config, msg string, args ...any) {
+	if config.Logger != nil {
+		config.Logger.Warn(msg, args...)
+	}
+}
+
 // applyReasoningConfig maps Dive's reasoning/thinking options onto the Anthropic
-// request, accounting for per-model differences:
-//   - Opus 4.5+, Sonnet 4.6, and the Claude 5 models (Opus 5, Fable 5, Mythos 5,
-//     Sonnet 5) take the native effort parameter via output_config; older models
-//     emulate effort with a thinking budget.
-//   - Opus 4.6/4.7/4.8, Sonnet 4.6, and the Claude 5 models support adaptive
-//     thinking. Opus 4.7/4.8 and the Claude 5 models reject manual budgets, so
-//     a budget set against them transparently falls back to adaptive thinking.
-//   - Opus 5 accepts an explicit thinking disable only at effort high or below.
+// request. Per-model differences come from modelCapabilityTable rather than from
+// prefix tests scattered through this file.
+//
+// Settings a model cannot accept are clamped or dropped with a warning, never
+// turned into an error: one ModelSettings is meant to survive being pointed at a
+// different model. Unknown models — fine-tunes, gateways, custom deployments —
+// keep their parameters untouched, since Dive cannot know what they accept.
 func applyReasoningConfig(req *Request, config *llm.Config) error {
 	model := req.Model
+	caps, known := lookupCapabilities(model)
 
-	thinking, err := resolveThinking(model, config)
-	if err != nil {
-		return err
-	}
+	thinking := resolveThinking(model, caps, known, config)
 
 	if config.ReasoningEffort != "" {
-		effort, err := normalizeReasoningEffort(model, config.ReasoningEffort)
-		if err != nil {
-			return err
-		}
-		if config.Thinking == llm.ThinkingTypeDisabled &&
-			modelRejectsDisabledThinkingAboveHighEffort(model) &&
-			(effort == llm.ReasoningEffortXHigh || effort == llm.ReasoningEffortMax) {
-			return fmt.Errorf("cannot set reasoning effort %s with thinking disabled on model %s: it accepts an explicit thinking disable only at effort high or below", effort, model)
-		}
-		if modelSupportsEffortParam(model) {
-			req.OutputConfig = &OutputConfig{Effort: string(effort)}
-		} else {
-			// Legacy: emulate the effort parameter with a thinking budget.
-			// This model lacks the native effort parameter, so honoring effort
-			// here would re-enable thinking — don't silently override an
-			// explicit disable.
-			if config.Thinking == llm.ThinkingTypeDisabled {
-				return fmt.Errorf("cannot set reasoning effort with thinking disabled on model %s: it has no native effort parameter and effort is emulated with a thinking budget", model)
-			}
-			if thinking != nil && config.ReasoningBudget != nil {
-				return fmt.Errorf("cannot set both reasoning budget and effort on model %s", model)
-			}
-			budget, err := legacyEffortBudget(effort)
-			if err != nil {
-				return err
-			}
-			thinking = &Thinking{Type: "enabled", BudgetTokens: budget}
-		}
+		thinking = applyEffort(req, config, model, caps, known, thinking)
 	}
 
 	if thinking != nil {
-		if err := validateThinkingBudget(req, config, thinking); err != nil {
-			return err
-		}
+		thinking = clampThinkingBudget(req, config, thinking)
+	}
+	if thinking != nil {
 		if config.ThinkingDisplay != "" && thinking.Type != "disabled" {
 			thinking.Display = string(config.ThinkingDisplay)
 		}
@@ -750,104 +733,205 @@ func applyReasoningConfig(req *Request, config *llm.Config) error {
 	return nil
 }
 
+// applyEffort places the requested effort on the request using whichever
+// mechanism the model has: the native effort parameter, an emulated thinking
+// budget, or neither.
+func applyEffort(
+	req *Request,
+	config *llm.Config,
+	model string,
+	caps modelCapabilities,
+	known bool,
+	thinking *Thinking,
+) *Thinking {
+	// An unknown model keeps the pre-table behavior: effort is emulated with a
+	// thinking budget, since the native parameter is newer than most gateways.
+	kind := reasoningLegacyBudget
+	if known {
+		kind = caps.reasoningKind()
+	}
+
+	switch kind {
+	case reasoningNone:
+		warnf(config, "model does not support reasoning; ignoring reasoning effort",
+			"model", model, "effort", config.ReasoningEffort)
+		return thinking
+
+	case reasoningNative:
+		effort, clamped := llm.ClampReasoningEffort(config.ReasoningEffort, caps.efforts)
+		if clamped {
+			warnf(config, "model does not support the requested reasoning effort; clamping",
+				"model", model, "requested", config.ReasoningEffort, "using", effort)
+		}
+		// Opus 5 rejects an effort above high while thinking is explicitly
+		// disabled, so the cap applies only to that combination.
+		if config.Thinking == llm.ThinkingTypeDisabled && caps.disabledEffortCap != "" {
+			capped, ok := llm.ClampReasoningEffort(effort, []llm.ReasoningEffort{caps.disabledEffortCap})
+			if ok && capped != effort {
+				warnf(config, "model caps reasoning effort while thinking is disabled; clamping",
+					"model", model, "requested", effort, "using", capped)
+				effort = capped
+			}
+		}
+		req.OutputConfig = &OutputConfig{Effort: string(effort)}
+		return thinking
+
+	default: // reasoningLegacyBudget
+		// The model has no native effort parameter, so effort is emulated with
+		// a thinking budget. That cannot coexist with an explicit disable or
+		// with a budget the caller set themselves. The disable is checked on
+		// the config rather than the resolved value, because for most models
+		// "disabled" is expressed by omitting the thinking parameter entirely.
+		if config.Thinking == llm.ThinkingTypeDisabled {
+			warnf(config, "model emulates reasoning effort with a thinking budget; ignoring effort because thinking is disabled",
+				"model", model, "effort", config.ReasoningEffort)
+			return thinking
+		}
+		if config.ReasoningBudget != nil {
+			warnf(config, "model emulates reasoning effort with a thinking budget; keeping the explicit budget and ignoring effort",
+				"model", model, "effort", config.ReasoningEffort)
+			return thinking
+		}
+		budget, ok := legacyEffortBudget(config.ReasoningEffort)
+		if !ok {
+			warnf(config, "unrecognized reasoning effort for a model without a native effort parameter; ignoring it",
+				"model", model, "effort", config.ReasoningEffort)
+			return thinking
+		}
+		return &Thinking{Type: "enabled", BudgetTokens: budget}
+	}
+}
+
 // resolveThinking determines the thinking configuration from the budget and
 // explicit thinking-type options, independent of the effort parameter.
-func resolveThinking(model string, config *llm.Config) (*Thinking, error) {
-	adaptiveOnly := modelRejectsManualThinking(model) // Opus 4.7/4.8, Fable 5, Mythos 5
+func resolveThinking(model string, caps modelCapabilities, known bool, config *llm.Config) *Thinking {
+	// Unknown models keep the pre-table assumption: manual budgets work,
+	// adaptive thinking is passed through as asked.
+	canBudget := !known || caps.manualBudget
+	canAdapt := !known || caps.adaptive
 
 	switch config.Thinking {
 	case llm.ThinkingTypeDisabled:
-		// Models that default thinking on (Sonnet 5) require an explicit
-		// disable to actually turn thinking off; omitting the parameter would
-		// leave adaptive thinking enabled. All other models treat an omitted
-		// thinking parameter as off.
-		if modelDefaultsThinkingOn(model) {
-			return &Thinking{Type: "disabled"}, nil
+		// Fable 5 and Mythos 5 reject an explicit disable; omitting the
+		// parameter is the accepted way to ask them for less.
+		if known && !caps.explicitDisable {
+			warnf(config, "model does not accept an explicit thinking disable; omitting the thinking parameter",
+				"model", model)
+			return nil
 		}
-		return nil, nil
+		// Models that think by default need the explicit disable to actually
+		// turn it off. Everywhere else an omitted parameter already means off.
+		if known && caps.thinkingOnByDefault {
+			return &Thinking{Type: "disabled"}
+		}
+		return nil
+
 	case llm.ThinkingTypeAdaptive:
-		return &Thinking{Type: "adaptive"}, nil
+		if canAdapt {
+			return &Thinking{Type: "adaptive"}
+		}
+		// The 4.5 generation answers 400 for adaptive thinking. The caller
+		// still asked to think, so fall back to the mechanism it does have.
+		if canBudget {
+			budget := defaultThinkingBudget
+			if config.ReasoningBudget != nil {
+				budget = *config.ReasoningBudget
+			} else if b, ok := legacyEffortBudget(config.ReasoningEffort); ok {
+				budget = b
+			}
+			warnf(config, "model does not support adaptive thinking; using a manual thinking budget",
+				"model", model, "budget", budget)
+			return &Thinking{Type: "enabled", BudgetTokens: clampBudgetFloor(budget)}
+		}
+		warnf(config, "model does not support thinking; ignoring the thinking setting", "model", model)
+		return nil
+
 	case llm.ThinkingTypeEnabled:
-		if adaptiveOnly {
-			return &Thinking{Type: "adaptive"}, nil
+		if !canBudget {
+			if canAdapt {
+				return &Thinking{Type: "adaptive"}
+			}
+			warnf(config, "model does not support thinking; ignoring the thinking setting", "model", model)
+			return nil
 		}
 		if config.ReasoningBudget == nil {
-			return nil, fmt.Errorf("thinking type %q requires a reasoning budget; use WithReasoningBudget or WithAdaptiveThinking", llm.ThinkingTypeEnabled)
+			// Asking to think without saying how much: prefer adaptive where
+			// the model has it, otherwise pick the default budget.
+			if canAdapt {
+				return &Thinking{Type: "adaptive"}
+			}
+			warnf(config, "thinking was enabled without a reasoning budget; using the default budget",
+				"model", model, "budget", defaultThinkingBudget)
+			return &Thinking{Type: "enabled", BudgetTokens: defaultThinkingBudget}
 		}
 		// Budget provided: handled by the block below.
 	}
 
 	if config.ReasoningBudget != nil {
 		budget := *config.ReasoningBudget
-		if budget < 1024 {
-			return nil, fmt.Errorf("reasoning budget must be at least 1024")
+		if budget < minThinkingBudget {
+			warnf(config, "reasoning budget is below the minimum; clamping",
+				"model", model, "requested", budget, "using", minThinkingBudget)
+			budget = minThinkingBudget
 		}
-		if adaptiveOnly {
-			if config.Logger != nil {
-				config.Logger.Warn("model does not support manual thinking budgets; using adaptive thinking",
+		if !canBudget {
+			if canAdapt {
+				warnf(config, "model does not support manual thinking budgets; using adaptive thinking",
 					"model", model)
+				return &Thinking{Type: "adaptive"}
 			}
-			return &Thinking{Type: "adaptive"}, nil
+			warnf(config, "model does not support thinking; ignoring the reasoning budget", "model", model)
+			return nil
 		}
-		return &Thinking{Type: "enabled", BudgetTokens: budget}, nil
+		return &Thinking{Type: "enabled", BudgetTokens: budget}
 	}
 
-	return nil, nil
+	return nil
 }
 
-// normalizeReasoningEffort maps provider-neutral efforts onto Anthropic's
-// documented effort levels while keeping older low/medium/high behavior intact.
-func normalizeReasoningEffort(model string, effort llm.ReasoningEffort) (llm.ReasoningEffort, error) {
-	switch effort {
-	case llm.ReasoningEffortLow,
-		llm.ReasoningEffortMedium,
-		llm.ReasoningEffortHigh:
-		return effort, nil
-	case llm.ReasoningEffortMinimal:
-		return llm.ReasoningEffortLow, nil
-	case llm.ReasoningEffortNone:
-		return "", fmt.Errorf("reasoning effort %q is not supported by Anthropic models", effort)
-	case llm.ReasoningEffortXHigh:
-		if modelSupportsXHighEffort(model) {
-			return effort, nil
-		}
-		return llm.ReasoningEffortHigh, nil
-	case llm.ReasoningEffortMax:
-		if modelSupportsMaxEffort(model) {
-			return effort, nil
-		}
-		return llm.ReasoningEffortHigh, nil
-	default:
-		return effort, nil
+func clampBudgetFloor(budget int) int {
+	if budget < minThinkingBudget {
+		return minThinkingBudget
 	}
+	return budget
 }
 
 // legacyEffortBudget maps a reasoning effort level to a thinking token budget
-// for older models that lack the native effort parameter.
-func legacyEffortBudget(effort llm.ReasoningEffort) (int, error) {
+// for models that lack the native effort parameter. The bool reports whether
+// the effort was recognized.
+func legacyEffortBudget(effort llm.ReasoningEffort) (int, bool) {
 	switch effort {
 	case llm.ReasoningEffortLow, llm.ReasoningEffortMinimal:
-		return 1024, nil
+		return 1024, true
 	case llm.ReasoningEffortMedium:
-		return 4096, nil
+		return 4096, true
 	case llm.ReasoningEffortHigh, llm.ReasoningEffortXHigh, llm.ReasoningEffortMax:
-		return 16384, nil
+		return 16384, true
 	default:
-		return 0, fmt.Errorf("invalid reasoning effort: %s", effort)
+		return 0, false
 	}
 }
 
-func validateThinkingBudget(req *Request, config *llm.Config, thinking *Thinking) error {
+// clampThinkingBudget keeps the thinking budget below max_tokens, which the API
+// requires outside interleaved thinking. When max_tokens leaves no room for a
+// valid budget at all, thinking is dropped rather than sent as a doomed request.
+func clampThinkingBudget(req *Request, config *llm.Config, thinking *Thinking) *Thinking {
 	if thinking.Type != "enabled" || config.IsFeatureEnabled(FeatureInterleavedThinking) {
+		return thinking
+	}
+	if req.MaxTokens == nil || thinking.BudgetTokens < *req.MaxTokens {
+		return thinking
+	}
+	capped := *req.MaxTokens - 1
+	if capped < minThinkingBudget {
+		warnf(config, "max_tokens leaves no room for a thinking budget; disabling thinking",
+			"model", req.Model, "max_tokens", *req.MaxTokens, "budget", thinking.BudgetTokens)
 		return nil
 	}
-	if req.MaxTokens == nil {
-		return nil
-	}
-	if thinking.BudgetTokens >= *req.MaxTokens {
-		return fmt.Errorf("anthropic reasoning budget (%d) must be less than max_tokens (%d)", thinking.BudgetTokens, *req.MaxTokens)
-	}
-	return nil
+	warnf(config, "reasoning budget must be below max_tokens; clamping",
+		"model", req.Model, "requested", thinking.BudgetTokens, "using", capped)
+	thinking.BudgetTokens = capped
+	return thinking
 }
 
 func requestHasThinkingEnabled(model string, thinking *Thinking) bool {
@@ -874,101 +958,80 @@ func forcedToolChoice(choice llm.ToolChoiceType) bool {
 	return choice == llm.ToolChoiceTypeAny || choice == llm.ToolChoiceTypeTool
 }
 
+// The predicates below read modelCapabilityTable. Each keeps the permissive
+// answer for an unknown model, so a fine-tune or gateway deployment behaves as
+// it did before the table existed.
+
 // modelSupportsEffortParam reports whether the model accepts the native
-// output_config.effort parameter (Opus 4.5+, Opus 5, Sonnet 4.6, Sonnet 5,
-// Fable 5, Mythos 5).
+// output_config.effort parameter.
 func modelSupportsEffortParam(model string) bool {
-	switch {
-	case strings.HasPrefix(model, "claude-opus-4-5"),
-		strings.HasPrefix(model, "claude-opus-4-6"),
-		strings.HasPrefix(model, "claude-opus-4-7"),
-		strings.HasPrefix(model, "claude-opus-4-8"),
-		strings.HasPrefix(model, "claude-opus-5"),
-		strings.HasPrefix(model, "claude-sonnet-4-6"),
-		strings.HasPrefix(model, "claude-sonnet-5"),
-		strings.HasPrefix(model, "claude-fable-5"),
-		strings.HasPrefix(model, "claude-mythos-5"):
-		return true
+	caps, known := lookupCapabilities(model)
+	return known && caps.reasoningKind() == reasoningNative
+}
+
+func modelSupportsXHighEffort(model string) bool {
+	return modelSupportsEffortLevel(model, llm.ReasoningEffortXHigh)
+}
+
+func modelSupportsMaxEffort(model string) bool {
+	return modelSupportsEffortLevel(model, llm.ReasoningEffortMax)
+}
+
+func modelSupportsEffortLevel(model string, effort llm.ReasoningEffort) bool {
+	caps, known := lookupCapabilities(model)
+	if !known {
+		return false
+	}
+	for _, level := range caps.efforts {
+		if level == effort {
+			return true
+		}
 	}
 	return false
 }
 
-func modelSupportsXHighEffort(model string) bool {
-	return strings.HasPrefix(model, "claude-opus-4-7") ||
-		strings.HasPrefix(model, "claude-opus-4-8") ||
-		strings.HasPrefix(model, "claude-opus-5") ||
-		strings.HasPrefix(model, "claude-sonnet-5") ||
-		strings.HasPrefix(model, "claude-fable-5") ||
-		strings.HasPrefix(model, "claude-mythos-5")
-}
-
-func modelSupportsMaxEffort(model string) bool {
-	return strings.HasPrefix(model, "claude-opus-4-6") ||
-		strings.HasPrefix(model, "claude-opus-4-7") ||
-		strings.HasPrefix(model, "claude-opus-4-8") ||
-		strings.HasPrefix(model, "claude-opus-5") ||
-		strings.HasPrefix(model, "claude-sonnet-4-6") ||
-		strings.HasPrefix(model, "claude-sonnet-5") ||
-		strings.HasPrefix(model, "claude-fable-5") ||
-		strings.HasPrefix(model, "claude-mythos-5")
-}
-
-// modelRejectsTemperature reports whether the model rejects the temperature
-// parameter (Opus 4.7/4.8, Opus 5, and the rest of the Claude 5 family: Fable 5,
-// Mythos 5, Sonnet 5). Opus 4.6 and Sonnet 4.6 still accept it.
-func modelRejectsTemperature(model string) bool {
-	return strings.HasPrefix(model, "claude-opus-4-7") ||
-		strings.HasPrefix(model, "claude-opus-4-8") ||
-		strings.HasPrefix(model, "claude-opus-5") ||
-		strings.HasPrefix(model, "claude-fable-5") ||
-		strings.HasPrefix(model, "claude-mythos-5") ||
-		strings.HasPrefix(model, "claude-sonnet-5")
+// modelAcceptsTemperature reports whether the model accepts the temperature
+// parameter. Unknown models are assumed to accept it, as they did before.
+func modelAcceptsTemperature(model string) bool {
+	caps, known := lookupCapabilities(model)
+	return !known || caps.temperature
 }
 
 // modelRejectsManualThinking reports whether the model rejects manual extended
-// thinking budgets and supports only adaptive thinking (Opus 4.7/4.8, Opus 5,
-// Fable 5, Mythos 5, Sonnet 5). On Fable 5 and Mythos 5 adaptive thinking is
-// always on and an explicit thinking disable is also rejected by the API; Dive
-// omits the thinking parameter entirely when thinking is disabled, which is the
-// accepted form. Opus 5 and Sonnet 5 also default thinking on but, unlike
-// Fable/Mythos, accept an explicit disable — see modelDefaultsThinkingOn.
+// thinking budgets and supports only adaptive thinking.
 func modelRejectsManualThinking(model string) bool {
-	return strings.HasPrefix(model, "claude-opus-4-7") ||
-		strings.HasPrefix(model, "claude-opus-4-8") ||
-		strings.HasPrefix(model, "claude-opus-5") ||
-		strings.HasPrefix(model, "claude-fable-5") ||
-		strings.HasPrefix(model, "claude-mythos-5") ||
-		strings.HasPrefix(model, "claude-sonnet-5")
+	caps, known := lookupCapabilities(model)
+	return known && !caps.manualBudget && caps.adaptive
+}
+
+// modelSupportsAdaptiveThinking reports whether thinking:{type:"adaptive"} is
+// accepted. The 4.5 generation predates it and answers 400.
+func modelSupportsAdaptiveThinking(model string) bool {
+	caps, known := lookupCapabilities(model)
+	return !known || caps.adaptive
 }
 
 // modelDefaultsThinkingOn reports whether the model runs with adaptive thinking
-// when the request omits the thinking parameter. For these models a caller that
-// asks to disable thinking must send an explicit thinking:{type:"disabled"} —
-// omitting the field would leave thinking on. Opus 5 and Sonnet 5 both default
-// thinking on and accept an explicit disable (Fable 5 and Mythos 5 default on
-// but reject the explicit disable, so Dive omits the field for them). On Opus 5
-// the explicit disable is only accepted at effort high or below — see
-// modelRejectsDisabledThinkingAboveHighEffort.
+// when the request omits the thinking parameter *and* accepts an explicit
+// disable to turn it off. Fable 5 and Mythos 5 also think by default but reject
+// the disable, so they are excluded here — see modelRunsThinkingByDefault.
 func modelDefaultsThinkingOn(model string) bool {
-	return strings.HasPrefix(model, "claude-opus-5") ||
-		strings.HasPrefix(model, "claude-sonnet-5")
+	caps, known := lookupCapabilities(model)
+	return known && caps.thinkingOnByDefault && caps.explicitDisable
 }
 
 // modelRejectsDisabledThinkingAboveHighEffort reports whether the model rejects
-// an explicit thinking disable combined with an effort level above high. Opus 5
-// accepts thinking:{type:"disabled"} only at effort high or below and returns a
-// 400 when it is paired with xhigh or max.
+// an explicit thinking disable combined with an effort level above high.
 func modelRejectsDisabledThinkingAboveHighEffort(model string) bool {
-	return strings.HasPrefix(model, "claude-opus-5")
+	caps, known := lookupCapabilities(model)
+	return known && caps.disabledEffortCap != ""
 }
 
 // modelRunsThinkingByDefault reports whether omitting the thinking parameter
 // still leaves adaptive thinking active.
 func modelRunsThinkingByDefault(model string) bool {
-	return strings.HasPrefix(model, "claude-fable-5") ||
-		strings.HasPrefix(model, "claude-mythos-5") ||
-		strings.HasPrefix(model, "claude-mythos-preview") ||
-		modelDefaultsThinkingOn(model)
+	caps, known := lookupCapabilities(model)
+	return known && caps.thinkingOnByDefault
 }
 
 // createRequest creates an HTTP request with appropriate headers for Anthropic API calls

--- a/providers/anthropic/capabilities.go
+++ b/providers/anthropic/capabilities.go
@@ -1,0 +1,212 @@
+package anthropic
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/deepnoodle-ai/dive/llm"
+)
+
+// modelCapabilities records which reasoning, thinking, and sampling parameters a
+// model accepts. Every field is a fact about the API, not a preference: each was
+// verified by sending the parameter to the live endpoint and recording whether
+// it returned 200 or 400.
+//
+// The zero value describes a model with no reasoning support at all, which is
+// the safe default — a model absent from the table is treated as unknown
+// instead, and its parameters pass through untouched.
+type modelCapabilities struct {
+	// efforts lists the levels output_config.effort accepts. Empty means the
+	// model has no native effort parameter.
+	efforts []llm.ReasoningEffort
+
+	// manualBudget reports whether thinking:{type:"enabled",budget_tokens:N} is
+	// accepted. Models with no native effort parameter but a manual budget
+	// emulate effort with a budget; models with neither cannot reason at all.
+	manualBudget bool
+
+	// adaptive reports whether thinking:{type:"adaptive"} is accepted. The 4.5
+	// generation predates adaptive thinking and returns
+	// "adaptive thinking is not supported on this model".
+	adaptive bool
+
+	// explicitDisable reports whether thinking:{type:"disabled"} is accepted.
+	// Fable 5 and Mythos 5 reject it; for them thinking is omitted instead.
+	explicitDisable bool
+
+	// thinkingOnByDefault reports whether omitting the thinking parameter still
+	// leaves thinking active. These models need an explicit disable to turn it
+	// off, where omission suffices everywhere else.
+	thinkingOnByDefault bool
+
+	// disabledEffortCap caps effort while thinking is explicitly disabled. Opus
+	// 5 answers 400 for xhigh or max paired with a disable but accepts high and
+	// below. Empty means no cap.
+	disabledEffortCap llm.ReasoningEffort
+
+	// temperature reports whether the temperature parameter is accepted.
+	temperature bool
+}
+
+// reasoningKind classifies how the model takes a reasoning effort.
+type reasoningKind int
+
+const (
+	// reasoningNone: the model cannot reason; effort must be dropped.
+	reasoningNone reasoningKind = iota
+	// reasoningLegacyBudget: no native effort parameter, but effort can be
+	// emulated with a thinking budget.
+	reasoningLegacyBudget
+	// reasoningNative: the model takes output_config.effort directly.
+	reasoningNative
+)
+
+func (c modelCapabilities) reasoningKind() reasoningKind {
+	switch {
+	case len(c.efforts) > 0:
+		return reasoningNative
+	case c.manualBudget:
+		return reasoningLegacyBudget
+	default:
+		return reasoningNone
+	}
+}
+
+var (
+	effortsThroughHigh = []llm.ReasoningEffort{
+		llm.ReasoningEffortLow,
+		llm.ReasoningEffortMedium,
+		llm.ReasoningEffortHigh,
+	}
+	// The 4.6 generation accepts max but rejects xhigh — an ordering that looks
+	// like a typo and is not. Verified against the live API.
+	effortsThroughHighPlusMax = []llm.ReasoningEffort{
+		llm.ReasoningEffortLow,
+		llm.ReasoningEffortMedium,
+		llm.ReasoningEffortHigh,
+		llm.ReasoningEffortMax,
+	}
+	effortsFull = []llm.ReasoningEffort{
+		llm.ReasoningEffortLow,
+		llm.ReasoningEffortMedium,
+		llm.ReasoningEffortHigh,
+		llm.ReasoningEffortXHigh,
+		llm.ReasoningEffortMax,
+	}
+)
+
+type capabilityEntry struct {
+	prefix string
+	caps   modelCapabilities
+}
+
+// modelCapabilityTable maps model-id prefixes to capabilities. Lookup takes the
+// longest matching prefix, so a family entry such as "claude-opus-4" can sit
+// alongside the narrower "claude-opus-4-5" without ordering hazards.
+//
+// Every model id in catalog.json must resolve to an entry here;
+// TestEveryCatalogModelHasCapabilities enforces it, so a newly added model
+// fails the build until it has been classified.
+var modelCapabilityTable = []capabilityEntry{
+	// --- Retired. These return 404 at inference and are kept only so the
+	// catalog stays fully classified; the values are historical. ---
+	{prefix: "claude-3-5-haiku", caps: modelCapabilities{temperature: true}},
+	{prefix: "claude-3-5-sonnet", caps: modelCapabilities{temperature: true}},
+	{prefix: "claude-3-7-sonnet", caps: modelCapabilities{
+		manualBudget: true, explicitDisable: true, temperature: true,
+	}},
+	{prefix: "claude-sonnet-4", caps: modelCapabilities{
+		manualBudget: true, explicitDisable: true, temperature: true,
+	}},
+	{prefix: "claude-opus-4", caps: modelCapabilities{
+		manualBudget: true, explicitDisable: true, temperature: true,
+	}},
+	{prefix: "claude-opus-4-1", caps: modelCapabilities{
+		manualBudget: true, explicitDisable: true, temperature: true,
+	}},
+
+	// --- 4.5: manual budgets only. No native effort, no adaptive thinking. ---
+	{prefix: "claude-haiku-4-5", caps: modelCapabilities{
+		manualBudget: true, explicitDisable: true, temperature: true,
+	}},
+	{prefix: "claude-sonnet-4-5", caps: modelCapabilities{
+		manualBudget: true, explicitDisable: true, temperature: true,
+	}},
+	// Opus 4.5 introduced the effort parameter but still predates adaptive
+	// thinking, and accepts a budget and an effort in the same request.
+	{prefix: "claude-opus-4-5", caps: modelCapabilities{
+		efforts: effortsThroughHigh, manualBudget: true,
+		explicitDisable: true, temperature: true,
+	}},
+
+	// --- 4.6: adds adaptive thinking and max effort; still takes temperature. ---
+	{prefix: "claude-sonnet-4-6", caps: modelCapabilities{
+		efforts: effortsThroughHighPlusMax, manualBudget: true,
+		adaptive: true, explicitDisable: true, temperature: true,
+	}},
+	{prefix: "claude-opus-4-6", caps: modelCapabilities{
+		efforts: effortsThroughHighPlusMax, manualBudget: true,
+		adaptive: true, explicitDisable: true, temperature: true,
+	}},
+
+	// --- 4.7/4.8: adaptive-only thinking; temperature and manual budgets rejected. ---
+	{prefix: "claude-opus-4-7", caps: modelCapabilities{
+		efforts: effortsFull, adaptive: true, explicitDisable: true,
+	}},
+	{prefix: "claude-opus-4-8", caps: modelCapabilities{
+		efforts: effortsFull, adaptive: true, explicitDisable: true,
+	}},
+
+	// --- Claude 5: thinking on by default, adaptive-only, no temperature. ---
+	// Opus 5 alone caps effort at high while thinking is explicitly disabled.
+	{prefix: "claude-opus-5", caps: modelCapabilities{
+		efforts: effortsFull, adaptive: true, explicitDisable: true,
+		thinkingOnByDefault: true, disabledEffortCap: llm.ReasoningEffortHigh,
+	}},
+	{prefix: "claude-sonnet-5", caps: modelCapabilities{
+		efforts: effortsFull, adaptive: true, explicitDisable: true,
+		thinkingOnByDefault: true,
+	}},
+	// Fable 5 and Mythos 5 always think and reject an explicit disable, so
+	// Dive omits the thinking parameter for them instead.
+	{prefix: "claude-fable-5", caps: modelCapabilities{
+		efforts: effortsFull, adaptive: true, thinkingOnByDefault: true,
+	}},
+	// Mythos 5 is catalogued but not currently served (404), so its entry
+	// mirrors Fable 5 and is untested against the live API.
+	{prefix: "claude-mythos-5", caps: modelCapabilities{
+		efforts: effortsFull, adaptive: true, thinkingOnByDefault: true,
+	}},
+	{prefix: "claude-mythos-preview", caps: modelCapabilities{
+		efforts: effortsFull, adaptive: true, thinkingOnByDefault: true,
+	}},
+}
+
+// sortedCapabilityTable is modelCapabilityTable ordered longest-prefix-first so
+// lookup can return the first match.
+var sortedCapabilityTable = func() []capabilityEntry {
+	entries := make([]capabilityEntry, len(modelCapabilityTable))
+	copy(entries, modelCapabilityTable)
+	sort.SliceStable(entries, func(i, j int) bool {
+		return len(entries[i].prefix) > len(entries[j].prefix)
+	})
+	return entries
+}()
+
+// lookupCapabilities returns the capabilities for a model id. The bool reports
+// whether the model is known: an unknown model — a fine-tune, a custom
+// deployment, or a base-URL passthrough — gets its parameters forwarded
+// untouched, since Dive cannot tell what it accepts.
+func lookupCapabilities(model string) (modelCapabilities, bool) {
+	id := strings.ToLower(strings.TrimSpace(model))
+	// Accept vendor-qualified ids such as "anthropic/claude-sonnet-5".
+	if _, rest, ok := strings.Cut(id, "/"); ok {
+		id = rest
+	}
+	for _, entry := range sortedCapabilityTable {
+		if strings.HasPrefix(id, entry.prefix) {
+			return entry.caps, true
+		}
+	}
+	return modelCapabilities{}, false
+}

--- a/providers/anthropic/capabilities.go
+++ b/providers/anthropic/capabilities.go
@@ -193,15 +193,38 @@ var sortedCapabilityTable = func() []capabilityEntry {
 	return entries
 }()
 
+// effortsUpTo returns the levels of an ordered ladder up to and including the
+// given cap. It exists so a cap can only ever lower a requested effort: passing
+// the cap alone as the supported set would clamp a below-cap request *up* to it.
+func effortsUpTo(efforts []llm.ReasoningEffort, capLevel llm.ReasoningEffort) []llm.ReasoningEffort {
+	for i, level := range efforts {
+		if level == capLevel {
+			return efforts[:i+1]
+		}
+	}
+	return efforts
+}
+
 // lookupCapabilities returns the capabilities for a model id. The bool reports
 // whether the model is known: an unknown model — a fine-tune, a custom
 // deployment, or a base-URL passthrough — gets its parameters forwarded
 // untouched, since Dive cannot tell what it accepts.
+//
+// Known limitation: matching is a plain prefix test, so an unreleased point
+// release inherits its family's entry — a future "claude-opus-4-9" would match
+// "claude-opus-4" and be treated as legacy-budget. providers/modelcaps guards
+// the same hazard by requiring the next character to begin a variant suffix,
+// but that rule cannot work here: Anthropic writes versions with the same "-"
+// that separates variants and dates ("claude-opus-4-5-20251101"), so there is
+// nothing to key on. Adding a model to catalog.json therefore means checking
+// that it lands on the right entry, not only that it lands on one.
 func lookupCapabilities(model string) (modelCapabilities, bool) {
 	id := strings.ToLower(strings.TrimSpace(model))
-	// Accept vendor-qualified ids such as "anthropic/claude-sonnet-5".
-	if _, rest, ok := strings.Cut(id, "/"); ok {
-		id = rest
+	// Accept vendor-qualified ids such as "anthropic/claude-sonnet-5" and
+	// doubly-qualified ones such as "openrouter/anthropic/claude-sonnet-5":
+	// only the final segment names the model.
+	if idx := strings.LastIndex(id, "/"); idx >= 0 {
+		id = id[idx+1:]
 	}
 	for _, entry := range sortedCapabilityTable {
 		if strings.HasPrefix(id, entry.prefix) {

--- a/providers/anthropic/capabilities_test.go
+++ b/providers/anthropic/capabilities_test.go
@@ -1,0 +1,110 @@
+package anthropic
+
+import (
+	"testing"
+
+	"github.com/deepnoodle-ai/dive/llm"
+	"github.com/deepnoodle-ai/wonton/assert"
+)
+
+// TestEveryCatalogModelHasCapabilities is the drift guard for
+// modelCapabilityTable: adding a model to catalog.json without classifying its
+// reasoning, thinking, and sampling support fails here rather than at runtime
+// against the API.
+func TestEveryCatalogModelHasCapabilities(t *testing.T) {
+	for _, model := range Catalog().Models {
+		if model.Kind != "" && model.Kind != "text" {
+			continue // only text models take reasoning parameters
+		}
+		id := model.ID
+		if id == "" {
+			continue // alias-only entries carry no id of their own
+		}
+		t.Run(id, func(t *testing.T) {
+			_, known := lookupCapabilities(id)
+			assert.True(t, known,
+				"model %q (%s) has no entry in modelCapabilityTable; add one so its "+
+					"reasoning and thinking parameters are gated", id, model.GoName)
+		})
+	}
+}
+
+func TestLookupCapabilitiesLongestPrefixWins(t *testing.T) {
+	// "claude-opus-4" and "claude-opus-4-5" both prefix this id; the narrower
+	// entry must win, or Opus 4.5 loses its native effort parameter.
+	caps, known := lookupCapabilities("claude-opus-4-5-20251101")
+	assert.True(t, known)
+	assert.Equal(t, reasoningNative, caps.reasoningKind())
+
+	caps, known = lookupCapabilities("claude-opus-4-20250514")
+	assert.True(t, known)
+	assert.Equal(t, reasoningLegacyBudget, caps.reasoningKind())
+}
+
+func TestLookupCapabilitiesUnknownModel(t *testing.T) {
+	_, known := lookupCapabilities("some-gateway/custom-tuned-model")
+	assert.False(t, known)
+}
+
+func TestLookupCapabilitiesAcceptsVendorPrefix(t *testing.T) {
+	caps, known := lookupCapabilities("anthropic/claude-sonnet-5")
+	assert.True(t, known)
+	assert.True(t, caps.thinkingOnByDefault)
+}
+
+// TestAdaptiveThinkingUnsupportedFallsBackToBudget covers the 4.5 generation,
+// which answers 400 with "adaptive thinking is not supported on this model".
+// The CLI's --show-thinking asks for adaptive thinking on every model, so this
+// path has to degrade rather than fail.
+func TestAdaptiveThinkingUnsupportedFallsBackToBudget(t *testing.T) {
+	for _, model := range []string{ModelClaudeHaiku45, ModelClaudeSonnet45, ModelClaudeOpus45} {
+		req := buildReq(t, model, llm.WithAdaptiveThinking())
+		assert.NotNil(t, req.Thinking, "model %s", model)
+		assert.Equal(t, "enabled", req.Thinking.Type, "model %s", model)
+		assert.Equal(t, defaultThinkingBudget, req.Thinking.BudgetTokens, "model %s", model)
+	}
+}
+
+func TestAdaptiveThinkingUnsupportedHonorsExplicitBudget(t *testing.T) {
+	req := buildReq(t, ModelClaudeSonnet45,
+		llm.WithAdaptiveThinking(),
+		llm.WithReasoningBudget(9000))
+	assert.NotNil(t, req.Thinking)
+	assert.Equal(t, "enabled", req.Thinking.Type)
+	assert.Equal(t, 9000, req.Thinking.BudgetTokens)
+}
+
+func TestAdaptiveThinkingSupportedStaysAdaptive(t *testing.T) {
+	for _, model := range []string{ModelClaudeSonnet46, ModelClaudeOpus47, ModelClaudeSonnet5} {
+		req := buildReq(t, model, llm.WithAdaptiveThinking())
+		assert.NotNil(t, req.Thinking, "model %s", model)
+		assert.Equal(t, "adaptive", req.Thinking.Type, "model %s", model)
+	}
+}
+
+// TestBudgetAndEffortCombineOnNativeModel covers a case Dive used to reject
+// outright: Opus 4.5 and Sonnet 4.6 accept a manual budget and an effort in the
+// same request (verified against the live API).
+func TestBudgetAndEffortCombineOnNativeModel(t *testing.T) {
+	for _, model := range []string{ModelClaudeOpus45, ModelClaudeSonnet46} {
+		req := buildReq(t, model,
+			llm.WithReasoningBudget(8000),
+			llm.WithReasoningEffort(llm.ReasoningEffortHigh))
+		assert.NotNil(t, req.OutputConfig, "model %s", model)
+		assert.Equal(t, "high", req.OutputConfig.Effort, "model %s", model)
+		assert.NotNil(t, req.Thinking, "model %s", model)
+		assert.Equal(t, 8000, req.Thinking.BudgetTokens, "model %s", model)
+	}
+}
+
+func TestReasoningBudgetBelowMinimumClamps(t *testing.T) {
+	req := buildReq(t, ModelClaudeOpus46, llm.WithReasoningBudget(10))
+	assert.NotNil(t, req.Thinking)
+	assert.Equal(t, minThinkingBudget, req.Thinking.BudgetTokens)
+}
+
+func TestUnknownModelKeepsParametersUntouched(t *testing.T) {
+	// Dive cannot know what a gateway model accepts, so it must not gate.
+	req := buildReq(t, "my-proxy-claude", llm.WithTemperature(0.5))
+	assert.NotNil(t, req.Temperature)
+}

--- a/providers/anthropic/capabilities_test.go
+++ b/providers/anthropic/capabilities_test.go
@@ -97,6 +97,38 @@ func TestBudgetAndEffortCombineOnNativeModel(t *testing.T) {
 	}
 }
 
+// TestDisabledThinkingCapNeverRaisesEffort guards a regression: the Opus 5 cap
+// was applied by passing the cap alone as the supported set, which clamped a
+// below-cap request *up* to it — asking for low with thinking disabled sent
+// high. The cap must only ever lower an effort.
+func TestDisabledThinkingCapNeverRaisesEffort(t *testing.T) {
+	for _, tt := range []struct {
+		requested llm.ReasoningEffort
+		want      string
+	}{
+		{llm.ReasoningEffortLow, "low"},
+		{llm.ReasoningEffortMedium, "medium"},
+		{llm.ReasoningEffortHigh, "high"},
+		// Above the cap, it still clamps down.
+		{llm.ReasoningEffortXHigh, "high"},
+		{llm.ReasoningEffortMax, "high"},
+	} {
+		t.Run(string(tt.requested), func(t *testing.T) {
+			req := buildReq(t, ModelClaudeOpus5,
+				llm.WithReasoningEffort(tt.requested),
+				llm.WithThinking(llm.ThinkingTypeDisabled))
+			assert.NotNil(t, req.OutputConfig)
+			assert.Equal(t, tt.want, req.OutputConfig.Effort)
+		})
+	}
+}
+
+func TestLookupCapabilitiesStripsAllVendorSegments(t *testing.T) {
+	caps, known := lookupCapabilities("openrouter/anthropic/claude-sonnet-5")
+	assert.True(t, known)
+	assert.True(t, caps.thinkingOnByDefault)
+}
+
 func TestReasoningBudgetBelowMinimumClamps(t *testing.T) {
 	req := buildReq(t, ModelClaudeOpus46, llm.WithReasoningBudget(10))
 	assert.NotNil(t, req.Thinking)

--- a/providers/anthropic/reasoning_test.go
+++ b/providers/anthropic/reasoning_test.go
@@ -43,16 +43,12 @@ func TestReasoningEffortMinimalMapsToLow(t *testing.T) {
 	assert.Equal(t, "low", req.OutputConfig.Effort)
 }
 
-func TestReasoningEffortNoneErrors(t *testing.T) {
-	cfg := &llm.Config{}
-	cfg.Apply(
-		llm.WithModel(ModelClaudeOpus48),
-		llm.WithReasoningEffort(llm.ReasoningEffortNone),
-	)
-	var req Request
-	err := New().applyRequestConfig(&req, cfg)
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "not supported")
+func TestReasoningEffortNoneClampsToLow(t *testing.T) {
+	// Anthropic has no "none" level — the API enumerates low..max — so the
+	// request clamps up to the least eager level instead of failing.
+	req := buildReq(t, ModelClaudeOpus48, llm.WithReasoningEffort(llm.ReasoningEffortNone))
+	assert.NotNil(t, req.OutputConfig)
+	assert.Equal(t, "low", req.OutputConfig.Effort)
 }
 
 func TestReasoningEffortXHighUnsupportedNativeModelMapsToHigh(t *testing.T) {
@@ -229,17 +225,21 @@ func TestThinkingAllowsToolChoiceAutoAndNone(t *testing.T) {
 	}
 }
 
-func TestManualThinkingBudgetMustBeLessThanMaxTokens(t *testing.T) {
-	cfg := &llm.Config{}
-	cfg.Apply(
-		llm.WithModel(ModelClaudeOpus46),
+func TestManualThinkingBudgetClampsBelowMaxTokens(t *testing.T) {
+	req := buildReq(t, ModelClaudeOpus46,
 		llm.WithMaxTokens(4096),
-		llm.WithReasoningBudget(4096),
-	)
-	var req Request
-	err := New().applyRequestConfig(&req, cfg)
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "must be less than max_tokens")
+		llm.WithReasoningBudget(4096))
+	assert.NotNil(t, req.Thinking)
+	assert.Equal(t, 4095, req.Thinking.BudgetTokens)
+}
+
+func TestThinkingDroppedWhenMaxTokensLeavesNoRoom(t *testing.T) {
+	// Below the 1024 minimum there is no valid budget to clamp to, so thinking
+	// is dropped rather than sent as a request that cannot succeed.
+	req := buildReq(t, ModelClaudeOpus46,
+		llm.WithMaxTokens(512),
+		llm.WithReasoningBudget(4096))
+	assert.Nil(t, req.Thinking)
 }
 
 func TestInterleavedThinkingAllowsBudgetAtOrAboveMaxTokens(t *testing.T) {
@@ -251,19 +251,16 @@ func TestInterleavedThinkingAllowsBudgetAtOrAboveMaxTokens(t *testing.T) {
 	assert.Equal(t, 8192, req.Thinking.BudgetTokens)
 }
 
-func TestEffortWithThinkingDisabledLegacyModelErrors(t *testing.T) {
+func TestEffortWithThinkingDisabledLegacyModelDropsEffort(t *testing.T) {
 	// On a model without the native effort parameter, effort is emulated with a
-	// thinking budget — which would override an explicit thinking disable. That
-	// conflict must error rather than silently re-enable thinking.
-	cfg := &llm.Config{}
-	cfg.Apply(
-		llm.WithModel(ModelClaude37Sonnet20250219),
+	// thinking budget — which would override an explicit thinking disable. The
+	// disable wins and the effort is dropped rather than silently re-enabling
+	// thinking.
+	req := buildReq(t, ModelClaudeSonnet45,
 		llm.WithReasoningEffort(llm.ReasoningEffortHigh),
-		llm.WithThinking(llm.ThinkingTypeDisabled),
-	)
-	var req Request
-	err := New().applyRequestConfig(&req, cfg)
-	assert.Error(t, err)
+		llm.WithThinking(llm.ThinkingTypeDisabled))
+	assert.Nil(t, req.Thinking)
+	assert.Nil(t, req.OutputConfig)
 }
 
 func TestEffortWithThinkingDisabledNativeModelOK(t *testing.T) {
@@ -326,12 +323,12 @@ func TestModelCapabilityHelpers(t *testing.T) {
 
 	// Opus 4.7/4.8 and the Claude 5 family reject sampling params; Opus 4.6 and
 	// Sonnet 4.6 still accept them.
-	assert.True(t, modelRejectsTemperature(ModelClaudeOpus47))
-	assert.True(t, modelRejectsTemperature(ModelClaudeOpus48))
-	assert.True(t, modelRejectsTemperature(ModelClaudeOpus5))
-	assert.True(t, modelRejectsTemperature(ModelClaudeSonnet5))
-	assert.False(t, modelRejectsTemperature(ModelClaudeOpus46))
-	assert.False(t, modelRejectsTemperature(ModelClaudeSonnet46))
+	assert.False(t, modelAcceptsTemperature(ModelClaudeOpus47))
+	assert.False(t, modelAcceptsTemperature(ModelClaudeOpus48))
+	assert.False(t, modelAcceptsTemperature(ModelClaudeOpus5))
+	assert.False(t, modelAcceptsTemperature(ModelClaudeSonnet5))
+	assert.True(t, modelAcceptsTemperature(ModelClaudeOpus46))
+	assert.True(t, modelAcceptsTemperature(ModelClaudeSonnet46))
 
 	// Opus 5 and Sonnet 5 default thinking on and accept an explicit disable.
 	assert.True(t, modelDefaultsThinkingOn(ModelClaudeOpus5))
@@ -458,22 +455,20 @@ func TestThinkingDisabledOpus5EmitsExplicitDisable(t *testing.T) {
 	assert.Equal(t, "disabled", req.Thinking.Type)
 }
 
-func TestThinkingDisabledOpus5AboveHighEffortErrors(t *testing.T) {
-	// Opus 5 accepts an explicit thinking disable only at effort high or below.
+func TestThinkingDisabledOpus5AboveHighEffortClampsToHigh(t *testing.T) {
+	// Opus 5 accepts an explicit thinking disable only at effort high or below,
+	// so the effort clamps down to high and the disable is preserved.
 	for _, effort := range []llm.ReasoningEffort{
 		llm.ReasoningEffortXHigh,
 		llm.ReasoningEffortMax,
 	} {
-		cfg := &llm.Config{}
-		cfg.Apply(
-			llm.WithModel(ModelClaudeOpus5),
+		req := buildReq(t, ModelClaudeOpus5,
 			llm.WithReasoningEffort(effort),
-			llm.WithThinking(llm.ThinkingTypeDisabled),
-		)
-		var req Request
-		err := New().applyRequestConfig(&req, cfg)
-		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "effort high or below")
+			llm.WithThinking(llm.ThinkingTypeDisabled))
+		assert.NotNil(t, req.OutputConfig)
+		assert.Equal(t, "high", req.OutputConfig.Effort)
+		assert.NotNil(t, req.Thinking)
+		assert.Equal(t, "disabled", req.Thinking.Type)
 	}
 }
 

--- a/providers/google/capabilities.go
+++ b/providers/google/capabilities.go
@@ -160,11 +160,17 @@ func lookupEntry(model string) (capabilityEntry, bool) {
 }
 
 // modelAcceptsTemperature reports whether Dive forwards a temperature for this
-// model. The API accepts and range-validates one on every Gemini model in the
-// catalog, including those excluded here; the exclusion is a deliberate policy
-// choice tracking Google's guidance against tuning temperature on that
-// generation, and it extends to unreleased models, so the rule stays in
-// shouldOmitTemperature rather than this table.
+// model. The rule lives in shouldOmitTemperature, which keys on the request
+// generation and so also covers models that do not exist yet.
+//
+// Do not "fix" this from probe results alone. Gemini 3.5 Flash-Lite and 3.6+
+// accept a temperature and even range-validate it — sending 5.0 returns
+// "temperature must be in the range [0.0, 2.0]" — so a probe that only records
+// status codes concludes the parameter is live. It is not honored. Sampling the
+// same prompt eight times shows gemini-3.5-flash pinned to a single answer at
+// temperature 0 while gemini-3.6-flash keeps varying, with thinking held at the
+// same level in both. The parameter is accepted and ignored, and withholding it
+// is correct.
 func modelAcceptsTemperature(model string) bool {
 	return !shouldOmitTemperature(model)
 }

--- a/providers/google/capabilities.go
+++ b/providers/google/capabilities.go
@@ -1,0 +1,170 @@
+package google
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/deepnoodle-ai/dive/llm"
+)
+
+// dynamicThinkingBudget asks the model to choose its own budget.
+const dynamicThinkingBudget = -1
+
+// modelCapabilities records which thinking parameters a Gemini model accepts.
+// Every field was verified against the live API by sending the parameter and
+// recording whether it returned 200 or 400 — including the budget bounds, which
+// the API reports in its error text and which differ per model.
+type modelCapabilities struct {
+	// efforts lists the levels thinkingConfig.thinkingLevel accepts, expressed
+	// in Dive's provider-neutral terms. Empty means the model has no thinking
+	// level at all ("Thinking level is not supported for this model") and
+	// effort must be emulated with a budget. Gemini's ladder tops out at HIGH,
+	// so no model lists xhigh or max.
+	efforts []llm.ReasoningEffort
+
+	// minBudget and maxBudget bound thinkingBudget. They vary by model: the 3.x
+	// generation takes [1, 65535], gemini-2.5-pro [128, 32768], and
+	// gemini-2.5-flash-lite [512, 24576].
+	minBudget int
+	maxBudget int
+
+	// canDisableThinking reports whether thinkingBudget: 0 is accepted. It is a
+	// value outside [minBudget, maxBudget] and varies within a family rather
+	// than by generation. Models that always think answer 400, so a request to
+	// disable thinking has to degrade instead.
+	canDisableThinking bool
+
+	// unverified marks a model that is catalogued but could not be reached — it
+	// answered 404 "no longer available". Lookup reports it as unknown so its
+	// parameters pass through untouched rather than being guessed at.
+	unverified bool
+}
+
+// supportsThinkingLevel reports whether the model takes thinkingConfig.thinkingLevel.
+func (c modelCapabilities) supportsThinkingLevel() bool {
+	return len(c.efforts) > 0
+}
+
+// effortsThroughHigh is Gemini 3.x's full ladder: MINIMAL, LOW, MEDIUM, HIGH.
+var effortsThroughHigh = []llm.ReasoningEffort{
+	llm.ReasoningEffortMinimal,
+	llm.ReasoningEffortLow,
+	llm.ReasoningEffortMedium,
+	llm.ReasoningEffortHigh,
+}
+
+// effortsLowThroughHigh drops MINIMAL, which the Pro models reject with
+// "Thinking level MINIMAL is not supported for this model".
+var effortsLowThroughHigh = []llm.ReasoningEffort{
+	llm.ReasoningEffortLow,
+	llm.ReasoningEffortMedium,
+	llm.ReasoningEffortHigh,
+}
+
+type capabilityEntry struct {
+	prefix string
+	caps   modelCapabilities
+}
+
+// modelCapabilityTable maps Gemini model-id prefixes to capabilities. Lookup
+// takes the longest matching prefix.
+//
+// Every model id in catalog.json must resolve to an entry here;
+// TestEveryCatalogModelHasCapabilities enforces it, so a newly added model
+// fails the build until it has been classified. That matters more than usual
+// on Gemini: thinking support varies *within* a family, not just by
+// generation — gemini-3.5-flash can turn thinking off and gemini-3.5-flash-lite
+// cannot, and the 2.5 generation has no thinking level at all.
+var modelCapabilityTable = []capabilityEntry{
+	// --- 3.x: thinking levels, budgets in [1, 65535]. ---
+	{prefix: "gemini-3.6-flash", caps: modelCapabilities{
+		efforts: effortsThroughHigh, minBudget: 1, maxBudget: 65535,
+	}},
+	{prefix: "gemini-3.5-flash", caps: modelCapabilities{
+		efforts: effortsThroughHigh, minBudget: 1, maxBudget: 65535,
+		canDisableThinking: true,
+	}},
+	{prefix: "gemini-3.5-flash-lite", caps: modelCapabilities{
+		efforts: effortsThroughHigh, minBudget: 1, maxBudget: 65535,
+	}},
+	{prefix: "gemini-3.1-flash-lite", caps: modelCapabilities{
+		efforts: effortsThroughHigh, minBudget: 1, maxBudget: 65535,
+		canDisableThinking: true,
+	}},
+	{prefix: "gemini-3-flash", caps: modelCapabilities{
+		efforts: effortsThroughHigh, minBudget: 1, maxBudget: 65535,
+		canDisableThinking: true,
+	}},
+	// Pro rejects MINIMAL and cannot turn thinking off.
+	{prefix: "gemini-3.1-pro", caps: modelCapabilities{
+		efforts: effortsLowThroughHigh, minBudget: 1, maxBudget: 65535,
+	}},
+
+	// --- 2.5: budgets only. "Thinking level is not supported for this model." ---
+	{prefix: "gemini-2.5-pro", caps: modelCapabilities{
+		minBudget: 128, maxBudget: 32768,
+	}},
+	{prefix: "gemini-2.5-flash", caps: modelCapabilities{
+		minBudget: 0, maxBudget: 24576, canDisableThinking: true,
+	}},
+	{prefix: "gemini-2.5-flash-lite", caps: modelCapabilities{
+		minBudget: 512, maxBudget: 24576, canDisableThinking: true,
+	}},
+
+	// --- Retired: 404 "no longer available". Passthrough rather than guessed. ---
+	{prefix: "gemini-3-pro-preview", caps: modelCapabilities{unverified: true}},
+	{prefix: "gemini-2.0-flash", caps: modelCapabilities{unverified: true}},
+	{prefix: "gemini-1.5-pro", caps: modelCapabilities{unverified: true}},
+	{prefix: "gemini-1.5-flash", caps: modelCapabilities{unverified: true}},
+}
+
+// sortedCapabilityTable is modelCapabilityTable ordered longest-prefix-first so
+// lookup can return the first match.
+var sortedCapabilityTable = func() []capabilityEntry {
+	entries := make([]capabilityEntry, len(modelCapabilityTable))
+	copy(entries, modelCapabilityTable)
+	sort.SliceStable(entries, func(i, j int) bool {
+		return len(entries[i].prefix) > len(entries[j].prefix)
+	})
+	return entries
+}()
+
+func normalizeModelID(model string) string {
+	id := strings.ToLower(strings.TrimSpace(model))
+	return strings.TrimPrefix(id, "models/")
+}
+
+// lookupCapabilities returns the capabilities for a model id. The bool reports
+// whether the model is known and verified: anything else — a preview id, a
+// tuned model, a Vertex deployment, a retired model — gets its parameters
+// forwarded untouched, since Dive cannot tell what it accepts.
+func lookupCapabilities(model string) (modelCapabilities, bool) {
+	entry, found := lookupEntry(model)
+	if !found || entry.caps.unverified {
+		return modelCapabilities{}, false
+	}
+	return entry.caps, true
+}
+
+// lookupEntry returns the raw entry, including unverified ones. It backs the
+// coverage test, which requires every catalogued model to be classified — even
+// when the classification is "could not verify".
+func lookupEntry(model string) (capabilityEntry, bool) {
+	id := normalizeModelID(model)
+	for _, entry := range sortedCapabilityTable {
+		if strings.HasPrefix(id, entry.prefix) {
+			return entry, true
+		}
+	}
+	return capabilityEntry{}, false
+}
+
+// modelAcceptsTemperature reports whether Dive forwards a temperature for this
+// model. The API accepts and range-validates one on every Gemini model in the
+// catalog, including those excluded here; the exclusion is a deliberate policy
+// choice tracking Google's guidance against tuning temperature on that
+// generation, and it extends to unreleased models, so the rule stays in
+// shouldOmitTemperature rather than this table.
+func modelAcceptsTemperature(model string) bool {
+	return !shouldOmitTemperature(model)
+}

--- a/providers/google/google.go
+++ b/providers/google/google.go
@@ -291,14 +291,14 @@ func (p *Provider) applyRequestConfig(req *Request, config *llm.Config) error {
 		req.Tools = tools
 	}
 
-	if !shouldOmitTemperature(req.Model) {
+	if modelAcceptsTemperature(req.Model) {
 		req.Temperature = config.Temperature
 	} else if config.Temperature != nil && config.Logger != nil {
 		config.Logger.Warn("temperature is not supported by this Google model and will be ignored",
 			"model", req.Model)
 	}
-	// Dive does not currently expose top_p or top_k. If those controls are
-	// added, apply the same Gemini request-generation cutoff used above.
+
+	req.Thinking = buildThinkingConfig(req.Model, config)
 	req.System = config.SystemPrompt
 
 	return nil

--- a/providers/google/stream_iterator.go
+++ b/providers/google/stream_iterator.go
@@ -36,6 +36,7 @@ type StreamIterator struct {
 	messageStartSent bool
 	nextBlockIndex   int
 	textBlockIndex   int // index of the open text block, or -1 if none
+	thinkingBlockIdx int // index of the open thinking block, or -1 if none
 	usage            *genai.GenerateContentResponseUsageMetadata
 	finishReason     genai.FinishReason
 
@@ -45,11 +46,12 @@ type StreamIterator struct {
 // NewStreamIteratorFromSeq creates a new StreamIterator from a streaming sequence
 func NewStreamIteratorFromSeq(ctx context.Context, streamSeq iter.Seq2[*genai.GenerateContentResponse, error], model string) *StreamIterator {
 	return &StreamIterator{
-		ctx:            ctx,
-		streamSeq:      streamSeq,
-		model:          model,
-		responseID:     fmt.Sprintf("google_%s_%d", model, time.Now().UnixNano()),
-		textBlockIndex: -1,
+		ctx:              ctx,
+		streamSeq:        streamSeq,
+		model:            model,
+		responseID:       fmt.Sprintf("google_%s_%d", model, time.Now().UnixNano()),
+		textBlockIndex:   -1,
+		thinkingBlockIdx: -1,
 	}
 }
 
@@ -172,9 +174,7 @@ func (s *StreamIterator) processChunk(response *genai.GenerateContentResponse) e
 			}
 		case part.Text != "":
 			if part.Thought {
-				// Thought-summary parts are not surfaced (matching the
-				// previous behavior based on response.Text(), which skips
-				// them).
+				s.queueThinking(part.Text)
 				continue
 			}
 			s.queueText(part.Text)
@@ -183,8 +183,37 @@ func (s *StreamIterator) processChunk(response *genai.GenerateContentResponse) e
 	return nil
 }
 
+// queueThinking emits a thinking delta, opening a new thinking content block if
+// needed. Gemini flags thought summaries on otherwise ordinary text parts, so
+// they are separated here rather than being folded into the answer.
+func (s *StreamIterator) queueThinking(text string) {
+	s.closeTextBlock()
+	if s.thinkingBlockIdx < 0 {
+		index := s.nextBlockIndex
+		s.nextBlockIndex++
+		s.thinkingBlockIdx = index
+		s.eventQueue = append(s.eventQueue, &llm.Event{
+			Type:  llm.EventTypeContentBlockStart,
+			Index: &index,
+			ContentBlock: &llm.EventContentBlock{
+				Type: llm.ContentTypeThinking,
+			},
+		})
+	}
+	index := s.thinkingBlockIdx
+	s.eventQueue = append(s.eventQueue, &llm.Event{
+		Type:  llm.EventTypeContentBlockDelta,
+		Index: &index,
+		Delta: &llm.EventDelta{
+			Type:     llm.EventDeltaTypeThinking,
+			Thinking: text,
+		},
+	})
+}
+
 // queueText emits a text delta, opening a new text content block if needed.
 func (s *StreamIterator) queueText(text string) {
+	s.closeThinkingBlock()
 	if s.textBlockIndex < 0 {
 		index := s.nextBlockIndex
 		s.nextBlockIndex++
@@ -214,6 +243,7 @@ func (s *StreamIterator) queueText(text string) {
 // as one delta, and stops immediately. Parallel calls each get their own
 // sequential block index.
 func (s *StreamIterator) queueFunctionCall(part *genai.Part) error {
+	s.closeThinkingBlock()
 	call := part.FunctionCall
 	args, err := json.Marshal(call.Args)
 	if err != nil {
@@ -259,6 +289,20 @@ func (s *StreamIterator) queueFunctionCall(part *genai.Part) error {
 	return nil
 }
 
+// closeThinkingBlock emits a content_block_stop for the open thinking block, if
+// any.
+func (s *StreamIterator) closeThinkingBlock() {
+	if s.thinkingBlockIdx < 0 {
+		return
+	}
+	index := s.thinkingBlockIdx
+	s.thinkingBlockIdx = -1
+	s.eventQueue = append(s.eventQueue, &llm.Event{
+		Type:  llm.EventTypeContentBlockStop,
+		Index: &index,
+	})
+}
+
 // closeTextBlock emits a content_block_stop for the open text block, if any.
 func (s *StreamIterator) closeTextBlock() {
 	if s.textBlockIndex < 0 {
@@ -279,6 +323,7 @@ func (s *StreamIterator) queueFinalEvents() {
 		// Stream ended without any chunks; nothing to finalize.
 		return
 	}
+	s.closeThinkingBlock()
 	s.closeTextBlock()
 
 	delta := &llm.EventDelta{}

--- a/providers/google/thinking.go
+++ b/providers/google/thinking.go
@@ -1,6 +1,8 @@
 package google
 
 import (
+	"math"
+
 	"github.com/deepnoodle-ai/dive/llm"
 	"google.golang.org/genai"
 )
@@ -158,6 +160,15 @@ func clampThinkingBudget(config *llm.Config, model string, caps modelCapabilitie
 		return dynamicThinkingBudget
 	}
 	if !known {
+		// No table entry to clamp against, but the conversion still has to be
+		// safe: int is 64-bit here, so a wild value would otherwise wrap into a
+		// plausible-looking budget.
+		switch {
+		case budget > math.MaxInt32:
+			return math.MaxInt32
+		case budget < math.MinInt32:
+			return math.MinInt32
+		}
 		return int32(budget)
 	}
 	if budget == 0 && caps.canDisableThinking {

--- a/providers/google/thinking.go
+++ b/providers/google/thinking.go
@@ -1,0 +1,183 @@
+package google
+
+import (
+	"github.com/deepnoodle-ai/dive/llm"
+	"google.golang.org/genai"
+)
+
+// thinkingLevelFor maps Dive's provider-neutral effort onto Gemini's ladder.
+// Gemini stops at HIGH, so xhigh and max clamp there.
+func thinkingLevelFor(effort llm.ReasoningEffort) (genai.ThinkingLevel, bool) {
+	switch effort {
+	case llm.ReasoningEffortMinimal:
+		return genai.ThinkingLevelMinimal, true
+	case llm.ReasoningEffortLow:
+		return genai.ThinkingLevelLow, true
+	case llm.ReasoningEffortMedium:
+		return genai.ThinkingLevelMedium, true
+	case llm.ReasoningEffortHigh, llm.ReasoningEffortXHigh, llm.ReasoningEffortMax:
+		return genai.ThinkingLevelHigh, true
+	default:
+		return "", false
+	}
+}
+
+// buildThinkingConfig maps Dive's reasoning and thinking options onto Gemini's
+// thinkingConfig. It returns nil when the request should carry no thinking
+// configuration at all.
+//
+// Gemini rejects a request that sets both a level and a budget ("You can only
+// set only one of thinking budget and thinking level"), so an explicit budget
+// wins and the effort is dropped with a warning — the budget is the more
+// specific instruction.
+//
+// Settings the model cannot take are clamped or dropped rather than sent:
+// effort clamps to the model's ladder, a budget clamps to [-1, 65535], and a
+// request to disable thinking on a model that always thinks degrades to the
+// least eager level it does accept.
+func buildThinkingConfig(model string, config *llm.Config) *genai.ThinkingConfig {
+	caps, known := lookupCapabilities(model)
+
+	// Surfacing thought summaries is orthogonal to how much the model thinks.
+	includeThoughts := config.ThinkingDisplay != "" ||
+		config.Thinking == llm.ThinkingTypeAdaptive ||
+		config.Thinking == llm.ThinkingTypeEnabled
+
+	thinkingOff := config.Thinking == llm.ThinkingTypeDisabled ||
+		config.ReasoningEffort == llm.ReasoningEffortNone
+
+	switch {
+	case thinkingOff:
+		if !known || caps.canDisableThinking {
+			budget := int32(0)
+			return &genai.ThinkingConfig{ThinkingBudget: &budget}
+		}
+		// The model always thinks. Ask for as little as it allows rather than
+		// sending a budget it rejects.
+		if level, ok := leastEagerLevel(caps); ok {
+			warnf(config, "model cannot disable thinking; using its least eager thinking level",
+				"model", model, "level", string(level))
+			return &genai.ThinkingConfig{ThinkingLevel: level}
+		}
+		budget := int32(caps.minBudget)
+		warnf(config, "model cannot disable thinking; using its smallest thinking budget",
+			"model", model, "budget", budget)
+		return &genai.ThinkingConfig{ThinkingBudget: &budget}
+
+	case config.ReasoningBudget != nil:
+		if config.ReasoningEffort != "" {
+			warnf(config, "Gemini accepts either a thinking budget or a thinking level, not both; keeping the budget",
+				"model", model, "effort", config.ReasoningEffort)
+		}
+		budget := clampThinkingBudget(config, model, caps, known, *config.ReasoningBudget)
+		return &genai.ThinkingConfig{
+			ThinkingBudget:  &budget,
+			IncludeThoughts: includeThoughts,
+		}
+
+	case config.ReasoningEffort != "":
+		effort := config.ReasoningEffort
+		// The 2.5 generation has no thinking level, so effort is emulated with
+		// a budget the same way Anthropic's pre-4.5 models do it.
+		if known && !caps.supportsThinkingLevel() {
+			budget := clampThinkingBudget(config, model, caps, known, effortBudget(effort))
+			return &genai.ThinkingConfig{
+				ThinkingBudget:  &budget,
+				IncludeThoughts: includeThoughts,
+			}
+		}
+		if known {
+			clamped, changed := llm.ClampReasoningEffort(effort, caps.efforts)
+			if changed {
+				warnf(config, "model does not support the requested thinking level; clamping",
+					"model", model, "requested", effort, "using", clamped)
+			}
+			effort = clamped
+		}
+		level, ok := thinkingLevelFor(effort)
+		if !ok {
+			// A provider-specific or misspelled value: leave it to the API to
+			// report rather than silently swallowing it.
+			warnf(config, "unrecognized reasoning effort for Gemini; omitting the thinking level",
+				"model", model, "effort", effort)
+			if includeThoughts {
+				return &genai.ThinkingConfig{IncludeThoughts: true}
+			}
+			return nil
+		}
+		return &genai.ThinkingConfig{
+			ThinkingLevel:   level,
+			IncludeThoughts: includeThoughts,
+		}
+
+	case config.Thinking == llm.ThinkingTypeAdaptive:
+		// Gemini's equivalent of "decide for yourself" is a dynamic budget.
+		budget := int32(dynamicThinkingBudget)
+		return &genai.ThinkingConfig{ThinkingBudget: &budget, IncludeThoughts: true}
+
+	case includeThoughts:
+		// Thinking was not configured, but the caller wants to see it.
+		return &genai.ThinkingConfig{IncludeThoughts: true}
+	}
+
+	return nil
+}
+
+// leastEagerLevel returns the lowest thinking level a model accepts.
+func leastEagerLevel(caps modelCapabilities) (genai.ThinkingLevel, bool) {
+	if len(caps.efforts) == 0 {
+		return "", false
+	}
+	return thinkingLevelFor(caps.efforts[0])
+}
+
+// effortBudget maps an effort level to a thinking budget for models that have
+// no thinking level. The values sit inside every budget-only model's range.
+func effortBudget(effort llm.ReasoningEffort) int {
+	switch effort {
+	case llm.ReasoningEffortMinimal, llm.ReasoningEffortLow:
+		return 1024
+	case llm.ReasoningEffortMedium:
+		return 4096
+	case llm.ReasoningEffortHigh, llm.ReasoningEffortXHigh, llm.ReasoningEffortMax:
+		return 16384
+	default:
+		return 4096
+	}
+}
+
+// clampThinkingBudget keeps the budget inside the range the model validates
+// against. The bounds differ per model, and the API reports them in its error
+// text: 3.x takes [1, 65535], gemini-2.5-pro [128, 32768], and
+// gemini-2.5-flash-lite [512, 24576].
+//
+// A dynamic budget (-1) is passed through: every model that takes budgets
+// accepts it, and it means "choose for yourself" rather than a token count.
+func clampThinkingBudget(config *llm.Config, model string, caps modelCapabilities, known bool, budget int) int32 {
+	if budget == dynamicThinkingBudget {
+		return dynamicThinkingBudget
+	}
+	if !known {
+		return int32(budget)
+	}
+	if budget == 0 && caps.canDisableThinking {
+		return 0
+	}
+	switch {
+	case budget < caps.minBudget:
+		warnf(config, "thinking budget is below this model's minimum; clamping",
+			"model", model, "requested", budget, "using", caps.minBudget)
+		return int32(caps.minBudget)
+	case budget > caps.maxBudget:
+		warnf(config, "thinking budget is above this model's maximum; clamping",
+			"model", model, "requested", budget, "using", caps.maxBudget)
+		return int32(caps.maxBudget)
+	}
+	return int32(budget)
+}
+
+func warnf(config *llm.Config, msg string, args ...any) {
+	if config.Logger != nil {
+		config.Logger.Warn(msg, args...)
+	}
+}

--- a/providers/google/thinking_test.go
+++ b/providers/google/thinking_test.go
@@ -1,6 +1,7 @@
 package google
 
 import (
+	"math"
 	"testing"
 
 	"github.com/deepnoodle-ai/dive/llm"
@@ -171,6 +172,24 @@ func TestBudgetOnlyModelCannotDisableDegradesToMinimum(t *testing.T) {
 	assert.NotNil(t, thinking)
 	assert.NotNil(t, thinking.ThinkingBudget)
 	assert.Equal(t, int32(128), *thinking.ThinkingBudget)
+}
+
+// TestUnknownModelBudgetDoesNotWrap guards the int32 narrowing on the
+// unknown-model path: without a bound check a wild value wraps into a
+// plausible-looking budget rather than being obviously clamped.
+func TestUnknownModelBudgetDoesNotWrap(t *testing.T) {
+	thinking := buildThinking(t, "my-tuned-gemini", llm.WithReasoningBudget(math.MaxInt32+1))
+	assert.NotNil(t, thinking)
+	assert.Equal(t, int32(math.MaxInt32), *thinking.ThinkingBudget)
+
+	thinking = buildThinking(t, "my-tuned-gemini", llm.WithReasoningBudget(math.MinInt32-1))
+	assert.NotNil(t, thinking)
+	assert.Equal(t, int32(math.MinInt32), *thinking.ThinkingBudget)
+
+	// In-range values still pass through untouched.
+	thinking = buildThinking(t, "my-tuned-gemini", llm.WithReasoningBudget(4096))
+	assert.NotNil(t, thinking)
+	assert.Equal(t, int32(4096), *thinking.ThinkingBudget)
 }
 
 func TestRetiredModelPassesThrough(t *testing.T) {

--- a/providers/google/thinking_test.go
+++ b/providers/google/thinking_test.go
@@ -1,0 +1,211 @@
+package google
+
+import (
+	"testing"
+
+	"github.com/deepnoodle-ai/dive/llm"
+	"github.com/deepnoodle-ai/wonton/assert"
+	"google.golang.org/genai"
+)
+
+// TestEveryCatalogModelHasCapabilities is the drift guard for
+// modelCapabilityTable. Thinking support varies within a family rather than by
+// generation — gemini-3.5-flash can disable thinking and gemini-3.5-flash-lite
+// cannot — so a new model has to be classified deliberately.
+func TestEveryCatalogModelHasCapabilities(t *testing.T) {
+	for _, model := range Catalog().Models {
+		if model.Kind != "" && model.Kind != "text" {
+			continue // only text models take thinking parameters
+		}
+		id := model.ID
+		if id == "" {
+			continue // alias-only entries carry no id of their own
+		}
+		t.Run(id, func(t *testing.T) {
+			_, found := lookupEntry(id)
+			assert.True(t, found,
+				"model %q (%s) has no entry in modelCapabilityTable; add one so "+
+					"its thinking parameters are gated", id, model.GoName)
+		})
+	}
+}
+
+func buildThinking(t *testing.T, model string, opts ...llm.Option) *genai.ThinkingConfig {
+	t.Helper()
+	cfg := &llm.Config{}
+	cfg.Apply(append([]llm.Option{llm.WithModel(model)}, opts...)...)
+	var req Request
+	assert.NoError(t, New().applyRequestConfig(&req, cfg))
+	return req.Thinking
+}
+
+func TestEffortMapsToThinkingLevel(t *testing.T) {
+	tests := []struct {
+		effort llm.ReasoningEffort
+		want   genai.ThinkingLevel
+	}{
+		{llm.ReasoningEffortMinimal, genai.ThinkingLevelMinimal},
+		{llm.ReasoningEffortLow, genai.ThinkingLevelLow},
+		{llm.ReasoningEffortMedium, genai.ThinkingLevelMedium},
+		{llm.ReasoningEffortHigh, genai.ThinkingLevelHigh},
+		// Gemini's ladder stops at HIGH.
+		{llm.ReasoningEffortXHigh, genai.ThinkingLevelHigh},
+		{llm.ReasoningEffortMax, genai.ThinkingLevelHigh},
+	}
+	for _, tt := range tests {
+		t.Run(string(tt.effort), func(t *testing.T) {
+			thinking := buildThinking(t, ModelGemini36Flash, llm.WithReasoningEffort(tt.effort))
+			assert.NotNil(t, thinking)
+			assert.Equal(t, tt.want, thinking.ThinkingLevel)
+			assert.Nil(t, thinking.ThinkingBudget)
+		})
+	}
+}
+
+func TestMinimalClampsOnProModels(t *testing.T) {
+	// "Thinking level MINIMAL is not supported for this model" — clamp up to
+	// the least eager level Pro accepts.
+	thinking := buildThinking(t, ModelGemini31ProPreview,
+		llm.WithReasoningEffort(llm.ReasoningEffortMinimal))
+	assert.NotNil(t, thinking)
+	assert.Equal(t, genai.ThinkingLevelLow, thinking.ThinkingLevel)
+}
+
+func TestReasoningBudgetMapsToThinkingBudget(t *testing.T) {
+	thinking := buildThinking(t, ModelGemini36Flash, llm.WithReasoningBudget(4096))
+	assert.NotNil(t, thinking)
+	assert.NotNil(t, thinking.ThinkingBudget)
+	assert.Equal(t, int32(4096), *thinking.ThinkingBudget)
+	assert.Equal(t, genai.ThinkingLevel(""), thinking.ThinkingLevel)
+}
+
+func TestBudgetAndEffortAreMutuallyExclusive(t *testing.T) {
+	// "You can only set only one of thinking budget and thinking level."
+	// The explicit budget is the more specific instruction, so it wins.
+	thinking := buildThinking(t, ModelGemini36Flash,
+		llm.WithReasoningBudget(4096),
+		llm.WithReasoningEffort(llm.ReasoningEffortHigh))
+	assert.NotNil(t, thinking)
+	assert.NotNil(t, thinking.ThinkingBudget)
+	assert.Equal(t, genai.ThinkingLevel(""), thinking.ThinkingLevel)
+}
+
+func TestThinkingBudgetClamps(t *testing.T) {
+	thinking := buildThinking(t, ModelGemini36Flash, llm.WithReasoningBudget(1_000_000))
+	assert.NotNil(t, thinking)
+	assert.Equal(t, int32(65535), *thinking.ThinkingBudget)
+}
+
+func TestAdaptiveThinkingUsesDynamicBudget(t *testing.T) {
+	thinking := buildThinking(t, ModelGemini36Flash, llm.WithAdaptiveThinking())
+	assert.NotNil(t, thinking)
+	assert.NotNil(t, thinking.ThinkingBudget)
+	assert.Equal(t, int32(dynamicThinkingBudget), *thinking.ThinkingBudget)
+	assert.True(t, thinking.IncludeThoughts)
+}
+
+func TestDisabledThinkingUsesZeroBudgetWhereSupported(t *testing.T) {
+	thinking := buildThinking(t, ModelGemini35Flash,
+		llm.WithThinking(llm.ThinkingTypeDisabled))
+	assert.NotNil(t, thinking)
+	assert.NotNil(t, thinking.ThinkingBudget)
+	assert.Equal(t, int32(0), *thinking.ThinkingBudget)
+}
+
+func TestDisabledThinkingDegradesWhereUnsupported(t *testing.T) {
+	// gemini-3.6-flash rejects thinkingBudget: 0, so the request asks for the
+	// least eager level instead of sending a budget that 400s.
+	thinking := buildThinking(t, ModelGemini36Flash,
+		llm.WithThinking(llm.ThinkingTypeDisabled))
+	assert.NotNil(t, thinking)
+	assert.Nil(t, thinking.ThinkingBudget)
+	assert.Equal(t, genai.ThinkingLevelMinimal, thinking.ThinkingLevel)
+}
+
+func TestEffortNoneDisablesThinking(t *testing.T) {
+	thinking := buildThinking(t, ModelGemini35Flash,
+		llm.WithReasoningEffort(llm.ReasoningEffortNone))
+	assert.NotNil(t, thinking)
+	assert.NotNil(t, thinking.ThinkingBudget)
+	assert.Equal(t, int32(0), *thinking.ThinkingBudget)
+}
+
+func TestThinkingDisplayRequestsThoughts(t *testing.T) {
+	thinking := buildThinking(t, ModelGemini36Flash,
+		llm.WithReasoningEffort(llm.ReasoningEffortLow),
+		llm.WithThinkingDisplay(llm.ThinkingDisplaySummarized))
+	assert.NotNil(t, thinking)
+	assert.True(t, thinking.IncludeThoughts)
+}
+
+func TestBudgetOnlyModelEmulatesEffortWithBudget(t *testing.T) {
+	// The 2.5 generation answers "Thinking level is not supported for this
+	// model", so effort becomes a budget instead.
+	thinking := buildThinking(t, "gemini-2.5-flash", llm.WithReasoningEffort(llm.ReasoningEffortHigh))
+	assert.NotNil(t, thinking)
+	assert.Equal(t, genai.ThinkingLevel(""), thinking.ThinkingLevel)
+	assert.NotNil(t, thinking.ThinkingBudget)
+	assert.Equal(t, int32(16384), *thinking.ThinkingBudget)
+}
+
+func TestBudgetClampsToPerModelRange(t *testing.T) {
+	// gemini-2.5-pro reports "choose a value between 128 and 32768".
+	thinking := buildThinking(t, "gemini-2.5-pro", llm.WithReasoningBudget(60000))
+	assert.NotNil(t, thinking)
+	assert.Equal(t, int32(32768), *thinking.ThinkingBudget)
+
+	thinking = buildThinking(t, "gemini-2.5-pro", llm.WithReasoningBudget(10))
+	assert.NotNil(t, thinking)
+	assert.Equal(t, int32(128), *thinking.ThinkingBudget)
+
+	// gemini-2.5-flash-lite starts at 512.
+	thinking = buildThinking(t, "gemini-2.5-flash-lite", llm.WithReasoningBudget(128))
+	assert.NotNil(t, thinking)
+	assert.Equal(t, int32(512), *thinking.ThinkingBudget)
+}
+
+func TestBudgetOnlyModelCannotDisableDegradesToMinimum(t *testing.T) {
+	// gemini-2.5-pro rejects thinkingBudget: 0 and has no thinking level, so it
+	// falls back to its smallest legal budget.
+	thinking := buildThinking(t, "gemini-2.5-pro", llm.WithThinking(llm.ThinkingTypeDisabled))
+	assert.NotNil(t, thinking)
+	assert.NotNil(t, thinking.ThinkingBudget)
+	assert.Equal(t, int32(128), *thinking.ThinkingBudget)
+}
+
+func TestRetiredModelPassesThrough(t *testing.T) {
+	// Retired models 404; their parameters are forwarded rather than guessed.
+	_, known := lookupCapabilities("gemini-1.5-pro")
+	assert.False(t, known)
+	_, found := lookupEntry("gemini-1.5-pro")
+	assert.True(t, found)
+}
+
+func TestNoThinkingOptionsLeavesConfigNil(t *testing.T) {
+	thinking := buildThinking(t, ModelGemini36Flash)
+	assert.Nil(t, thinking)
+}
+
+func TestUnknownModelForwardsEffort(t *testing.T) {
+	// A Vertex deployment or tuned model: Dive cannot know its ladder, so the
+	// level is sent as asked rather than clamped against a guess.
+	thinking := buildThinking(t, "my-tuned-gemini",
+		llm.WithReasoningEffort(llm.ReasoningEffortMinimal))
+	assert.NotNil(t, thinking)
+	assert.Equal(t, genai.ThinkingLevelMinimal, thinking.ThinkingLevel)
+}
+
+func TestThinkingConfigReachesGenAIConfig(t *testing.T) {
+	cfg := &llm.Config{}
+	cfg.Apply(
+		llm.WithModel(ModelGemini36Flash),
+		llm.WithReasoningEffort(llm.ReasoningEffortHigh),
+	)
+	var req Request
+	assert.NoError(t, New().applyRequestConfig(&req, cfg))
+
+	genConfig, err := buildGenAIGenerateConfig(&req)
+	assert.NoError(t, err)
+	assert.NotNil(t, genConfig.ThinkingConfig)
+	assert.Equal(t, genai.ThinkingLevelHigh, genConfig.ThinkingConfig.ThinkingLevel)
+}

--- a/providers/google/types.go
+++ b/providers/google/types.go
@@ -3,6 +3,7 @@ package google
 import (
 	"github.com/deepnoodle-ai/dive/llm"
 	"github.com/deepnoodle-ai/wonton/schema"
+	"google.golang.org/genai"
 )
 
 type Request struct {
@@ -12,6 +13,11 @@ type Request struct {
 	Temperature *float64         `json:"temperature,omitempty"`
 	System      string           `json:"system,omitempty"`
 	Tools       []map[string]any `json:"tools,omitempty"`
+
+	// Thinking carries Gemini's thinkingConfig: the thinking level or budget,
+	// plus whether to surface thought summaries. Nil leaves the model on its
+	// own default.
+	Thinking *genai.ThinkingConfig `json:"thinking,omitempty"`
 }
 
 type Tool struct {

--- a/providers/google/util.go
+++ b/providers/google/util.go
@@ -31,6 +31,13 @@ func convertGoogleResponse(resp *genai.GenerateContentResponse, model string) (*
 	var content []llm.Content
 	for _, part := range candidate.Content.Parts {
 		if part.Text != "" {
+			// Thought summaries arrive as text parts flagged Thought. Emitting
+			// them as TextContent would splice the model's reasoning into its
+			// answer.
+			if part.Thought {
+				content = append(content, &llm.ThinkingContent{Thinking: part.Text})
+				continue
+			}
 			content = append(content, &llm.TextContent{Text: part.Text})
 		} else if part.FunctionCall != nil {
 			// Handle function calls - convert args to JSON
@@ -420,6 +427,9 @@ func buildGenAIGenerateConfig(request *Request) (*genai.GenerateContentConfig, e
 	}
 	if request.MaxTokens > 0 {
 		genConfig.MaxOutputTokens = int32(request.MaxTokens)
+	}
+	if request.Thinking != nil {
+		genConfig.ThinkingConfig = request.Thinking
 	}
 	if request.System != "" {
 		genConfig.SystemInstruction = &genai.Content{

--- a/providers/grok/capabilities_test.go
+++ b/providers/grok/capabilities_test.go
@@ -1,0 +1,30 @@
+package grok
+
+import (
+	"testing"
+
+	"github.com/deepnoodle-ai/dive/providers/modelcaps"
+	"github.com/deepnoodle-ai/wonton/assert"
+)
+
+// TestEveryCatalogModelHasCapabilities is the drift guard for the Grok table.
+// Four Grok models reject the reasoning parameter outright — including
+// grok-4.20-0309-reasoning, whose name suggests otherwise — so a new model must
+// be classified deliberately rather than inheriting a family default.
+func TestEveryCatalogModelHasCapabilities(t *testing.T) {
+	for _, model := range Catalog().Models {
+		if model.Kind != "" && model.Kind != "text" {
+			continue // only text models take reasoning parameters
+		}
+		id := model.ID
+		if id == "" {
+			continue // alias-only entries carry no id of their own
+		}
+		t.Run(id, func(t *testing.T) {
+			_, found := modelcaps.LookupEntry("grok", id)
+			assert.True(t, found,
+				"model %q (%s) has no entry in modelcaps.Grok; add one so its "+
+					"reasoning parameters are gated", id, model.GoName)
+		})
+	}
+}

--- a/providers/grok/capabilities_test.go
+++ b/providers/grok/capabilities_test.go
@@ -23,7 +23,7 @@ func TestEveryCatalogModelHasCapabilities(t *testing.T) {
 		t.Run(id, func(t *testing.T) {
 			_, found := modelcaps.LookupEntry("grok", id)
 			assert.True(t, found,
-				"model %q (%s) has no entry in modelcaps.Grok; add one so its "+
+				"model %q (%s) has no entry in the modelcaps Grok table; add one so its "+
 					"reasoning parameters are gated", id, model.GoName)
 		})
 	}

--- a/providers/modelcaps/modelcaps.go
+++ b/providers/modelcaps/modelcaps.go
@@ -63,6 +63,24 @@ func NormalizeModelID(model string) string {
 	return id
 }
 
+// matchesPrefix reports whether an id belongs to the family a prefix names.
+//
+// A plain strings.HasPrefix is not enough: OpenAI and xAI separate versions with
+// "." and variants with "-", so "gpt-5" prefixes "gpt-5.7" and "grok-4" prefixes
+// "grok-4.7". Inheriting a family's ladder that way silently misclassifies the
+// next point release — gpt-5.7 would be capped at gpt-5's "high" — and the
+// catalog coverage test would still pass, because the id does resolve to an
+// entry. Requiring the next character to start a variant or date suffix keeps
+// "gpt-5-pro", "o4-mini-deep-research" and "grok-4-1-fast-reasoning" matching
+// while letting unknown point releases fall through as unknown.
+func matchesPrefix(id, prefix string) bool {
+	if !strings.HasPrefix(id, prefix) {
+		return false
+	}
+	rest := id[len(prefix):]
+	return rest == "" || rest[0] == '-'
+}
+
 // TableFor picks the table for a provider and model. It consults the model id
 // as well as the provider name, because OpenRouter serves both vendors' models
 // through one provider. An unrecognized vendor returns nil, which Lookup
@@ -92,11 +110,31 @@ func TableFor(providerName, model string) Table {
 // deployment, an unverified entry — is reported as unknown, and the caller must
 // forward its parameters untouched, since Dive cannot tell what it accepts.
 func Lookup(providerName, model string) (Capabilities, bool) {
+	caps, known := lookup(providerName, model)
+	if !known {
+		return Capabilities{}, false
+	}
+	// Hand back an independent slice: the tables are package-level and a caller
+	// indexing or appending into Efforts would corrupt every later lookup.
+	return Capabilities{Efforts: cloneEfforts(caps.Efforts), Temperature: caps.Temperature}, true
+}
+
+// lookup is the internal, allocation-free form used on the request path.
+func lookup(providerName, model string) (Capabilities, bool) {
 	entry, found := LookupEntry(providerName, model)
 	if !found || entry.Unverified {
 		return Capabilities{}, false
 	}
 	return entry.Caps, true
+}
+
+func cloneEfforts(efforts []llm.ReasoningEffort) []llm.ReasoningEffort {
+	if len(efforts) == 0 {
+		return nil
+	}
+	out := make([]llm.ReasoningEffort, len(efforts))
+	copy(out, efforts)
+	return out
 }
 
 // LookupEntry returns the raw entry, including unverified ones. It backs the
@@ -105,7 +143,7 @@ func Lookup(providerName, model string) (Capabilities, bool) {
 func LookupEntry(providerName, model string) (Entry, bool) {
 	id := NormalizeModelID(model)
 	for _, entry := range TableFor(providerName, model) {
-		if strings.HasPrefix(id, entry.Prefix) {
+		if matchesPrefix(id, entry.Prefix) {
 			return entry, true
 		}
 	}
@@ -126,7 +164,7 @@ func ResolveEffort(
 	if effort == "" {
 		return "", false
 	}
-	caps, known := Lookup(providerName, model)
+	caps, known := lookup(providerName, model)
 	if !known {
 		return effort, true // unknown model: forward untouched
 	}
@@ -146,7 +184,7 @@ func ResolveEffort(
 // AcceptsTemperature reports whether the model takes a temperature. Unknown
 // models are assumed to accept it, as they did before these tables existed.
 func AcceptsTemperature(providerName, model string) bool {
-	caps, known := Lookup(providerName, model)
+	caps, known := lookup(providerName, model)
 	return !known || caps.Temperature
 }
 

--- a/providers/modelcaps/modelcaps.go
+++ b/providers/modelcaps/modelcaps.go
@@ -1,0 +1,157 @@
+// Package modelcaps records which reasoning and sampling parameters each model
+// accepts, so providers can clamp or drop a setting a model cannot take instead
+// of sending a request the API will reject.
+//
+// Every entry is a fact about the API, verified by sending the parameter to the
+// live endpoint and recording whether it returned 200 or 400. Nothing here is
+// inferred from a model's name or generation — several models contradict what
+// their names suggest, and a few contradict their own families.
+//
+// The tables live here rather than in each provider package because the OpenAI
+// Responses API, the Chat Completions API, and OpenRouter all serve the same
+// models and previously carried separate, separately-wrong copies.
+package modelcaps
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/deepnoodle-ai/dive/llm"
+)
+
+// Capabilities describes the parameters a single model accepts.
+type Capabilities struct {
+	// Efforts lists the levels reasoning.effort accepts. Empty means the model
+	// has no reasoning parameter at all, and sending one is rejected with
+	// "Unsupported parameter: 'reasoning.effort'".
+	Efforts []llm.ReasoningEffort
+
+	// Temperature reports whether the temperature parameter is accepted.
+	Temperature bool
+}
+
+// Entry binds a model-id prefix to its capabilities.
+type Entry struct {
+	Prefix string
+	Caps   Capabilities
+
+	// Unverified marks a model that is catalogued but could not be reached for
+	// verification — it answered "does not exist" or 404. Lookup reports it as
+	// unknown so its parameters pass through untouched, rather than having its
+	// behavior guessed at from a sibling model.
+	Unverified bool
+}
+
+// Table is a set of entries, searched by longest matching prefix.
+type Table []Entry
+
+func sortByPrefixLength(entries Table) Table {
+	out := make(Table, len(entries))
+	copy(out, entries)
+	sort.SliceStable(out, func(i, j int) bool {
+		return len(out[i].Prefix) > len(out[j].Prefix)
+	})
+	return out
+}
+
+// NormalizeModelID lowercases a model id and strips the vendor prefixes that
+// OpenRouter-style ids carry.
+func NormalizeModelID(model string) string {
+	id := strings.ToLower(strings.TrimSpace(model))
+	id = strings.TrimPrefix(id, "openai/")
+	id = strings.TrimPrefix(id, "x-ai/")
+	return id
+}
+
+// TableFor picks the table for a provider and model. It consults the model id
+// as well as the provider name, because OpenRouter serves both vendors' models
+// through one provider. An unrecognized vendor returns nil, which Lookup
+// reports as unknown so the request is left alone.
+func TableFor(providerName, model string) Table {
+	id := strings.ToLower(strings.TrimSpace(model))
+	switch {
+	case strings.EqualFold(providerName, "grok"),
+		strings.HasPrefix(id, "x-ai/"),
+		strings.HasPrefix(id, "grok-"):
+		return sortedGrok
+	case strings.EqualFold(providerName, "openai"),
+		strings.HasPrefix(id, "openai/"),
+		strings.HasPrefix(id, "gpt-"),
+		strings.HasPrefix(id, "o1"),
+		strings.HasPrefix(id, "o3"),
+		strings.HasPrefix(id, "o4"),
+		strings.HasPrefix(id, "codex"):
+		return sortedOpenAI
+	default:
+		return nil
+	}
+}
+
+// Lookup returns the capabilities for a model. The bool reports whether the
+// model is known and verified; anything else — a fine-tune, a gateway
+// deployment, an unverified entry — is reported as unknown, and the caller must
+// forward its parameters untouched, since Dive cannot tell what it accepts.
+func Lookup(providerName, model string) (Capabilities, bool) {
+	entry, found := LookupEntry(providerName, model)
+	if !found || entry.Unverified {
+		return Capabilities{}, false
+	}
+	return entry.Caps, true
+}
+
+// LookupEntry returns the raw entry, including unverified ones. It backs the
+// coverage tests, which require every catalogued model to be classified — even
+// when the classification is "could not verify".
+func LookupEntry(providerName, model string) (Entry, bool) {
+	id := NormalizeModelID(model)
+	for _, entry := range TableFor(providerName, model) {
+		if strings.HasPrefix(id, entry.Prefix) {
+			return entry, true
+		}
+	}
+	return Entry{}, false
+}
+
+// ResolveEffort maps a requested effort onto what the model accepts. The bool
+// reports whether an effort should be sent at all: a model with no reasoning
+// parameter yields false, and the caller omits the field entirely.
+//
+// Unsupported settings are clamped or dropped, never turned into an error, so
+// that one set of options survives being pointed at a different model.
+func ResolveEffort(
+	providerName, model string,
+	effort llm.ReasoningEffort,
+	logger llm.Logger,
+) (llm.ReasoningEffort, bool) {
+	if effort == "" {
+		return "", false
+	}
+	caps, known := Lookup(providerName, model)
+	if !known {
+		return effort, true // unknown model: forward untouched
+	}
+	if len(caps.Efforts) == 0 {
+		warn(logger, "model does not accept a reasoning effort; omitting it",
+			"model", model, "effort", effort)
+		return "", false
+	}
+	clamped, changed := llm.ClampReasoningEffort(effort, caps.Efforts)
+	if changed {
+		warn(logger, "model does not support the requested reasoning effort; clamping",
+			"model", model, "requested", effort, "using", clamped)
+	}
+	return clamped, true
+}
+
+// AcceptsTemperature reports whether the model takes a temperature. Unknown
+// models are assumed to accept it, as they did before these tables existed.
+func AcceptsTemperature(providerName, model string) bool {
+	caps, known := Lookup(providerName, model)
+	return !known || caps.Temperature
+}
+
+func warn(logger llm.Logger, msg string, args ...any) {
+	if logger != nil {
+		logger.Warn(msg, args...)
+	}
+}

--- a/providers/modelcaps/modelcaps_test.go
+++ b/providers/modelcaps/modelcaps_test.go
@@ -1,0 +1,149 @@
+package modelcaps
+
+import (
+	"testing"
+
+	"github.com/deepnoodle-ai/dive/llm"
+	"github.com/deepnoodle-ai/wonton/assert"
+)
+
+func TestResolveEffortDropsForModelsWithoutReasoning(t *testing.T) {
+	// gpt-4o and gpt-4.1 answer 400 "Unsupported parameter: 'reasoning.effort'".
+	// The CLI defaults effort to medium, so this fires on every request unless
+	// the parameter is dropped.
+	for _, model := range []string{"gpt-4o", "gpt-4.1"} {
+		effort, send := ResolveEffort("openai", model, llm.ReasoningEffortMedium, nil)
+		assert.False(t, send, "model %s", model)
+		assert.Equal(t, llm.ReasoningEffort(""), effort, "model %s", model)
+	}
+}
+
+func TestResolveEffortDropsForGrokModelsWithoutReasoning(t *testing.T) {
+	// "does not support parameter reasoningEffort" — including a model whose
+	// own name says reasoning.
+	for _, model := range []string{
+		"grok-build-0.1",
+		"grok-code-fast-1",
+		"grok-4.20-0309-reasoning",
+		"grok-4.20-0309-non-reasoning",
+	} {
+		_, send := ResolveEffort("grok", model, llm.ReasoningEffortMedium, nil)
+		assert.False(t, send, "model %s", model)
+	}
+}
+
+func TestResolveEffortClampsDown(t *testing.T) {
+	tests := []struct {
+		provider  string
+		model     string
+		requested llm.ReasoningEffort
+		want      llm.ReasoningEffort
+	}{
+		// gpt-5.5 stops at xhigh.
+		{"openai", "gpt-5.5", llm.ReasoningEffortMax, llm.ReasoningEffortXHigh},
+		// gpt-5.1 stops at high.
+		{"openai", "gpt-5.1", llm.ReasoningEffortXHigh, llm.ReasoningEffortHigh},
+		// gpt-5-pro accepts high and nothing else, in either direction.
+		{"openai", "gpt-5-pro", llm.ReasoningEffortMax, llm.ReasoningEffortHigh},
+		{"openai", "gpt-5-pro", llm.ReasoningEffortLow, llm.ReasoningEffortHigh},
+		// The pro variant is narrower than its family, not wider.
+		{"openai", "gpt-5.2-pro", llm.ReasoningEffortLow, llm.ReasoningEffortMedium},
+		// The chat-tuned model takes medium only.
+		{"openai", "gpt-5.3-chat-latest", llm.ReasoningEffortHigh, llm.ReasoningEffortMedium},
+		// grok-4.5 accepts xhigh, so max clamps one level, not two.
+		{"grok", "grok-4.5", llm.ReasoningEffortMax, llm.ReasoningEffortXHigh},
+		// Only the multi-agent model accepts max.
+		{"grok", "grok-4.20-multi-agent-0309", llm.ReasoningEffortMax, llm.ReasoningEffortMax},
+	}
+	for _, tt := range tests {
+		t.Run(tt.model+"/"+string(tt.requested), func(t *testing.T) {
+			effort, send := ResolveEffort(tt.provider, tt.model, tt.requested, nil)
+			assert.True(t, send)
+			assert.Equal(t, tt.want, effort)
+		})
+	}
+}
+
+func TestResolveEffortClampsUpToLeastEager(t *testing.T) {
+	// none sits below every graduated level, so it clamps up to the least eager
+	// level the model accepts rather than being sent and rejected.
+	effort, send := ResolveEffort("openai", "gpt-5", llm.ReasoningEffortNone, nil)
+	assert.True(t, send)
+	assert.Equal(t, llm.ReasoningEffortMinimal, effort)
+
+	// o-series has no minimal either.
+	effort, send = ResolveEffort("openai", "o3", llm.ReasoningEffortMinimal, nil)
+	assert.True(t, send)
+	assert.Equal(t, llm.ReasoningEffortLow, effort)
+
+	// grok-4.5 is the only Grok model that rejects none.
+	effort, send = ResolveEffort("grok", "grok-4.5", llm.ReasoningEffortNone, nil)
+	assert.True(t, send)
+	assert.Equal(t, llm.ReasoningEffortMinimal, effort)
+}
+
+func TestResolveEffortKeepsSupportedLevels(t *testing.T) {
+	// none is a real level on gpt-5.1+ and must not be clamped away.
+	effort, send := ResolveEffort("openai", "gpt-5.4", llm.ReasoningEffortNone, nil)
+	assert.True(t, send)
+	assert.Equal(t, llm.ReasoningEffortNone, effort)
+}
+
+func TestResolveEffortPassesThroughUnknownModels(t *testing.T) {
+	// A gateway or fine-tune: Dive cannot know what it accepts.
+	effort, send := ResolveEffort("openrouter", "deepseek/deepseek-r1", llm.ReasoningEffortMax, nil)
+	assert.True(t, send)
+	assert.Equal(t, llm.ReasoningEffortMax, effort)
+
+	// An unverified entry behaves the same way.
+	effort, send = ResolveEffort("openai", "gpt-5.1-codex", llm.ReasoningEffortMax, nil)
+	assert.True(t, send)
+	assert.Equal(t, llm.ReasoningEffortMax, effort)
+}
+
+func TestResolveEffortPassesThroughUnrecognizedValues(t *testing.T) {
+	// A provider-specific or misspelled value is forwarded so the API can
+	// report it, rather than being silently swallowed.
+	effort, send := ResolveEffort("openai", "gpt-5.5", llm.ReasoningEffort("superdeep"), nil)
+	assert.True(t, send)
+	assert.Equal(t, llm.ReasoningEffort("superdeep"), effort)
+}
+
+func TestAcceptsTemperature(t *testing.T) {
+	for _, model := range []string{"gpt-5", "gpt-5.5", "gpt-5.6", "o3", "o4-mini"} {
+		assert.False(t, AcceptsTemperature("openai", model), "model %s", model)
+	}
+	for _, model := range []string{"gpt-4o", "gpt-4.1", "gpt-5.1", "gpt-5.4"} {
+		assert.True(t, AcceptsTemperature("openai", model), "model %s", model)
+	}
+	// Every Grok model accepts temperature.
+	for _, model := range []string{"grok-4.5", "grok-build-0.1", "grok-3"} {
+		assert.True(t, AcceptsTemperature("grok", model), "model %s", model)
+	}
+	// Unknown models are assumed to accept it.
+	assert.True(t, AcceptsTemperature("openrouter", "deepseek/deepseek-r1"))
+}
+
+func TestLookupLongestPrefixWins(t *testing.T) {
+	// "gpt-5" and "gpt-5-pro" both match; the narrower entry must win.
+	caps, known := Lookup("openai", "gpt-5-pro")
+	assert.True(t, known)
+	assert.Equal(t, 1, len(caps.Efforts))
+
+	caps, known = Lookup("openai", "gpt-5")
+	assert.True(t, known)
+	assert.Equal(t, 4, len(caps.Efforts))
+}
+
+func TestLookupHandlesVendorPrefixes(t *testing.T) {
+	caps, known := Lookup("openrouter", "openai/gpt-5.6")
+	assert.True(t, known)
+	assert.Equal(t, llm.ReasoningEffortMax, caps.Efforts[len(caps.Efforts)-1])
+
+	_, known = Lookup("openrouter", "x-ai/grok-build-0.1")
+	assert.True(t, known)
+}
+
+func TestTableForUnknownVendorIsNil(t *testing.T) {
+	assert.Nil(t, TableFor("openrouter", "mistralai/mistral-large"))
+}

--- a/providers/modelcaps/modelcaps_test.go
+++ b/providers/modelcaps/modelcaps_test.go
@@ -144,6 +144,52 @@ func TestLookupHandlesVendorPrefixes(t *testing.T) {
 	assert.True(t, known)
 }
 
+// TestUnknownPointReleasesDoNotInheritFamilyLadder guards the prefix boundary.
+// "gpt-5" prefixes "gpt-5.7" as a string, so a plain HasPrefix would hand the
+// next point release gpt-5's narrower ladder and silently clamp max to high —
+// and the catalog coverage test would not catch it, since the id does resolve.
+func TestUnknownPointReleasesDoNotInheritFamilyLadder(t *testing.T) {
+	for _, model := range []string{"gpt-5.7", "gpt-5.9-turbo", "grok-4.7", "grok-3.9"} {
+		t.Run(model, func(t *testing.T) {
+			_, found := LookupEntry("", model)
+			assert.False(t, found)
+			// Unknown means the caller forwards what it was given.
+			effort, send := ResolveEffort("", model, llm.ReasoningEffortMax, nil)
+			assert.True(t, send)
+			assert.Equal(t, llm.ReasoningEffortMax, effort)
+		})
+	}
+}
+
+func TestVariantAndDateSuffixesStillMatch(t *testing.T) {
+	for _, tt := range []struct{ model, prefix string }{
+		{"gpt-5-pro", "gpt-5-pro"},
+		{"gpt-5-mini", "gpt-5-mini"},
+		{"o4-mini-deep-research", "o4-mini-deep-research"},
+		{"gpt-5.3-chat-latest", "gpt-5.3-chat"},
+		{"grok-4-1-fast-reasoning", "grok-4"},
+		{"grok-4-0709", "grok-4"},
+		{"grok-build-0.1", "grok-build"},
+		{"grok-code-fast-1", "grok-code-fast"},
+	} {
+		t.Run(tt.model, func(t *testing.T) {
+			entry, found := LookupEntry("", tt.model)
+			assert.True(t, found)
+			assert.Equal(t, tt.prefix, entry.Prefix)
+		})
+	}
+}
+
+func TestLookupReturnsIndependentEffortSlice(t *testing.T) {
+	first, known := Lookup("openai", "gpt-5.6")
+	assert.True(t, known)
+	assert.True(t, len(first.Efforts) > 0)
+	first.Efforts[0] = llm.ReasoningEffort("mutated")
+
+	second, _ := Lookup("openai", "gpt-5.6")
+	assert.Equal(t, llm.ReasoningEffortNone, second.Efforts[0])
+}
+
 func TestTableForUnknownVendorIsNil(t *testing.T) {
 	assert.Nil(t, TableFor("openrouter", "mistralai/mistral-large"))
 }

--- a/providers/modelcaps/tables.go
+++ b/providers/modelcaps/tables.go
@@ -1,0 +1,157 @@
+package modelcaps
+
+import "github.com/deepnoodle-ai/dive/llm"
+
+var (
+	// The o-series and its pro/mini variants.
+	effortsLowToHigh = []llm.ReasoningEffort{
+		llm.ReasoningEffortLow,
+		llm.ReasoningEffortMedium,
+		llm.ReasoningEffortHigh,
+	}
+	// The original gpt-5 family: takes minimal, but not none.
+	effortsMinimalToHigh = []llm.ReasoningEffort{
+		llm.ReasoningEffortMinimal,
+		llm.ReasoningEffortLow,
+		llm.ReasoningEffortMedium,
+		llm.ReasoningEffortHigh,
+	}
+	// gpt-5.1 onward: none replaces minimal.
+	effortsNoneToHigh = []llm.ReasoningEffort{
+		llm.ReasoningEffortNone,
+		llm.ReasoningEffortLow,
+		llm.ReasoningEffortMedium,
+		llm.ReasoningEffortHigh,
+	}
+	// gpt-5.2 through gpt-5.5: adds xhigh.
+	effortsNoneToXHigh = []llm.ReasoningEffort{
+		llm.ReasoningEffortNone,
+		llm.ReasoningEffortLow,
+		llm.ReasoningEffortMedium,
+		llm.ReasoningEffortHigh,
+		llm.ReasoningEffortXHigh,
+	}
+	// gpt-5.6: the first OpenAI family to accept max.
+	effortsNoneToMax = []llm.ReasoningEffort{
+		llm.ReasoningEffortNone,
+		llm.ReasoningEffortLow,
+		llm.ReasoningEffortMedium,
+		llm.ReasoningEffortHigh,
+		llm.ReasoningEffortXHigh,
+		llm.ReasoningEffortMax,
+	}
+	// The ladder most Grok models accept: everything except max.
+	grokBelowMax = []llm.ReasoningEffort{
+		llm.ReasoningEffortNone,
+		llm.ReasoningEffortMinimal,
+		llm.ReasoningEffortLow,
+		llm.ReasoningEffortMedium,
+		llm.ReasoningEffortHigh,
+		llm.ReasoningEffortXHigh,
+	}
+	grokThroughMax = append(append([]llm.ReasoningEffort{}, grokBelowMax...), llm.ReasoningEffortMax)
+)
+
+// OpenAI maps OpenAI model-id prefixes to capabilities. Lookup takes the
+// longest matching prefix, so "gpt-5" and "gpt-5-pro" can coexist.
+var OpenAI = Table{
+	// No reasoning parameter at all. Sending one is rejected outright, which is
+	// what makes a non-empty default effort a request-breaking change.
+	{Prefix: "gpt-4o", Caps: Capabilities{Temperature: true}},
+	{Prefix: "gpt-4.1", Caps: Capabilities{Temperature: true}},
+
+	{Prefix: "gpt-5", Caps: Capabilities{Efforts: effortsMinimalToHigh}},
+	{Prefix: "gpt-5-mini", Caps: Capabilities{Efforts: effortsMinimalToHigh}},
+	{Prefix: "gpt-5-nano", Caps: Capabilities{Efforts: effortsMinimalToHigh}},
+	// gpt-5-pro accepts high and nothing else.
+	{Prefix: "gpt-5-pro", Caps: Capabilities{
+		Efforts: []llm.ReasoningEffort{llm.ReasoningEffortHigh},
+	}},
+
+	{Prefix: "gpt-5.1", Caps: Capabilities{Efforts: effortsNoneToHigh, Temperature: true}},
+
+	{Prefix: "gpt-5.2", Caps: Capabilities{Efforts: effortsNoneToXHigh, Temperature: true}},
+	// The pro variant narrows the range rather than widening it: no none, no low.
+	{Prefix: "gpt-5.2-pro", Caps: Capabilities{
+		Efforts: []llm.ReasoningEffort{
+			llm.ReasoningEffortMedium,
+			llm.ReasoningEffortHigh,
+			llm.ReasoningEffortXHigh,
+		},
+	}},
+
+	// The chat-tuned model accepts medium and nothing else.
+	{Prefix: "gpt-5.3-chat", Caps: Capabilities{
+		Efforts: []llm.ReasoningEffort{llm.ReasoningEffortMedium},
+	}},
+	{Prefix: "gpt-5.3-codex", Caps: Capabilities{Efforts: effortsNoneToXHigh, Temperature: true}},
+
+	{Prefix: "gpt-5.4", Caps: Capabilities{Efforts: effortsNoneToXHigh, Temperature: true}},
+	{Prefix: "gpt-5.4-mini", Caps: Capabilities{Efforts: effortsNoneToXHigh, Temperature: true}},
+	{Prefix: "gpt-5.4-nano", Caps: Capabilities{Efforts: effortsNoneToXHigh, Temperature: true}},
+
+	{Prefix: "gpt-5.5", Caps: Capabilities{Efforts: effortsNoneToXHigh}},
+
+	{Prefix: "gpt-5.6", Caps: Capabilities{Efforts: effortsNoneToMax}},
+	{Prefix: "gpt-5.6-sol", Caps: Capabilities{Efforts: effortsNoneToMax}},
+	{Prefix: "gpt-5.6-terra", Caps: Capabilities{Efforts: effortsNoneToMax}},
+	{Prefix: "gpt-5.6-luna", Caps: Capabilities{Efforts: effortsNoneToMax}},
+
+	{Prefix: "o3", Caps: Capabilities{Efforts: effortsLowToHigh}},
+	{Prefix: "o3-pro", Caps: Capabilities{Efforts: effortsLowToHigh}},
+	{Prefix: "o3-mini", Caps: Capabilities{Efforts: effortsLowToHigh}},
+	{Prefix: "o4-mini", Caps: Capabilities{Efforts: effortsLowToHigh}},
+
+	// Catalogued but unreachable for verification ("does not exist" or 404 for
+	// the probing account). Left as passthrough rather than guessed at from a
+	// sibling — the gpt-5.2-pro and gpt-5.3-chat entries above show that
+	// variants do not reliably inherit their family's range.
+	{Prefix: "o3-deep-research", Unverified: true},
+	{Prefix: "o4-mini-deep-research", Unverified: true},
+	{Prefix: "gpt-5-codex", Unverified: true},
+	{Prefix: "gpt-5-codex-mini", Unverified: true},
+	{Prefix: "gpt-5.1-codex", Unverified: true},
+	{Prefix: "gpt-5.1-codex-max", Unverified: true},
+	{Prefix: "gpt-5.2-codex", Unverified: true},
+	{Prefix: "codex-mini-latest", Unverified: true},
+	{Prefix: "codex-ask", Unverified: true},
+}
+
+// Grok maps xAI model-id prefixes to capabilities. Grok is broadly more
+// permissive than OpenAI — most models take the full ladder below max — but
+// several reject the reasoning parameter entirely, including one whose name
+// says "reasoning".
+var Grok = Table{
+	// "does not support parameter reasoningEffort". Note that
+	// grok-4.20-0309-reasoning is among them despite its name.
+	{Prefix: "grok-4.20-0309-reasoning", Caps: Capabilities{Temperature: true}},
+	{Prefix: "grok-4.20-0309-non-reasoning", Caps: Capabilities{Temperature: true}},
+	{Prefix: "grok-build", Caps: Capabilities{Temperature: true}},
+	{Prefix: "grok-code-fast", Caps: Capabilities{Temperature: true}},
+
+	// grok-4.5 is the one Grok model that rejects none.
+	{Prefix: "grok-4.5", Caps: Capabilities{
+		Efforts: []llm.ReasoningEffort{
+			llm.ReasoningEffortMinimal,
+			llm.ReasoningEffortLow,
+			llm.ReasoningEffortMedium,
+			llm.ReasoningEffortHigh,
+			llm.ReasoningEffortXHigh,
+		},
+		Temperature: true,
+	}},
+
+	{Prefix: "grok-4.3", Caps: Capabilities{Efforts: grokBelowMax, Temperature: true}},
+	{Prefix: "grok-4", Caps: Capabilities{Efforts: grokBelowMax, Temperature: true}},
+	{Prefix: "grok-3", Caps: Capabilities{Efforts: grokBelowMax, Temperature: true}},
+
+	// The multi-agent model is the only Grok model that accepts max.
+	{Prefix: "grok-4.20-multi-agent", Caps: Capabilities{
+		Efforts: grokThroughMax, Temperature: true,
+	}},
+}
+
+var (
+	sortedOpenAI = sortByPrefixLength(OpenAI)
+	sortedGrok   = sortByPrefixLength(Grok)
+)

--- a/providers/modelcaps/tables.go
+++ b/providers/modelcaps/tables.go
@@ -52,9 +52,11 @@ var (
 	grokThroughMax = append(append([]llm.ReasoningEffort{}, grokBelowMax...), llm.ReasoningEffortMax)
 )
 
-// OpenAI maps OpenAI model-id prefixes to capabilities. Lookup takes the
-// longest matching prefix, so "gpt-5" and "gpt-5-pro" can coexist.
-var OpenAI = Table{
+// openAITable maps OpenAI model-id prefixes to capabilities. It is declared in
+// readable order rather than lookup order and so is unexported; callers go
+// through Lookup, which searches the longest-prefix-first copy below so that
+// "gpt-5" and "gpt-5-pro" can coexist.
+var openAITable = Table{
 	// No reasoning parameter at all. Sending one is rejected outright, which is
 	// what makes a non-empty default effort a request-breaking change.
 	{Prefix: "gpt-4o", Caps: Capabilities{Temperature: true}},
@@ -117,11 +119,11 @@ var OpenAI = Table{
 	{Prefix: "codex-ask", Unverified: true},
 }
 
-// Grok maps xAI model-id prefixes to capabilities. Grok is broadly more
-// permissive than OpenAI — most models take the full ladder below max — but
-// several reject the reasoning parameter entirely, including one whose name
-// says "reasoning".
-var Grok = Table{
+// grokTable maps xAI model-id prefixes to capabilities, unexported for the same
+// reason as openAITable. Grok is broadly more permissive than OpenAI — most
+// models take the full ladder below max — but several reject the reasoning
+// parameter entirely, including one whose name says "reasoning".
+var grokTable = Table{
 	// "does not support parameter reasoningEffort". Note that
 	// grok-4.20-0309-reasoning is among them despite its name.
 	{Prefix: "grok-4.20-0309-reasoning", Caps: Capabilities{Temperature: true}},
@@ -152,6 +154,6 @@ var Grok = Table{
 }
 
 var (
-	sortedOpenAI = sortByPrefixLength(OpenAI)
-	sortedGrok   = sortByPrefixLength(Grok)
+	sortedOpenAI = sortByPrefixLength(openAITable)
+	sortedGrok   = sortByPrefixLength(grokTable)
 )

--- a/providers/openai/capabilities_test.go
+++ b/providers/openai/capabilities_test.go
@@ -24,7 +24,7 @@ func TestEveryCatalogModelHasCapabilities(t *testing.T) {
 		t.Run(id, func(t *testing.T) {
 			_, found := modelcaps.LookupEntry("openai", id)
 			assert.True(t, found,
-				"model %q (%s) has no entry in modelcaps.OpenAI; add one so its "+
+				"model %q (%s) has no entry in the modelcaps OpenAI table; add one so its "+
 					"reasoning and temperature parameters are gated, or mark it "+
 					"Unverified if it cannot be reached", id, model.GoName)
 		})

--- a/providers/openai/capabilities_test.go
+++ b/providers/openai/capabilities_test.go
@@ -1,0 +1,32 @@
+package openai
+
+import (
+	"testing"
+
+	"github.com/deepnoodle-ai/dive/providers/modelcaps"
+	"github.com/deepnoodle-ai/wonton/assert"
+)
+
+// TestEveryCatalogModelHasCapabilities is the drift guard for the OpenAI table:
+// adding a model to catalog.json without classifying its reasoning and
+// temperature support fails here rather than at runtime against the API. An
+// entry marked Unverified counts as classified — the point is that someone
+// decided, not that every model is gated.
+func TestEveryCatalogModelHasCapabilities(t *testing.T) {
+	for _, model := range Catalog().Models {
+		if model.Kind != "" && model.Kind != "text" {
+			continue // only text models take reasoning parameters
+		}
+		id := model.ID
+		if id == "" {
+			continue // alias-only entries carry no id of their own
+		}
+		t.Run(id, func(t *testing.T) {
+			_, found := modelcaps.LookupEntry("openai", id)
+			assert.True(t, found,
+				"model %q (%s) has no entry in modelcaps.OpenAI; add one so its "+
+					"reasoning and temperature parameters are gated, or mark it "+
+					"Unverified if it cannot be reached", id, model.GoName)
+		})
+	}
+}

--- a/providers/openai/provider.go
+++ b/providers/openai/provider.go
@@ -231,19 +231,22 @@ func (p *Provider) buildRequestParams(config *llm.Config) (responses.ResponseNew
 		params.MaxOutputTokens = openai.Int(int64(p.maxTokens))
 	}
 
-	// Set temperature
+	// Set temperature, unless the model rejects it. Several reasoning models
+	// answer 400 for "Unsupported parameter: 'temperature'".
 	if config.Temperature != nil {
-		params.Temperature = openai.Float(*config.Temperature)
+		if modelAcceptsTemperature(p.Name(), string(params.Model)) {
+			params.Temperature = openai.Float(*config.Temperature)
+		} else if config.Logger != nil {
+			config.Logger.Warn("model does not support temperature; omitting it",
+				"model", string(params.Model))
+		}
 	}
 
 	includes := map[Include]bool{}
 
-	// Handle reasoning effort
-	if config.ReasoningEffort != "" {
-		effort, err := normalizeResponsesReasoningEffort(p.Name(), string(params.Model), config.ReasoningEffort)
-		if err != nil {
-			return responses.ResponseNewParams{}, err
-		}
+	// Handle reasoning effort. A model with no reasoning parameter gets none:
+	// gpt-4o and gpt-4.1 reject the field outright rather than ignoring it.
+	if effort, send := resolveResponsesReasoningEffort(p.Name(), string(params.Model), config); send {
 		params.Reasoning = responses.ReasoningParam{
 			Effort: responses.ReasoningEffort(effort),
 		}

--- a/providers/openai/reasoning.go
+++ b/providers/openai/reasoning.go
@@ -1,158 +1,21 @@
 package openai
 
 import (
-	"fmt"
-	"strings"
-
 	"github.com/deepnoodle-ai/dive/llm"
+	"github.com/deepnoodle-ai/dive/providers/modelcaps"
 )
 
-func normalizeResponsesReasoningEffort(providerName, model string, effort llm.ReasoningEffort) (llm.ReasoningEffort, error) {
-	if strings.EqualFold(providerName, "grok") {
-		return normalizeGrokReasoningEffort(model, effort)
-	}
-	return normalizeOpenAIReasoningEffort(model, effort)
+// resolveResponsesReasoningEffort maps the requested effort onto what the model
+// accepts. The bool reports whether to send a reasoning parameter at all:
+// gpt-4o and gpt-4.1 have none, and sending one is a 400.
+func resolveResponsesReasoningEffort(
+	providerName, model string,
+	config *llm.Config,
+) (llm.ReasoningEffort, bool) {
+	return modelcaps.ResolveEffort(providerName, model, config.ReasoningEffort, config.Logger)
 }
 
-func normalizeOpenAIReasoningEffort(model string, effort llm.ReasoningEffort) (llm.ReasoningEffort, error) {
-	model = strings.ToLower(model)
-	model = strings.TrimPrefix(model, "openai/")
-	if strings.Contains(model, "codex") {
-		return effort, nil
-	}
-
-	switch {
-	case strings.HasPrefix(model, "gpt-5.6"):
-		return mapReasoningEffort(model, effort,
-			[]llm.ReasoningEffort{
-				llm.ReasoningEffortNone,
-				llm.ReasoningEffortLow,
-				llm.ReasoningEffortMedium,
-				llm.ReasoningEffortHigh,
-				llm.ReasoningEffortXHigh,
-				llm.ReasoningEffortMax,
-			},
-			map[llm.ReasoningEffort]llm.ReasoningEffort{
-				llm.ReasoningEffortMinimal: llm.ReasoningEffortLow,
-			})
-	case strings.HasPrefix(model, "gpt-5.5"),
-		strings.HasPrefix(model, "gpt-5.4"),
-		strings.HasPrefix(model, "gpt-5.3"),
-		strings.HasPrefix(model, "gpt-5.2"):
-		return mapReasoningEffort(model, effort,
-			[]llm.ReasoningEffort{
-				llm.ReasoningEffortNone,
-				llm.ReasoningEffortLow,
-				llm.ReasoningEffortMedium,
-				llm.ReasoningEffortHigh,
-				llm.ReasoningEffortXHigh,
-			},
-			map[llm.ReasoningEffort]llm.ReasoningEffort{
-				llm.ReasoningEffortMinimal: llm.ReasoningEffortLow,
-				llm.ReasoningEffortMax:     llm.ReasoningEffortXHigh,
-			})
-	case strings.HasPrefix(model, "gpt-5.1"):
-		return mapReasoningEffort(model, effort,
-			[]llm.ReasoningEffort{
-				llm.ReasoningEffortNone,
-				llm.ReasoningEffortLow,
-				llm.ReasoningEffortMedium,
-				llm.ReasoningEffortHigh,
-			},
-			map[llm.ReasoningEffort]llm.ReasoningEffort{
-				llm.ReasoningEffortMinimal: llm.ReasoningEffortLow,
-				llm.ReasoningEffortXHigh:   llm.ReasoningEffortHigh,
-				llm.ReasoningEffortMax:     llm.ReasoningEffortHigh,
-			})
-	case strings.HasPrefix(model, "gpt-5-pro"):
-		return mapReasoningEffort(model, effort,
-			[]llm.ReasoningEffort{llm.ReasoningEffortHigh},
-			map[llm.ReasoningEffort]llm.ReasoningEffort{
-				llm.ReasoningEffortMinimal: llm.ReasoningEffortHigh,
-				llm.ReasoningEffortLow:     llm.ReasoningEffortHigh,
-				llm.ReasoningEffortMedium:  llm.ReasoningEffortHigh,
-				llm.ReasoningEffortXHigh:   llm.ReasoningEffortHigh,
-				llm.ReasoningEffortMax:     llm.ReasoningEffortHigh,
-			})
-	case strings.HasPrefix(model, "gpt-5"):
-		return mapReasoningEffort(model, effort,
-			[]llm.ReasoningEffort{
-				llm.ReasoningEffortMinimal,
-				llm.ReasoningEffortLow,
-				llm.ReasoningEffortMedium,
-				llm.ReasoningEffortHigh,
-			},
-			map[llm.ReasoningEffort]llm.ReasoningEffort{
-				llm.ReasoningEffortXHigh: llm.ReasoningEffortHigh,
-				llm.ReasoningEffortMax:   llm.ReasoningEffortHigh,
-			})
-	case strings.HasPrefix(model, "o"):
-		return mapReasoningEffort(model, effort,
-			[]llm.ReasoningEffort{
-				llm.ReasoningEffortLow,
-				llm.ReasoningEffortMedium,
-				llm.ReasoningEffortHigh,
-			},
-			map[llm.ReasoningEffort]llm.ReasoningEffort{
-				llm.ReasoningEffortMinimal: llm.ReasoningEffortLow,
-				llm.ReasoningEffortXHigh:   llm.ReasoningEffortHigh,
-				llm.ReasoningEffortMax:     llm.ReasoningEffortHigh,
-			})
-	default:
-		return effort, nil
-	}
-}
-
-func normalizeGrokReasoningEffort(model string, effort llm.ReasoningEffort) (llm.ReasoningEffort, error) {
-	model = strings.ToLower(strings.TrimPrefix(model, "x-ai/"))
-
-	switch {
-	case strings.HasPrefix(model, "grok-4.5"),
-		strings.HasPrefix(model, "grok-4.3"),
-		// "grok-build" rather than a pinned version: xAI serves grok-build-0.1,
-		// and this previously keyed on grok-build-latest, an id xAI does not
-		// serve, so the real model fell through without clamping.
-		strings.HasPrefix(model, "grok-build"):
-		return mapReasoningEffort(model, effort,
-			[]llm.ReasoningEffort{
-				llm.ReasoningEffortNone,
-				llm.ReasoningEffortLow,
-				llm.ReasoningEffortMedium,
-				llm.ReasoningEffortHigh,
-			},
-			map[llm.ReasoningEffort]llm.ReasoningEffort{
-				llm.ReasoningEffortMinimal: llm.ReasoningEffortLow,
-				llm.ReasoningEffortXHigh:   llm.ReasoningEffortHigh,
-				llm.ReasoningEffortMax:     llm.ReasoningEffortHigh,
-			})
-	case strings.Contains(model, "multi-agent"):
-		return mapReasoningEffort(model, effort,
-			[]llm.ReasoningEffort{
-				llm.ReasoningEffortLow,
-				llm.ReasoningEffortMedium,
-				llm.ReasoningEffortHigh,
-				llm.ReasoningEffortXHigh,
-			},
-			map[llm.ReasoningEffort]llm.ReasoningEffort{
-				llm.ReasoningEffortMinimal: llm.ReasoningEffortLow,
-				llm.ReasoningEffortMax:     llm.ReasoningEffortXHigh,
-			})
-	default:
-		return effort, nil
-	}
-}
-
-func mapReasoningEffort(model string, effort llm.ReasoningEffort, allowed []llm.ReasoningEffort, aliases map[llm.ReasoningEffort]llm.ReasoningEffort) (llm.ReasoningEffort, error) {
-	for _, value := range allowed {
-		if effort == value {
-			return effort, nil
-		}
-	}
-	if mapped, ok := aliases[effort]; ok {
-		return mapped, nil
-	}
-	if !effort.IsValid() {
-		return effort, nil
-	}
-	return "", fmt.Errorf("reasoning effort %q is not supported by model %s", effort, model)
+// modelAcceptsTemperature reports whether the model takes a temperature.
+func modelAcceptsTemperature(providerName, model string) bool {
+	return modelcaps.AcceptsTemperature(providerName, model)
 }

--- a/providers/openai/responses_extra_test.go
+++ b/providers/openai/responses_extra_test.go
@@ -183,6 +183,8 @@ func TestBuildRequestParams_NormalizesOpenAIReasoningEffort(t *testing.T) {
 }
 
 func TestBuildRequestParams_ReasoningEffortUnsupportedForOpenAIModel(t *testing.T) {
+	// The gpt-5 family takes minimal but not none, so none clamps up to the
+	// least eager supported level rather than failing the request.
 	provider := New(WithAPIKey("test"), WithModel(ModelGPT5))
 	config := &llm.Config{}
 	config.Apply(
@@ -190,9 +192,38 @@ func TestBuildRequestParams_ReasoningEffortUnsupportedForOpenAIModel(t *testing.
 		llm.WithReasoningEffort(llm.ReasoningEffortNone),
 	)
 
-	_, err := provider.buildRequestParams(config)
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "not supported")
+	params, err := provider.buildRequestParams(config)
+	assert.NoError(t, err)
+	assert.Equal(t, responses.ReasoningEffort("minimal"), params.Reasoning.Effort)
+}
+
+func TestBuildRequestParams_ModelWithoutReasoningOmitsEffort(t *testing.T) {
+	// gpt-4o rejects the field outright ("Unsupported parameter:
+	// 'reasoning.effort'"), and the CLI now defaults effort to medium, so this
+	// would otherwise 400 on every request.
+	provider := New(WithAPIKey("test"), WithModel("gpt-4o"))
+	config := &llm.Config{}
+	config.Apply(
+		llm.WithMessages(llm.NewUserTextMessage("hi")),
+		llm.WithReasoningEffort(llm.ReasoningEffortMedium),
+	)
+
+	params, err := provider.buildRequestParams(config)
+	assert.NoError(t, err)
+	assert.Equal(t, responses.ReasoningEffort(""), params.Reasoning.Effort)
+}
+
+func TestBuildRequestParams_ModelWithoutTemperatureOmitsIt(t *testing.T) {
+	provider := New(WithAPIKey("test"), WithModel(ModelGPT5))
+	config := &llm.Config{}
+	config.Apply(
+		llm.WithMessages(llm.NewUserTextMessage("hi")),
+		llm.WithTemperature(0.5),
+	)
+
+	params, err := provider.buildRequestParams(config)
+	assert.NoError(t, err)
+	assert.False(t, params.Temperature.Valid())
 }
 
 func TestBuildRequestParams_NormalizesGrokReasoningEffort(t *testing.T) {
@@ -204,28 +235,52 @@ func TestBuildRequestParams_NormalizesGrokReasoningEffort(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name:   "grok 4.5 max maps to high",
+			// grok-4.5 accepts xhigh, so max clamps one level rather than two.
+			name:   "grok 4.5 max maps to xhigh",
 			model:  "grok-4.5",
-			effort: llm.ReasoningEffortMax,
-			want:   responses.ReasoningEffort("high"),
-		},
-		{
-			name:   "grok build minimal maps to low",
-			model:  "grok-build-0.1",
-			effort: llm.ReasoningEffortMinimal,
-			want:   responses.ReasoningEffort("low"),
-		},
-		{
-			name:   "grok multi-agent max maps to xhigh",
-			model:  "grok-4.20-multi-agent-0309",
 			effort: llm.ReasoningEffortMax,
 			want:   responses.ReasoningEffort("xhigh"),
 		},
 		{
-			name:    "grok multi-agent rejects none",
-			model:   "grok-4.20-multi-agent-0309",
-			effort:  llm.ReasoningEffortNone,
-			wantErr: true,
+			// grok-4.5 is the one Grok model that rejects none.
+			name:   "grok 4.5 none clamps to minimal",
+			model:  "grok-4.5",
+			effort: llm.ReasoningEffortNone,
+			want:   responses.ReasoningEffort("minimal"),
+		},
+		{
+			// "does not support parameter reasoningEffort": omit the field.
+			name:   "grok build omits effort",
+			model:  "grok-build-0.1",
+			effort: llm.ReasoningEffortMinimal,
+			want:   responses.ReasoningEffort(""),
+		},
+		{
+			// grok-code-fast-1 likewise has no reasoning parameter.
+			name:   "grok code fast omits effort",
+			model:  "grok-code-fast-1",
+			effort: llm.ReasoningEffortHigh,
+			want:   responses.ReasoningEffort(""),
+		},
+		{
+			// Despite the name, this model rejects the reasoning parameter.
+			name:   "grok 4.20 reasoning omits effort",
+			model:  "grok-4.20-0309-reasoning",
+			effort: llm.ReasoningEffortHigh,
+			want:   responses.ReasoningEffort(""),
+		},
+		{
+			// The multi-agent model is the only Grok model that accepts max.
+			name:   "grok multi-agent keeps max",
+			model:  "grok-4.20-multi-agent-0309",
+			effort: llm.ReasoningEffortMax,
+			want:   responses.ReasoningEffort("max"),
+		},
+		{
+			name:   "grok multi-agent accepts none",
+			model:  "grok-4.20-multi-agent-0309",
+			effort: llm.ReasoningEffortNone,
+			want:   responses.ReasoningEffort("none"),
 		},
 	}
 

--- a/providers/openai/responses_extra_test.go
+++ b/providers/openai/responses_extra_test.go
@@ -228,11 +228,10 @@ func TestBuildRequestParams_ModelWithoutTemperatureOmitsIt(t *testing.T) {
 
 func TestBuildRequestParams_NormalizesGrokReasoningEffort(t *testing.T) {
 	tests := []struct {
-		name    string
-		model   string
-		effort  llm.ReasoningEffort
-		want    responses.ReasoningEffort
-		wantErr bool
+		name   string
+		model  string
+		effort llm.ReasoningEffort
+		want   responses.ReasoningEffort
 	}{
 		{
 			// grok-4.5 accepts xhigh, so max clamps one level rather than two.
@@ -294,11 +293,6 @@ func TestBuildRequestParams_NormalizesGrokReasoningEffort(t *testing.T) {
 			)
 
 			params, err := provider.buildRequestParams(config)
-			if tt.wantErr {
-				assert.Error(t, err)
-				assert.Contains(t, err.Error(), "not supported")
-				return
-			}
 			assert.NoError(t, err)
 			assert.Equal(t, tt.want, params.Reasoning.Effort)
 		})

--- a/providers/openaicompletions/openai.go
+++ b/providers/openaicompletions/openai.go
@@ -15,6 +15,7 @@ import (
 	"github.com/deepnoodle-ai/dive"
 	"github.com/deepnoodle-ai/dive/llm"
 	"github.com/deepnoodle-ai/dive/providers"
+	"github.com/deepnoodle-ai/dive/providers/modelcaps"
 	"github.com/deepnoodle-ai/wonton/retry"
 )
 
@@ -604,13 +605,16 @@ func (p *Provider) applyRequestConfig(req *Request, config *llm.Config) error {
 	}
 
 	req.Tools = tools
-	req.Temperature = config.Temperature
+	if config.Temperature != nil && !modelcaps.AcceptsTemperature(p.Name(), req.Model) {
+		if config.Logger != nil {
+			config.Logger.Warn("model does not support temperature; omitting it", "model", req.Model)
+		}
+	} else {
+		req.Temperature = config.Temperature
+	}
 	req.PresencePenalty = config.PresencePenalty
 	req.FrequencyPenalty = config.FrequencyPenalty
-	reasoningEffort, includeReasoningEffort, err := p.resolveReasoningEffort(req.Model, config)
-	if err != nil {
-		return err
-	}
+	reasoningEffort, includeReasoningEffort := p.resolveReasoningEffort(req.Model, config)
 	if includeReasoningEffort {
 		requestedReasoningEffort := config.ReasoningEffort
 		var adjusted bool

--- a/providers/openaicompletions/openai_test.go
+++ b/providers/openaicompletions/openai_test.go
@@ -45,16 +45,20 @@ func TestApplyRequestConfig_NormalizesReasoningEffort(t *testing.T) {
 			want:   ReasoningEffortHigh,
 		},
 		{
-			name:   "openrouter x-ai grok max maps to high",
+			// grok-4.5 accepts xhigh, so max clamps to xhigh rather than
+			// dropping two levels to high.
+			name:   "openrouter x-ai grok max maps to xhigh",
 			model:  "x-ai/grok-4.5",
 			effort: llm.ReasoningEffortMax,
-			want:   ReasoningEffortHigh,
+			want:   ReasoningEffortXHigh,
 		},
 		{
-			name:   "openrouter x-ai grok build minimal maps to low",
+			// grok-build rejects the reasoning parameter entirely
+			// ("does not support parameter reasoningEffort"), so it is omitted.
+			name:   "openrouter x-ai grok build omits effort",
 			model:  "x-ai/grok-build-0.1",
 			effort: llm.ReasoningEffortMinimal,
-			want:   ReasoningEffortLow,
+			want:   ReasoningEffort(""),
 		},
 		{
 			name:   "unknown model effort passes through",
@@ -81,12 +85,14 @@ func TestApplyRequestConfig_NormalizesReasoningEffort(t *testing.T) {
 	}
 }
 
-func TestApplyRequestConfig_UnsupportedReasoningEffortErrorsForKnownModel(t *testing.T) {
+func TestApplyRequestConfig_UnsupportedReasoningEffortClampsForKnownModel(t *testing.T) {
+	// The gpt-5 family takes minimal but not none, so none clamps up to the
+	// least eager level the model actually accepts instead of failing.
 	provider := New(WithModel(ModelGPT5))
 	var req Request
 	err := provider.applyRequestConfig(&req, &llm.Config{ReasoningEffort: llm.ReasoningEffortNone})
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "not supported")
+	assert.NoError(t, err)
+	assert.Equal(t, ReasoningEffortMinimal, req.ReasoningEffort)
 }
 
 func TestApplyRequestConfig_MistralOmitsReasoningEffort(t *testing.T) {

--- a/providers/openaicompletions/openai_test.go
+++ b/providers/openaicompletions/openai_test.go
@@ -95,6 +95,36 @@ func TestApplyRequestConfig_UnsupportedReasoningEffortClampsForKnownModel(t *tes
 	assert.Equal(t, ReasoningEffortMinimal, req.ReasoningEffort)
 }
 
+func TestApplyRequestConfig_OmitsTemperatureForModelsThatRejectIt(t *testing.T) {
+	// gpt-5 answers 400 "Unsupported parameter: 'temperature'".
+	temperature := 0.5
+	logger := &recordingLogger{}
+	provider := New(WithModel(ModelGPT5))
+	var req Request
+	err := provider.applyRequestConfig(&req, &llm.Config{
+		Temperature: &temperature,
+		Logger:      logger,
+	})
+	assert.NoError(t, err)
+	assert.Nil(t, req.Temperature)
+	assert.Len(t, logger.warnings, 1)
+}
+
+func TestApplyRequestConfig_KeepsTemperatureForModelsThatAcceptIt(t *testing.T) {
+	temperature := 0.5
+	logger := &recordingLogger{}
+	provider := New(WithModel(ModelGPT51))
+	var req Request
+	err := provider.applyRequestConfig(&req, &llm.Config{
+		Temperature: &temperature,
+		Logger:      logger,
+	})
+	assert.NoError(t, err)
+	assert.NotNil(t, req.Temperature)
+	assert.Equal(t, temperature, *req.Temperature)
+	assert.Len(t, logger.warnings, 0)
+}
+
 func TestApplyRequestConfig_MistralOmitsReasoningEffort(t *testing.T) {
 	provider := New(
 		WithEndpoint("https://api.mistral.ai/v1/chat/completions"),

--- a/providers/openaicompletions/reasoning.go
+++ b/providers/openaicompletions/reasoning.go
@@ -1,38 +1,38 @@
 package openaicompletions
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/deepnoodle-ai/dive/llm"
+	"github.com/deepnoodle-ai/dive/providers/modelcaps"
 )
 
-func (p *Provider) resolveReasoningEffort(model string, config *llm.Config) (ReasoningEffort, bool, error) {
+// resolveReasoningEffort maps the requested effort onto what the model accepts.
+// The bool reports whether to send a reasoning_effort field at all: several
+// models reject the parameter outright rather than ignoring it.
+//
+// Model capabilities come from the shared modelcaps tables, so the Chat
+// Completions path and the Responses path agree about the same model. Anything
+// modelcaps does not recognize — a Mistral, DeepSeek, or other OpenRouter model
+// — is forwarded untouched, except Mistral's own endpoint, which has no
+// reasoning parameter at all.
+func (p *Provider) resolveReasoningEffort(model string, config *llm.Config) (ReasoningEffort, bool) {
 	effort := config.ReasoningEffort
 	if effort == "" {
-		return "", false, nil
+		return "", false
 	}
-
-	modelLower := strings.ToLower(model)
-	switch {
-	case strings.HasPrefix(modelLower, "openai/"):
-		normalized, err := normalizeOpenAIReasoningEffort(strings.TrimPrefix(modelLower, "openai/"), effort)
-		return ReasoningEffort(normalized), true, err
-	case strings.HasPrefix(modelLower, "x-ai/"):
-		normalized, err := normalizeGrokReasoningEffort(strings.TrimPrefix(modelLower, "x-ai/"), effort)
-		return ReasoningEffort(normalized), true, err
-	case strings.HasPrefix(modelLower, "gpt-") || strings.HasPrefix(modelLower, "o"):
-		normalized, err := normalizeOpenAIReasoningEffort(modelLower, effort)
-		return ReasoningEffort(normalized), true, err
-	case strings.Contains(p.endpoint, "api.mistral.ai"):
+	if _, known := modelcaps.Lookup(p.Name(), model); known {
+		resolved, send := modelcaps.ResolveEffort(p.Name(), model, effort, config.Logger)
+		return ReasoningEffort(resolved), send
+	}
+	if strings.Contains(p.endpoint, "api.mistral.ai") {
 		if config.Logger != nil {
 			config.Logger.Warn("provider does not support reasoning effort; omitting option",
 				"provider", "mistral", "model", model, "reasoning_effort", effort)
 		}
-		return "", false, nil
-	default:
-		return ReasoningEffort(effort), true, nil
+		return "", false
 	}
+	return ReasoningEffort(effort), true
 }
 
 // normalizeToolReasoningEffort handles Chat Completions constraints that only
@@ -50,141 +50,3 @@ func normalizeToolReasoningEffort(model string, effort ReasoningEffort, hasFunct
 	return effort, false
 }
 
-func normalizeOpenAIReasoningEffort(model string, effort llm.ReasoningEffort) (llm.ReasoningEffort, error) {
-	if strings.Contains(model, "codex") {
-		return effort, nil
-	}
-
-	switch {
-	case strings.HasPrefix(model, "gpt-5.6"):
-		return mapReasoningEffort(model, effort,
-			[]llm.ReasoningEffort{
-				llm.ReasoningEffortNone,
-				llm.ReasoningEffortLow,
-				llm.ReasoningEffortMedium,
-				llm.ReasoningEffortHigh,
-				llm.ReasoningEffortXHigh,
-				llm.ReasoningEffortMax,
-			},
-			map[llm.ReasoningEffort]llm.ReasoningEffort{
-				llm.ReasoningEffortMinimal: llm.ReasoningEffortLow,
-			})
-	case strings.HasPrefix(model, "gpt-5.5"),
-		strings.HasPrefix(model, "gpt-5.4"),
-		strings.HasPrefix(model, "gpt-5.3"),
-		strings.HasPrefix(model, "gpt-5.2"):
-		return mapReasoningEffort(model, effort,
-			[]llm.ReasoningEffort{
-				llm.ReasoningEffortNone,
-				llm.ReasoningEffortLow,
-				llm.ReasoningEffortMedium,
-				llm.ReasoningEffortHigh,
-				llm.ReasoningEffortXHigh,
-			},
-			map[llm.ReasoningEffort]llm.ReasoningEffort{
-				llm.ReasoningEffortMinimal: llm.ReasoningEffortLow,
-				llm.ReasoningEffortMax:     llm.ReasoningEffortXHigh,
-			})
-	case strings.HasPrefix(model, "gpt-5.1"):
-		return mapReasoningEffort(model, effort,
-			[]llm.ReasoningEffort{
-				llm.ReasoningEffortNone,
-				llm.ReasoningEffortLow,
-				llm.ReasoningEffortMedium,
-				llm.ReasoningEffortHigh,
-			},
-			map[llm.ReasoningEffort]llm.ReasoningEffort{
-				llm.ReasoningEffortMinimal: llm.ReasoningEffortLow,
-				llm.ReasoningEffortXHigh:   llm.ReasoningEffortHigh,
-				llm.ReasoningEffortMax:     llm.ReasoningEffortHigh,
-			})
-	case strings.HasPrefix(model, "gpt-5-pro"):
-		return mapReasoningEffort(model, effort,
-			[]llm.ReasoningEffort{llm.ReasoningEffortHigh},
-			map[llm.ReasoningEffort]llm.ReasoningEffort{
-				llm.ReasoningEffortMinimal: llm.ReasoningEffortHigh,
-				llm.ReasoningEffortLow:     llm.ReasoningEffortHigh,
-				llm.ReasoningEffortMedium:  llm.ReasoningEffortHigh,
-				llm.ReasoningEffortXHigh:   llm.ReasoningEffortHigh,
-				llm.ReasoningEffortMax:     llm.ReasoningEffortHigh,
-			})
-	case strings.HasPrefix(model, "gpt-5"):
-		return mapReasoningEffort(model, effort,
-			[]llm.ReasoningEffort{
-				llm.ReasoningEffortMinimal,
-				llm.ReasoningEffortLow,
-				llm.ReasoningEffortMedium,
-				llm.ReasoningEffortHigh,
-			},
-			map[llm.ReasoningEffort]llm.ReasoningEffort{
-				llm.ReasoningEffortXHigh: llm.ReasoningEffortHigh,
-				llm.ReasoningEffortMax:   llm.ReasoningEffortHigh,
-			})
-	case strings.HasPrefix(model, "o"):
-		return mapReasoningEffort(model, effort,
-			[]llm.ReasoningEffort{
-				llm.ReasoningEffortLow,
-				llm.ReasoningEffortMedium,
-				llm.ReasoningEffortHigh,
-			},
-			map[llm.ReasoningEffort]llm.ReasoningEffort{
-				llm.ReasoningEffortMinimal: llm.ReasoningEffortLow,
-				llm.ReasoningEffortXHigh:   llm.ReasoningEffortHigh,
-				llm.ReasoningEffortMax:     llm.ReasoningEffortHigh,
-			})
-	default:
-		return effort, nil
-	}
-}
-
-func normalizeGrokReasoningEffort(model string, effort llm.ReasoningEffort) (llm.ReasoningEffort, error) {
-	switch {
-	case strings.HasPrefix(model, "grok-4.5"),
-		strings.HasPrefix(model, "grok-4.3"),
-		// "grok-build" rather than a pinned version: xAI serves grok-build-0.1,
-		// and this previously keyed on grok-build-latest, an id xAI does not
-		// serve, so the real model fell through without clamping.
-		strings.HasPrefix(model, "grok-build"):
-		return mapReasoningEffort(model, effort,
-			[]llm.ReasoningEffort{
-				llm.ReasoningEffortNone,
-				llm.ReasoningEffortLow,
-				llm.ReasoningEffortMedium,
-				llm.ReasoningEffortHigh,
-			},
-			map[llm.ReasoningEffort]llm.ReasoningEffort{
-				llm.ReasoningEffortMinimal: llm.ReasoningEffortLow,
-				llm.ReasoningEffortXHigh:   llm.ReasoningEffortHigh,
-				llm.ReasoningEffortMax:     llm.ReasoningEffortHigh,
-			})
-	case strings.Contains(model, "multi-agent"):
-		return mapReasoningEffort(model, effort,
-			[]llm.ReasoningEffort{
-				llm.ReasoningEffortLow,
-				llm.ReasoningEffortMedium,
-				llm.ReasoningEffortHigh,
-				llm.ReasoningEffortXHigh,
-			},
-			map[llm.ReasoningEffort]llm.ReasoningEffort{
-				llm.ReasoningEffortMinimal: llm.ReasoningEffortLow,
-				llm.ReasoningEffortMax:     llm.ReasoningEffortXHigh,
-			})
-	default:
-		return effort, nil
-	}
-}
-
-func mapReasoningEffort(model string, effort llm.ReasoningEffort, allowed []llm.ReasoningEffort, aliases map[llm.ReasoningEffort]llm.ReasoningEffort) (llm.ReasoningEffort, error) {
-	for _, value := range allowed {
-		if effort == value {
-			return effort, nil
-		}
-	}
-	if mapped, ok := aliases[effort]; ok {
-		return mapped, nil
-	}
-	if !effort.IsValid() {
-		return effort, nil
-	}
-	return "", fmt.Errorf("reasoning effort %q is not supported by model %s", effort, model)
-}

--- a/providers/openaicompletions/reasoning.go
+++ b/providers/openaicompletions/reasoning.go
@@ -49,4 +49,3 @@ func normalizeToolReasoningEffort(model string, effort ReasoningEffort, hasFunct
 	}
 	return effort, false
 }
-


### PR DESCRIPTION
## The problem

Provider code decided what a model accepts by testing whether its id matched a newer prefix, with a permissive fallback (`default: return effort, nil`). That makes a model that is **known and lacks a feature** indistinguishable from one that is **unknown**, so parameters were sent to models that reject them.

Most of this was latent until #245 defaulted the CLI's `--thinking-effort` to `medium`. `dive -m gpt-4o "hi"` now 400s on every request.

## How the tables were built

By probing the APIs directly — ~500 minimal requests across the model × parameter matrix on Anthropic, OpenAI and xAI, recording which combinations return 400. Every entry is a recorded response, not an inference from a model's name or generation.

That distinction earned its keep. Several models contradict their families, one contradicts its own name, and two facts I would have written from memory were wrong:

- `grok-4.20-0309-reasoning` **rejects** the reasoning parameter
- Claude 4.6 accepts `max` but rejects `xhigh`
- `gpt-5.2-pro` is *narrower* than `gpt-5.2`, not wider
- `codex-mini-latest` looked like "rejects effort" until the error text turned out to be `does not exist`
- `minimal` on gpt-5 looked unsupported until a 500 turned out to be my own `max_output_tokens: 16`

## Six bugs, each reproduced live before and after

| | before | after |
|---|---|---|
| `gpt-4o`, `gpt-4.1` + effort | `400 Unsupported parameter: 'reasoning.effort'` | dropped |
| `grok-code-fast-1`, `grok-build`, both `grok-4.20-0309` | `400 does not support parameter reasoningEffort` | dropped |
| adaptive thinking on 4.5-tier | `400 adaptive thinking is not supported` | falls back to a manual budget |
| temperature on `gpt-5`/`5.5`/`5.6`/`o3`/`o4-mini` | `400` | dropped |
| codex early-return | bypassed all clamping | clamped |
| budget + effort on Opus 4.5 / Sonnet 4.6 | rejected client-side | sent (the API accepts it) |

The adaptive bug was masked in the CLI: the legacy effort path overwrote the adaptive block with a budget, so it only fires when no effort is set (`--thinking-effort ""`, or `WithAdaptiveThinking()` from the library).

Ranges corrected in passing: `grok-4.5` accepts `xhigh` and rejects `none`; the Grok multi-agent model accepts `max` and `none`; `gpt-5.2-pro` is `medium`/`high`/`xhigh` only; `gpt-5.3-chat-latest` is `medium` only.

## Approach

**Clamp or drop, never error.** Unsupported settings are clamped to the nearest supported level or dropped with a `config.Logger` warning, so one `ModelSettings` survives being pointed at a model with a narrower range — the thing a cross-provider library exists to do. Eight error paths in `anthropic.go` became clamps.

**Unknown models keep today's passthrough behavior.** Fine-tunes, gateways and custom deployments are forwarded untouched, since Dive cannot know what they accept. Entries that could not be reached for verification are marked `Unverified` and pass through rather than being guessed at from a sibling.

**Unparseable values still reach the API.** A typo or provider-specific value is forwarded so the API can report it, rather than being silently swallowed — dropping is for settings that are valid but unsupported.

**One table per parameter space.** The Responses, Chat Completions and OpenRouter paths carried three separate copies of the same switches, so the shared tables live in a new `providers/modelcaps`. Anthropic keeps its own, since thinking budgets and adaptive mode have no OpenAI analogue.

**Drift guard.** Coverage tests require every catalogued model to resolve to an entry, so adding a model to `catalog.json` fails the build until it has been classified.

## Review notes

- **New public API:** `llm.ClampReasoningEffort` and the `providers/modelcaps` package.
- **Release ordering:** `providers/openai` and `providers/grok` are separate modules that now import `modelcaps` from the root. They build in-repo via the existing `replace`, but publishing them needs a root release containing `modelcaps` first.
- **Not included:** `claude-mythos-5` is catalogued but returns `404 not_found_error`, and six retired pre-4.5 Claude models are still in the catalog. They have table entries so coverage passes (Mythos 5's marked unverified). Pruning them is a breaking change to the model constants — worth a separate PR.

## Verification

All modules build, vet and test clean. Both bugs confirmed fixed end-to-end through the CLI against the live APIs, with a baseline build from `main` confirming they failed before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added model-aware reasoning and temperature support across providers.
  - Added Gemini thinking controls, adaptive fallbacks, and separate thought-content streaming.
  - Added capability detection for provider models and variants.
  - Unknown models preserve configured parameters when capabilities are unverified.

- **Bug Fixes**
  - Unsupported reasoning levels are now clamped or omitted as appropriate.
  - Corrected reasoning ranges, budget validation, and temperature handling.
  - Prevented thinking budgets from exceeding available token limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

# Second commit: Gemini

Prompted by the review question "no modelcaps for google/gemini?". Google turned out not to have the same bug — because it never forwarded the parameter at all.

## Gemini thinking control was entirely unwired

`applyRequestConfig` discarded `WithReasoningEffort`, `WithReasoningBudget`, `WithAdaptiveThinking` and `WithThinkingDisplay` before the request was built, so Gemini always ran on its own defaults. It read `ThoughtsTokenCount` back out of usage, so it *reported* thinking it could not *configure*.

Nothing was ready for thoughts to arrive, either. Gemini flags thought summaries on ordinary text parts:

- **non-streaming** tested only `part.Text`, so enabling thoughts would have spliced the model's reasoning into its answer
- **streaming** recognized `part.Thought` and silently dropped it

Both now emit `llm.ThinkingContent`, and the stream closes an open thinking block before opening a text or tool_use block so the two never interleave.

## Gemini needed three classes, and they don't track generations

Probed the same way — ~230 requests across the model × parameter matrix:

| | thinkingLevel | budget range | can disable |
|---|---|---|---|
| 3.x flash family | MINIMAL–HIGH | `[1, 65535]` | varies per model |
| gemini-3.1-pro | **LOW**–HIGH | `[1, 65535]` | no |
| gemini-2.5-pro | **none** | `[128, 32768]` | no |
| gemini-2.5-flash | **none** | `[0, 24576]` | yes |
| gemini-2.5-flash-lite | **none** | `[512, 24576]` | yes |

The 2.5 generation answers "Thinking level is not supported for this model", so effort is emulated with a budget exactly as on Anthropic's pre-4.5 models. Budget bounds differ per model and the API states them in its error text.

The detail that most justifies the coverage test: **whether thinking can be turned off varies *within* a family.** `gemini-3.5-flash` accepts `thinkingBudget: 0`; `gemini-3.5-flash-lite` rejects it. No version rule predicts that. A request to disable thinking on a model that always thinks degrades to its least eager setting instead of 400ing.

Also: a level and a budget together are always rejected ("You can only set only one of thinking budget and thinking level") — the explicit budget wins as the more specific instruction. Pro rejects MINIMAL, so it clamps up to LOW.

The coverage test caught six catalogued models missing from my first draft of the table.

## Verification

Eleven option combinations run against the live API return correct answers with reasoning-token counts that track the requested level — 0 at minimal, 128 at high, 200+ adaptive. Streaming yields a thinking block followed by a text block, 6 thinking deltas / 2439 chars, with no leakage between them.

## Temperature: probed clean, behaviorally dead — left withheld

This one reversed twice, so the reasoning is worth recording.

Gemini 3.5 Flash-Lite and every 3.6+ model **accept** a temperature and **range-validate** it — sending `5.0` returns `temperature must be in the range [0.0, 2.0]`, which an ignored field would not do. On status codes alone, `shouldOmitTemperature` looks like a bug that withholds a live parameter, and I changed it to forward.

Behavioral testing says otherwise. Sampling one prompt eight times with thinking held at MINIMAL:

| | temp=0.0 | temp=2.0 |
|---|---|---|
| gemini-3.5-flash (forwarded today) | **1 distinct** | 3 distinct |
| gemini-3.6-flash (withheld today) | **5 distinct** | 3 distinct |

No coherent response on 3.6-flash, and slightly inverted. The control is what makes this conclusive: gemini-3.5-flash behaves identically at MINIMAL thinking and with thinking fully off (1 distinct at temp 0 either way), so thinking noise is *not* what masks the signal on 3.6-flash.

The parameter is accepted, schema-validated, and ignored. `shouldOmitTemperature` is correct, the change is reverted, and the finding is recorded next to the lookup so the next reader working from probe status codes doesn't "fix" it back.

This is the counterexample to the PR's own method: a 200/400 probe is necessary but not sufficient. Where a parameter's effect is observable, it's worth observing.
