### PR TITLE
Recover from unknown tool names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **Unknown tool names no longer abort and discard an agent turn.** Dive returns
+  a typed `UnknownToolError` result with deterministic suggestions, preserves
+  valid sibling calls, and uses the standard tool-iteration limit.
+
 ## [1.20.0] - 2026-08-09
 
 ### Changed

--- a/agent.go
+++ b/agent.go
@@ -2204,6 +2204,7 @@ type toolCallPrep struct {
 	preview *ToolCallPreview
 	preHctx *HookContext
 	denied  bool
+	unknown bool
 	input   []byte
 }
 
@@ -2245,7 +2246,22 @@ func (a *Agent) executeToolCallsParallel(
 	for i, toolCall := range toolCalls {
 		tool, ok := toolsByName[toolCall.Name]
 		if !ok {
-			return nil, fmt.Errorf("tool call error: unknown tool %q", toolCall.Name)
+			if err := callback(childCtx, &ResponseItem{
+				Type:     ResponseItemTypeToolCall,
+				ToolCall: toolCall,
+			}); err != nil {
+				return nil, err
+			}
+			result := unknownToolResult(toolCall, toolsByName)
+			unknownErr := result.Error.(*UnknownToolError)
+			a.logger.Warn("unknown tool requested",
+				"tool_name", toolCall.Name,
+				"suggestions", unknownErr.Suggestions,
+				"agent_name", a.name,
+			)
+			preps[i] = toolCallPrep{denied: true, unknown: true}
+			deniedResults[i] = result
+			continue
 		}
 
 		a.logger.Debug("executing tool call",
@@ -2371,6 +2387,16 @@ func (a *Agent) executeToolCallsParallel(
 		i := ct.index
 		result := ct.result
 		prep := preps[i]
+		if prep.unknown {
+			batch.Outcomes[i] = toolCallOutcome{Result: result}
+			if err := callback(ctx, &ResponseItem{
+				Type:           ResponseItemTypeToolCallResult,
+				ToolCallResult: result,
+			}); err != nil {
+				return nil, err
+			}
+			continue
+		}
 
 		// Suspend path: skip PostToolUse hooks but still emit a tool_call_result
 		// event so stream consumers can see the suspend signal.
@@ -2494,7 +2520,26 @@ func (a *Agent) executeOneToolCall(
 ) (*ToolCallResult, error) {
 	tool, ok := toolsByName[toolCall.Name]
 	if !ok {
-		return nil, fmt.Errorf("tool call error: unknown tool %q", toolCall.Name)
+		if err := callback(ctx, &ResponseItem{
+			Type:     ResponseItemTypeToolCall,
+			ToolCall: toolCall,
+		}); err != nil {
+			return nil, err
+		}
+		result := unknownToolResult(toolCall, toolsByName)
+		unknownErr := result.Error.(*UnknownToolError)
+		a.logger.Warn("unknown tool requested",
+			"tool_name", toolCall.Name,
+			"suggestions", unknownErr.Suggestions,
+			"agent_name", a.name,
+		)
+		if err := callback(ctx, &ResponseItem{
+			Type:           ResponseItemTypeToolCallResult,
+			ToolCallResult: result,
+		}); err != nil {
+			return nil, err
+		}
+		return result, nil
 	}
 
 	a.logger.Debug("executing tool call",

--- a/agent_unknown_tool.go
+++ b/agent_unknown_tool.go
@@ -1,0 +1,213 @@
+package dive
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/deepnoodle-ai/dive/llm"
+)
+
+// UnknownToolError reports a tool call whose name matched nothing in the
+// toolset declared for the request. No tool was dispatched.
+type UnknownToolError struct {
+	Name        string
+	Suggestions []string
+}
+
+func (e *UnknownToolError) Error() string {
+	return fmt.Sprintf("unknown tool %q", e.Name)
+}
+
+func unknownToolResult(call *llm.ToolUseContent, toolsByName map[string]Tool) *ToolCallResult {
+	suggestions := suggestToolNames(call.Name, toolsByName)
+	return &ToolCallResult{
+		ID:    call.ID,
+		Name:  call.Name,
+		Input: call.Input,
+		Result: NewToolResultError(
+			unknownToolMessage(call.Name, suggestions),
+		),
+		Error: &UnknownToolError{
+			Name:        call.Name,
+			Suggestions: suggestions,
+		},
+	}
+}
+
+func unknownToolMessage(name string, suggestions []string) string {
+	message := fmt.Sprintf("Tool %q does not exist and was not called.", name)
+	if len(suggestions) > 0 {
+		message += " Did you mean: " + strings.Join(suggestions, ", ") + "."
+	}
+	return message + " Call one of the tools declared for this turn."
+}
+
+const maxUnknownToolSuggestions = 3
+
+type toolNameMatch struct {
+	name      string
+	primary   int
+	secondary int
+}
+
+// suggestToolNames returns candidates from the first matching tier only:
+// segment suffix, bounded edit distance, then exact namespace. Each tier has
+// a deterministic total ordering so map iteration cannot affect the message.
+func suggestToolNames(name string, toolsByName map[string]Tool) []string {
+	querySegments := splitToolName(name)
+
+	var suffixMatches []toolNameMatch
+	for candidate := range toolsByName {
+		candidateSegments := splitToolName(candidate)
+		segments, chars := commonSegmentSuffix(querySegments, candidateSegments)
+		if segments >= 2 || (segments == 1 && chars >= 6) {
+			suffixMatches = append(suffixMatches, toolNameMatch{
+				name:      candidate,
+				primary:   segments,
+				secondary: chars,
+			})
+		}
+	}
+	if len(suffixMatches) > 0 {
+		sort.Slice(suffixMatches, func(i, j int) bool {
+			if suffixMatches[i].primary != suffixMatches[j].primary {
+				return suffixMatches[i].primary > suffixMatches[j].primary
+			}
+			if suffixMatches[i].secondary != suffixMatches[j].secondary {
+				return suffixMatches[i].secondary > suffixMatches[j].secondary
+			}
+			return suffixMatches[i].name < suffixMatches[j].name
+		})
+		return matchNames(suffixMatches)
+	}
+
+	maxDistance := min(3, utf8.RuneCountInString(name)/4)
+	var editMatches []toolNameMatch
+	if maxDistance > 0 {
+		for candidate := range toolsByName {
+			distance := levenshteinDistance(name, candidate)
+			if distance <= maxDistance {
+				editMatches = append(editMatches, toolNameMatch{
+					name:    candidate,
+					primary: distance,
+				})
+			}
+		}
+	}
+	if len(editMatches) > 0 {
+		sort.Slice(editMatches, func(i, j int) bool {
+			if editMatches[i].primary != editMatches[j].primary {
+				return editMatches[i].primary < editMatches[j].primary
+			}
+			return editMatches[i].name < editMatches[j].name
+		})
+		return matchNames(editMatches)
+	}
+
+	if len(querySegments) < 2 {
+		return nil
+	}
+	queryNamespace := querySegments[:len(querySegments)-1]
+	var prefixMatches []toolNameMatch
+	for candidate := range toolsByName {
+		candidateSegments := splitToolName(candidate)
+		if len(candidateSegments) < 2 {
+			continue
+		}
+		candidateNamespace := candidateSegments[:len(candidateSegments)-1]
+		if equalSegments(queryNamespace, candidateNamespace) {
+			prefixMatches = append(prefixMatches, toolNameMatch{
+				name:      candidate,
+				primary:   len(candidateNamespace),
+				secondary: segmentCharacterCount(candidateNamespace),
+			})
+		}
+	}
+	sort.Slice(prefixMatches, func(i, j int) bool {
+		if prefixMatches[i].primary != prefixMatches[j].primary {
+			return prefixMatches[i].primary > prefixMatches[j].primary
+		}
+		if prefixMatches[i].secondary != prefixMatches[j].secondary {
+			return prefixMatches[i].secondary > prefixMatches[j].secondary
+		}
+		return prefixMatches[i].name < prefixMatches[j].name
+	})
+	return matchNames(prefixMatches)
+}
+
+func splitToolName(name string) []string {
+	return strings.FieldsFunc(name, func(r rune) bool {
+		return r == '_' || r == '-' || r == '.'
+	})
+}
+
+func commonSegmentSuffix(a, b []string) (segments, chars int) {
+	for ai, bi := len(a)-1, len(b)-1; ai >= 0 && bi >= 0 && a[ai] == b[bi]; ai, bi = ai-1, bi-1 {
+		segments++
+		chars += utf8.RuneCountInString(a[ai])
+	}
+	return segments, chars
+}
+
+func segmentCharacterCount(segments []string) int {
+	count := 0
+	for _, segment := range segments {
+		count += utf8.RuneCountInString(segment)
+	}
+	return count
+}
+
+func equalSegments(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func matchNames(matches []toolNameMatch) []string {
+	limit := min(maxUnknownToolSuggestions, len(matches))
+	if limit == 0 {
+		return nil
+	}
+	names := make([]string, limit)
+	for i := range limit {
+		names[i] = matches[i].name
+	}
+	return names
+}
+
+func levenshteinDistance(a, b string) int {
+	aRunes := []rune(a)
+	bRunes := []rune(b)
+	if len(aRunes) < len(bRunes) {
+		aRunes, bRunes = bRunes, aRunes
+	}
+	previous := make([]int, len(bRunes)+1)
+	for i := range previous {
+		previous[i] = i
+	}
+	for i, aRune := range aRunes {
+		current := make([]int, len(bRunes)+1)
+		current[0] = i + 1
+		for j, bRune := range bRunes {
+			cost := 0
+			if aRune != bRune {
+				cost = 1
+			}
+			current[j+1] = min(
+				previous[j+1]+1,
+				current[j]+1,
+				previous[j]+cost,
+			)
+		}
+		previous = current
+	}
+	return previous[len(bRunes)]
+}

--- a/agent_unknown_tool_test.go
+++ b/agent_unknown_tool_test.go
@@ -1,0 +1,416 @@
+package dive
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"slices"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/deepnoodle-ai/dive/llm"
+	"github.com/deepnoodle-ai/wonton/assert"
+)
+
+func TestSuggestToolNames(t *testing.T) {
+	tools := func(names ...string) map[string]Tool {
+		result := make(map[string]Tool, len(names))
+		for _, name := range names {
+			result[name] = &mockTool{name: name}
+		}
+		return result
+	}
+
+	t.Run("segment suffix recovers wrong namespace", func(t *testing.T) {
+		query := "mobius_market_clock"
+		assert.True(t,
+			levenshteinDistance(query, "core_market_clock") > min(3, len(query)/4),
+			"the production incident must be recovered by the suffix tier, not edit distance",
+		)
+		assert.Equal(t,
+			suggestToolNames(query, tools("core_market_clock", "mobius_memory_recall")),
+			[]string{"core_market_clock"},
+		)
+	})
+
+	t.Run("short single suffix is below the floor", func(t *testing.T) {
+		assert.Nil(t, suggestToolNames("mobius_clock", tools("core_clock")))
+	})
+
+	t.Run("equal suffix scores use complete wire name and cap at three", func(t *testing.T) {
+		expected := []string{"a_market_clock", "m_market_clock", "q_market_clock"}
+		orders := [][]string{
+			{"z_market_clock", "a_market_clock", "q_market_clock", "m_market_clock"},
+			{"m_market_clock", "q_market_clock", "a_market_clock", "z_market_clock"},
+		}
+		for _, order := range orders {
+			assert.Equal(t, suggestToolNames("mobius_market_clock", tools(order...)), expected)
+		}
+	})
+
+	t.Run("bounded edit distance handles ordinary typo", func(t *testing.T) {
+		assert.Equal(t,
+			suggestToolNames("core_market_clok", tools("core_market_clock", "core_portfolio_value")),
+			[]string{"core_market_clock"},
+		)
+	})
+
+	t.Run("namespace tier normalizes all supported delimiters", func(t *testing.T) {
+		assert.Equal(t,
+			suggestToolNames("core.market.missing", tools(
+				"core_market_beta",
+				"core-market-alpha",
+				"core.market.gamma",
+				"flat",
+			)),
+			[]string{"core-market-alpha", "core.market.gamma", "core_market_beta"},
+		)
+	})
+
+	t.Run("flat names do not qualify as namespaces", func(t *testing.T) {
+		assert.Nil(t, suggestToolNames("unsupported", tools("unrelated", "another")))
+	})
+
+	t.Run("suggestions contain declared tools only", func(t *testing.T) {
+		declared := tools("core_market_clock")
+		suggestions := suggestToolNames("mobius_market_clock", declared)
+		assert.Equal(t, suggestions, []string{"core_market_clock"})
+		for _, suggestion := range suggestions {
+			_, ok := declared[suggestion]
+			assert.True(t, ok)
+		}
+	})
+}
+
+func TestUnknownToolMessage(t *testing.T) {
+	assert.Equal(t,
+		unknownToolMessage("mobius_market_clock", []string{"core_market_clock"}),
+		`Tool "mobius_market_clock" does not exist and was not called. Did you mean: core_market_clock. Call one of the tools declared for this turn.`,
+	)
+	assert.Equal(t,
+		unknownToolMessage("invented", nil),
+		`Tool "invented" does not exist and was not called. Call one of the tools declared for this turn.`,
+	)
+}
+
+func TestUnknownToolRecoversMixedBatch(t *testing.T) {
+	for _, parallel := range []bool{false, true} {
+		t.Run(fmt.Sprintf("parallel=%t", parallel), func(t *testing.T) {
+			var toolCalls atomic.Int32
+			validTool := &mockTool{
+				name: "core_market_clock",
+				callFunc: func(context.Context, any) (*ToolResult, error) {
+					toolCalls.Add(1)
+					return NewToolResultText("market is open"), nil
+				},
+			}
+
+			modelCalls := 0
+			var secondRequest []*llm.Message
+			model := &mockLLM{generateFunc: func(_ context.Context, opts ...llm.Option) (*llm.Response, error) {
+				modelCalls++
+				var cfg llm.Config
+				cfg.Apply(opts...)
+				if modelCalls == 1 {
+					return unknownToolUseResponse("first",
+						&llm.ToolUseContent{ID: "valid", Name: "core_market_clock", Input: []byte(`{}`)},
+						&llm.ToolUseContent{ID: "unknown", Name: "mobius_market_clock", Input: []byte(`{"timezone":"UTC"}`)},
+					), nil
+				}
+				secondRequest = slices.Clone(cfg.Messages)
+				return unknownTextResponse("second", "Recovered and finished"), nil
+			}}
+
+			var preNames, postNames, failureNames []string
+			logger := &recordingLogger{}
+			agent, err := NewAgent(AgentOptions{
+				Name:                  "market-agent",
+				Model:                 model,
+				Tools:                 []Tool{validTool},
+				ParallelToolExecution: parallel,
+				Logger:                logger,
+				Hooks: Hooks{
+					PreToolUse: []PreToolUseHook{func(_ context.Context, hctx *HookContext) error {
+						preNames = append(preNames, hctx.Call.Name)
+						return nil
+					}},
+					PostToolUse: []PostToolUseHook{func(_ context.Context, hctx *HookContext) error {
+						postNames = append(postNames, hctx.Call.Name)
+						return nil
+					}},
+					PostToolUseFailure: []PostToolUseFailureHook{func(_ context.Context, hctx *HookContext) error {
+						failureNames = append(failureNames, hctx.Call.Name)
+						return nil
+					}},
+				},
+			})
+			assert.NoError(t, err)
+
+			resp, err := agent.CreateResponse(context.Background(), WithInput("check the market"))
+			assert.NoError(t, err)
+			assert.Equal(t, resp.OutputText(), "Recovered and finished")
+			assert.Equal(t, toolCalls.Load(), int32(1))
+			assert.Equal(t, preNames, []string{"core_market_clock"})
+			assert.Equal(t, postNames, []string{"core_market_clock"})
+			assert.Len(t, failureNames, 0)
+
+			results := resp.ToolCallResults()
+			assert.Len(t, results, 2)
+			resultsByName := map[string]*ToolCallResult{}
+			for _, result := range results {
+				resultsByName[result.Name] = result
+			}
+			validResult := resultsByName["core_market_clock"]
+			unknownResult := resultsByName["mobius_market_clock"]
+			assert.NotNil(t, validResult)
+			assert.NotNil(t, unknownResult)
+			assert.False(t, validResult.Result.IsError)
+			assert.True(t, unknownResult.Result.IsError)
+			var unknownErr *UnknownToolError
+			assert.True(t, errors.As(unknownResult.Error, &unknownErr))
+			assert.Equal(t, unknownErr.Name, "mobius_market_clock")
+			assert.Equal(t, unknownErr.Suggestions, []string{"core_market_clock"})
+			assert.True(t, strings.Contains(toolResultText(unknownResult.Result), "was not called"))
+
+			assert.Equal(t, countResponseItems(resp.Items, ResponseItemTypeToolCall), 2)
+			assert.Equal(t, countResponseItems(resp.Items, ResponseItemTypeToolCallResult), 2)
+			assert.Equal(t, countToolResultsInMessages(secondRequest), 2,
+				"each tool_use in the mixed batch must have one tool_result")
+			assert.Equal(t, logger.warnCount("unknown tool requested"), 1)
+			warning := logger.firstWarn("unknown tool requested")
+			assert.Equal(t, warning.value("tool_name"), "mobius_market_clock")
+			assert.Equal(t, warning.value("agent_name"), "market-agent")
+			assert.Equal(t, warning.value("suggestions"), []string{"core_market_clock"})
+		})
+	}
+}
+
+func TestUnknownOnlyCallContinuesGeneration(t *testing.T) {
+	calls := 0
+	model := &mockLLM{generateFunc: func(_ context.Context, _ ...llm.Option) (*llm.Response, error) {
+		calls++
+		if calls == 1 {
+			return unknownToolUseResponse("unknown", &llm.ToolUseContent{
+				ID: "unknown", Name: "invented", Input: []byte(`{}`),
+			}), nil
+		}
+		return unknownTextResponse("final", "I could not call that tool."), nil
+	}}
+	agent, err := NewAgent(AgentOptions{Model: model})
+	assert.NoError(t, err)
+
+	resp, err := agent.CreateResponse(context.Background(), WithInput("continue"))
+	assert.NoError(t, err)
+	assert.Equal(t, calls, 2)
+	assert.Equal(t, resp.OutputText(), "I could not call that tool.")
+	assert.Len(t, resp.ToolCallResults(), 1)
+	assert.True(t, resp.ToolCallResults()[0].Result.IsError)
+}
+
+func TestRepeatedUnknownToolsUseStandardIterationLimit(t *testing.T) {
+	calls := 0
+	model := &mockLLM{generateFunc: func(_ context.Context, opts ...llm.Option) (*llm.Response, error) {
+		calls++
+		var cfg llm.Config
+		cfg.Apply(opts...)
+		if calls <= 2 {
+			if cfg.ToolChoice != nil && cfg.ToolChoice.Type == llm.ToolChoiceTypeNone {
+				return nil, fmt.Errorf("tool choice disabled before the standard iteration limit")
+			}
+			return unknownToolUseResponse(fmt.Sprintf("unknown-%d", calls), &llm.ToolUseContent{
+				ID: fmt.Sprintf("unknown-%d", calls), Name: "invented", Input: []byte(`{}`),
+			}), nil
+		}
+		if cfg.ToolChoice == nil || cfg.ToolChoice.Type != llm.ToolChoiceTypeNone {
+			return nil, fmt.Errorf("standard final iteration did not force tool choice none")
+		}
+		return unknownTextResponse("final", "Stopped at the configured limit."), nil
+	}}
+	agent, err := NewAgent(AgentOptions{Model: model, ToolIterationLimit: 2})
+	assert.NoError(t, err)
+
+	resp, err := agent.CreateResponse(context.Background(), WithInput("continue"))
+	assert.NoError(t, err)
+	assert.Equal(t, calls, 3)
+	assert.Equal(t, resp.OutputText(), "Stopped at the configured limit.")
+}
+
+func TestUnknownToolDuringResumeBecomesResult(t *testing.T) {
+	var dynamicAvailable atomic.Bool
+	dynamicAvailable.Store(true)
+	laterTool := &mockTool{
+		name: "later_tool",
+		callFunc: func(context.Context, any) (*ToolResult, error) {
+			return NewToolResultText("should not run"), nil
+		},
+	}
+	toolset := &ToolsetFunc{
+		ToolsetName: "dynamic",
+		Resolve: func(context.Context) ([]Tool, error) {
+			if dynamicAvailable.Load() {
+				return []Tool{laterTool}, nil
+			}
+			return nil, nil
+		},
+	}
+	approve := &mockTool{
+		name: "approve",
+		callFunc: func(context.Context, any) (*ToolResult, error) {
+			return NewSuspendResult("approve the turn", nil), nil
+		},
+	}
+	modelCalls := 0
+	model := &mockLLM{generateFunc: func(_ context.Context, _ ...llm.Option) (*llm.Response, error) {
+		modelCalls++
+		if modelCalls == 1 {
+			return unknownToolUseResponse("suspend",
+				&llm.ToolUseContent{ID: "approval", Name: "approve", Input: []byte(`{}`)},
+				&llm.ToolUseContent{ID: "later", Name: "later_tool", Input: []byte(`{}`)},
+			), nil
+		}
+		return unknownTextResponse("final", "Resume recovered."), nil
+	}}
+
+	var preNames, postNames, failureNames []string
+	agent, err := NewAgent(AgentOptions{
+		Model:    model,
+		Tools:    []Tool{approve},
+		Toolsets: []Toolset{toolset},
+		Hooks: Hooks{
+			PreToolUse: []PreToolUseHook{func(_ context.Context, hctx *HookContext) error {
+				preNames = append(preNames, hctx.Call.Name)
+				return nil
+			}},
+			PostToolUse: []PostToolUseHook{func(_ context.Context, hctx *HookContext) error {
+				postNames = append(postNames, hctx.Call.Name)
+				return nil
+			}},
+			PostToolUseFailure: []PostToolUseFailureHook{func(_ context.Context, hctx *HookContext) error {
+				failureNames = append(failureNames, hctx.Call.Name)
+				return nil
+			}},
+		},
+	})
+	assert.NoError(t, err)
+
+	resp, err := agent.CreateResponse(context.Background(), WithInput("start"))
+	assert.NoError(t, err)
+	assert.Equal(t, resp.Status, ResponseStatusSuspended)
+	dynamicAvailable.Store(false)
+
+	resp, err = agent.CreateResponse(context.Background(),
+		WithResume(resp.Suspension, map[string]*ToolResult{
+			"approval": NewToolResultText("approved"),
+		}),
+	)
+	assert.NoError(t, err)
+	assert.Equal(t, resp.Status, ResponseStatusCompleted)
+	assert.Equal(t, resp.OutputText(), "Resume recovered.")
+	assert.Equal(t, preNames, []string{"approve"})
+	assert.Equal(t, postNames, []string{"approve"})
+	assert.Len(t, failureNames, 0)
+
+	var recovered *ToolCallResult
+	for _, result := range resp.ToolCallResults() {
+		if result.ID == "later" {
+			recovered = result
+		}
+	}
+	assert.NotNil(t, recovered)
+	assert.True(t, recovered.Result.IsError)
+	var unknownErr *UnknownToolError
+	assert.True(t, errors.As(recovered.Error, &unknownErr))
+	assert.Equal(t, unknownErr.Name, "later_tool")
+}
+
+func unknownToolUseResponse(id string, calls ...*llm.ToolUseContent) *llm.Response {
+	content := make([]llm.Content, len(calls))
+	for i, call := range calls {
+		content[i] = call
+	}
+	return &llm.Response{
+		ID: id, Role: llm.Assistant, Content: content, Type: "message", StopReason: "tool_use",
+	}
+}
+
+func unknownTextResponse(id, text string) *llm.Response {
+	return &llm.Response{
+		ID: id, Role: llm.Assistant, Content: []llm.Content{&llm.TextContent{Text: text}}, Type: "message", StopReason: "stop",
+	}
+}
+
+func countResponseItems(items []*ResponseItem, itemType ResponseItemType) int {
+	count := 0
+	for _, item := range items {
+		if item.Type == itemType {
+			count++
+		}
+	}
+	return count
+}
+
+func countToolResultsInMessages(messages []*llm.Message) int {
+	count := 0
+	for _, message := range messages {
+		for _, content := range message.Content {
+			if _, ok := content.(*llm.ToolResultContent); ok {
+				count++
+			}
+		}
+	}
+	return count
+}
+
+type recordedLog struct {
+	message string
+	args    []any
+}
+
+func (l recordedLog) value(key string) any {
+	for i := 0; i+1 < len(l.args); i += 2 {
+		if l.args[i] == key {
+			return l.args[i+1]
+		}
+	}
+	return nil
+}
+
+type recordingLogger struct {
+	mu    sync.Mutex
+	warns []recordedLog
+}
+
+func (l *recordingLogger) Debug(string, ...any) {}
+func (l *recordingLogger) Info(string, ...any)  {}
+func (l *recordingLogger) Error(string, ...any) {}
+func (l *recordingLogger) Warn(message string, args ...any) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.warns = append(l.warns, recordedLog{message: message, args: slices.Clone(args)})
+}
+func (l *recordingLogger) With(...any) llm.Logger { return l }
+
+func (l *recordingLogger) warnCount(message string) int {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	count := 0
+	for _, warning := range l.warns {
+		if warning.message == message {
+			count++
+		}
+	}
+	return count
+}
+
+func (l *recordingLogger) firstWarn(message string) recordedLog {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	for _, warning := range l.warns {
+		if warning.message == message {
+			return warning
+		}
+	}
+	return recordedLog{}
+}

--- a/docs/plans/plan-10-unknown-tool-name-recovery.md
+++ b/docs/plans/plan-10-unknown-tool-name-recovery.md
@@ -1,7 +1,7 @@
 ---
 Title: Recover from unknown tool names instead of failing the generation
 Author: Curtis Myzie
-Status: Proposed
+Status: Implemented
 Last Updated: 2026-08-10
 ---
 
@@ -260,31 +260,18 @@ via the tools parameter, so suggestions are a nudge, not documentation. Emit
 none rather than a poor one; a bare "does not exist" is still recoverable, and
 a confident wrong suggestion is worse than silence.
 
-### Bounding the loop
+### Iteration limit
 
-Today a bad name is at least bounded: it ends the turn. After this change a
-model stuck on one name could consume iterations up to
-`defaultToolIterationLimit` (100). That is an unacceptable worst case.
+Unknown-name results use the same agent-wide `ToolIterationLimit` as every
+other recoverable tool failure. There is no unknown-specific counter or retry
+budget. If the model keeps calling a missing tool, the existing final-iteration
+mechanism appends the "respond with a final answer now" instruction and forces
+`ToolChoiceNone`.
 
-Add a per-generation counter of consecutive unknown-only _iterations_: an
-iteration increments it when it produced at least one unknown name and zero
-successful dispatches; any successful dispatch resets it. Counting per
-iteration rather than per call means a mixed batch — the actual incident
-shape, two good calls and one bad — never advances the bound. That is
-correct: a model still doing useful work is not stuck.
-
-When the counter exceeds the threshold (proposed: 3), do **not** return the
-fatal error. A fatal return at iteration N discards everything since the turn
-began — N iterations of executed tools and their transcript — because a
-`CreateResponse` error means `SaveTurn` never runs. That recreates the exact
-loss this plan exists to fix, at larger scale than the bug it bounds. Instead,
-trip the mechanism that already exists for the iteration limit
-(`agent.go:2052`): set `lastIteration`, append the "respond with a final
-answer now" instruction to the tool-result message, and force
-`ToolChoiceNone`. The turn ends gracefully with a persisted transcript and a
-user-visible explanation instead of a blank response. A model that corrects
-itself is unaffected; a model that cannot is wound down within four iterations
-rather than a hundred.
+This keeps recovery consistent with tool execution errors, panics, malformed
+results, and hook denials. Deployments that want a tighter overall bound can
+already lower `ToolIterationLimit`; unknown names do not justify a second state
+machine with different reset semantics.
 
 ### Observability
 
@@ -386,18 +373,18 @@ detectable failure for an undetectable one.
 ## Tradeoffs and consequences
 
 - **Loud becomes quiet.** The main cost, mitigated by the warning log, the
-  countable `*UnknownToolError`, and the iteration bound. Worth stating
+  countable `*UnknownToolError`, and the existing agent-wide iteration limit. Worth stating
   plainly in review: we are choosing to handle something automatically that
   currently pages a human.
 - **The worst case is now an apology, not an error.** With the graceful
-  wind-down, a systemic defect that makes every tool name unknown manifests
-  as degraded answers plus warn-log volume, never as failed turns. Monitoring
-  must watch the log line and the typed-error count, because error rates will
-  no longer move.
+  final iteration, a systemic defect that makes every tool name unknown
+  manifests as degraded answers plus warn-log volume, never as failed turns.
+  Monitoring must watch the log line and the typed-error count, because error
+  rates will no longer move.
 - **Cost per incident rises.** Today the turn dies at ~13 seconds. After, the
   model spends at least one extra generation, sometimes more. That is the right
-  trade for a recovered turn, and it is the argument for keeping the
-  consecutive-unknown threshold tight rather than generous.
+  trade for a recovered turn. `ToolIterationLimit` remains the caller's common
+  cost bound for all recoverable tool failures.
 - **Public behavior change.** Callers relying on the hard error stop receiving
   it. Minor version bump and a changelog entry, not a patch release.
 - **Sequential side effects still precede the failure.** This change means the
@@ -424,13 +411,9 @@ detectable failure for an undetectable one.
    with `prep.tool` (nil here) as `HookContext.Tool` (`agent.go:2406`),
    violating safety invariant 3 and handing existing hooks a nil interface.
    Still emit the `tool_call` event in Phase 1 as for any other call.
-4. Add the consecutive-unknown-iteration counter to the generation loop. When
-   it exceeds the threshold, set `lastIteration` and force `ToolChoiceNone`
-   via the existing final-answer mechanism at `agent.go:2052` — not a fatal
-   error.
-5. Add the logger warning to the parallel path (the sequential path gets it
+4. Add the logger warning to the parallel path (the sequential path gets it
    in step 2).
-6. Changelog entry and minor version bump.
+5. Changelog entry; ship the behavior change in the next minor release.
 
 ## Tests
 
@@ -454,12 +437,8 @@ detectable failure for an undetectable one.
   and flat names that must not qualify as namespace matches.
 - No suggestion is emitted when nothing scores within threshold.
 - Suggestions never include a name absent from `toolsByName`.
-- A mixed batch (valid + unknown) does not advance the consecutive-unknown
-  counter.
-- Consecutive unknown-only iterations beyond the threshold force a final
-  answer via `ToolChoiceNone`; the turn completes without error, and earlier
-  executed tool results are present in the saved turn.
-- The counter resets after a successful dispatch.
+- Repeated unknown-only iterations use the standard `ToolIterationLimit`
+  final-answer path; there is no unknown-specific counter.
 - No `PreToolUse`, `PostToolUse`, or `PostToolUseFailure` hook fires for an
   unknown name — in the sequential path and in the parallel drain loop.
 - Every `tool_use` in a batch containing an unknown name has a matching
@@ -484,11 +463,10 @@ this cause go to zero.
    `ToolCallResult.Error`, delivered on the standard `tool_call_result` item.
    Counting works through `errors.As`, stream consumers need no new type, and
    nothing double-counts. Rationale in Observability.
-2. **Is 3 the right consecutive-unknown threshold?** Yes, and it is cheap to
-   hold tight now that tripping it ends the turn gracefully instead of
-   fatally. Each recovery message carries suggestions, so a model that will
-   ever self-correct does so on the first one; the threshold exists for the
-   model that never will.
+2. **Should unknown names have a separate retry threshold?** No. Every other
+   recoverable tool failure uses `ToolIterationLimit`, and unknown names should
+   follow the same policy. A dedicated counter adds state and ambiguous reset
+   semantics without establishing a broader failure-budget abstraction.
 3. **Suggestion list size?** Cap at three and never fall back to dumping the
    toolset. The full tool list is already in the model's context via the
    tools parameter; a longer list is documentation, not a nudge.

--- a/docs/plans/plan-10-unknown-tool-name-recovery.md
+++ b/docs/plans/plan-10-unknown-tool-name-recovery.md
@@ -59,14 +59,15 @@ The user-visible outcome was a blank response after thirteen seconds. The two
 `mobius_memory_recall` calls had already executed and returned results; those
 results were discarded along with the turn.
 
-## Current behavior and root cause
+## Historical behavior and root cause
 
-Two call sites return a fatal error on an unrecognized name:
+Before this implementation, two call sites returned a fatal error on an
+unrecognized name:
 
 - `agent.go:2497` in `executeOneToolCall` (sequential path)
 - `agent.go:2248` in `executeToolCallsParallel`, Phase 1
 
-Both are the same shape:
+Both used the same shape:
 
 ```go
 tool, ok := toolsByName[toolCall.Name]
@@ -75,11 +76,11 @@ if !ok {
 }
 ```
 
-That error propagates through `executeToolCalls` to the generation loop, which
-returns it from `CreateResponse`. No `tool_result` message is ever built, so
-the batch produces nothing.
+That error propagated through `executeToolCalls` to the generation loop, which
+returned it from `CreateResponse`. No `tool_result` message was built, so the
+batch produced nothing.
 
-Compare that to every other failure mode in the same file:
+At the time, every other failure mode in the same file was recoverable:
 
 | Failure                        | Handling                                |
 | ------------------------------ | --------------------------------------- |
@@ -88,18 +89,18 @@ Compare that to every other failure mode in the same file:
 | Tool returns a malformed union | `IsError` result so the agent converges |
 | Tool name is unknown           | **Fatal, turn ends**                    |
 
-The panic path states the principle directly: results are converted "so the
+The panic path stated the principle directly: results were converted "so the
 LLM can see the failure and adapt, rather than crashing the process." A tool
-that panics is currently handled more gracefully than a name with a typo.
+that panicked was handled more gracefully than a name with a typo.
 
-`batchHasSequentialOnlyTool` already treats an unknown name as a skippable,
-non-fatal condition (`agent.go:2160`), so the file is not internally consistent
-about this either.
+`batchHasSequentialOnlyTool` already treated an unknown name as a skippable,
+non-fatal condition (`agent.go:2160`), so the file was not internally
+consistent about this either.
 
 ### Not only a hallucination
 
-The incident above is a model inventing a name, but fatal-on-unknown also
-breaks two supported configurations where the name is not invented at all:
+The incident above was a model inventing a name, but fatal-on-unknown also
+broke two supported configurations where the name was not invented at all:
 
 - **Dynamic toolsets.** Tool resolution is per-iteration: the generation loop
   calls `resolveTools` (`agent.go:1912`) before every LLM request, and
@@ -109,23 +110,23 @@ breaks two supported configurations where the name is not invented at all:
 - **Resume.** `executeToolCalls` is also invoked when resuming a suspended
   turn (`agent.go:827`) against a freshly resolved toolset. If the toolset
   changed across suspend/resume, a pending call's name can be unknown by the
-  time it runs, and today that fails the resume.
+  time it runs, which caused the resume to fail.
 
-Both are reasons this is a correctness fix, not just hallucination tolerance.
+Both were reasons this was a correctness fix, not just hallucination tolerance.
 
-### Batch loss differs by execution mode
+### Batch loss differed by execution mode
 
-The two paths discard work differently, and neither is good:
+The two paths discarded work differently, and neither was good:
 
-- **Parallel:** the name check runs in Phase 1 before any tool executes, so
-  every valid call in the batch is discarded unrun. Pure wasted latency.
-- **Sequential:** calls preceding the bad one execute to completion. Their side
-  effects land; their results are thrown away with the batch. The caller has no
-  durable record that they ran.
+- **Parallel:** the name check ran in Phase 1 before any tool executed, so every
+  valid call in the batch was discarded unrun. Pure wasted latency.
+- **Sequential:** calls preceding the bad one executed to completion. Their side
+  effects landed; their results were thrown away with the batch. The caller had
+  no durable record that they ran.
 
 Dive defaults to sequential (`ParallelToolExecution` is opt-in), so the
-side-effect case is the live one. In the two incidents above the completed
-calls were read-only, but that was luck, not design.
+side-effect case was the live pre-change behavior. In the two incidents above
+the completed calls were read-only, but that was luck, not design.
 
 ## Goals
 

--- a/tool.go
+++ b/tool.go
@@ -577,7 +577,7 @@ type ToolCallResult struct {
 	Input              any
 	Preview            *ToolCallPreview      // Preview generated before execution (if tool implements ToolPreviewer)
 	Result             *ToolResult           // Protocol-level result sent to the LLM
-	Error              error                 // Go error if tool.Call() itself failed
+	Error              error                 // Go error from tool.Call() or dispatch, including UnknownToolError
 	AdditionalContext  string                // Context injected by hooks, appended to the tool result message
 	BackgroundHandle   *BackgroundTaskHandle // Non-nil when the tool returned BackgroundResult
 	reminderDeliveries []reminderDelivery

--- a/tool.go
+++ b/tool.go
@@ -566,7 +566,9 @@ func (f *funcTool[T]) Call(ctx context.Context, input T) (*ToolResult, error) {
 // what calls have happened during an LLM interaction.
 //
 // Error and Result.IsError track different failure modes:
-//   - Error is a Go error from tool.Call() — the tool itself crashed or failed unexpectedly.
+//   - Error is a Go-level execution or dispatch error, such as tool.Call()
+//     failing unexpectedly or an unknown tool name. Inspect typed errors with
+//     errors.As when the distinction matters.
 //   - Result.IsError is a protocol-level flag — the tool ran but reported a failure to the LLM
 //     (e.g. via NewToolResultError). Both are surfaced to the LLM as an error result.
 type ToolCallResult struct {


### PR DESCRIPTION
## Summary

- convert unknown tool names from fatal generation errors into ordinary error `ToolCallResult` values
- return deterministic suggestions from the declared toolset and expose a typed `UnknownToolError` for counting
- preserve valid sibling calls and emit the standard `tool_call` / `tool_call_result` event pair in sequential and parallel modes
- skip previews, dispatch, tracer spans, and all tool hooks for names that do not resolve
- keep repeated failures on Dive's existing `ToolIterationLimit` path, with no unknown-specific counter
- mark Plan 10 implemented and add the unreleased changelog entry

## Why

Unknown names were the only tool failure that unwound `CreateResponse`. In sequential mode, earlier tools could already have executed while their results were discarded; in parallel mode, one unknown name prevented every valid sibling from running. The model received no result it could use to correct itself.

The root cause was an early fatal return at both dispatch lookups. This change keeps exact-name dispatch—the unknown tool is never called—but reports the miss through the same recoverable result channel used by other tool failures.

## Impact

Models can correct a hallucinated, stale, or resumed tool name on the next iteration. Callers can detect the event with `errors.As(result.Error, &unknownErr)`, logs include the invented name and suggestions, and existing stream consumers need no new item type. This is intended for the next minor release because callers relying on the former hard error will observe a behavior change.

## Validation

- `make check`
- `go test -race ./...`
- `go vet ./...`
- `go test ./...` and `go vet ./...` in all eight tagged nested modules
- focused sequential, parallel, suggestion-ranking, event-pairing, hook, standard-iteration-limit, dynamic-toolset, and suspend/resume regressions
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Unknown tool requests now return structured errors with clear messages and deterministic suggestions.
  * Valid tool calls continue processing when mixed with unknown requests, including during parallel execution.
  * Tool recovery follows the standard iteration limit and supports resumed tool availability.

* **Bug Fixes**
  * Prevented unknown tool names from aborting otherwise valid tool execution.
  * Improved distinction between execution errors and tool-reported failures.

* **Documentation**
  * Updated changelog and recovery guidance for unknown tool handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->