### PR TITLE
Prepare v1.20.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [1.20.0] - 2026-08-09
+
 ### Changed
 
 - **`anthropic.DefaultModel` is now `ModelClaudeSonnet5`** (`claude-sonnet-5`),

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 
-.PHONY: help test test-race cover cover-html fmt fmt-check fmt-md fmt-md-check vet build tidy tidy-all release-prep tag-modules provider-catalog-generate provider-catalog-check provider-watch-test check
+.PHONY: help test test-race cover cover-html fmt fmt-check fmt-md fmt-md-check vet build tidy tidy-all release-prep tag-modules release-notes release-publish provider-catalog-generate provider-catalog-check provider-watch-test release-notes-test check
 
 COVER_PROFILE := cover.out
 
@@ -30,9 +30,12 @@ help:
 	@echo "  make provider-catalog-generate - Generate provider Go files from catalog.json"
 	@echo "  make provider-catalog-check - Verify provider catalogs and generated Go files"
 	@echo "  make provider-watch-test - Run the provider watcher unit tests"
+	@echo "  make release-notes-test - Run the release-notes tooling unit tests"
 	@echo "  make release-prep VERSION=v1.0.0 - Point sub-module requirements at VERSION"
+	@echo "  make release-notes VERSION=v1.0.0 - Draft docs/releases/v1.0.0.md"
 	@echo "  make tag-modules VERSION=v1.0.0 - Tag all sub-modules"
-	@echo "  make check       - Run catalog checks, watcher tests, fmt-check, vet, and test"
+	@echo "  make release-publish VERSION=v1.0.0 - Create the GitHub release from the notes"
+	@echo "  make check       - Run catalog checks, script tests, fmt-check, vet, and test"
 
 test:
 	go test ./...
@@ -91,6 +94,12 @@ endif
 	@echo ""
 	@echo "Commit the go.mod updates, then run: make tag-modules VERSION=$(VERSION)"
 
+release-notes:
+ifndef VERSION
+	$(error VERSION is required. Usage: make release-notes VERSION=v1.0.0)
+endif
+	@python3 scripts/release_notes.py $(VERSION)
+
 tag-modules:
 ifndef VERSION
 	$(error VERSION is required. Usage: make tag-modules VERSION=v1.0.0)
@@ -103,6 +112,18 @@ endif
 	@echo ""
 	@echo "Tags created. Push with: git push origin --tags"
 
+# --verify-tag so a mistyped version fails here rather than silently creating a
+# release against a tag gh invents from the default branch.
+release-publish:
+ifndef VERSION
+	$(error VERSION is required. Usage: make release-publish VERSION=v1.0.0)
+endif
+	@python3 scripts/release_notes.py $(VERSION) --check
+	gh release create $(VERSION) \
+		--title $(VERSION) \
+		--verify-tag \
+		--notes-file docs/releases/$(VERSION).md
+
 provider-catalog-generate:
 	python3 scripts/generate_provider_catalogs.py
 
@@ -113,4 +134,7 @@ provider-catalog-check:
 provider-watch-test:
 	python3 -B -m unittest -v scripts/test_provider_watch.py
 
-check: provider-catalog-check provider-watch-test fmt-check vet test
+release-notes-test:
+	python3 -B -m unittest -v scripts.test_changelog_section scripts.test_release_notes
+
+check: provider-catalog-check provider-watch-test release-notes-test fmt-check vet test

--- a/a2a/go.mod
+++ b/a2a/go.mod
@@ -6,7 +6,7 @@ toolchain go1.26.5
 
 require (
 	github.com/a2aproject/a2a-go/v2 v2.4.0
-	github.com/deepnoodle-ai/dive v1.19.0
+	github.com/deepnoodle-ai/dive v1.20.0
 	github.com/deepnoodle-ai/wonton v0.0.37
 )
 

--- a/demos/colosseum/go.mod
+++ b/demos/colosseum/go.mod
@@ -5,11 +5,11 @@ go 1.25.0
 toolchain go1.26.5
 
 require (
-	github.com/deepnoodle-ai/dive v1.19.0
-	github.com/deepnoodle-ai/dive/a2a v1.19.0
-	github.com/deepnoodle-ai/dive/providers/google v1.19.0
-	github.com/deepnoodle-ai/dive/providers/grok v1.19.0
-	github.com/deepnoodle-ai/dive/providers/openai v1.19.0
+	github.com/deepnoodle-ai/dive v1.20.0
+	github.com/deepnoodle-ai/dive/a2a v1.20.0
+	github.com/deepnoodle-ai/dive/providers/google v1.20.0
+	github.com/deepnoodle-ai/dive/providers/grok v1.20.0
+	github.com/deepnoodle-ai/dive/providers/openai v1.20.0
 	github.com/deepnoodle-ai/wonton v0.0.37
 )
 

--- a/demos/noodleville/go.mod
+++ b/demos/noodleville/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 toolchain go1.26.5
 
 require (
-	github.com/deepnoodle-ai/dive v1.19.0
+	github.com/deepnoodle-ai/dive v1.20.0
 	github.com/deepnoodle-ai/wonton v0.0.37
 )
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -31,3 +31,8 @@ These cover packages in `experimental/` with unstable APIs:
 
 - [Sandboxing](design/sandboxing.md) - Sandboxing design
 - [Runtime Context Injection](design/context-injection.md) - Implemented context authority, delivery, ordering, persistence, and provider-rendering contract
