### PR TITLE
Add plans 10 and 11: unknown-tool-name recovery and usage bucket conventions

### DIFF
--- a/docs/plans/plan-10-unknown-tool-name-recovery.md
+++ b/docs/plans/plan-10-unknown-tool-name-recovery.md
@@ -81,12 +81,12 @@ the batch produces nothing.
 
 Compare that to every other failure mode in the same file:
 
-| Failure | Handling |
-| --- | --- |
-| `tool.Call` returns an error | `IsError`, `"Tool execution error: %v"` |
-| Tool panics | Recovered, converted to an error result |
+| Failure                        | Handling                                |
+| ------------------------------ | --------------------------------------- |
+| `tool.Call` returns an error   | `IsError`, `"Tool execution error: %v"` |
+| Tool panics                    | Recovered, converted to an error result |
 | Tool returns a malformed union | `IsError` result so the agent converges |
-| Tool name is unknown | **Fatal, turn ends** |
+| Tool name is unknown           | **Fatal, turn ends**                    |
 
 The panic path states the principle directly: results are converted "so the
 LLM can see the failure and adapt, rather than crashing the process." A tool
@@ -143,7 +143,7 @@ calls were read-only, but that was luck, not design.
   analogy to structured output. It is not offered by the hosted provider APIs,
   and it would be the wrong fix regardless: masking an invalid name does not
   make the model want the right one, it makes it emit the next most probable
-  *valid* one. That converts a loud failure into a silent call against the
+  _valid_ one. That converts a loud failure into a silent call against the
   wrong tool. The error is the useful signal here.
 - **Fuzzy name correction at dispatch.** Dive stays an exact-name dispatcher.
   Suggestions are returned to the model; they are never silently substituted.
@@ -230,24 +230,30 @@ core_market_clock. Call one of the tools declared for this turn.
 ### Suggestion algorithm
 
 Suggestions are drawn only from `toolsByName`, which is the agent's declared
-set for that turn. Candidate names are sorted before ranking so the output is
-deterministic — map iteration order must not leak into messages or tests.
-Ranking, first tier with any match wins:
+set for that turn. Split names into non-empty segments on every `_`, `-`, or
+`.` delimiter. Evaluate every candidate, keep only the first tier with a
+match, then order that tier by its match score and finally by the complete wire
+name in ascending lexical order. This is the total ordering; map iteration
+order must not leak into messages or tests.
 
 1. **Segment-suffix match.** Split both names on `_`, `-`, and `.`; rank by
-   the longest common suffix of segments. A match requires at least two
-   shared trailing segments, or one shared trailing segment of five or more
-   characters — `mobius_market_clock` matches `core_market_clock` on the
-   two-segment suffix `market_clock`, while a lone shared `clock` is below
-   the floor and cannot tie `core_market_clock` with `core_portfolio_clock`.
-   This is the dominant real-world shape: right leaf, wrong namespace. Note
-   that the incident name is *not* reachable by edit distance —
-   `mobius_` → `core_` exceeds the tier-2 bound — so this tier is
-   load-bearing and gets its own test.
+   the longest common suffix of segments, then by the suffix's total character
+   count, both descending. A match requires at least two shared trailing
+   segments, or one shared trailing segment of at least six characters —
+   `mobius_market_clock` matches `core_market_clock` on the two-segment suffix
+   `market_clock`, while a lone shared `clock` is below the floor and cannot
+   tie `core_market_clock` with `core_portfolio_clock`. This is the dominant
+   real-world shape: right leaf, wrong namespace. Note that the incident name
+   is _not_ reachable by edit distance — `mobius_` → `core_` exceeds the
+   tier-2 bound — so this tier is load-bearing and gets its own test.
 2. **Bounded edit distance.** Levenshtein within `min(3, len/4)` on the full
-   name, for ordinary typos.
-3. **Prefix match.** Shared namespace, unrecognized leaf. Return that
-   namespace's members so the model can pick.
+   name, for ordinary typos; lower distance ranks first.
+3. **Prefix match.** The namespace is the complete sequence of segments before
+   the terminal leaf. A candidate matches when that sequence equals the
+   query's sequence, regardless of which supported delimiter appeared in the
+   original names; longer namespaces rank first. A flat, single-segment name
+   has no namespace and therefore cannot match this tier. Return matching
+   namespace members so the model can pick.
 
 Cap at three suggestions. The full toolset is already in the model's context
 via the tools parameter, so suggestions are a nudge, not documentation. Emit
@@ -260,7 +266,7 @@ Today a bad name is at least bounded: it ends the turn. After this change a
 model stuck on one name could consume iterations up to
 `defaultToolIterationLimit` (100). That is an unacceptable worst case.
 
-Add a per-generation counter of consecutive unknown-only *iterations*: an
+Add a per-generation counter of consecutive unknown-only _iterations_: an
 iteration increments it when it produced at least one unknown name and zero
 successful dispatches; any successful dispatch resets it. Counting per
 iteration rather than per call means a mixed batch — the actual incident
@@ -442,8 +448,10 @@ detectable failure for an undetectable one.
   distance bound, so this pins that tier 1 is load-bearing.
 - A single shared trailing segment below the length floor produces no
   suggestion (`core_market_clock` vs a query sharing only `clock`).
-- Suggestion output is deterministic across runs (candidates sorted before
-  ranking).
+- Equal-score candidates are ordered by complete wire name, and suggestion
+  output is deterministic across runs and map insertion orders.
+- Prefix-tier tests cover `_`, `-`, and `.` delimiters, equal namespace scores,
+  and flat names that must not qualify as namespace matches.
 - No suggestion is emitted when nothing scores within threshold.
 - Suggestions never include a name absent from `toolsByName`.
 - A mixed batch (valid + unknown) does not advance the consecutive-unknown

