### PR TITLE
Prepare v1.21.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [1.21.0] - 2026-08-10
+
 ### Fixed
 
 - **Unknown tool names no longer abort and discard an agent turn.** Dive returns

--- a/a2a/go.mod
+++ b/a2a/go.mod
@@ -6,7 +6,7 @@ toolchain go1.26.5
 
 require (
 	github.com/a2aproject/a2a-go/v2 v2.4.0
-	github.com/deepnoodle-ai/dive v1.20.0
+	github.com/deepnoodle-ai/dive v1.21.0
 	github.com/deepnoodle-ai/wonton v0.0.37
 )
 

--- a/demos/colosseum/go.mod
+++ b/demos/colosseum/go.mod
@@ -5,11 +5,11 @@ go 1.25.0
 toolchain go1.26.5
 
 require (
-	github.com/deepnoodle-ai/dive v1.20.0
-	github.com/deepnoodle-ai/dive/a2a v1.20.0
-	github.com/deepnoodle-ai/dive/providers/google v1.20.0
-	github.com/deepnoodle-ai/dive/providers/grok v1.20.0
-	github.com/deepnoodle-ai/dive/providers/openai v1.20.0
+	github.com/deepnoodle-ai/dive v1.21.0
+	github.com/deepnoodle-ai/dive/a2a v1.21.0
+	github.com/deepnoodle-ai/dive/providers/google v1.21.0
+	github.com/deepnoodle-ai/dive/providers/grok v1.21.0
+	github.com/deepnoodle-ai/dive/providers/openai v1.21.0
 	github.com/deepnoodle-ai/wonton v0.0.37
 )
 

--- a/demos/noodleville/go.mod
+++ b/demos/noodleville/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 toolchain go1.26.5
 
 require (
-	github.com/deepnoodle-ai/dive v1.20.0
+	github.com/deepnoodle-ai/dive v1.21.0
 	github.com/deepnoodle-ai/wonton v0.0.37
 )
 