+
+## Project
+
+- [Releasing](releasing.md) - Cutting the changelog, tagging modules, and publishing the GitHub release
+- [Release notes](releases/) - Published release bodies, one file per version

--- a/docs/releases/v1.20.0.md
+++ b/docs/releases/v1.20.0.md
@@ -1,0 +1,95 @@
+## Highlights
+
+**Sonnet 5 is the new default model** for the Anthropic and OpenRouter
+providers and for the CLI. It lands close to Opus 5 on coding and agentic work
+at $3/$15 per MTok against $5/$25. If you were relying on the default and want
+Opus back, pass `WithModel(anthropic.ModelClaudeOpus5)` — nothing was removed.
+The CLI's Anthropic branch now reads `anthropic.DefaultModel` instead of its own
+hardcoded constant, so the library and the CLI can no longer drift apart.
+
+**Reasoning and sampling parameters are now gated on a verified capability
+table.** Provider code used to decide what a model accepts by testing its id
+against a prefix and falling through permissively, which made a model that is
+known and lacks a feature indistinguishable from one nobody has heard of. The
+new `providers/modelcaps` tables were built by probing the Anthropic, OpenAI and
+xAI APIs directly — roughly 500 minimal requests across the model × parameter
+matrix, recording which combinations actually return a 400. Several models
+contradict their own families, so every entry is a recorded response rather than
+an inference from a name.
+
+That closes six ways a request could be rejected before it did any work, most
+visibly `dive -m gpt-4o` returning a 400 on every call once the CLI started
+defaulting `--thinking-effort` to `medium`. The behavior change underneath is
+worth knowing about: **unsupported settings are now clamped or dropped with a
+warning instead of returning an error.** One `ModelSettings` survives being
+pointed at a model with a narrower range, which is the thing a cross-provider
+library exists to do. Unknown models — fine-tunes, gateways, custom deployments
+— keep today's passthrough behavior, since Dive cannot know what they accept.
+
+**Gemini thinking control is wired up for the first time.** `WithReasoningEffort`,
+`WithReasoningBudget`, `WithAdaptiveThinking` and `WithThinkingDisplay` were all
+being discarded before the request was built. Relatedly, Gemini thought
+summaries were being spliced into answer text on the non-streaming path and
+dropped on the streaming one; both now produce `llm.ThinkingContent`.
+
+## Pull requests
+
+- Gate reasoning and sampling parameters on verified per-model capability (#246)
+- Default to Sonnet 5 across Anthropic/OpenRouter/CLI, and fix per-model reasoning capability gaps (#245)
+
+## Changelog
+
+### Changed
+
+- **`anthropic.DefaultModel` is now `ModelClaudeSonnet5`** (`claude-sonnet-5`),
+  replacing `claude-opus-5`. Pass `WithModel(ModelClaudeOpus5)` to keep Opus 5.
+- **`openrouter.DefaultModel` is now `ModelClaudeSonnet5`**
+  (`anthropic/claude-sonnet-5`), matching the Anthropic provider default.
+- **The CLI's Anthropic default follows `anthropic.DefaultModel`** rather than a
+  separate hardcoded `claude-haiku-4-5`.
+- **The CLI defaults `--thinking-effort` to `medium`.** Providers now drop the
+  parameter on models that have none, so this is safe on every model.
+- **Unsupported reasoning and sampling settings are clamped or dropped with a
+  warning instead of returning an error.** One `ModelSettings` now survives
+  being pointed at a model with a narrower range.
+- **New `providers/modelcaps` package** holds the verified per-model capability
+  tables shared by the Responses and Chat Completions providers, replacing three
+  separate copies of the same prefix switches.
+- **New `llm.ClampReasoningEffort`** maps a requested effort onto the closest
+  level a model accepts.
+- **Gemini thinking control is now wired up.** `WithReasoningEffort` maps to
+  `thinkingConfig.thinkingLevel`, or to a clamped `thinkingBudget` on models
+  with no thinking level (the 2.5 generation); `WithReasoningBudget` maps to
+  `thinkingBudget`, `WithAdaptiveThinking` to a dynamic budget, and
+  `WithThinkingDisplay` to `includeThoughts`. All four were previously
+  discarded before the request was built.
+
+### Fixed
+
+- **Gemini thought summaries were emitted as answer text.** With thoughts
+  enabled, the non-streaming path spliced the model's reasoning into its reply;
+  the streaming path dropped it. Both now produce `llm.ThinkingContent`.
+- **Reasoning effort was sent to models that have no reasoning parameter**,
+  producing a 400 on every request. Affects `gpt-4o` and `gpt-4.1`, plus
+  `grok-build`, `grok-code-fast`, and both `grok-4.20-0309` models. The CLI's new
+  `medium` default made this fire on every call.
+- **`temperature` was sent to models that reject it** on the OpenAI providers:
+  `gpt-5`/`-mini`/`-nano`, `gpt-5.5`, `gpt-5.6`, `o3`, and `o4-mini`.
+- **Adaptive thinking was sent to models that do not support it.** Haiku 4.5,
+  Sonnet 4.5, and Opus 4.5 answer "adaptive thinking is not supported on this
+  model"; the request now falls back to a manual thinking budget.
+- **Codex models bypassed effort clamping entirely**, so `minimal` and `max`
+  reached `gpt-5.3-codex`, which rejects both.
+- **A reasoning budget and an effort together were rejected client-side** on
+  Opus 4.5 and Sonnet 4.6, which accept the combination.
+- **Effort ranges corrected against the live API:** `grok-4.5` accepts `xhigh`
+  (was downgraded to `high`) and rejects `none`; the Grok multi-agent model
+  accepts `max` and `none`; `gpt-5.2-pro` accepts only `medium`/`high`/`xhigh`;
+  `gpt-5.3-chat-latest` accepts only `medium`.
+- **`claude-opus-5` was missing from every Anthropic reasoning classification**,
+  so effort fell through to the legacy thinking-budget path and `max`/`xhigh`
+  silently became `high`. It now uses native `output_config.effort`.
+- **`temperature` is now dropped on Opus 4.7/4.8**, which reject it with a 400.
+- **`xhigh` is no longer downgraded on Sonnet 5**, which supports the full ladder.
+- **Forced `tool_choice` no longer fails client-side on Opus 5 and Sonnet 5**,
+  which default thinking on but accept an explicit disable.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,0 +1,88 @@
+# Releasing
+
+Dive is one Go module plus eight tagged sub-modules. Everything below assumes
+you are on an up-to-date `main` and have `gh` authenticated.
+
+## 1. Cut the changelog
+
+Rename `## [Unreleased]` to the version being released and leave a fresh empty
+`## [Unreleased]` above it:
+
+```markdown
+## [Unreleased]
+
+## [1.20.0] - 2026-08-09
+```
+
+Before moving on, confirm every merged PR since the last release has an entry.
+`git log v<previous>..HEAD --oneline` is the list to check against.
+
+## 2. Sync the module requirements
+
+```sh
+make release-prep VERSION=v1.20.0
+```
+
+Every sub-module builds locally through a `replace` directive, so a stale
+`github.com/deepnoodle-ai/dive vX.Y.Z` requirement is invisible to CI but breaks
+anyone who resolves the tag. This rewrites them all, including the untagged
+`demos/` modules.
+
+## 3. Draft the release notes
+
+```sh
+make release-notes VERSION=v1.20.0
+```
+
+This writes `docs/releases/v1.20.0.md` with three sections:
+
+| Section         | Source                                                    |
+| --------------- | --------------------------------------------------------- |
+| `Highlights`    | You. A placeholder comment until you replace it.          |
+| `Pull requests` | Commit subjects between the previous root tag and `HEAD`. |
+| `Changelog`     | The version's `CHANGELOG.md` section, verbatim.           |
+
+**Write the Highlights.** This is the part the changelog cannot give you: what
+changed, who it affects, and what they need to do about it. Two to four short
+paragraphs, no restating the bullets below it. An agent drafting this should
+read the merged PR bodies (`gh pr view <n>`), not just the commit subjects — the
+reasoning behind a change rarely survives into a one-line subject.
+
+Re-running the command is safe. Highlights you have already written are carried
+over and only the mechanical sections are refreshed, so you can regenerate after
+a late PR merges.
+
+## 4. Open the release PR
+
+Commit the changelog, the `go.mod` updates, and `docs/releases/v1.20.0.md`
+together as `Prepare v1.20.0 release`. The notes get reviewed alongside the code
+they describe, and nothing is published until the tag goes up.
+
+## 5. Tag
+
+After the PR merges, from an updated `main`:
+
+```sh
+git tag v1.20.0
+make tag-modules VERSION=v1.20.0
+git push origin --tags
+```
+
+`tag-modules` re-runs the requirement check first and refuses to tag if anything
+is stale, so a skipped step 2 stops here rather than shipping.
+
+## 6. Publish the GitHub release
+
+```sh
+make release-publish VERSION=v1.20.0
+```
+
+This creates the release from `docs/releases/v1.20.0.md`. It refuses to publish
+while the Highlights are still a placeholder, and `--verify-tag` means a mistyped
+version fails instead of creating a release against a tag `gh` invents from the
+default branch.
+
+## Checking a draft
+
+`make release-notes-test` covers the tooling. To see the assembled body without
+publishing, read `docs/releases/<version>.md` — it is exactly what gets posted.

--- a/examples/go.mod
+++ b/examples/go.mod
@@ -5,13 +5,13 @@ go 1.25.5
 toolchain go1.26.5
 
 require (
-	github.com/deepnoodle-ai/dive v1.19.0
-	github.com/deepnoodle-ai/dive/a2a v1.19.0
-	github.com/deepnoodle-ai/dive/experimental/mcp v1.19.0
-	github.com/deepnoodle-ai/dive/otel v1.19.0
-	github.com/deepnoodle-ai/dive/providers/google v1.19.0
-	github.com/deepnoodle-ai/dive/providers/grok v1.19.0
-	github.com/deepnoodle-ai/dive/providers/openai v1.19.0
+	github.com/deepnoodle-ai/dive v1.20.0
+	github.com/deepnoodle-ai/dive/a2a v1.20.0
+	github.com/deepnoodle-ai/dive/experimental/mcp v1.20.0
+	github.com/deepnoodle-ai/dive/otel v1.20.0
+	github.com/deepnoodle-ai/dive/providers/google v1.20.0
+	github.com/deepnoodle-ai/dive/providers/grok v1.20.0
+	github.com/deepnoodle-ai/dive/providers/openai v1.20.0
 	github.com/deepnoodle-ai/wonton v0.0.37
 	github.com/fatih/color v1.19.0
 	github.com/mark3labs/mcp-go v0.57.0

--- a/experimental/cmd/dive/go.mod
+++ b/experimental/cmd/dive/go.mod
@@ -5,10 +5,10 @@ go 1.25.0
 toolchain go1.26.5
 
 require (
-	github.com/deepnoodle-ai/dive v1.19.0
-	github.com/deepnoodle-ai/dive/providers/google v1.19.0
-	github.com/deepnoodle-ai/dive/providers/grok v1.19.0
-	github.com/deepnoodle-ai/dive/providers/openai v1.19.0
+	github.com/deepnoodle-ai/dive v1.20.0
+	github.com/deepnoodle-ai/dive/providers/google v1.20.0
+	github.com/deepnoodle-ai/dive/providers/grok v1.20.0
+	github.com/deepnoodle-ai/dive/providers/openai v1.20.0
 	github.com/deepnoodle-ai/wonton v0.0.37
 	github.com/mattn/go-runewidth v0.0.27
 )

--- a/experimental/mcp/go.mod
+++ b/experimental/mcp/go.mod
@@ -5,7 +5,7 @@ go 1.25.5
 toolchain go1.26.5
 
 require (
-	github.com/deepnoodle-ai/dive v1.19.0
+	github.com/deepnoodle-ai/dive v1.20.0
 	github.com/deepnoodle-ai/wonton v0.0.37
 	github.com/mark3labs/mcp-go v0.57.0
 )

--- a/otel/go.mod
+++ b/otel/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 toolchain go1.26.5
 
 require (
-	github.com/deepnoodle-ai/dive v1.19.0
+	github.com/deepnoodle-ai/dive v1.20.0
 	go.opentelemetry.io/otel v1.45.0
 	go.opentelemetry.io/otel/metric v1.45.0
 	go.opentelemetry.io/otel/sdk v1.45.0

--- a/providers/google/go.mod
+++ b/providers/google/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 toolchain go1.26.5
 
 require (
-	github.com/deepnoodle-ai/dive v1.19.0
+	github.com/deepnoodle-ai/dive v1.20.0
 	github.com/deepnoodle-ai/wonton v0.0.37
 	google.golang.org/genai v1.67.0
 )

--- a/providers/grok/go.mod
+++ b/providers/grok/go.mod
@@ -5,8 +5,8 @@ go 1.25.0
 toolchain go1.26.5
 
 require (
-	github.com/deepnoodle-ai/dive v1.19.0
-	github.com/deepnoodle-ai/dive/providers/openai v1.19.0
+	github.com/deepnoodle-ai/dive v1.20.0
+	github.com/deepnoodle-ai/dive/providers/openai v1.20.0
 	github.com/deepnoodle-ai/wonton v0.0.37
 	github.com/openai/openai-go/v3 v3.50.0
 	golang.org/x/image v0.44.0

--- a/providers/openai/go.mod
+++ b/providers/openai/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 toolchain go1.26.5
 
 require (
-	github.com/deepnoodle-ai/dive v1.19.0
+	github.com/deepnoodle-ai/dive v1.20.0
 	github.com/deepnoodle-ai/wonton v0.0.37
 	github.com/openai/openai-go/v3 v3.50.0
 	golang.org/x/image v0.44.0

--- a/scripts/changelog_section.py
+++ b/scripts/changelog_section.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Extract one version's section from CHANGELOG.md for a GitHub release body.
+
+The changelog is the only place release notes are written, so publishing a
+release reads from it rather than restating it. ``make release-notes`` prints a
+section to review; ``make release-publish`` pipes the same output into
+``gh release create``.
+
+A missing or empty section is an error: an empty release body is worse than a
+failed publish, because the tag is already pushed by the time this runs.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import re
+import sys
+from typing import Sequence
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CHANGELOG = REPO_ROOT / "CHANGELOG.md"
+
+# "## [1.19.0] - 2026-08-09" and "## [Unreleased]".
+HEADING_RE = re.compile(r"^## \[(?P<version>[^\]]+)\](?:\s+-\s+(?P<date>\S+))?\s*$")
+
+
+def normalize(version: str) -> str:
+    """Accept ``v1.19.0``, ``1.19.0``, and ``Unreleased`` alike."""
+    version = version.strip()
+    if version.lower() == "unreleased":
+        return "unreleased"
+    return version[1:] if version.startswith(("v", "V")) else version
+
+
+def sections(text: str) -> list[tuple[str, str]]:
+    """Return ``(version, body)`` pairs in the order they appear."""
+    found: list[tuple[str, list[str]]] = []
+    for line in text.splitlines():
+        match = HEADING_RE.match(line)
+        if match:
+            found.append((normalize(match.group("version")), []))
+        elif found:
+            found[-1][1].append(line)
+    return [(version, "\n".join(body).strip()) for version, body in found]
+
+
+def section(text: str, version: str) -> str:
+    wanted = normalize(version)
+    available = sections(text)
+    for candidate, body in available:
+        if candidate == wanted:
+            if not body:
+                raise SystemExit(
+                    f"CHANGELOG.md section for {version} is empty; "
+                    "write the notes before publishing the release."
+                )
+            return body
+    known = ", ".join(candidate for candidate, _ in available[:5])
+    raise SystemExit(
+        f"No CHANGELOG.md section for {version}. Most recent: {known}"
+    )
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("version", help="release version, for example v1.20.0")
+    parser.add_argument(
+        "--changelog",
+        type=Path,
+        default=CHANGELOG,
+        help="changelog to read (default: the repo's CHANGELOG.md)",
+    )
+    args = parser.parse_args(argv)
+    print(section(args.changelog.read_text(encoding="utf-8"), args.version))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/release_notes.py
+++ b/scripts/release_notes.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+"""Assemble the GitHub release body for a version under ``docs/releases/``.
+
+A release note has three parts, and only one of them can be generated:
+
+``## Highlights``
+    Prose. What actually changed, who it affects, what they should do. Written
+    by a human or an agent; this script only reserves the space and preserves
+    what is already there.
+
+``## Pull requests``
+    Collected from the commit range between the previous release tag and HEAD.
+    The repo squash-merges, so every merged PR is one commit ending in
+    ``(#NNN)``.
+
+``## Changelog``
+    The version's ``CHANGELOG.md`` section, verbatim. Already curated, so it is
+    copied rather than restated.
+
+Re-running is safe: an existing file's Highlights are carried over and only the
+mechanical sections are refreshed.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import re
+import subprocess
+import sys
+from typing import Sequence
+
+import changelog_section
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+RELEASE_DIR = REPO_ROOT / "docs" / "releases"
+
+VERSION_RE = re.compile(r"^v\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$")
+# Root release tags only. Sub-module tags carry a directory prefix
+# ("a2a/v1.19.0") and would otherwise sort into the same list.
+ROOT_TAG_RE = re.compile(r"^v\d+\.\d+\.\d+$")
+PR_RE = re.compile(r"^(?P<title>.+?)\s+\(#(?P<number>\d+)\)$")
+# The release-prep commit is bookkeeping for the release it belongs to.
+PREP_RE = re.compile(r"^Prepare v\d+\.\d+\.\d+ release$")
+
+HIGHLIGHTS_PLACEHOLDER = """<!-- Replace this comment with the release story: what changed, who it
+affects, and what they need to do. Two to four short paragraphs. The
+mechanical detail lives in the sections below - do not restate it here.
+`make release-publish` refuses to publish while this comment remains. -->"""
+
+
+def git(*args: str) -> str:
+    process = subprocess.run(
+        ["git", *args], cwd=REPO_ROOT, text=True, capture_output=True, check=False
+    )
+    if process.returncode != 0:
+        raise SystemExit(f"git {' '.join(args)} failed: {process.stderr.strip()}")
+    return process.stdout.strip()
+
+
+def previous_tag(version: str) -> str | None:
+    """The most recent root release tag that is not the one being released."""
+    tags = [
+        tag
+        for tag in git("tag", "--sort=-version:refname").splitlines()
+        if ROOT_TAG_RE.fullmatch(tag) and tag != version
+    ]
+    return tags[0] if tags else None
+
+
+def pull_requests(since: str | None) -> list[tuple[int, str]]:
+    revision = f"{since}..HEAD" if since else "HEAD"
+    subjects = git("log", "--no-merges", "--pretty=%s", revision).splitlines()
+    found: list[tuple[int, str]] = []
+    for subject in subjects:
+        if PREP_RE.match(subject):
+            continue
+        match = PR_RE.match(subject)
+        if match:
+            found.append((int(match.group("number")), match.group("title")))
+    return found
+
+
+def existing_highlights(path: Path) -> str | None:
+    """The Highlights body of an already-written file, if it has one."""
+    if not path.exists():
+        return None
+    body: list[str] = []
+    capturing = False
+    for line in path.read_text(encoding="utf-8").splitlines():
+        if line.startswith("## "):
+            if capturing:
+                break
+            capturing = line.strip() == "## Highlights"
+            continue
+        if capturing:
+            body.append(line)
+    text = "\n".join(body).strip()
+    return text or None
+
+
+def prose(highlights: str) -> str:
+    """``highlights`` with HTML comments removed, to tell a draft from a note."""
+    return re.sub(r"<!--.*?-->", "", highlights, flags=re.DOTALL).strip()
+
+
+def render(highlights: str, prs: Sequence[tuple[int, str]], changelog: str) -> str:
+    parts = [f"## Highlights\n\n{highlights}\n"]
+    if prs:
+        listed = "\n".join(f"- {title} (#{number})" for number, title in prs)
+        parts.append(f"## Pull requests\n\n{listed}\n")
+    parts.append(f"## Changelog\n\n{changelog}\n")
+    return "\n".join(parts)
+
+
+def build(version: str, changelog_path: Path) -> tuple[Path, bool]:
+    path = RELEASE_DIR / f"{version}.md"
+    highlights = existing_highlights(path)
+    drafted = not prose(highlights or "")
+    since = previous_tag(version)
+    prs = pull_requests(since)
+    changelog = changelog_section.section(
+        changelog_path.read_text(encoding="utf-8"), version
+    )
+    RELEASE_DIR.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        render(highlights or HIGHLIGHTS_PLACEHOLDER, prs, changelog),
+        encoding="utf-8",
+    )
+    print(
+        f"{path.relative_to(REPO_ROOT)}: {len(prs)} pull request(s) since "
+        f"{since or 'the first commit'}",
+        file=sys.stderr,
+    )
+    if drafted:
+        print(
+            "Highlights are a placeholder - write them before publishing.",
+            file=sys.stderr,
+        )
+    else:
+        print("Kept the existing Highlights.", file=sys.stderr)
+    return path, drafted
+
+
+def check(version: str) -> int:
+    """Fail if the notes are missing or still hold the placeholder."""
+    path = RELEASE_DIR / f"{version}.md"
+    if not path.exists():
+        print(
+            f"No release notes at {path.relative_to(REPO_ROOT)}.\n"
+            f"Run: make release-notes VERSION={version}",
+            file=sys.stderr,
+        )
+        return 1
+    if not prose(existing_highlights(path) or ""):
+        print(
+            f"{path.relative_to(REPO_ROOT)} still has placeholder Highlights.\n"
+            "Write the release story before publishing.",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("version", help="release version, for example v1.20.0")
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="verify the notes exist and the Highlights are written",
+    )
+    parser.add_argument(
+        "--changelog",
+        type=Path,
+        default=changelog_section.CHANGELOG,
+        help="changelog to read (default: the repo's CHANGELOG.md)",
+    )
+    args = parser.parse_args(argv)
+    if not VERSION_RE.fullmatch(args.version):
+        raise SystemExit(f"invalid version {args.version!r}; expected a vX.Y.Z tag")
+    if args.check:
+        return check(args.version)
+    build(args.version, args.changelog)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/sync_module_versions.py
+++ b/scripts/sync_module_versions.py
@@ -26,6 +26,8 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 MODULE_PREFIX = "github.com/deepnoodle-ai/dive"
 VERSION_RE = re.compile(r"^v\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$")
 
+# Tagged modules. Their requirements are what downstream consumers resolve, so a
+# stale entry here is a broken release.
 SUB_MODULES = (
     "providers/google",
     "providers/openai",
@@ -36,6 +38,16 @@ SUB_MODULES = (
     "experimental/cmd/dive",
     "examples",
 )
+
+# Never tagged, so nothing downstream resolves these. They are synced anyway to
+# keep every go.mod in the repo naming one version - the v1.18.0 and v1.19.0
+# release commits both bumped them by hand, which is the step this replaces.
+UNTAGGED_MODULES = (
+    "demos/colosseum",
+    "demos/noodleville",
+)
+
+ALL_MODULES = SUB_MODULES + UNTAGGED_MODULES
 
 
 def go_mod_json(directory: Path) -> dict:
@@ -63,7 +75,7 @@ def dive_requirements(directory: Path) -> list[tuple[str, str]]:
 
 def check(version: str) -> int:
     stale: list[str] = []
-    for module in SUB_MODULES:
+    for module in ALL_MODULES:
         for path, current in dive_requirements(REPO_ROOT / module):
             if current != version:
                 stale.append(f"  {module}: requires {path} {current}, expected {version}")
@@ -83,7 +95,7 @@ def check(version: str) -> int:
 
 
 def write(version: str) -> int:
-    for module in SUB_MODULES:
+    for module in ALL_MODULES:
         directory = REPO_ROOT / module
         for path, current in dive_requirements(directory):
             if current == version:

--- a/scripts/test_changelog_section.py
+++ b/scripts/test_changelog_section.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Unit tests for the changelog section extractor."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+import sys
+import unittest
+
+
+SCRIPT = Path(__file__).with_name("changelog_section.py")
+SPEC = importlib.util.spec_from_file_location("changelog_section", SCRIPT)
+assert SPEC and SPEC.loader
+changelog_section = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = changelog_section
+SPEC.loader.exec_module(changelog_section)
+
+
+CHANGELOG = """# Changelog
+
+Preamble that is not part of any release.
+
+## [Unreleased]
+
+### Added
+
+- Something not yet cut.
+
+## [1.20.0] - 2026-08-09
+
+### Changed
+
+- **A changed thing.**
+
+### Fixed
+
+- **A fixed thing.**
+
+## [1.19.0] - 2026-08-09
+
+### Added
+
+- An older thing.
+
+## [1.18.0] - 2026-07-22
+
+### Added
+
+- An even older thing.
+"""
+
+
+class SectionTest(unittest.TestCase):
+    def test_extracts_named_version(self) -> None:
+        body = changelog_section.section(CHANGELOG, "v1.20.0")
+        self.assertIn("**A changed thing.**", body)
+        self.assertIn("**A fixed thing.**", body)
+
+    def test_stops_at_the_next_version(self) -> None:
+        body = changelog_section.section(CHANGELOG, "v1.20.0")
+        self.assertNotIn("An older thing", body)
+        self.assertNotIn("Something not yet cut", body)
+
+    def test_excludes_the_preamble(self) -> None:
+        body = changelog_section.section(CHANGELOG, "v1.19.0")
+        self.assertNotIn("Preamble", body)
+
+    def test_accepts_version_with_or_without_v(self) -> None:
+        self.assertEqual(
+            changelog_section.section(CHANGELOG, "1.20.0"),
+            changelog_section.section(CHANGELOG, "v1.20.0"),
+        )
+
+    def test_extracts_unreleased(self) -> None:
+        body = changelog_section.section(CHANGELOG, "Unreleased")
+        self.assertIn("Something not yet cut", body)
+
+    def test_body_is_stripped_of_surrounding_blank_lines(self) -> None:
+        body = changelog_section.section(CHANGELOG, "v1.18.0")
+        self.assertTrue(body.startswith("### Added"))
+        self.assertTrue(body.endswith("An even older thing."))
+
+    def test_missing_version_is_an_error(self) -> None:
+        with self.assertRaises(SystemExit) as raised:
+            changelog_section.section(CHANGELOG, "v9.9.9")
+        self.assertIn("1.20.0", str(raised.exception))
+
+    def test_empty_section_is_an_error(self) -> None:
+        empty = "## [1.21.0] - 2026-08-10\n\n## [1.20.0] - 2026-08-09\n\n- Cut.\n"
+        with self.assertRaises(SystemExit) as raised:
+            changelog_section.section(empty, "v1.21.0")
+        self.assertIn("empty", str(raised.exception))
+
+    def test_repo_changelog_parses(self) -> None:
+        text = changelog_section.CHANGELOG.read_text(encoding="utf-8")
+        versions = [version for version, _ in changelog_section.sections(text)]
+        self.assertIn("unreleased", versions)
+        self.assertIn("1.19.0", versions)
+        # Every heading the repo owns must yield a non-empty body, so a release
+        # can never be published with notes the parser silently dropped.
+        for version in versions:
+            if version == "unreleased":
+                continue
+            self.assertTrue(changelog_section.section(text, version))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_release_notes.py
+++ b/scripts/test_release_notes.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+"""Unit tests for the release-notes assembler."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+import sys
+import tempfile
+import unittest
+from unittest import mock
+
+
+SCRIPTS = Path(__file__).parent
+sys.path.insert(0, str(SCRIPTS))
+
+SCRIPT = SCRIPTS / "release_notes.py"
+SPEC = importlib.util.spec_from_file_location("release_notes", SCRIPT)
+assert SPEC and SPEC.loader
+release_notes = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = release_notes
+SPEC.loader.exec_module(release_notes)
+
+
+CHANGELOG = """# Changelog
+
+## [Unreleased]
+
+## [1.20.0] - 2026-08-09
+
+### Changed
+
+- **A changed thing.**
+"""
+
+
+class PullRequestTest(unittest.TestCase):
+    def collect(self, *subjects: str) -> list[tuple[int, str]]:
+        with mock.patch.object(release_notes, "git", return_value="\n".join(subjects)):
+            return release_notes.pull_requests("v1.19.0")
+
+    def test_parses_squash_merge_subjects(self) -> None:
+        self.assertEqual(
+            self.collect("Do a thing (#246)", "Do another (#245)"),
+            [(246, "Do a thing"), (245, "Do another")],
+        )
+
+    def test_skips_the_release_prep_commit(self) -> None:
+        self.assertEqual(
+            self.collect("Prepare v1.19.0 release", "Do a thing (#246)"),
+            [(246, "Do a thing")],
+        )
+
+    def test_skips_commits_with_no_pr_number(self) -> None:
+        self.assertEqual(self.collect("Fix a typo"), [])
+
+    def test_keeps_parenthetical_titles(self) -> None:
+        self.assertEqual(
+            self.collect("Format Markdown with Prettier (one-time) (#241)"),
+            [(241, "Format Markdown with Prettier (one-time)")],
+        )
+
+
+class PreviousTagTest(unittest.TestCase):
+    TAGS = "v1.20.0\nv1.19.0\na2a/v1.19.0\nexperimental/cmd/dive/v1.19.0\nv1.18.0"
+
+    def test_ignores_sub_module_tags(self) -> None:
+        with mock.patch.object(release_notes, "git", return_value=self.TAGS):
+            self.assertEqual(release_notes.previous_tag("v1.20.0"), "v1.19.0")
+
+    def test_excludes_the_version_being_released(self) -> None:
+        with mock.patch.object(release_notes, "git", return_value=self.TAGS):
+            self.assertEqual(release_notes.previous_tag("v1.19.0"), "v1.20.0")
+
+    def test_no_tags_yet(self) -> None:
+        with mock.patch.object(release_notes, "git", return_value=""):
+            self.assertIsNone(release_notes.previous_tag("v1.0.0"))
+
+
+class ProseTest(unittest.TestCase):
+    def test_placeholder_has_no_prose(self) -> None:
+        self.assertEqual(release_notes.prose(release_notes.HIGHLIGHTS_PLACEHOLDER), "")
+
+    def test_comment_alongside_prose_leaves_prose(self) -> None:
+        self.assertEqual(
+            release_notes.prose("<!-- a note -->\n\nReal words."), "Real words."
+        )
+
+
+class BuildTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        root = Path(self.tmp.name)
+        self.changelog = root / "CHANGELOG.md"
+        self.changelog.write_text(CHANGELOG, encoding="utf-8")
+        patches = [
+            mock.patch.object(release_notes, "REPO_ROOT", root),
+            mock.patch.object(release_notes, "RELEASE_DIR", root / "docs" / "releases"),
+            mock.patch.object(release_notes, "previous_tag", return_value="v1.19.0"),
+            mock.patch.object(
+                release_notes, "pull_requests", return_value=[(246, "Do a thing")]
+            ),
+        ]
+        for patch in patches:
+            patch.start()
+            self.addCleanup(patch.stop)
+
+    def build(self) -> tuple[Path, bool]:
+        return release_notes.build("v1.20.0", self.changelog)
+
+    def test_first_build_writes_all_three_sections(self) -> None:
+        path, drafted = self.build()
+        text = path.read_text(encoding="utf-8")
+        self.assertTrue(drafted)
+        self.assertIn("## Highlights", text)
+        self.assertIn("- Do a thing (#246)", text)
+        self.assertIn("**A changed thing.**", text)
+
+    def test_check_fails_on_a_placeholder(self) -> None:
+        self.build()
+        self.assertEqual(release_notes.check("v1.20.0"), 1)
+
+    def test_check_passes_once_highlights_are_written(self) -> None:
+        path, _ = self.build()
+        path.write_text(
+            path.read_text(encoding="utf-8").replace(
+                release_notes.HIGHLIGHTS_PLACEHOLDER, "A real story."
+            ),
+            encoding="utf-8",
+        )
+        self.assertEqual(release_notes.check("v1.20.0"), 0)
+
+    def test_rebuild_preserves_written_highlights(self) -> None:
+        path, _ = self.build()
+        path.write_text(
+            path.read_text(encoding="utf-8").replace(
+                release_notes.HIGHLIGHTS_PLACEHOLDER, "A real story."
+            ),
+            encoding="utf-8",
+        )
+        with mock.patch.object(
+            release_notes, "pull_requests", return_value=[(246, "Do a thing"), (247, "And another")]
+        ):
+            path, drafted = self.build()
+        text = path.read_text(encoding="utf-8")
+        self.assertFalse(drafted)
+        self.assertIn("A real story.", text)
+        self.assertIn("- And another (#247)", text)
+        self.assertNotIn("Replace this comment", text)
+
+    def test_check_fails_when_notes_are_missing(self) -> None:
+        self.assertEqual(release_notes.check("v9.9.9"), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Cuts the `v1.20.0` changelog heading, points every intra-repo module requirement
at it, and adds the tooling to publish a real GitHub release rather than a bare
tag.

## Why the tooling

Releases v1.11.0 through v1.19.0 were tagged but never published as GitHub
releases, so the Releases page still ends at v1.10.1. The gap was process, not
policy: nothing assembled a release body, so the step was easy to skip.

Release notes now live at `docs/releases/<version>.md` with three sections:

| Section | Source |
| --- | --- |
| `Highlights` | Hand-written. The changelog says what changed; this says what it means for a caller. |
| `Pull requests` | Commit subjects between the previous root tag and `HEAD`. |
| `Changelog` | The version's `CHANGELOG.md` section, verbatim. |

Committing the notes puts them through the same review as the code they
describe, and nothing is public until the tag goes up.

`scripts/release_notes.py` assembles and re-assembles the file, **preserving
Highlights already written** so a late PR merge only refreshes the mechanical
sections. `make release-publish` refuses while the Highlights are still a
placeholder, and passes `--verify-tag` so a mistyped version fails rather than
creating a release against a tag `gh` invents from the default branch.

`docs/releasing.md` documents the six steps end to end — previously only
reconstructable from prior release PR descriptions.

## Changelog

`Unreleased` already covered both merged PRs (#245, #246) exactly, so the cut is
just the new heading. No entries needed backfilling.

## Module requirements

`make release-prep VERSION=v1.20.0` bumped all eight tagged sub-modules.

`sync_module_versions.py` now also syncs `demos/colosseum` and
`demos/noodleville`. They are never tagged, so the script's downstream-breakage
rationale does not cover them — but the v1.18.0 and v1.19.0 release commits both
bumped them by hand, and this replaces that recurring manual step. They stay out
of the Makefile's tagging list, so nothing changes about what gets tagged. This
answers the open question raised in #244.

## Verification

- `make check` passes, except `providers/anthropic` — those are live-API tests
  failing `401 API key is invalid` on this machine. Confirmed via `git stash`
  that they fail identically on the clean tree; CI has the secret.
- 23 new unit tests across `scripts/test_changelog_section.py` and
  `scripts/test_release_notes.py`, wired into `make check` via
  `make release-notes-test`.
- All eight sub-modules plus both demos build.
- `python3 scripts/sync_module_versions.py v1.20.0 --check` passes, so
  `make tag-modules` will not refuse.

## After this merges

\`\`\`sh
git tag v1.20.0
make tag-modules VERSION=v1.20.0
git push origin --tags
make release-publish VERSION=v1.20.0
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)