--- a/docs/plans/plan-10-unknown-tool-name-recovery.md
+++ b/docs/plans/plan-10-unknown-tool-name-recovery.md
@@ -1,0 +1,486 @@
+---
+Title: Recover from unknown tool names instead of failing the generation
+Author: Curtis Myzie
+Status: Proposed
+Last Updated: 2026-08-10
+---
+
+# Recover from unknown tool names instead of failing the generation
+
+**Workflow:** Standard-tier spec, Dive team feedback, then implementation.
+
+## Context
+
+When a model emits a tool name that is not in the agent's declared toolset,
+Dive returns a Go error from the tool-dispatch path. That error unwinds the
+whole `CreateResponse` call. The turn ends, every tool call in the same
+assistant message is discarded, and the caller receives a generation failure
+with no transcript continuation.
+
+This is the only tool-related failure in Dive that behaves this way. Every
+other one becomes an error result the model can read and adapt to.
+
+On 2026-08-09, two production sessions in a downstream deployment failed this
+way within eighteen hours of each other, both on `claude-sonnet-5`. Each turn
+died in roughly thirteen seconds. (Some identifiers in this document are
+anonymized for publication; the shape and structure of the names are
+preserved.)
+
+Both recorded the same failure:
+
+```text
+model="claude-sonnet-5" route_mode=managed detected_provider=anthropic
+llm=anthropic: tool call error: unknown tool "mobius_market_clock"
+```
+
+`mobius_market_clock` does not exist. The agent's toolkit grants
+`core.market.clock`, which renders as the wire name `core_market_clock`. The
+invented name is a blend: the `mobius_` prefix from one namespace with the
+`market_clock` leaf from another.
+
+The blend is easy to explain from the batch it appeared in. Both turns produced
+the identical assistant message:
+
+```text
+tool_use  mobius_memory_recall     executed, result recorded
+tool_use  mobius_memory_recall     executed, result recorded
+tool_use  mobius_market_clock      does not exist -> turn failed
+```
+
+The model emitted `mobius_` twice successfully and then a third time with the
+wrong leaf. It was priming on its own immediately preceding tokens.
+
+The toolkit makes that likely. Of its 33 granted actions, 22 are `core.*`, 8
+are `mobius.*` (`mobius.memory.*`, `mobius.artifacts.*`, `mobius.self.*`), and
+3 are `firecrawl.*`. All are presented flat, so `mobius_` is not a foreign
+prefix in that list. It is one the agent uses constantly.
+
+The user-visible outcome was a blank response after thirteen seconds. The two
+`mobius_memory_recall` calls had already executed and returned results; those
+results were discarded along with the turn.
+
+## Current behavior and root cause
+
+Two call sites return a fatal error on an unrecognized name:
+
+- `agent.go:2497` in `executeOneToolCall` (sequential path)
+- `agent.go:2248` in `executeToolCallsParallel`, Phase 1
+
+Both are the same shape:
+
+```go
+tool, ok := toolsByName[toolCall.Name]
+if !ok {
+    return nil, fmt.Errorf("tool call error: unknown tool %q", toolCall.Name)
+}
+```
+
+That error propagates through `executeToolCalls` to the generation loop, which
+returns it from `CreateResponse`. No `tool_result` message is ever built, so
+the batch produces nothing.
+
+Compare that to every other failure mode in the same file:
+
+| Failure | Handling |
+| --- | --- |
+| `tool.Call` returns an error | `IsError`, `"Tool execution error: %v"` |
+| Tool panics | Recovered, converted to an error result |
+| Tool returns a malformed union | `IsError` result so the agent converges |
+| Tool name is unknown | **Fatal, turn ends** |
+
+The panic path states the principle directly: results are converted "so the
+LLM can see the failure and adapt, rather than crashing the process." A tool
+that panics is currently handled more gracefully than a name with a typo.
+
+`batchHasSequentialOnlyTool` already treats an unknown name as a skippable,
+non-fatal condition (`agent.go:2160`), so the file is not internally consistent
+about this either.
+
+### Not only a hallucination
+
+The incident above is a model inventing a name, but fatal-on-unknown also
+breaks two supported configurations where the name is not invented at all:
+
+- **Dynamic toolsets.** Tool resolution is per-iteration: the generation loop
+  calls `resolveTools` (`agent.go:1912`) before every LLM request, and
+  `Toolset` implementations are dynamic by design. A tool can legitimately
+  disappear between iterations while its earlier calls remain in the
+  transcript, and models re-call tools they have seen in context.
+- **Resume.** `executeToolCalls` is also invoked when resuming a suspended
+  turn (`agent.go:827`) against a freshly resolved toolset. If the toolset
+  changed across suspend/resume, a pending call's name can be unknown by the
+  time it runs, and today that fails the resume.
+
+Both are reasons this is a correctness fix, not just hallucination tolerance.
+
+### Batch loss differs by execution mode
+
+The two paths discard work differently, and neither is good:
+
+- **Parallel:** the name check runs in Phase 1 before any tool executes, so
+  every valid call in the batch is discarded unrun. Pure wasted latency.
+- **Sequential:** calls preceding the bad one execute to completion. Their side
+  effects land; their results are thrown away with the batch. The caller has no
+  durable record that they ran.
+
+Dive defaults to sequential (`ParallelToolExecution` is opt-in), so the
+side-effect case is the live one. In the two incidents above the completed
+calls were read-only, but that was luck, not design.
+
+## Goals
+
+1. An unknown tool name becomes a recoverable, in-turn error rather than a
+   terminal generation failure.
+2. The model receives enough information to correct itself on the next
+   iteration, rather than merely being told it failed.
+3. Valid tool calls in the same batch are unaffected.
+4. Sequential and parallel paths behave identically.
+5. The event stays countable. Recovery must not make a real defect invisible.
+
+## Non-goals
+
+- **Constraining tool-name generation.** Raised by the reporting customer by
+  analogy to structured output. It is not offered by the hosted provider APIs,
+  and it would be the wrong fix regardless: masking an invalid name does not
+  make the model want the right one, it makes it emit the next most probable
+  *valid* one. That converts a loud failure into a silent call against the
+  wrong tool. The error is the useful signal here.
+- **Fuzzy name correction at dispatch.** Dive stays an exact-name dispatcher.
+  Suggestions are returned to the model; they are never silently substituted.
+  Remapping a name the model did not emit risks dispatching to the wrong tool,
+  which is strictly worse than an extra round trip.
+- **Retrying the generation.** Recovery happens through the normal tool-result
+  loop, not a retry wrapper.
+- **Fixing downstream transcript handling.** Mobius has a separate defect where
+  a failed turn's dangling tool calls are not closed when the assistant message
+  was already committed mid-turn. That is tracked on the Mobius side and is not
+  specific to unknown names; timeouts and provider errors hit it too.
+
+## Proposal
+
+Return an error `ToolCallResult` instead of a Go error, mirroring the existing
+`tool.Call` failure shape so the result flows through the normal path. This is
+also what Claude Code itself does with an unknown tool name — an error
+`tool_result` the model reads and corrects on the next iteration — and Dive's
+stated design philosophy is to align its tool behavior with Claude Code. That
+makes this a parity fix, not a judgment call.
+
+In the sequential path (`executeOneToolCall`) the lookup becomes:
+
+```go
+tool, ok := toolsByName[toolCall.Name]
+if !ok {
+    return unknownToolResult(toolCall, toolsByName), nil
+}
+```
+
+(The parallel path has a different return shape and routes the same result
+through its prep slots; see the implementation section, which also covers the
+hook and event details both paths must get right.)
+
+```go
+func unknownToolResult(
+    call *llm.ToolUseContent,
+    toolsByName map[string]Tool,
+) *ToolCallResult {
+    suggestions := suggestToolNames(call.Name, toolsByName)
+    return &ToolCallResult{
+        ID:    call.ID,
+        Name:  call.Name,
+        Input: call.Input,
+        Result: &ToolResult{
+            Content: []*ToolResultContent{{
+                Type: ToolResultContentTypeText,
+                Text: unknownToolMessage(call.Name, suggestions),
+            }},
+            IsError: true,
+        },
+        Error: &UnknownToolError{Name: call.Name, Suggestions: suggestions},
+    }
+}
+```
+
+The error is a typed `UnknownToolError` rather than a bare `fmt.Errorf`, so
+callers can detect and count the event with `errors.As` — no parsing of
+result text, and no new `ResponseItemType` needed (see Observability):
+
+```go
+// UnknownToolError reports a tool call whose name matched nothing in the
+// toolset declared for the request. No tool was dispatched.
+type UnknownToolError struct {
+    Name        string
+    Suggestions []string
+}
+
+func (e *UnknownToolError) Error() string {
+    return fmt.Sprintf("unknown tool %q", e.Name)
+}
+```
+
+Setting `Error` preserves the Go-level signal for anything inspecting the
+result, while `Result.IsError` is what reaches the model.
+
+The message carries the correction:
+
+```text
+Tool "mobius_market_clock" does not exist and was not called. Did you mean:
+core_market_clock. Call one of the tools declared for this turn.
+```
+
+### Suggestion algorithm
+
+Suggestions are drawn only from `toolsByName`, which is the agent's declared
+set for that turn. Candidate names are sorted before ranking so the output is
+deterministic — map iteration order must not leak into messages or tests.
+Ranking, first tier with any match wins:
+
+1. **Segment-suffix match.** Split both names on `_`, `-`, and `.`; rank by
+   the longest common suffix of segments. A match requires at least two
+   shared trailing segments, or one shared trailing segment of five or more
+   characters — `mobius_market_clock` matches `core_market_clock` on the
+   two-segment suffix `market_clock`, while a lone shared `clock` is below
+   the floor and cannot tie `core_market_clock` with `core_portfolio_clock`.
+   This is the dominant real-world shape: right leaf, wrong namespace. Note
+   that the incident name is *not* reachable by edit distance —
+   `mobius_` → `core_` exceeds the tier-2 bound — so this tier is
+   load-bearing and gets its own test.
+2. **Bounded edit distance.** Levenshtein within `min(3, len/4)` on the full
+   name, for ordinary typos.
+3. **Prefix match.** Shared namespace, unrecognized leaf. Return that
+   namespace's members so the model can pick.
+
+Cap at three suggestions. The full toolset is already in the model's context
+via the tools parameter, so suggestions are a nudge, not documentation. Emit
+none rather than a poor one; a bare "does not exist" is still recoverable, and
+a confident wrong suggestion is worse than silence.
+
+### Bounding the loop
+
+Today a bad name is at least bounded: it ends the turn. After this change a
+model stuck on one name could consume iterations up to
+`defaultToolIterationLimit` (100). That is an unacceptable worst case.
+
+Add a per-generation counter of consecutive unknown-only *iterations*: an
+iteration increments it when it produced at least one unknown name and zero
+successful dispatches; any successful dispatch resets it. Counting per
+iteration rather than per call means a mixed batch — the actual incident
+shape, two good calls and one bad — never advances the bound. That is
+correct: a model still doing useful work is not stuck.
+
+When the counter exceeds the threshold (proposed: 3), do **not** return the
+fatal error. A fatal return at iteration N discards everything since the turn
+began — N iterations of executed tools and their transcript — because a
+`CreateResponse` error means `SaveTurn` never runs. That recreates the exact
+loss this plan exists to fix, at larger scale than the bug it bounds. Instead,
+trip the mechanism that already exists for the iteration limit
+(`agent.go:2052`): set `lastIteration`, append the "respond with a final
+answer now" instruction to the tool-result message, and force
+`ToolChoiceNone`. The turn ends gracefully with a persisted transcript and a
+user-visible explanation instead of a blank response. A model that corrects
+itself is unaffected; a model that cannot is wound down within four iterations
+rather than a hundred.
+
+### Observability
+
+Recovery must not make this invisible. Three surfaces:
+
+- `a.logger.Warn` with the invented name, the suggestions offered, and the
+  agent name.
+- `ToolCallResult.Error` set to `*UnknownToolError`, so callers count the
+  event with `errors.As` — no parsing of result text.
+- The unknown call emits the standard `ResponseItemTypeToolCall` /
+  `ResponseItemTypeToolCallResult` pair, exactly like an executed or denied
+  call. The `tool_use` exists in the assistant message and the error result
+  occupies its transcript slot, so stream consumers that pair the two events
+  keep working unmodified.
+
+A distinct `ResponseItemType` for the event was considered and rejected:
+existing stream consumers silently drop item types they do not know,
+exhaustive switches break on a new one, and it raises a double-counting
+question against the `tool_call_result` item the slot already emits. The
+typed error on the existing item carries the same information.
+
+This matters for a class the recovery does not cover. If a real defect starts
+producing wrong names — a wire-name transform regression, a broken alias map,
+a toolkit migration that renames actions under running agents — the
+pre-change behavior surfaces it within the hour. Post-change the agent
+quietly self-heals, or quietly burns tokens failing to. The warning log and
+the countable typed error are what keep that discoverable, and monitoring
+must watch them rather than error rates (see Tradeoffs).
+
+### No configuration
+
+This should ship unconditionally, with no opt-out.
+
+The behavior it replaces is not one a caller would knowingly choose. A flag
+would exist only to preserve "a misspelled name should end the turn," which no
+deployment wants on purpose.
+
+The security argument that might justify strictness does not apply. An
+unknown name dispatches nothing: the lookup fails, no tool runs, no boundary
+is crossed. Halting on it is theater.
+
+There is deliberately no hook escape hatch either. No `PreToolUse` or
+`PostToolUse` hook fires for a name that resolves to nothing (safety
+invariant 3), so no hook could see the event to veto it — an earlier draft
+claimed a deployment could "express halt-on-unknown as a hook," which is
+inconsistent with that invariant. A deployment that wants to react can watch
+for `*UnknownToolError` on the emitted `tool_call_result` items via the event
+callback, or inspect results after the turn.
+
+## Safety invariants
+
+1. No undeclared tool is ever dispatched. The lookup still fails; only the
+   reporting changes.
+2. Suggestions come only from `toolsByName`, so the message cannot reveal a
+   tool the agent does not have.
+3. Hooks do not fire for a tool that does not exist. Both call sites already
+   perform the lookup before hook construction, but preserving the invariant
+   takes more than that in the parallel path: the drain loop must also skip
+   `PostToolUse`/`PostToolUseFailure` for the unknown slot. Routing the result
+   through `deniedResults` alone is **not** sufficient — denied slots are
+   skipped for execution but still flow through the drain loop, which fires
+   `PostToolUseFailure` with `HookContext.Tool` taken from the prep
+   (`agent.go:2406`), and for an unknown name that is nil. See implementation
+   step 3.
+4. Exactly one `tool_result` per `tool_use`. Providers reject an assistant
+   tool-call batch that is not fully answered, so the error result must occupy
+   the same slot the real result would have.
+5. Valid calls in the batch execute and report normally.
+6. An unknown name never produces a `Suspend` or `Background` outcome.
+7. An unknown call still emits the standard `tool_call` and
+   `tool_call_result` response items, in both execution modes.
+
+## Alternatives considered
+
+### Keep it fatal, but preserve the batch
+
+Return the error while still building the `tool_result` message from completed
+calls. Fixes the discarded-work half but not the dead turn, and still gives the
+model no path to correct itself. Strictly less useful for the same effort.
+
+### Remap near-miss names at dispatch
+
+Resolve `mobius_market_clock` to `core_market_clock` automatically when the
+match is unambiguous. Tempting, and it would have silently fixed both
+incidents. Rejected: it makes dispatch inexact, so a wrong-but-confident match
+calls a tool the model did not ask for. Mobius already made this call in its
+own alias layer, which accepts exact canonical-to-wire mappings and explicitly
+refuses lookalikes. Dive should hold the same line.
+
+### Configuration flag
+
+Covered above. The knob has no defensible "on" setting.
+
+### Constrained decoding of tool names
+
+Covered in non-goals. Not available on hosted providers, and it trades a
+detectable failure for an undetectable one.
+
+## Tradeoffs and consequences
+
+- **Loud becomes quiet.** The main cost, mitigated by the warning log, the
+  countable `*UnknownToolError`, and the iteration bound. Worth stating
+  plainly in review: we are choosing to handle something automatically that
+  currently pages a human.
+- **The worst case is now an apology, not an error.** With the graceful
+  wind-down, a systemic defect that makes every tool name unknown manifests
+  as degraded answers plus warn-log volume, never as failed turns. Monitoring
+  must watch the log line and the typed-error count, because error rates will
+  no longer move.
+- **Cost per incident rises.** Today the turn dies at ~13 seconds. After, the
+  model spends at least one extra generation, sometimes more. That is the right
+  trade for a recovered turn, and it is the argument for keeping the
+  consecutive-unknown threshold tight rather than generous.
+- **Public behavior change.** Callers relying on the hard error stop receiving
+  it. Minor version bump and a changelog entry, not a patch release.
+- **Sequential side effects still precede the failure.** This change means the
+  batch is no longer discarded, so completed results are now recorded rather
+  than lost. That is an improvement, but callers with non-idempotent tools
+  should still not assume a failed turn ran nothing.
+
+## Implementation
+
+1. Add `UnknownToolError`, `unknownToolResult`, `unknownToolMessage`, and
+   `suggestToolNames` with the suggestion ranking, in a new
+   `agent_unknown_tool.go` alongside their tests.
+2. Replace the fatal return at `agent.go:2497` (`executeOneToolCall`). On
+   lookup failure: emit the `ResponseItemTypeToolCall` event (the early
+   return otherwise skips the emission at `agent.go:2512`), emit the
+   `ResponseItemTypeToolCallResult` event, log the warning, and return
+   `unknownToolResult(...)` — before preview generation and before any hook
+   context is built.
+3. Replace the fatal return at `agent.go:2248` (parallel Phase 1): set
+   `deniedResults[i]` to the unknown result **and** add an `unknown bool`
+   flag to `toolCallPrep` that the drain loop checks to bypass
+   `PostToolUse`/`PostToolUseFailure`. The existing `denied` flag alone is
+   not sufficient — denied slots skip execution but still fire failure hooks
+   with `prep.tool` (nil here) as `HookContext.Tool` (`agent.go:2406`),
+   violating safety invariant 3 and handing existing hooks a nil interface.
+   Still emit the `tool_call` event in Phase 1 as for any other call.
+4. Add the consecutive-unknown-iteration counter to the generation loop. When
+   it exceeds the threshold, set `lastIteration` and force `ToolChoiceNone`
+   via the existing final-answer mechanism at `agent.go:2052` — not a fatal
+   error.
+5. Add the logger warning to the parallel path (the sequential path gets it
+   in step 2).
+6. Changelog entry and minor version bump.
+
+## Tests
+
+- Unknown name in a single-call batch returns an `IsError` result and the
+  generation continues to the next iteration.
+- Unknown name alongside valid calls: valid calls execute, all calls receive
+  results, and the batch is not discarded. Both execution modes.
+- `ToolCallResult.Error` unwraps to `*UnknownToolError` via `errors.As`,
+  carrying the invented name and the suggestions offered.
+- The unknown call emits the standard `tool_call` and `tool_call_result`
+  response items, in both execution modes.
+- The suggestion for `mobius_market_clock` against a toolset containing
+  `core_market_clock` and `mobius_memory_recall` is `core_market_clock`, and
+  it comes from the segment-suffix tier — the name is beyond the edit
+  distance bound, so this pins that tier 1 is load-bearing.
+- A single shared trailing segment below the length floor produces no
+  suggestion (`core_market_clock` vs a query sharing only `clock`).
+- Suggestion output is deterministic across runs (candidates sorted before
+  ranking).
+- No suggestion is emitted when nothing scores within threshold.
+- Suggestions never include a name absent from `toolsByName`.
+- A mixed batch (valid + unknown) does not advance the consecutive-unknown
+  counter.
+- Consecutive unknown-only iterations beyond the threshold force a final
+  answer via `ToolChoiceNone`; the turn completes without error, and earlier
+  executed tool results are present in the saved turn.
+- The counter resets after a successful dispatch.
+- No `PreToolUse`, `PostToolUse`, or `PostToolUseFailure` hook fires for an
+  unknown name — in the sequential path and in the parallel drain loop.
+- Every `tool_use` in a batch containing an unknown name has a matching
+  `tool_result`.
+- Resuming a suspended turn whose pending call names a tool no longer in the
+  re-resolved toolset produces an error result instead of failing the resume.
+
+## Rollout and verification
+
+Ship in the next minor release. Mobius picks it up by bumping its pin in
+`go.mod` alongside the provider modules, which move together.
+
+Verification is available directly: the reporting deployment is collecting a
+count of unknown-name errors over a week. After the bump, that count should
+persist as a recovery counter while `generation_failed` turns attributable to
+this cause go to zero.
+
+## Resolved questions
+
+1. **Distinct `ResponseItemType`, or a field on the existing item?** Neither
+   a new type nor an extra field: a typed `*UnknownToolError` on
+   `ToolCallResult.Error`, delivered on the standard `tool_call_result` item.
+   Counting works through `errors.As`, stream consumers need no new type, and
+   nothing double-counts. Rationale in Observability.
+2. **Is 3 the right consecutive-unknown threshold?** Yes, and it is cheap to
+   hold tight now that tripping it ends the turn gracefully instead of
+   fatally. Each recovery message carries suggestions, so a model that will
+   ever self-correct does so on the first one; the threshold exists for the
+   model that never will.
+3. **Suggestion list size?** Cap at three and never fall back to dumping the
+   toolset. The full tool list is already in the model's context via the
+   tools parameter; a longer list is documentation, not a nudge.