--- a/docs/releases/v1.21.0.md
+++ b/docs/releases/v1.21.0.md
@@ -1,0 +1,74 @@
+## Highlights
+
+**Unknown tool names are recoverable now.** A hallucinated or stale name no
+longer aborts the turn, discards valid sibling calls, or hides earlier tool
+effects. The model receives a normal error result with deterministic suggestions
+and can correct itself on the next iteration. Callers that used the former
+`CreateResponse` error as a signal should instead inspect tool results with
+`errors.As` for `*dive.UnknownToolError`.
+
+**Usage and cost reporting now follow the providers' actual billing shapes.**
+Input, cache-read, and cache-write tokens are disjoint across supported
+providers; Gemini accounts for thinking, tools, modalities, regional rates, and
+long-context tiers; and OpenRouter uses the charge it reports rather than a
+necessarily incomplete static price table. Existing consumers that treated
+`InputTokens` as total prompt input should switch to `TotalInputTokens()`.
+
+**Prompt caching is routed consistently across agent sessions and stateless
+agents.** OpenAI GPT-5.6 requests mark reusable prefix boundaries, Grok receives
+stable cache keys, and CLI skill catalogs stay in the reusable prefix. A
+session-backed agent works automatically; applications that recreate agents or
+multiplex conversations through one agent should pass the same conversation key
+with `dive.WithPromptCacheKey` on every turn.
+
+## Pull requests
+
+- fix: harden provider billing and prompt-cache routing (#254)
+- Fix Grok prompt cache routing and pricing (#253)
+- Align GPT-5.6 prompt cache accounting and routing (#252)
+- Define disjoint usage input buckets (#251)
+- Recover from unknown tool names (#250)
+- Add plans 10 and 11: unknown-tool-name recovery and usage bucket conventions (#249)
+
+## Changelog
+
+### Fixed
+
+- **Unknown tool names no longer abort and discard an agent turn.** Dive returns
+  a typed `UnknownToolError` result with deterministic suggestions, preserves
+  valid sibling calls, and uses the standard tool-iteration limit.
+- **`llm.Usage` input buckets are now consistently disjoint.** OpenAI
+  Responses, OpenAI Completions, OpenRouter, Mistral, Grok, and Google now
+  subtract cache hits from `InputTokens` before pricing. This fixes cached
+  tokens being charged at both the normal input rate and the cache-read rate.
+  GPT-5.6 cache writes are also decoded into `CacheCreationInputTokens`, so
+  they receive the published write rate instead of the normal input rate. To
+  reconstruct the pre-fix value, use
+  `old input = new input + cache read + cache write`.
+- **OpenAI prompt-cache reporting and routing now match GPT-5.6.** Agent
+  sessions use a stable hashed `prompt_cache_key`, native OpenAI requests mark
+  reusable prefix breakpoints, and the CLI's cache-hit percentage is cache
+  reads divided by total input rather than reads divided only by cache
+  activity. A small cached prefix can no longer render as `100%`. The CLI's
+  model-only skill catalog is also delivered before durable conversation
+  history so it remains reusable instead of being rewritten on every turn.
+- **Cache-read pricing is populated for every Google and OpenAI text model
+  with a published discounted-input rate.** The OpenAI catalog also corrects
+  the stale GPT-4o row to the current $2.50 input, $1.25 cached-input, and
+  $10 output rates per million tokens. Dated provider model IDs now resolve to
+  their stable catalog ID so live OpenAI responses retain `Cost.Total`.
+- **Grok agents now send a stable `prompt_cache_key`.** Session-backed agents
+  derive a private key from the session ID; stateless agents use an
+  agent-instance key and can provide a conversation key per call. The Grok
+  catalog also uses xAI's current cached-input rates and applies its input,
+  cached-input, and output long-context tier at 200K total input tokens.
+- **Gemini usage and cost estimates now reconcile to Google's billing shape.**
+  Thinking and tool-use tokens are included, multimodal and Vertex regional
+  rates are honored, all Pro rates switch above 200K input, and unsupported
+  tiers or incomplete price dimensions remain explicitly unpriced. A provider
+  aggregate mismatch preserves completed content and component counts while
+  marking the cost estimate unavailable.
+- **OpenRouter costs now use the authoritative charge returned in `usage.cost`.**
+  This covers arbitrary routed models and provider-specific cache/tool charges
+  without depending on a necessarily incomplete static price snapshot. A null
+  usage object is treated as missing telemetry rather than a measured zero.

--- a/examples/go.mod
+++ b/examples/go.mod
@@ -5,13 +5,13 @@ go 1.25.5
 toolchain go1.26.5
 
 require (
-	github.com/deepnoodle-ai/dive v1.20.0
-	github.com/deepnoodle-ai/dive/a2a v1.20.0
-	github.com/deepnoodle-ai/dive/experimental/mcp v1.20.0
-	github.com/deepnoodle-ai/dive/otel v1.20.0
-	github.com/deepnoodle-ai/dive/providers/google v1.20.0
-	github.com/deepnoodle-ai/dive/providers/grok v1.20.0
-	github.com/deepnoodle-ai/dive/providers/openai v1.20.0
+	github.com/deepnoodle-ai/dive v1.21.0
+	github.com/deepnoodle-ai/dive/a2a v1.21.0
+	github.com/deepnoodle-ai/dive/experimental/mcp v1.21.0
+	github.com/deepnoodle-ai/dive/otel v1.21.0
+	github.com/deepnoodle-ai/dive/providers/google v1.21.0
+	github.com/deepnoodle-ai/dive/providers/grok v1.21.0
+	github.com/deepnoodle-ai/dive/providers/openai v1.21.0
 	github.com/deepnoodle-ai/wonton v0.0.37
 	github.com/fatih/color v1.19.0
 	github.com/mark3labs/mcp-go v0.57.0

--- a/experimental/cmd/dive/go.mod
+++ b/experimental/cmd/dive/go.mod
@@ -5,12 +5,13 @@ go 1.25.0
 toolchain go1.26.5
 
 require (
-	github.com/deepnoodle-ai/dive v1.20.0
-	github.com/deepnoodle-ai/dive/providers/google v1.20.0
-	github.com/deepnoodle-ai/dive/providers/grok v1.20.0
-	github.com/deepnoodle-ai/dive/providers/openai v1.20.0
+	github.com/deepnoodle-ai/dive v1.21.0
+	github.com/deepnoodle-ai/dive/providers/google v1.21.0
+	github.com/deepnoodle-ai/dive/providers/grok v1.21.0
+	github.com/deepnoodle-ai/dive/providers/openai v1.21.0
 	github.com/deepnoodle-ai/wonton v0.0.37
 	github.com/mattn/go-runewidth v0.0.27
+	google.golang.org/genai v1.67.0
 )
 
 require (
@@ -49,7 +50,6 @@ require (
 	golang.org/x/term v0.45.0 // indirect
 	golang.org/x/text v0.40.0 // indirect
 	google.golang.org/api v0.292.0 // indirect
-	google.golang.org/genai v1.67.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260807164820-c8921c73eeea // indirect
 	google.golang.org/grpc v1.83.0 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect

--- a/experimental/mcp/go.mod
+++ b/experimental/mcp/go.mod
@@ -5,7 +5,7 @@ go 1.25.5
 toolchain go1.26.5
 
 require (
-	github.com/deepnoodle-ai/dive v1.20.0
+	github.com/deepnoodle-ai/dive v1.21.0
 	github.com/deepnoodle-ai/wonton v0.0.37
 	github.com/mark3labs/mcp-go v0.57.0
 )

--- a/otel/go.mod
+++ b/otel/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 toolchain go1.26.5
 
 require (
-	github.com/deepnoodle-ai/dive v1.20.0
+	github.com/deepnoodle-ai/dive v1.21.0
 	go.opentelemetry.io/otel v1.45.0
 	go.opentelemetry.io/otel/metric v1.45.0
 	go.opentelemetry.io/otel/sdk v1.45.0

--- a/providers/google/go.mod
+++ b/providers/google/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 toolchain go1.26.5
 
 require (
-	github.com/deepnoodle-ai/dive v1.20.0
+	github.com/deepnoodle-ai/dive v1.21.0
 	github.com/deepnoodle-ai/wonton v0.0.37
 	google.golang.org/genai v1.67.0
 )

--- a/providers/grok/go.mod
+++ b/providers/grok/go.mod
@@ -5,8 +5,8 @@ go 1.25.0
 toolchain go1.26.5
 
 require (
-	github.com/deepnoodle-ai/dive v1.20.0
-	github.com/deepnoodle-ai/dive/providers/openai v1.20.0
+	github.com/deepnoodle-ai/dive v1.21.0
+	github.com/deepnoodle-ai/dive/providers/openai v1.21.0
 	github.com/deepnoodle-ai/wonton v0.0.37
 	github.com/openai/openai-go/v3 v3.50.0
 	golang.org/x/image v0.44.0

--- a/providers/openai/go.mod
+++ b/providers/openai/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 toolchain go1.26.5
 
 require (
-	github.com/deepnoodle-ai/dive v1.20.0
+	github.com/deepnoodle-ai/dive v1.21.0
 	github.com/deepnoodle-ai/wonton v0.0.37
 	github.com/openai/openai-go/v3 v3.50.0
 	golang.org/x/image v0.44.0


### PR DESCRIPTION
## Summary

- cut the existing Unreleased changelog as `v1.21.0` and leave a fresh Unreleased section
- point all eight tagged sub-modules and both demo modules at `v1.21.0`
- add reviewed GitHub release notes covering the six merged PRs since `v1.20.0`

## Why v1.21.0

Unknown-tool recovery intentionally changes observable caller behavior: a missing tool now returns a typed tool result instead of aborting `CreateResponse`. Together with the corrected `llm.Usage` bucket contract, that makes a minor release the appropriate boundary rather than a patch.

## Impact

The release notes call out the two caller migrations:

- inspect tool results with `errors.As` for `*dive.UnknownToolError` if the former hard error was used as a signal
- use `TotalInputTokens()` when total prompt input is needed, because `InputTokens` now excludes cache reads and writes

This PR prepares the release but does not publish it. After merge, the release sequence is:

```sh
git tag v1.21.0
make tag-modules VERSION=v1.21.0
git push origin --tags
make release-publish VERSION=v1.21.0
```

## Validation

- `make check` with external provider credentials unset
- `go vet ./...` and `go test ./...` in the root module, all eight tagged modules, and both demo modules
- `python3 scripts/release_notes.py v1.21.0 --check`
- `python3 scripts/sync_module_versions.py v1.21.0 --check`
- Prettier check for `docs/releases/v1.21.0.md`
- `git diff --check`