--- a/docs/plans/plan-11-usage-bucket-conventions.md
+++ b/docs/plans/plan-11-usage-bucket-conventions.md
@@ -32,8 +32,8 @@ c.Total = c.Input + c.Output + c.CacheRead + c.CacheWrite
 ```
 
 That formula is correct exactly when the buckets are **disjoint** — every
-token counted once, in one bucket. That is Anthropic's convention, and only
-Anthropic's.
+token counted once, in one bucket. Anthropic's direct decoder uses that
+convention, and Ollama inherits it through its embedded Anthropic provider.
 
 This was found during a downstream consumer's capability-gap review of
 Dive: that deployment enforces spend budgets on `Cost.Total` and persists
@@ -44,23 +44,26 @@ refusals and money reporting, not just logs.
 
 Per-provider population of the input-side buckets:
 
-| Provider | Convention | Mapping sites |
-| --- | --- | --- |
-| `anthropic` | **Disjoint** — the API reports `input_tokens` excluding cached; read/creation are separate additive fields | decoder passes them through unchanged |
-| `openai` (Responses) | **Subset** — `InputTokens` is the full prompt; `CachedTokens` is part of it | `providers/openai/decode.go:29`, `providers/openai/stream_iterator.go:452,475` |
-| `openaicompletions` | **Subset**, documented on the wire type itself: "a subset of PromptTokens, not additive" | `providers/openaicompletions/types.go:182-188,204` |
-| `grok` | **Subset** — embeds the OpenAI Responses provider (`providers/grok/grok.go:20-24`); verified `grok.go` only embeds and configures it, with no usage mapping of its own | inherited |
-| `google` | **Subset** — `CachedContentTokenCount` is part of `PromptTokenCount` per the Gemini API contract | `providers/google/util.go:89-97` |
-| `openrouter`, `mistral` | **Subset today, by inheritance** — both embed `*openaic.Provider` (`providers/openrouter/openrouter.go:35`, `providers/mistral/mistral.go:34`) with no usage code of their own, so their mapping *is* `toLLMUsage`. Whenever the served endpoint reports `prompt_tokens_details.cached_tokens` — OpenRouter passes it through for many upstreams — they are on the broken arithmetic now | shared `toLLMUsage`; fixed automatically by the `openaicompletions` change |
-| `ollama` | **Disjoint by construction** — embeds the Anthropic provider (`providers/ollama/ollama.go:34`) and speaks its Anthropic-compatible Messages convention | none needed |
+| Provider                | Convention                                                                                                                                                                                                                                                                                                                                                                               | Mapping sites                                                                  |
+| ----------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
+| `anthropic`             | **Disjoint** — the API reports `input_tokens` excluding cached; read/creation are separate additive fields                                                                                                                                                                                                                                                                               | decoder passes them through unchanged                                          |
+| `openai` (Responses)    | **Subset** — `InputTokens` is the full prompt; `CachedTokens` is part of it                                                                                                                                                                                                                                                                                                              | `providers/openai/decode.go:29`, `providers/openai/stream_iterator.go:452,475` |
+| `openaicompletions`     | **Subset**, documented on the wire type itself: "a subset of PromptTokens, not additive"                                                                                                                                                                                                                                                                                                 | `providers/openaicompletions/types.go:182-188,204`                             |
+| `grok`                  | **Subset** — embeds the OpenAI Responses provider (`providers/grok/grok.go:20-24`); verified `grok.go` only embeds and configures it, with no usage mapping of its own                                                                                                                                                                                                                   | inherited                                                                      |
+| `google`                | **Subset** — `CachedContentTokenCount` is part of `PromptTokenCount` per the Gemini API contract                                                                                                                                                                                                                                                                                         | `providers/google/util.go:89-97`                                               |
+| `openrouter`, `mistral` | **Subset today, by inheritance** — both embed `*openaic.Provider` (`providers/openrouter/openrouter.go:35`, `providers/mistral/mistral.go:34`) with no usage code of their own, so their mapping _is_ `toLLMUsage`. Whenever the served endpoint reports `prompt_tokens_details.cached_tokens` — OpenRouter passes it through for many upstreams — they are on the broken arithmetic now | shared `toLLMUsage`; fixed automatically by the `openaicompletions` change     |
+| `ollama`                | **Disjoint by construction** — embeds the Anthropic provider (`providers/ollama/ollama.go:34`) and speaks its Anthropic-compatible Messages convention                                                                                                                                                                                                                                   | none needed                                                                    |
 
 On every subset-convention path, `CostOf` charges a cached token at
-`InputPrice + CacheReadPrice` instead of `CacheReadPrice`. The overstatement
-of the cached portion is `1 + InputPrice/CacheReadPrice` — with cache reads
-at a tenth of input price, exactly **11x** on the current GPT-5.6 tier
-(`providers/openai/pricing_gen.go`: input 5.00, cache read 0.50 per
-million). The better a consumer's prompt caching works, the more its
-reported cost *rises*.
+`InputPrice + CacheReadPrice` instead of `CacheReadPrice`. When
+`CacheReadPrice` is nonzero, the ratio of the incorrect cached component to
+the correct one is `1 + InputPrice/CacheReadPrice`: exactly **11x** on the
+current GPT-5.6 tier (`providers/openai/pricing_gen.go`: input 5.00, cache
+read 0.50 per million). The excess charge itself is `InputPrice`, or **10x**
+the correct cached component at those rates. When `CacheReadPrice` is zero,
+that ratio is undefined; the missing-rate problem is addressed separately
+below. The better a consumer's prompt caching works, the more its reported
+cost _rises_.
 
 The root cause is that the type never chose a convention, so each decoder
 faithfully preserved its provider's wire shape and the shared pricing code
@@ -72,7 +75,7 @@ silently assumed Anthropic's.
 catalog. Google has no cache-read price on any model, and neither do
 GPT-5.5/5.4 and earlier — models that do report cached tokens. This is
 invisible today because the subset double-count overwhelms it, but it
-determines the *direction* of error after the decoder fix: see proposal
+determines the _direction_ of error after the decoder fix: see proposal
 step 3.
 
 There is also a fourth mapping surface easy to miss: `llm.Usage`'s own
@@ -104,6 +107,10 @@ reintroduce the subset convention behind the decoders' backs.
 - No renaming of any field; no wire-format changes toward providers.
 - No attempt to reconstruct historical usage for downstream consumers
   (the reporting consumer has decided its own cutover is forward-only).
+  Provider adapters decode typed response structs rather than raw JSON into
+  `llm.Usage`, while session storage emits Dive's canonical usage shape without
+  provider-native input-detail objects. Historical raw provider payloads
+  therefore do not pass through `Usage.UnmarshalJSON` during this migration.
 
 ## Proposal
 
@@ -114,38 +121,77 @@ reintroduce the subset convention behind the decoders' backs.
    of the three. Note the contrast with `ReasoningTokens`' documented
    subset-of-output convention so the asymmetry is explicit rather than
    surprising.
-2. **Fix the subset decoders at their mapping sites.** Subtract cached
-   tokens from the prompt count where the wire shape is mapped to
-   `llm.Usage`, clamping at zero:
+2. **Fix the subset decoders at their mapping sites.** Every subset decoder
+   uses the same normalization before constructing `llm.Usage`:
+
+   ```go
+   prompt := max(0, wirePrompt)
+   cached := min(max(0, wireCached), prompt)
+   InputTokens = prompt - cached
+   CacheReadInputTokens = cached
+   ```
+
+   For a valid provider payload (`0 <= wireCached <= wirePrompt`),
+   `TotalInputTokens()` therefore equals the raw wire prompt count. For an
+   invalid payload, tests assert the exact clamped buckets against the
+   normalized prompt instead of treating the invalid raw fields as an
+   invariant oracle. Apply that rule at every subset mapping site:
+
    - `providers/openai/decode.go:29` and
      `providers/openai/stream_iterator.go:452,475`:
-     `InputTokens = max(0, wire.InputTokens - wire.InputTokensDetails.CachedTokens)`.
+     normalize `InputTokens` with `InputTokensDetails.CachedTokens`.
    - `providers/openaicompletions/types.go` `toLLMUsage`: same subtraction
      from `PromptTokens`; update the `PromptTokensDetails` comment to say
-     the subset relationship is a *wire* fact that the conversion resolves.
+     the subset relationship is a _wire_ fact that the conversion resolves.
      This one site also fixes `openrouter` and `mistral`, which embed the
      provider and have no usage code of their own.
    - `providers/google/util.go` `convertUsageMetadata`: subtract
      `CachedContentTokenCount` from `PromptTokenCount`.
    - `grok` inherits the OpenAI Responses fix — verified: `grok.go` only
      embeds and configures the Responses provider.
-   - `llm/usage.go` `UnmarshalJSON`: apply the same map-and-subtract for
+   - `llm/usage.go` `UnmarshalJSON`: apply the same map-and-clamp for
      provider-native input-side details, mirroring the existing
-     `output_tokens_details` handling, so this entry point cannot
-     reintroduce the subset convention. Dive's own serialized shape has no
-     input-details object, so round-tripping stored usage cannot
-     double-subtract.
+     `output_tokens_details` handling. Precedence is based on JSON key
+     presence, not zero values: if either canonical
+     `cache_read_input_tokens` or `cache_creation_input_tokens` is present,
+     the canonical disjoint fields win and native detail objects are ignored;
+     otherwise `input_tokens_details.cached_tokens` paired with
+     `input_tokens` wins over the Chat Completions fallback of
+     `prompt_tokens_details.cached_tokens` paired with `prompt_tokens`.
+     Whenever that native normalization changes token fields, clear `Cost`
+     because `UnmarshalJSON` has no pricing snapshot from which to recompute
+     it. When no normalization occurs, preserve the alias-unmarshaled `Cost`
+     exactly — including an existing `Cost.Total` that does not equal its
+     components — so canonical historical data is not silently rewritten.
+
 3. **Backfill cache-read prices where cached tokens are actually
    reported.** The decoder fix changes the effective formula to
    `uncached × InputPrice + cached × CacheReadPrice`, and a zero
    `CacheReadPrice` then prices cache hits at $0. Google (no cache-read
    prices at all) and OpenAI models before the 5.6 tier would flip from
-   overstating cost to *understating* it — the worse direction for the
+   overstating cost to _understating_ it — the worse direction for the
    budget-enforcement use case that motivated this plan, since budgets trip
-   late instead of early. Backfill `CacheReadPrice` for the Google catalog
-   (Gemini publishes cached-token rates) and for the older OpenAI models
-   that support caching, in the same change, so the correction never ships
-   through an understating intermediate state.
+   late instead of early. Treat `providers/google/catalog.json` and
+   `providers/openai/catalog.json` as the authoritative inputs. In the
+   implementation diff, enumerate every `pricing.text` model for which the
+   provider's official pricing page publishes a cache-read/context-caching
+   rate, and record `cache_read_price_per_1m_tokens`, `updated_at`, and the
+   exact official pricing URL in the catalog's `sources`. Validate the rest of
+   each row against that same source rather than grafting a cache rate onto a
+   stale input/output row. Models with no published cache discount stay zero
+   and are listed explicitly in the pricing test's exclusions with the source
+   reason.
+
+   The OpenAI catalog generates both `providers/openai/pricing_gen.go` and the
+   filtered `providers/openaicompletions/pricing_gen.go`; the Google catalog
+   generates `providers/google/pricing_gen.go`. Do not edit generated pricing
+   files directly. Run `make provider-catalog-generate`, then
+   `make provider-catalog-check`, and make the pricing regression table name
+   every cache-capable model so a missing row cannot hide behind iteration over
+   only the entries that already have nonzero prices. Backfill Google and
+   older OpenAI rates in the same change so the correction never ships through
+   an understating intermediate state.
+
 4. **Add the derived total.** A method on `Usage`, `TotalInputTokens() int`,
    returning `InputTokens + CacheCreationInputTokens + CacheReadInputTokens`,
    so consumers that want the provider's full prompt count (context-size
@@ -178,7 +224,7 @@ reintroduce the subset convention behind the decoders' backs.
   double-correct — one more reason the changelog entry must be explicit.
 - The pricing backfill (step 3) is part of the correction, not a side
   quest: with it, subset-path estimates drop to the true discounted price;
-  without it they would drop *below* it, and a budget enforced on
+  without it they would drop _below_ it, and a budget enforced on
   `Cost.Total` would refuse too late instead of too early.
 
 ## Alternatives considered
@@ -208,33 +254,48 @@ reconciled against each provider's own reported usage on real calls with
 observed cache hits.
 
 - Per-decoder unit tests from wire fixtures with cached tokens present:
-  assert disjoint output and the clamp at zero (cached > prompt is a
-  provider bug, not a panic), on all three decode paths for OpenAI
+  assert disjoint output for valid payloads and the exact upper/lower clamp for
+  invalid cached counts, on all three decode paths for OpenAI
   Responses (non-streaming, `ResponseCompletedEvent`, and
   `ResponseIncompleteEvent`).
-- A cross-provider invariant test over usage produced by every registered
-  provider's fixtures: `TotalInputTokens()` equals the wire prompt count,
-  and `CostOf` equals the disjoint formula.
+- A cross-provider invariant test over valid usage fixtures, with the expected
+  prompt total computed from provider-specific raw metadata before decoding:
+  OpenAI Responses and Grok use `usage.input_tokens`; OpenAI-compatible,
+  OpenRouter, and Mistral use `usage.prompt_tokens`; Google uses
+  `usageMetadata.promptTokenCount`; Anthropic and Ollama sum the wire
+  `input_tokens`, `cache_creation_input_tokens`, and
+  `cache_read_input_tokens`. Compare that independent oracle with
+  `TotalInputTokens()`, and assert that `CostOf` equals the disjoint formula.
+  Invalid fixtures use the normalized-prompt expectation defined in step 2
+  instead of the raw-field invariant.
 - A pricing regression test with a subset-shaped fixture proving the old
   double-count can no longer be produced.
 - A streamed end-to-end case: a subset-shaped fixture through the stream
   iterator and `ResponseAccumulator`, asserting the cost attached by
   `PopulateCost` at stream end (`llm/stream.go:224`) is the disjoint cost.
-- An inheritance canary at the OpenRouter or Mistral provider surface
-  pinning that they produce disjoint usage via the shared `toLLMUsage` —
-  the inheritance is load-bearing and otherwise invisible.
-- `Usage.UnmarshalJSON` with a provider-native input-details payload
-  produces disjoint buckets; round-tripping Dive's own serialized shape is
-  unchanged.
-- Pricing backfill: `CostOf` with the backfilled Google and older-OpenAI
-  prices yields a nonzero `CacheRead` component for cached fixtures, so a
-  future catalog regeneration that drops the prices fails a test instead of
-  silently zeroing cache-hit cost.
+- Separate inheritance canaries at both the OpenRouter and Mistral provider
+  surfaces pin that each produces disjoint usage via the shared
+  `toLLMUsage`; the inheritance is load-bearing and otherwise invisible.
+- `Usage.UnmarshalJSON` tests cover Responses-native and
+  Chat-Completions-native input details, both detail shapes together, mixed
+  canonical/native fields, explicit canonical zero buckets, invalid cached
+  counts, and a native payload whose stale `Cost` must be cleared. A canonical
+  round trip preserves its serialized `Cost`, including an intentionally
+  inconsistent `Cost.Total`, proving alias unmarshaling remains lossless when
+  no token normalization occurs.
+- Pricing backfill: a table enumerates every cache-capable Google and OpenAI
+  model expected from the authoritative catalogs (including the
+  OpenAI-completions generated view), asserts `CacheReadPrice > 0`, and proves
+  cached usage produces `Cost.CacheRead > 0`. A future catalog regeneration
+  that drops any listed rate therefore fails instead of silently zeroing
+  cache-hit cost.
 
 ## Rollout and verification
 
-1. Land the contract docs, decoder fixes, pricing backfill, helper, and
-   tests in one change.
+1. Land the contract docs, decoder fixes, pricing backfill, helper, and tests
+   in one change. Generate and verify the catalog outputs with
+   `make provider-catalog-generate` and `make provider-catalog-check`; review
+   the catalog inputs rather than hand-editing `pricing_gen.go`.
 2. Before tagging, run Dive-side live smoke calls with observed cache hits
    against the subset providers (OpenAI, Google, and Grok at minimum;
    OpenRouter and Mistral where keys allow), reconciling decoded buckets
@@ -265,4 +326,5 @@ observed cache hits.
 - **OpenRouter comment-vs-test: moot.** OpenRouter has no independent
   usage-mapping site — it embeds `openaicompletions` and inherits
   `toLLMUsage`, so it is covered by the fix today, not "when its decoder
-  maps them." Same for Mistral. The inheritance canary test pins this.
+  maps them." Same for Mistral. Separate inheritance canaries pin both
+  provider surfaces.

--- a/docs/plans/plan-11-usage-bucket-conventions.md
+++ b/docs/plans/plan-11-usage-bucket-conventions.md
@@ -1,0 +1,268 @@
+---
+Title: Define llm.Usage input buckets as disjoint and fix the subset-convention decoders
+Author: Claude, with Curtis Myzie
+Status: Proposed
+Last Updated: 2026-08-10
+---
+
+# Define llm.Usage input buckets as disjoint and fix the subset-convention decoders
+
+**Workflow:** Standard-tier spec, Dive team feedback, then implementation.
+
+## Context
+
+`llm.Usage` carries four token buckets and a priced `Cost`. Nothing on the
+type states how `InputTokens` relates to `CacheReadInputTokens`
+(`llm/usage.go:6-15` — the only documented relationship is that
+`ReasoningTokens` is a subset of `OutputTokens`). In practice Dive's
+providers populate the input-side buckets under two incompatible
+conventions, and the pricing formula assumes only one of them.
+
+`PricingInfo.CostOf` (`llm/pricing.go`) prices every bucket independently
+and sums them:
+
+```go
+c := Cost{
+    Input:      float64(u.InputTokens) * p.InputPrice / perMillion,
+    Output:     float64(u.OutputTokens) * p.OutputPrice / perMillion,
+    CacheRead:  float64(u.CacheReadInputTokens) * p.CacheReadPrice / perMillion,
+    CacheWrite: float64(u.CacheCreationInputTokens) * p.CacheWritePrice / perMillion,
+}
+c.Total = c.Input + c.Output + c.CacheRead + c.CacheWrite
+```
+
+That formula is correct exactly when the buckets are **disjoint** — every
+token counted once, in one bucket. That is Anthropic's convention, and only
+Anthropic's.
+
+This was found during a downstream consumer's capability-gap review of
+Dive: that deployment enforces spend budgets on `Cost.Total` and persists
+it as its durable spend record, so the overstatement below reaches budget
+refusals and money reporting, not just logs.
+
+## Current behavior and root cause
+
+Per-provider population of the input-side buckets:
+
+| Provider | Convention | Mapping sites |
+| --- | --- | --- |
+| `anthropic` | **Disjoint** — the API reports `input_tokens` excluding cached; read/creation are separate additive fields | decoder passes them through unchanged |
+| `openai` (Responses) | **Subset** — `InputTokens` is the full prompt; `CachedTokens` is part of it | `providers/openai/decode.go:29`, `providers/openai/stream_iterator.go:452,475` |
+| `openaicompletions` | **Subset**, documented on the wire type itself: "a subset of PromptTokens, not additive" | `providers/openaicompletions/types.go:182-188,204` |
+| `grok` | **Subset** — embeds the OpenAI Responses provider (`providers/grok/grok.go:20-24`); verified `grok.go` only embeds and configures it, with no usage mapping of its own | inherited |
+| `google` | **Subset** — `CachedContentTokenCount` is part of `PromptTokenCount` per the Gemini API contract | `providers/google/util.go:89-97` |
+| `openrouter`, `mistral` | **Subset today, by inheritance** — both embed `*openaic.Provider` (`providers/openrouter/openrouter.go:35`, `providers/mistral/mistral.go:34`) with no usage code of their own, so their mapping *is* `toLLMUsage`. Whenever the served endpoint reports `prompt_tokens_details.cached_tokens` — OpenRouter passes it through for many upstreams — they are on the broken arithmetic now | shared `toLLMUsage`; fixed automatically by the `openaicompletions` change |
+| `ollama` | **Disjoint by construction** — embeds the Anthropic provider (`providers/ollama/ollama.go:34`) and speaks its Anthropic-compatible Messages convention | none needed |
+
+On every subset-convention path, `CostOf` charges a cached token at
+`InputPrice + CacheReadPrice` instead of `CacheReadPrice`. The overstatement
+of the cached portion is `1 + InputPrice/CacheReadPrice` — with cache reads
+at a tenth of input price, exactly **11x** on the current GPT-5.6 tier
+(`providers/openai/pricing_gen.go`: input 5.00, cache read 0.50 per
+million). The better a consumer's prompt caching works, the more its
+reported cost *rises*.
+
+The root cause is that the type never chose a convention, so each decoder
+faithfully preserved its provider's wire shape and the shared pricing code
+silently assumed Anthropic's.
+
+### The pricing tables have their own gap
+
+`CacheReadPrice` is populated only for the GPT-5.6 family and Grok's
+catalog. Google has no cache-read price on any model, and neither do
+GPT-5.5/5.4 and earlier — models that do report cached tokens. This is
+invisible today because the subset double-count overwhelms it, but it
+determines the *direction* of error after the decoder fix: see proposal
+step 3.
+
+There is also a fourth mapping surface easy to miss: `llm.Usage`'s own
+`UnmarshalJSON` (`llm/usage.go:26-50`) advertises accepting provider-native
+usage shapes and maps `output_tokens_details` onto `ReasoningTokens`, but
+ignores input-side details. A provider-native payload with
+`input_tokens_details`/`prompt_tokens_details` parsed through it would
+reintroduce the subset convention behind the decoders' backs.
+
+## Goals
+
+- `llm.Usage`'s input-side buckets (`InputTokens`,
+  `CacheCreationInputTokens`, `CacheReadInputTokens`) are **disjoint by
+  documented contract**, for every provider, on both the non-streaming and
+  streaming paths.
+- `CostOf` is correct as written, for every provider, with no per-provider
+  arithmetic anywhere outside decoders.
+- Consumers that need the full prompt size can derive it without
+  re-learning per-provider conventions.
+
+## Non-goals
+
+- No change to Anthropic's decoder or to cache-write pricing (no subset
+  provider populates `CacheCreationInputTokens`; it remains an
+  Anthropic-convention bucket).
+- No change to `ReasoningTokens`, which stays a documented subset of
+  `OutputTokens` and is deliberately not priced as its own bucket —
+  output-side subset with documentation is a coherent, existing design.
+- No renaming of any field; no wire-format changes toward providers.
+- No attempt to reconstruct historical usage for downstream consumers
+  (the reporting consumer has decided its own cutover is forward-only).
+
+## Proposal
+
+1. **State the contract on the type.** Document on `llm.Usage`
+   (`llm/usage.go`) that `InputTokens`, `CacheCreationInputTokens`, and
+   `CacheReadInputTokens` are mutually disjoint: `InputTokens` counts
+   uncached, unwritten prompt tokens only, and the full prompt is the sum
+   of the three. Note the contrast with `ReasoningTokens`' documented
+   subset-of-output convention so the asymmetry is explicit rather than
+   surprising.
+2. **Fix the subset decoders at their mapping sites.** Subtract cached
+   tokens from the prompt count where the wire shape is mapped to
+   `llm.Usage`, clamping at zero:
+   - `providers/openai/decode.go:29` and
+     `providers/openai/stream_iterator.go:452,475`:
+     `InputTokens = max(0, wire.InputTokens - wire.InputTokensDetails.CachedTokens)`.
+   - `providers/openaicompletions/types.go` `toLLMUsage`: same subtraction
+     from `PromptTokens`; update the `PromptTokensDetails` comment to say
+     the subset relationship is a *wire* fact that the conversion resolves.
+     This one site also fixes `openrouter` and `mistral`, which embed the
+     provider and have no usage code of their own.
+   - `providers/google/util.go` `convertUsageMetadata`: subtract
+     `CachedContentTokenCount` from `PromptTokenCount`.
+   - `grok` inherits the OpenAI Responses fix — verified: `grok.go` only
+     embeds and configures the Responses provider.
+   - `llm/usage.go` `UnmarshalJSON`: apply the same map-and-subtract for
+     provider-native input-side details, mirroring the existing
+     `output_tokens_details` handling, so this entry point cannot
+     reintroduce the subset convention. Dive's own serialized shape has no
+     input-details object, so round-tripping stored usage cannot
+     double-subtract.
+3. **Backfill cache-read prices where cached tokens are actually
+   reported.** The decoder fix changes the effective formula to
+   `uncached × InputPrice + cached × CacheReadPrice`, and a zero
+   `CacheReadPrice` then prices cache hits at $0. Google (no cache-read
+   prices at all) and OpenAI models before the 5.6 tier would flip from
+   overstating cost to *understating* it — the worse direction for the
+   budget-enforcement use case that motivated this plan, since budgets trip
+   late instead of early. Backfill `CacheReadPrice` for the Google catalog
+   (Gemini publishes cached-token rates) and for the older OpenAI models
+   that support caching, in the same change, so the correction never ships
+   through an understating intermediate state.
+4. **Add the derived total.** A method on `Usage`, `TotalInputTokens() int`,
+   returning `InputTokens + CacheCreationInputTokens + CacheReadInputTokens`,
+   so consumers that want the provider's full prompt count (context-size
+   tracking, display) have one blessed answer. The CLI already hand-rolls
+   exactly this sum (`experimental/cmd/dive/app.go:2550`) — double-counting
+   cached tokens on subset providers today — and becomes the helper's first
+   caller. Audit Dive's other internal consumers of `InputTokens` (CLI
+   display in `render.go`, accumulators; Anthropic's `logCacheThrash` is
+   unaffected since that path doesn't change) and move any that meant "full
+   prompt" onto it.
+5. **Say it loudly in the changelog.** For consumers on the
+   subset-convention paths — OpenAI Responses, `openaicompletions` and its
+   embedders OpenRouter and Mistral, Grok, Google — this changes reported
+   values: `InputTokens` drops by the cached amount and `Cost.Total` drops
+   accordingly. That is the bug fix, but anyone comparing across the
+   upgrade will see the discontinuity; the release notes must state it as a
+   semantic correction with the one-line formula for reconstructing the old
+   value (`old input = new input + cache read`).
+
+## Downstream impact
+
+- **The reporting consumer** enforces budgets and persists spend from
+  `Cost.Total` unreconciled; its own tracking work pins the Dive release
+  carrying this fix, declares each provider's convention at registration,
+  and validates the disjoint invariant per served provider — Dive
+  computes, the consumer verifies. It needs a tagged release to pin.
+- Any other consumer summing buckets or comparing usage across providers
+  gets correct, comparable numbers for the first time. Consumers that were
+  independently compensating for the subset convention (none known) would
+  double-correct — one more reason the changelog entry must be explicit.
+- The pricing backfill (step 3) is part of the correction, not a side
+  quest: with it, subset-path estimates drop to the true discounted price;
+  without it they would drop *below* it, and a budget enforced on
+  `Cost.Total` would refuse too late instead of too early.
+
+## Alternatives considered
+
+- **Standardize on the subset convention instead.** Rejected: it makes the
+  four-field struct ambiguous (a cached token lives in two buckets), forces
+  the subtraction into `CostOf` and every other consumer forever, and
+  contradicts the additive semantics `Usage.Add` and `Cost.Add` already
+  assume.
+- **Keep per-provider conventions and price per provider.** Rejected: it
+  spreads wire knowledge from decoders into shared pricing code and leaves
+  every downstream consumer with the comparability problem this plan
+  exists to remove.
+- **Fix only pricing and leave the token counts as reported.** Rejected:
+  cost would be right while cross-provider token sums stayed meaningless,
+  and every consumer doing its own arithmetic on tokens (budgeting per
+  token, analytics) would still be wrong.
+
+## Tests
+
+**Thorough post-implementation testing is a hard requirement of this plan,
+not a nicety.** This change alters money-bearing numbers on every
+non-Anthropic path. The implementation is not done until every fixture
+below is in place and green, and the live per-provider verification in the
+Rollout section has actually been run — decoded buckets and `Cost.Total`
+reconciled against each provider's own reported usage on real calls with
+observed cache hits.
+
+- Per-decoder unit tests from wire fixtures with cached tokens present:
+  assert disjoint output and the clamp at zero (cached > prompt is a
+  provider bug, not a panic), on all three decode paths for OpenAI
+  Responses (non-streaming, `ResponseCompletedEvent`, and
+  `ResponseIncompleteEvent`).
+- A cross-provider invariant test over usage produced by every registered
+  provider's fixtures: `TotalInputTokens()` equals the wire prompt count,
+  and `CostOf` equals the disjoint formula.
+- A pricing regression test with a subset-shaped fixture proving the old
+  double-count can no longer be produced.
+- A streamed end-to-end case: a subset-shaped fixture through the stream
+  iterator and `ResponseAccumulator`, asserting the cost attached by
+  `PopulateCost` at stream end (`llm/stream.go:224`) is the disjoint cost.
+- An inheritance canary at the OpenRouter or Mistral provider surface
+  pinning that they produce disjoint usage via the shared `toLLMUsage` —
+  the inheritance is load-bearing and otherwise invisible.
+- `Usage.UnmarshalJSON` with a provider-native input-details payload
+  produces disjoint buckets; round-tripping Dive's own serialized shape is
+  unchanged.
+- Pricing backfill: `CostOf` with the backfilled Google and older-OpenAI
+  prices yields a nonzero `CacheRead` component for cached fixtures, so a
+  future catalog regeneration that drops the prices fails a test instead of
+  silently zeroing cache-hit cost.
+
+## Rollout and verification
+
+1. Land the contract docs, decoder fixes, pricing backfill, helper, and
+   tests in one change.
+2. Before tagging, run Dive-side live smoke calls with observed cache hits
+   against the subset providers (OpenAI, Google, and Grok at minimum;
+   OpenRouter and Mistral where keys allow), reconciling decoded buckets
+   and `Cost.Total` against each provider's own reported totals.
+3. Tag a release; changelog states the semantic correction and the
+   reconstruction formula.
+4. The reporting consumer bumps its pin and runs its live qualification
+   per subset provider — one real call with observed cache reads per
+   provider, confirming decoded disjoint counts against the provider's own
+   reported totals. Treat that as the field verification for this plan
+   too.
+
+## Resolved questions
+
+- **Method name:** `TotalInputTokens()`. The struct's vocabulary is the
+  Input family (`InputTokens`, `CacheReadInputTokens`,
+  `CacheCreationInputTokens`); "prompt" would import the completions wire
+  vocabulary into a type that deliberately doesn't use it.
+  (`TotalPromptTokens` and `PromptTokens` were the earlier candidates.)
+- **Streaming-accumulator assertion: no — because it is impossible, which
+  is a stronger answer than "not worth it."** Disjointness is not
+  observable from a decoded `Usage`: nothing in the struct records whether
+  `InputTokens` already includes the cached count, and the accumulator
+  (`llm/stream.go:204-209`) just sums whatever decoders emit. The only
+  place the invariant can be checked is at decode time against wire
+  fixtures — which is exactly the cross-provider fixture test above.
+  Recorded here so nobody re-proposes the runtime assert later.
+- **OpenRouter comment-vs-test: moot.** OpenRouter has no independent
+  usage-mapping site — it embeds `openaicompletions` and inherits
+  `toLLMUsage`, so it is covered by the fix today, not "when its decoder
+  maps them." Same for Mistral. The inheritance canary test pins this.


### PR DESCRIPTION
## Summary

Two proposed specs, both reviewed against the codebase and sanitized for publication:

**Plan 10 — Recover from unknown tool names instead of failing the generation** (`docs/plans/plan-10-unknown-tool-name-recovery.md`)

- An unknown tool name currently returns a fatal error from tool dispatch, killing the whole turn and discarding every other tool call in the batch — the only tool failure mode in Dive that behaves this way.
- Proposes returning an `IsError` tool result with correction suggestions (segment-suffix match first), a typed `UnknownToolError` for observability, and a consecutive-unknown iteration counter that winds the turn down via the existing `ToolChoiceNone` final-answer mechanism rather than failing fatally.
- Review pass resolved all open questions and fixed two design gaps: the parallel-path `deniedResults` routing would have fired `PostToolUseFailure` hooks with a nil `Tool`, and the original fatal fallback at the threshold would have discarded more work than the bug it bounds.

**Plan 11 — Define llm.Usage input buckets as disjoint and fix the subset-convention decoders** (`docs/plans/plan-11-usage-bucket-conventions.md`)

- `CostOf` prices the input buckets as disjoint, but the OpenAI Responses, openaicompletions (and its embedders OpenRouter and Mistral), Grok, and Google decoders populate them as subsets — charging cached tokens at `InputPrice + CacheReadPrice`, an ~11x overstatement of the cached portion at current GPT-5.6 prices.
- Proposes declaring the disjoint contract on the type, subtracting at the decoder mapping sites (including `Usage.UnmarshalJSON`), backfilling missing `CacheReadPrice` entries so the fix doesn't flip overstatement into understatement, and adding a `TotalInputTokens()` helper.
- Post-implementation testing is written into the plan as a hard requirement, including live per-provider verification with observed cache hits before tagging.

## Notes for reviewers

- These are spec documents only — no code changes. Both follow the standard-tier spec workflow: team feedback on the plan, then implementation.
- Both docs are sanitized for the public repo (customer/deployment names, turn IDs, and internal doc paths removed; plan 10 notes its identifiers are anonymized with name shapes preserved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a proposal for graceful recovery when an unknown tool is requested, including error reporting, suggestions, mixed-call handling, and safe iteration limits.
  * Added a proposal to standardize input-token usage buckets across providers and prevent double-counting in usage and pricing calculations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->