### PR TITLE
Preserve reasoning blocks across provider adapters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **Provider reasoning blocks now survive response copying, streaming, and
+  multi-turn replay.** Gemini preserves thought parts and positional thought
+  signatures (including signed text and empty parts); Mistral preserves its
+  structured thinking chunks; OpenRouter retains plaintext and structured
+  `reasoning_details`; and OpenAI Responses retains summaries, raw reasoning
+  text, reasoning item IDs, and encrypted content from streamed responses.
+
 ## [1.21.0] - 2026-08-10
 
 ### Fixed

--- a/llm/content.go
+++ b/llm/content.go
@@ -168,6 +168,9 @@ type TextContent struct {
 	Text         string        `json:"text"`
 	CacheControl *CacheControl `json:"cache_control,omitempty"`
 	Citations    []Citation    `json:"citations,omitempty"`
+	// Metadata carries opaque provider-specific data (see ProviderMetadata)
+	// that must remain attached to this exact text block when replayed.
+	Metadata ProviderMetadata `json:"metadata,omitempty"`
 }
 
 func (c *TextContent) Type() ContentType {
@@ -177,15 +180,17 @@ func (c *TextContent) Type() ContentType {
 func (c *TextContent) MarshalJSON() ([]byte, error) {
 	// Create a struct with Citations as json.RawMessage to handle custom marshaling
 	type TextWithRawCitations struct {
-		Text         string          `json:"text"`
-		CacheControl *CacheControl   `json:"cache_control,omitempty"`
-		Citations    json.RawMessage `json:"citations,omitempty"`
+		Text         string           `json:"text"`
+		CacheControl *CacheControl    `json:"cache_control,omitempty"`
+		Citations    json.RawMessage  `json:"citations,omitempty"`
+		Metadata     ProviderMetadata `json:"metadata,omitempty"`
 	}
 
 	// Start with base fields
 	twc := TextWithRawCitations{
 		Text:         c.Text,
 		CacheControl: c.CacheControl,
+		Metadata:     c.Metadata,
 	}
 
 	// Marshal Citations if present
@@ -214,6 +219,7 @@ func (c *TextContent) SetCacheControl(cacheControl *CacheControl) {
 func (c *TextContent) CloneContent() Content {
 	cp := *c
 	cp.CacheControl = nil
+	cp.Metadata = c.Metadata.Clone()
 	return &cp
 }
 
@@ -809,6 +815,15 @@ type ThinkingContent struct {
 	ID        string `json:"id,omitempty"`
 	Thinking  string `json:"thinking"`
 	Signature string `json:"signature,omitempty"`
+	// Metadata carries provider-specific replay state that cannot safely use
+	// Signature because its wire meaning differs between providers.
+	Metadata ProviderMetadata `json:"metadata,omitempty"`
+}
+
+func (c *ThinkingContent) CloneContent() Content {
+	cp := *c
+	cp.Metadata = c.Metadata.Clone()
+	return &cp
 }
 
 func (c *ThinkingContent) Type() ContentType {
@@ -1355,15 +1370,17 @@ func UnmarshalContent(data []byte) (Content, error) {
 	case ContentTypeText:
 		text := &TextContent{}
 		type textContent struct {
-			Text         string          `json:"text"`
-			CacheControl *CacheControl   `json:"cache_control"`
-			Citations    json.RawMessage `json:"citations"`
+			Text         string           `json:"text"`
+			CacheControl *CacheControl    `json:"cache_control"`
+			Citations    json.RawMessage  `json:"citations"`
+			Metadata     ProviderMetadata `json:"metadata"`
 		}
 		var tc textContent
 		if err := json.Unmarshal(data, &tc); err != nil {
 			return nil, err
 		}
 		text.Text = tc.Text
+		text.Metadata = tc.Metadata
 		if tc.CacheControl != nil {
 			text.CacheControl = tc.CacheControl
 		}

--- a/llm/content_test.go
+++ b/llm/content_test.go
@@ -700,8 +700,11 @@ func TestThinkingContent(t *testing.T) {
 				content: &ThinkingContent{
 					Thinking:  "Let me analyze this step by step...",
 					Signature: "signature123",
+					Metadata: ProviderMetadata{
+						"example.replay_state": "opaque",
+					},
 				},
-				expected: `{"type":"thinking","thinking":"Let me analyze this step by step...","signature":"signature123"}`,
+				expected: `{"type":"thinking","thinking":"Let me analyze this step by step...","signature":"signature123","metadata":{"example.replay_state":"opaque"}}`,
 			},
 			{
 				name: "empty thinking",
@@ -766,13 +769,33 @@ func TestCloneContent(t *testing.T) {
 	cc := &CacheControl{Type: CacheControlTypeEphemeral}
 
 	t.Run("TextContent", func(t *testing.T) {
-		orig := &TextContent{Text: "hello", CacheControl: cc, Citations: []Citation{&MockCitation{Text: "cite"}}}
+		orig := &TextContent{
+			Text:         "hello",
+			CacheControl: cc,
+			Citations:    []Citation{&MockCitation{Text: "cite"}},
+			Metadata:     ProviderMetadata{"example.state": "opaque"},
+		}
 		clone := orig.CloneContent()
 		cloned := clone.(*TextContent)
 		assert.True(t, orig != cloned)
 		assert.Equal(t, "hello", cloned.Text)
 		assert.Nil(t, cloned.CacheControl)
 		assert.Len(t, cloned.Citations, 1)
+		assert.Equal(t, "opaque", cloned.Metadata["example.state"])
+		cloned.Metadata["example.state"] = "changed"
+		assert.Equal(t, "opaque", orig.Metadata["example.state"])
+	})
+
+	t.Run("ThinkingContent", func(t *testing.T) {
+		orig := &ThinkingContent{
+			Thinking: "reasoning",
+			Metadata: ProviderMetadata{"example.state": "opaque"},
+		}
+		cloned := orig.CloneContent().(*ThinkingContent)
+		assert.True(t, orig != cloned)
+		assert.Equal(t, "opaque", cloned.Metadata["example.state"])
+		cloned.Metadata["example.state"] = "changed"
+		assert.Equal(t, "opaque", orig.Metadata["example.state"])
 	})
 
 	t.Run("RefusalContent", func(t *testing.T) {

--- a/llm/stream.go
+++ b/llm/stream.go
@@ -59,19 +59,21 @@ const (
 	EventDeltaTypeInputJSON EventDeltaType = "input_json_delta"
 	EventDeltaTypeThinking  EventDeltaType = "thinking_delta"
 	EventDeltaTypeSignature EventDeltaType = "signature_delta"
+	EventDeltaTypeMetadata  EventDeltaType = "metadata_delta"
 	EventDeltaTypeCitations EventDeltaType = "citations_delta"
 )
 
 // EventDelta carries a portion of an LLM response.
 type EventDelta struct {
-	Type         EventDeltaType `json:"type,omitempty"`
-	Text         string         `json:"text,omitempty"`
-	Index        int            `json:"index,omitempty"`
-	StopReason   string         `json:"stop_reason,omitempty"`
-	StopSequence string         `json:"stop_sequence,omitempty"`
-	PartialJSON  string         `json:"partial_json,omitempty"`
-	Thinking     string         `json:"thinking,omitempty"`
-	Signature    string         `json:"signature,omitempty"`
+	Type         EventDeltaType   `json:"type,omitempty"`
+	Text         string           `json:"text,omitempty"`
+	Index        int              `json:"index,omitempty"`
+	StopReason   string           `json:"stop_reason,omitempty"`
+	StopSequence string           `json:"stop_sequence,omitempty"`
+	PartialJSON  string           `json:"partial_json,omitempty"`
+	Thinking     string           `json:"thinking,omitempty"`
+	Signature    string           `json:"signature,omitempty"`
+	Metadata     ProviderMetadata `json:"metadata,omitempty"`
 }
 
 // ResponseAccumulator builds up a complete response from a stream of events.
@@ -111,7 +113,8 @@ func (r *ResponseAccumulator) AddEvent(event *Event) error {
 		switch event.ContentBlock.Type {
 		case ContentTypeText:
 			content = &TextContent{
-				Text: event.ContentBlock.Text,
+				Text:     event.ContentBlock.Text,
+				Metadata: event.ContentBlock.Metadata.Clone(),
 			}
 		case ContentTypeToolUse:
 			content = &ToolUseContent{
@@ -121,8 +124,10 @@ func (r *ResponseAccumulator) AddEvent(event *Event) error {
 			}
 		case ContentTypeThinking:
 			content = &ThinkingContent{
+				ID:        event.ContentBlock.ID,
 				Thinking:  event.ContentBlock.Thinking,
 				Signature: event.ContentBlock.Signature,
+				Metadata:  event.ContentBlock.Metadata.Clone(),
 			}
 		case ContentTypeRedactedThinking:
 			content = &RedactedThinkingContent{}
@@ -181,6 +186,10 @@ func (r *ResponseAccumulator) AddEvent(event *Event) error {
 			} else {
 				return errors.New("in-progress block is not a thinking content")
 			}
+		case EventDeltaTypeMetadata:
+			if err := mergeContentMetadata(content, event.Delta.Metadata); err != nil {
+				return err
+			}
 		}
 
 	case EventTypeMessageDelta:
@@ -218,6 +227,30 @@ func (r *ResponseAccumulator) AddEvent(event *Event) error {
 	// after usage accumulation, so the final token counts are reflected.
 	if r.complete && r.response != nil {
 		PopulateCost(r.response.Model, r.response.Usage.Speed == string(SpeedFast), &r.response.Usage)
+	}
+	return nil
+}
+
+func mergeContentMetadata(content Content, metadata ProviderMetadata) error {
+	if len(metadata) == 0 {
+		return nil
+	}
+	var target *ProviderMetadata
+	switch typed := content.(type) {
+	case *TextContent:
+		target = &typed.Metadata
+	case *ThinkingContent:
+		target = &typed.Metadata
+	case *ToolUseContent:
+		target = &typed.Metadata
+	default:
+		return errors.New("in-progress block does not support provider metadata")
+	}
+	if *target == nil {
+		*target = make(ProviderMetadata, len(metadata))
+	}
+	for key, value := range metadata {
+		(*target)[key] = value
 	}
 	return nil
 }

--- a/llm/stream_test.go
+++ b/llm/stream_test.go
@@ -150,3 +150,81 @@ func TestResponseAccumulatorPreservesOmittedThinkingSignature(t *testing.T) {
 	assert.True(t, ok)
 	assert.Equal(t, "done", text.Text)
 }
+
+func TestResponseAccumulatorMergesProviderMetadataDelta(t *testing.T) {
+	acc := NewResponseAccumulator()
+	index := 0
+	assert.NoError(t, acc.AddEvent(&Event{
+		Type:    EventTypeMessageStart,
+		Message: &Response{ID: "msg_1", Role: Assistant},
+	}))
+	assert.NoError(t, acc.AddEvent(&Event{
+		Type:  EventTypeContentBlockStart,
+		Index: &index,
+		ContentBlock: &EventContentBlock{
+			Type:     ContentTypeThinking,
+			Metadata: ProviderMetadata{"provider.initial": "true"},
+		},
+	}))
+	assert.NoError(t, acc.AddEvent(&Event{
+		Type:  EventTypeContentBlockDelta,
+		Index: &index,
+		Delta: &EventDelta{
+			Type: EventDeltaTypeMetadata,
+			Metadata: ProviderMetadata{
+				"provider.initial": "updated",
+				"provider.detail":  "preserved",
+			},
+		},
+	}))
+	assert.NoError(t, acc.AddEvent(&Event{Type: EventTypeMessageStop}))
+
+	thinking := acc.Response().Content[0].(*ThinkingContent)
+	assert.Equal(t, "updated", thinking.Metadata["provider.initial"])
+	assert.Equal(t, "preserved", thinking.Metadata["provider.detail"])
+}
+
+func TestResponseAccumulatorPreservesContentMetadataAndThinkingID(t *testing.T) {
+	acc := NewResponseAccumulator()
+	textIndex, thinkingIndex := 0, 1
+
+	assert.NoError(t, acc.AddEvent(&Event{
+		Type:    EventTypeMessageStart,
+		Message: &Response{ID: "msg_1", Role: Assistant},
+	}))
+	assert.NoError(t, acc.AddEvent(&Event{
+		Type:  EventTypeContentBlockStart,
+		Index: &textIndex,
+		ContentBlock: &EventContentBlock{
+			Type:     ContentTypeText,
+			Metadata: ProviderMetadata{"google.thought_signature": "text-sig"},
+		},
+	}))
+	assert.NoError(t, acc.AddEvent(&Event{
+		Type:  EventTypeContentBlockDelta,
+		Index: &textIndex,
+		Delta: &EventDelta{Type: EventDeltaTypeText, Text: "answer"},
+	}))
+	assert.NoError(t, acc.AddEvent(&Event{
+		Type:  EventTypeContentBlockStart,
+		Index: &thinkingIndex,
+		ContentBlock: &EventContentBlock{
+			Type:     ContentTypeThinking,
+			ID:       "rs_123",
+			Metadata: ProviderMetadata{"google.thought": "true"},
+		},
+	}))
+	assert.NoError(t, acc.AddEvent(&Event{
+		Type:  EventTypeContentBlockDelta,
+		Index: &thinkingIndex,
+		Delta: &EventDelta{Type: EventDeltaTypeThinking, Thinking: "summary"},
+	}))
+	assert.NoError(t, acc.AddEvent(&Event{Type: EventTypeMessageStop}))
+
+	response := acc.Response()
+	text := response.Content[0].(*TextContent)
+	assert.Equal(t, "text-sig", text.Metadata["google.thought_signature"])
+	thinking := response.Content[1].(*ThinkingContent)
+	assert.Equal(t, "rs_123", thinking.ID)
+	assert.Equal(t, "true", thinking.Metadata["google.thought"])
+}

--- a/providers/anthropic/anthropic.go
+++ b/providers/anthropic/anthropic.go
@@ -257,6 +257,22 @@ func convertMessages(messages []*llm.Message) ([]*llm.Message, error) {
 		var copiedContent []llm.Content
 		for _, content := range message.Content {
 			switch c := content.(type) {
+			case *llm.TextContent:
+				text := c.CloneContent().(*llm.TextContent)
+				text.Metadata = nil
+				copiedContent = append(copiedContent, text)
+			case *llm.ToolUseContent:
+				toolUse := c.CloneContent().(*llm.ToolUseContent)
+				toolUse.Metadata = nil
+				copiedContent = append(copiedContent, toolUse)
+			case *llm.ThinkingContent:
+				// Anthropic thinking blocks have no item ID or provider metadata.
+				// Skip reasoning captured from another provider instead of leaking
+				// its opaque replay fields into the Anthropic wire format.
+				if c.ID != "" || len(c.Metadata) > 0 {
+					continue
+				}
+				copiedContent = append(copiedContent, c.CloneContent())
 			case *llm.ToolResultContent:
 				copiedContent = append(copiedContent, &llm.ToolResultContent{
 					Content:      convertToolResultBlocks(c),
@@ -296,10 +312,19 @@ func convertMessages(messages []*llm.Message) ([]*llm.Message, error) {
 			Content: copiedContent,
 		}
 	}
+	nonEmpty := copied[:0]
+	for _, message := range copied {
+		if len(message.Content) > 0 {
+			nonEmpty = append(nonEmpty, message)
+		}
+	}
+	if len(nonEmpty) == 0 {
+		return nil, fmt.Errorf("all messages are empty after provider conversion")
+	}
 	// Workaround for Anthropic bug. Run on the copies so the caller's
 	// messages are not mutated.
-	reorderMessageContent(copied)
-	return copied, nil
+	reorderMessageContent(nonEmpty)
+	return nonEmpty, nil
 }
 
 // convertToolResultBlocks renders tool_result content in the Anthropic wire

--- a/providers/anthropic/util_test.go
+++ b/providers/anthropic/util_test.go
@@ -38,3 +38,47 @@ func TestConvertMessagesDoesNotMutateCaller(t *testing.T) {
 	assert.Equal(t, copied[1].Content[0].Type(), llm.ContentTypeText)
 	assert.Equal(t, copied[1].Content[1].Type(), llm.ContentTypeToolUse)
 }
+
+func TestConvertMessagesKeepsProviderMetadataOutOfAnthropicWire(t *testing.T) {
+	messages := []*llm.Message{{
+		Role: llm.Assistant,
+		Content: []llm.Content{
+			&llm.ThinkingContent{
+				Thinking: "Gemini summary",
+				Metadata: llm.ProviderMetadata{"google.thought": "true"},
+			},
+			&llm.TextContent{
+				Text:     "answer",
+				Metadata: llm.ProviderMetadata{"google.thought_signature": "signature"},
+			},
+			&llm.ToolUseContent{
+				ID:       "call_1",
+				Name:     "lookup",
+				Input:    []byte(`{}`),
+				Metadata: llm.ProviderMetadata{"google.thought_signature": "signature"},
+			},
+			&llm.ThinkingContent{
+				Thinking:  "Anthropic thought",
+				Signature: "anthropic-signature",
+			},
+		},
+	}}
+
+	converted, err := convertMessages(messages)
+	assert.NoError(t, err)
+	assert.Len(t, converted, 1)
+	assert.Len(t, converted[0].Content, 3)
+
+	text := converted[0].Content[0].(*llm.TextContent)
+	assert.Nil(t, text.Metadata)
+	thinking := converted[0].Content[1].(*llm.ThinkingContent)
+	assert.Equal(t, "Anthropic thought", thinking.Thinking)
+	assert.Nil(t, thinking.Metadata)
+	toolUse := converted[0].Content[2].(*llm.ToolUseContent)
+	assert.Nil(t, toolUse.Metadata)
+
+	// The durable caller-owned blocks retain their originating provider state.
+	assert.NotNil(t, messages[0].Content[0].(*llm.ThinkingContent).Metadata)
+	assert.NotNil(t, messages[0].Content[1].(*llm.TextContent).Metadata)
+	assert.NotNil(t, messages[0].Content[2].(*llm.ToolUseContent).Metadata)
+}

--- a/providers/google/stream_iterator.go
+++ b/providers/google/stream_iterator.go
@@ -188,17 +188,16 @@ func (s *StreamIterator) processChunk(response *genai.GenerateContentResponse) e
 	}
 
 	for _, part := range candidate.Content.Parts {
+		metadata := providerMetadataForGooglePart(part)
 		switch {
 		case part.FunctionCall != nil:
 			if err := s.queueFunctionCall(part); err != nil {
 				return err
 			}
-		case part.Text != "":
-			if part.Thought {
-				s.queueThinking(part.Text)
-				continue
-			}
-			s.queueText(part.Text)
+		case part.Thought:
+			s.queueThinking(part.Text, metadata)
+		case part.Text != "" || metadata != nil:
+			s.queueText(part.Text, metadata)
 		}
 	}
 	return nil
@@ -207,8 +206,13 @@ func (s *StreamIterator) processChunk(response *genai.GenerateContentResponse) e
 // queueThinking emits a thinking delta, opening a new thinking content block if
 // needed. Gemini flags thought summaries on otherwise ordinary text parts, so
 // they are separated here rather than being folded into the answer.
-func (s *StreamIterator) queueThinking(text string) {
+func (s *StreamIterator) queueThinking(text string, metadata llm.ProviderMetadata) {
 	s.closeTextBlock()
+	// A signature is positional metadata for one exact Gemini Part. Do not
+	// merge that signed part into an already-open unsigned thinking block.
+	if metadata[googleThoughtSignatureMetadataKey] != "" {
+		s.closeThinkingBlock()
+	}
 	if s.thinkingBlockIdx < 0 {
 		index := s.nextBlockIndex
 		s.nextBlockIndex++
@@ -217,9 +221,13 @@ func (s *StreamIterator) queueThinking(text string) {
 			Type:  llm.EventTypeContentBlockStart,
 			Index: &index,
 			ContentBlock: &llm.EventContentBlock{
-				Type: llm.ContentTypeThinking,
+				Type:     llm.ContentTypeThinking,
+				Metadata: metadata.Clone(),
 			},
 		})
+	}
+	if text == "" {
+		return
 	}
 	index := s.thinkingBlockIdx
 	s.eventQueue = append(s.eventQueue, &llm.Event{
@@ -233,8 +241,13 @@ func (s *StreamIterator) queueThinking(text string) {
 }
 
 // queueText emits a text delta, opening a new text content block if needed.
-func (s *StreamIterator) queueText(text string) {
+func (s *StreamIterator) queueText(text string, metadata llm.ProviderMetadata) {
 	s.closeThinkingBlock()
+	// Google warns that signed and unsigned Parts must not be merged. A signed
+	// text/empty part therefore gets its own canonical block.
+	if metadata[googleThoughtSignatureMetadataKey] != "" {
+		s.closeTextBlock()
+	}
 	if s.textBlockIndex < 0 {
 		index := s.nextBlockIndex
 		s.nextBlockIndex++
@@ -243,9 +256,13 @@ func (s *StreamIterator) queueText(text string) {
 			Type:  llm.EventTypeContentBlockStart,
 			Index: &index,
 			ContentBlock: &llm.EventContentBlock{
-				Type: llm.ContentTypeText,
+				Type:     llm.ContentTypeText,
+				Metadata: metadata.Clone(),
 			},
 		})
+	}
+	if text == "" {
+		return
 	}
 	index := s.textBlockIndex
 	s.eventQueue = append(s.eventQueue, &llm.Event{

--- a/providers/google/stream_iterator.go
+++ b/providers/google/stream_iterator.go
@@ -35,12 +35,14 @@ type StreamIterator struct {
 	started      bool
 
 	// Event generation state
-	messageStartSent bool
-	nextBlockIndex   int
-	textBlockIndex   int // index of the open text block, or -1 if none
-	thinkingBlockIdx int // index of the open thinking block, or -1 if none
-	usage            *genai.GenerateContentResponseUsageMetadata
-	finishReason     genai.FinishReason
+	messageStartSent    bool
+	nextBlockIndex      int
+	textBlockIndex      int // index of the open text block, or -1 if none
+	thinkingBlockIdx    int // index of the open thinking block, or -1 if none
+	textBlockSigned     bool
+	thinkingBlockSigned bool
+	usage               *genai.GenerateContentResponseUsageMetadata
+	finishReason        genai.FinishReason
 
 	mu sync.Mutex
 }
@@ -208,15 +210,17 @@ func (s *StreamIterator) processChunk(response *genai.GenerateContentResponse) e
 // they are separated here rather than being folded into the answer.
 func (s *StreamIterator) queueThinking(text string, metadata llm.ProviderMetadata) {
 	s.closeTextBlock()
+	signed := metadata[googleThoughtSignatureMetadataKey] != ""
 	// A signature is positional metadata for one exact Gemini Part. Do not
-	// merge that signed part into an already-open unsigned thinking block.
-	if metadata[googleThoughtSignatureMetadataKey] != "" {
+	// merge signed and unsigned parts, or two independently signed parts.
+	if signed || (s.thinkingBlockIdx >= 0 && signed != s.thinkingBlockSigned) {
 		s.closeThinkingBlock()
 	}
 	if s.thinkingBlockIdx < 0 {
 		index := s.nextBlockIndex
 		s.nextBlockIndex++
 		s.thinkingBlockIdx = index
+		s.thinkingBlockSigned = signed
 		s.eventQueue = append(s.eventQueue, &llm.Event{
 			Type:  llm.EventTypeContentBlockStart,
 			Index: &index,
@@ -243,15 +247,17 @@ func (s *StreamIterator) queueThinking(text string, metadata llm.ProviderMetadat
 // queueText emits a text delta, opening a new text content block if needed.
 func (s *StreamIterator) queueText(text string, metadata llm.ProviderMetadata) {
 	s.closeThinkingBlock()
+	signed := metadata[googleThoughtSignatureMetadataKey] != ""
 	// Google warns that signed and unsigned Parts must not be merged. A signed
 	// text/empty part therefore gets its own canonical block.
-	if metadata[googleThoughtSignatureMetadataKey] != "" {
+	if signed || (s.textBlockIndex >= 0 && signed != s.textBlockSigned) {
 		s.closeTextBlock()
 	}
 	if s.textBlockIndex < 0 {
 		index := s.nextBlockIndex
 		s.nextBlockIndex++
 		s.textBlockIndex = index
+		s.textBlockSigned = signed
 		s.eventQueue = append(s.eventQueue, &llm.Event{
 			Type:  llm.EventTypeContentBlockStart,
 			Index: &index,
@@ -335,6 +341,7 @@ func (s *StreamIterator) closeThinkingBlock() {
 	}
 	index := s.thinkingBlockIdx
 	s.thinkingBlockIdx = -1
+	s.thinkingBlockSigned = false
 	s.eventQueue = append(s.eventQueue, &llm.Event{
 		Type:  llm.EventTypeContentBlockStop,
 		Index: &index,
@@ -348,6 +355,7 @@ func (s *StreamIterator) closeTextBlock() {
 	}
 	index := s.textBlockIndex
 	s.textBlockIndex = -1
+	s.textBlockSigned = false
 	s.eventQueue = append(s.eventQueue, &llm.Event{
 		Type:  llm.EventTypeContentBlockStop,
 		Index: &index,

--- a/providers/google/stream_iterator_test.go
+++ b/providers/google/stream_iterator_test.go
@@ -340,6 +340,56 @@ func TestStreamIteratorPreservesSignedThinkingAndEmptyTextParts(t *testing.T) {
 	assert.Equal(t, textSignature, contents[0].Parts[3].ThoughtSignature)
 }
 
+func TestStreamIteratorSeparatesSignedToUnsignedParts(t *testing.T) {
+	tests := []struct {
+		name    string
+		thought bool
+	}{
+		{name: "thinking", thought: true},
+		{name: "text", thought: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			signature := []byte("signed-part")
+			chunks := chunkSeq(
+				&genai.GenerateContentResponse{Candidates: []*genai.Candidate{{
+					Content: &genai.Content{Parts: []*genai.Part{{
+						Text: "signed", Thought: tt.thought, ThoughtSignature: signature,
+					}}},
+				}}},
+				&genai.GenerateContentResponse{Candidates: []*genai.Candidate{{
+					Content:      &genai.Content{Parts: []*genai.Part{{Text: "unsigned", Thought: tt.thought}}},
+					FinishReason: genai.FinishReasonStop,
+				}}},
+			)
+
+			iterator := NewStreamIteratorFromSeq(context.Background(), chunks, ModelGemini36Flash)
+			t.Cleanup(func() { assert.NoError(t, iterator.Close()) })
+			_, accumulator := collectStreamEvents(t, iterator)
+			response := accumulator.Response()
+			assert.Len(t, response.Content, 2)
+
+			if tt.thought {
+				first := response.Content[0].(*llm.ThinkingContent)
+				second := response.Content[1].(*llm.ThinkingContent)
+				assert.Equal(t, "signed", first.Thinking)
+				assert.Equal(t, "unsigned", second.Thinking)
+				assert.Equal(t, base64.StdEncoding.EncodeToString(signature),
+					first.Metadata[googleThoughtSignatureMetadataKey])
+				assert.Empty(t, second.Metadata[googleThoughtSignatureMetadataKey])
+			} else {
+				first := response.Content[0].(*llm.TextContent)
+				second := response.Content[1].(*llm.TextContent)
+				assert.Equal(t, "signed", first.Text)
+				assert.Equal(t, "unsigned", second.Text)
+				assert.Equal(t, base64.StdEncoding.EncodeToString(signature),
+					first.Metadata[googleThoughtSignatureMetadataKey])
+				assert.Empty(t, second.Metadata[googleThoughtSignatureMetadataKey])
+			}
+		})
+	}
+}
+
 func TestStreamIteratorStreamError(t *testing.T) {
 	seq := func(yield func(*genai.GenerateContentResponse, error) bool) {
 		if !yield(textChunk("partial"), nil) {

--- a/providers/google/stream_iterator_test.go
+++ b/providers/google/stream_iterator_test.go
@@ -2,6 +2,7 @@ package google
 
 import (
 	"context"
+	"encoding/base64"
 	"errors"
 	"iter"
 	"strings"
@@ -289,6 +290,54 @@ func TestStreamIteratorMaxTokensStopReason(t *testing.T) {
 	_, accumulator := collectStreamEvents(t, iterator)
 	assert.True(t, accumulator.IsComplete())
 	assert.Equal(t, "max_tokens", accumulator.Response().StopReason)
+}
+
+func TestStreamIteratorPreservesSignedThinkingAndEmptyTextParts(t *testing.T) {
+	thoughtSignature := []byte("thought-sig")
+	textSignature := []byte("text-sig")
+	chunks := chunkSeq(
+		&genai.GenerateContentResponse{Candidates: []*genai.Candidate{{
+			Content: &genai.Content{Parts: []*genai.Part{{Text: "thinking ", Thought: true}}},
+		}}},
+		&genai.GenerateContentResponse{Candidates: []*genai.Candidate{{
+			Content: &genai.Content{Parts: []*genai.Part{{
+				Text: "summary", Thought: true, ThoughtSignature: thoughtSignature,
+			}}},
+		}}},
+		&genai.GenerateContentResponse{Candidates: []*genai.Candidate{{
+			Content: &genai.Content{Parts: []*genai.Part{{Text: "answer"}}},
+		}}},
+		&genai.GenerateContentResponse{Candidates: []*genai.Candidate{{
+			Content:      &genai.Content{Parts: []*genai.Part{{ThoughtSignature: textSignature}}},
+			FinishReason: genai.FinishReasonStop,
+		}}},
+	)
+
+	iterator := NewStreamIteratorFromSeq(context.Background(), chunks, ModelGemini36Flash)
+	t.Cleanup(func() { assert.NoError(t, iterator.Close()) })
+	_, accumulator := collectStreamEvents(t, iterator)
+	response := accumulator.Response()
+	assert.Len(t, response.Content, 4)
+
+	firstThought := response.Content[0].(*llm.ThinkingContent)
+	assert.Equal(t, "thinking ", firstThought.Thinking)
+	assert.Equal(t, "true", firstThought.Metadata[googleThoughtMetadataKey])
+	secondThought := response.Content[1].(*llm.ThinkingContent)
+	assert.Equal(t, "summary", secondThought.Thinking)
+	assert.Equal(t, base64.StdEncoding.EncodeToString(thoughtSignature),
+		secondThought.Metadata[googleThoughtSignatureMetadataKey])
+	answer := response.Content[2].(*llm.TextContent)
+	assert.Equal(t, "answer", answer.Text)
+	empty := response.Content[3].(*llm.TextContent)
+	assert.Equal(t, "", empty.Text)
+	assert.Equal(t, base64.StdEncoding.EncodeToString(textSignature),
+		empty.Metadata[googleThoughtSignatureMetadataKey])
+
+	contents, err := messagesToContents([]*llm.Message{response.Message().Copy()})
+	assert.NoError(t, err)
+	assert.Len(t, contents[0].Parts, 4)
+	assert.Equal(t, thoughtSignature, contents[0].Parts[1].ThoughtSignature)
+	assert.Equal(t, textSignature, contents[0].Parts[3].ThoughtSignature)
 }
 
 func TestStreamIteratorStreamError(t *testing.T) {

--- a/providers/google/util.go
+++ b/providers/google/util.go
@@ -15,7 +15,10 @@ import (
 	"google.golang.org/genai"
 )
 
-const googleThoughtSignatureMetadataKey = "google.thought_signature"
+const (
+	googleThoughtMetadataKey          = "google.thought"
+	googleThoughtSignatureMetadataKey = "google.thought_signature"
+)
 
 // convertGoogleResponse converts a Google GenAI response to a Dive LLM response
 func convertGoogleResponse(resp *genai.GenerateContentResponse, model string) (*llm.Response, error) {
@@ -31,15 +34,22 @@ func convertGoogleResponse(resp *genai.GenerateContentResponse, model string) (*
 	// Convert parts to Dive content
 	var content []llm.Content
 	for _, part := range candidate.Content.Parts {
-		if part.Text != "" {
+		metadata := providerMetadataForGooglePart(part)
+		if part.Text != "" || (part.FunctionCall == nil && metadata != nil) {
 			// Thought summaries arrive as text parts flagged Thought. Emitting
 			// them as TextContent would splice the model's reasoning into its
 			// answer.
 			if part.Thought {
-				content = append(content, &llm.ThinkingContent{Thinking: part.Text})
+				content = append(content, &llm.ThinkingContent{
+					Thinking: part.Text,
+					Metadata: metadata,
+				})
 				continue
 			}
-			content = append(content, &llm.TextContent{Text: part.Text})
+			content = append(content, &llm.TextContent{
+				Text:     part.Text,
+				Metadata: metadata,
+			})
 		} else if part.FunctionCall != nil {
 			// Handle function calls - convert args to JSON
 			args, err := json.Marshal(part.FunctionCall.Args)
@@ -354,27 +364,60 @@ func convertToolResultToFunctionResponse(content *llm.ToolResultContent, functio
 }
 
 func providerMetadataForGooglePart(part *genai.Part) llm.ProviderMetadata {
-	if part == nil || len(part.ThoughtSignature) == 0 {
+	if part == nil {
 		return nil
 	}
-	return llm.ProviderMetadata{
-		googleThoughtSignatureMetadataKey: base64.StdEncoding.EncodeToString(part.ThoughtSignature),
+	metadata := llm.ProviderMetadata{}
+	if part.Thought {
+		metadata[googleThoughtMetadataKey] = "true"
 	}
+	if len(part.ThoughtSignature) > 0 {
+		metadata[googleThoughtSignatureMetadataKey] = base64.StdEncoding.EncodeToString(part.ThoughtSignature)
+	}
+	if len(metadata) == 0 {
+		return nil
+	}
+	return metadata
 }
 
-func googleThoughtSignatureFromToolUse(toolUse *llm.ToolUseContent) ([]byte, error) {
-	if toolUse == nil || toolUse.Metadata == nil {
+func googleThoughtSignatureFromMetadata(metadata llm.ProviderMetadata, label string) ([]byte, error) {
+	if metadata == nil {
 		return nil, nil
 	}
-	encoded := strings.TrimSpace(toolUse.Metadata[googleThoughtSignatureMetadataKey])
+	encoded := strings.TrimSpace(metadata[googleThoughtSignatureMetadataKey])
 	if encoded == "" {
 		return nil, nil
 	}
 	signature, err := base64.StdEncoding.DecodeString(encoded)
 	if err != nil {
-		return nil, fmt.Errorf("invalid Google thought signature for tool %q: %w", toolUse.Name, err)
+		return nil, fmt.Errorf("invalid Google thought signature for %s: %w", label, err)
 	}
 	return signature, nil
+}
+
+func googleThoughtSignatureFromToolUse(toolUse *llm.ToolUseContent) ([]byte, error) {
+	if toolUse == nil {
+		return nil, nil
+	}
+	return googleThoughtSignatureFromMetadata(toolUse.Metadata, fmt.Sprintf("tool %q", toolUse.Name))
+}
+
+func googlePartFromText(text string, thought bool, metadata llm.ProviderMetadata) (*genai.Part, error) {
+	part := &genai.Part{Text: text, Thought: thought}
+	signature, err := googleThoughtSignatureFromMetadata(metadata, "text part")
+	if err != nil {
+		return nil, err
+	}
+	part.ThoughtSignature = signature
+	return part, nil
+}
+
+func isGoogleThinkingContent(content *llm.ThinkingContent) bool {
+	if content == nil || content.Metadata == nil {
+		return false
+	}
+	return content.Metadata[googleThoughtMetadataKey] == "true" ||
+		content.Metadata[googleThoughtSignatureMetadataKey] != ""
 }
 
 // messagesToContents converts Dive messages to genai.Content format for GenerateContent API
@@ -404,7 +447,11 @@ func messagesToContents(messages []*llm.Message) ([]*genai.Content, error) {
 		for _, c := range message.Content {
 			switch ct := c.(type) {
 			case *llm.TextContent:
-				content.Parts = append(content.Parts, genai.NewPartFromText(ct.Text))
+				part, err := googlePartFromText(ct.Text, false, ct.Metadata)
+				if err != nil {
+					return nil, err
+				}
+				content.Parts = append(content.Parts, part)
 			case *llm.ImageContent:
 				if ct.Source == nil {
 					return nil, fmt.Errorf("image content has nil source")
@@ -475,10 +522,21 @@ func messagesToContents(messages []*llm.Message) ([]*genai.Content, error) {
 					return nil, err
 				}
 				content.Parts = append(content.Parts, part)
-			case *llm.ThinkingContent, *llm.RedactedThinkingContent:
-				// Gemini has no field for replaying another model's reasoning,
-				// so thinking blocks (e.g. from a session started on Anthropic)
-				// are skipped on encode rather than erroring.
+			case *llm.ThinkingContent:
+				// Only replay thinking that originated from Gemini. Sending an
+				// Anthropic/OpenAI signature in a Gemini Part would corrupt the
+				// provider-specific reasoning state.
+				if !isGoogleThinkingContent(ct) {
+					continue
+				}
+				part, err := googlePartFromText(ct.Thinking, true, ct.Metadata)
+				if err != nil {
+					return nil, err
+				}
+				content.Parts = append(content.Parts, part)
+			case *llm.RedactedThinkingContent:
+				// RedactedThinkingContent is an Anthropic wire type. It has no
+				// safe Gemini representation and is intentionally skipped.
 			default:
 				return nil, fmt.Errorf("unsupported content type for google provider: %s", c.Type())
 			}

--- a/providers/google/util.go
+++ b/providers/google/util.go
@@ -541,7 +541,13 @@ func messagesToContents(messages []*llm.Message) ([]*genai.Content, error) {
 				return nil, fmt.Errorf("unsupported content type for google provider: %s", c.Type())
 			}
 		}
+		if len(content.Parts) == 0 {
+			continue
+		}
 		contents = append(contents, content)
+	}
+	if len(contents) == 0 {
+		return nil, fmt.Errorf("no messages remain after filtering unsupported content")
 	}
 
 	return contents, nil

--- a/providers/google/util_test.go
+++ b/providers/google/util_test.go
@@ -319,3 +319,73 @@ func TestGoogleThoughtSignatureSurvivesMessageRoundTrip(t *testing.T) {
 	assert.Len(t, contents, 2)
 	assert.Equal(t, signature, contents[0].Parts[0].ThoughtSignature)
 }
+
+func TestGoogleTextAndThinkingPartsSurviveMessageRoundTrip(t *testing.T) {
+	thoughtSignature := []byte("opaque-thought-signature")
+	textSignature := []byte("opaque-text-signature")
+	emptySignature := []byte("opaque-empty-signature")
+	resp := &genai.GenerateContentResponse{
+		Candidates: []*genai.Candidate{{
+			Content: &genai.Content{
+				Role: "model",
+				Parts: []*genai.Part{
+					{Text: "working it out", Thought: true, ThoughtSignature: thoughtSignature},
+					{Text: "answer", ThoughtSignature: textSignature},
+					{ThoughtSignature: emptySignature},
+				},
+			},
+		}},
+	}
+
+	converted, err := convertGoogleResponse(resp, ModelGemini36Flash)
+	assert.NoError(t, err)
+	assert.Len(t, converted.Content, 3)
+
+	thought, ok := converted.Content[0].(*llm.ThinkingContent)
+	assert.True(t, ok)
+	assert.Equal(t, "working it out", thought.Thinking)
+	assert.Equal(t, "true", thought.Metadata[googleThoughtMetadataKey])
+	assert.Equal(t, base64.StdEncoding.EncodeToString(thoughtSignature),
+		thought.Metadata[googleThoughtSignatureMetadataKey])
+
+	answer, ok := converted.Content[1].(*llm.TextContent)
+	assert.True(t, ok)
+	assert.Equal(t, "answer", answer.Text)
+	assert.Equal(t, base64.StdEncoding.EncodeToString(textSignature),
+		answer.Metadata[googleThoughtSignatureMetadataKey])
+
+	empty, ok := converted.Content[2].(*llm.TextContent)
+	assert.True(t, ok)
+	assert.Equal(t, "", empty.Text)
+	assert.Equal(t, base64.StdEncoding.EncodeToString(emptySignature),
+		empty.Metadata[googleThoughtSignatureMetadataKey])
+
+	replayed := converted.Message().Copy()
+	contents, err := messagesToContents([]*llm.Message{replayed})
+	assert.NoError(t, err)
+	assert.Len(t, contents, 1)
+	assert.Len(t, contents[0].Parts, 3)
+	assert.True(t, contents[0].Parts[0].Thought)
+	assert.Equal(t, "working it out", contents[0].Parts[0].Text)
+	assert.Equal(t, thoughtSignature, contents[0].Parts[0].ThoughtSignature)
+	assert.False(t, contents[0].Parts[1].Thought)
+	assert.Equal(t, "answer", contents[0].Parts[1].Text)
+	assert.Equal(t, textSignature, contents[0].Parts[1].ThoughtSignature)
+	assert.Equal(t, "", contents[0].Parts[2].Text)
+	assert.Equal(t, emptySignature, contents[0].Parts[2].ThoughtSignature)
+}
+
+func TestGoogleSkipsThinkingFromAnotherProvider(t *testing.T) {
+	contents, err := messagesToContents([]*llm.Message{{
+		Role: llm.Assistant,
+		Content: []llm.Content{
+			&llm.ThinkingContent{Thinking: "anthropic thought", Signature: "anthropic-signature"},
+			&llm.TextContent{Text: "answer"},
+		},
+	}})
+	assert.NoError(t, err)
+	assert.Len(t, contents, 1)
+	assert.Len(t, contents[0].Parts, 1)
+	assert.Equal(t, "answer", contents[0].Parts[0].Text)
+	assert.Equal(t, 0, len(contents[0].Parts[0].ThoughtSignature))
+}

--- a/providers/google/util_test.go
+++ b/providers/google/util_test.go
@@ -1,6 +1,7 @@
 package google
 
 import (
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"strings"
@@ -388,4 +389,54 @@ func TestGoogleSkipsThinkingFromAnotherProvider(t *testing.T) {
 	assert.Len(t, contents[0].Parts, 1)
 	assert.Equal(t, "answer", contents[0].Parts[0].Text)
 	assert.Equal(t, 0, len(contents[0].Parts[0].ThoughtSignature))
+}
+
+func TestGoogleSkipsMessagesFilteredToNoParts(t *testing.T) {
+	contents, err := messagesToContents([]*llm.Message{
+		{
+			Role: llm.Assistant,
+			Content: []llm.Content{
+				&llm.ThinkingContent{Thinking: "foreign thought", Signature: "foreign-signature"},
+			},
+		},
+		llm.NewUserTextMessage("continue"),
+	})
+	assert.NoError(t, err)
+	assert.Len(t, contents, 1)
+	assert.Equal(t, "user", contents[0].Role)
+	assert.Len(t, contents[0].Parts, 1)
+	assert.Equal(t, "continue", contents[0].Parts[0].Text)
+}
+
+func TestGoogleRequestPathsRejectMessagesFilteredToEmpty(t *testing.T) {
+	tests := []struct {
+		name    string
+		content llm.Content
+	}{
+		{
+			name: "foreign thinking",
+			content: &llm.ThinkingContent{
+				Thinking:  "foreign thought",
+				Signature: "foreign-signature",
+			},
+		},
+		{
+			name:    "redacted thinking",
+			content: &llm.RedactedThinkingContent{Data: "opaque"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			provider := New(WithAPIKey("test-key"))
+			message := llm.NewAssistantMessage(tt.content)
+
+			_, err := provider.Generate(context.Background(), llm.WithMessages(message))
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), "no messages remain")
+
+			_, err = provider.Stream(context.Background(), llm.WithMessages(message))
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), "no messages remain")
+		})
+	}
 }

--- a/providers/openai/decode.go
+++ b/providers/openai/decode.go
@@ -258,14 +258,48 @@ func decodeReasoningContent(reasoning responses.ResponseReasoningItem) ([]llm.Co
 	for _, summary := range reasoning.Summary {
 		summaryItems = append(summaryItems, summary.Text)
 	}
-	// Do we need to capture the reasoning.ID field?
+	var reasoningItems []string
+	for _, content := range reasoning.Content {
+		reasoningItems = append(reasoningItems, content.Text)
+	}
+	metadata, err := openAIReasoningMetadata(summaryItems, reasoningItems)
+	if err != nil {
+		return nil, err
+	}
+	displayItems := summaryItems
+	if len(reasoningItems) > 0 {
+		displayItems = reasoningItems
+	}
 	return []llm.Content{
 		&llm.ThinkingContent{
 			ID:        reasoning.ID,
-			Thinking:  strings.Join(summaryItems, "\n\n"),
+			Thinking:  strings.Join(displayItems, "\n\n"),
 			Signature: reasoning.EncryptedContent,
+			Metadata:  metadata,
 		},
 	}, nil
+}
+
+func openAIReasoningMetadata(summaryItems, reasoningItems []string) (llm.ProviderMetadata, error) {
+	metadata := llm.ProviderMetadata{}
+	if len(summaryItems) > 0 {
+		data, err := json.Marshal(summaryItems)
+		if err != nil {
+			return nil, err
+		}
+		metadata[openAIReasoningSummaryMetadataKey] = string(data)
+	}
+	if len(reasoningItems) > 0 {
+		data, err := json.Marshal(reasoningItems)
+		if err != nil {
+			return nil, err
+		}
+		metadata[openAIReasoningContentMetadataKey] = string(data)
+	}
+	if len(metadata) == 0 {
+		return nil, nil
+	}
+	return metadata, nil
 }
 
 func decodeCodeInterpreterCallContent(codeCall responses.ResponseCodeInterpreterToolCall) ([]llm.Content, error) {

--- a/providers/openai/encode.go
+++ b/providers/openai/encode.go
@@ -187,6 +187,13 @@ func encodeAssistantMessage(message *llm.Message) ([]responses.ResponseInputItem
 		if processed[i] {
 			continue // Skip if already processed
 		}
+		if thinking, ok := c.(*llm.ThinkingContent); ok && thinking.ID == "" {
+			// Responses reasoning items require their provider-issued ID. A
+			// ThinkingContent without one originated elsewhere and has no safe
+			// OpenAI representation.
+			processed[i] = true
+			continue
+		}
 		if mcpToolUse, ok := c.(*llm.MCPToolUseContent); ok {
 			// Handle MCP tool use, potentially pairing it with a result
 			mcpCallParam, pairedResultIndex, err := findAndEncodeMCPPair(mcpToolUse, message.Content, i, processed)
@@ -288,16 +295,7 @@ func encodeAssistantToolUseContent(c *llm.ToolUseContent) (responses.ResponseInp
 
 func encodeAssistantThinkingContent(c *llm.ThinkingContent) (responses.ResponseInputItemUnionParam, error) {
 	return responses.ResponseInputItemUnionParam{
-		OfReasoning: &responses.ResponseReasoningItemParam{
-			ID: c.ID,
-			Summary: []responses.ResponseReasoningItemSummaryParam{
-				{
-					Type: "summary_text",
-					Text: c.Thinking,
-				},
-			},
-			EncryptedContent: openai.String(c.Signature),
-		},
+		OfReasoning: openAIReasoningItemParam(c),
 	}, nil
 }
 
@@ -508,8 +506,11 @@ func encodeInputMessageWithPromptCacheBreakpoint(message *llm.Message, breakpoin
 			}
 			standaloneItems = append(standaloneItems, item)
 		case *llm.ThinkingContent:
-			// ThinkingContent is also handled as a standalone item (Reasoning)
-			standaloneItems = append(standaloneItems, encodeReasoningContent(typedContent))
+			// Responses reasoning items require their provider-issued ID. Skip
+			// thinking captured from another provider.
+			if typedContent.ID != "" {
+				standaloneItems = append(standaloneItems, encodeReasoningContent(typedContent))
+			}
 		default:
 			encodedContent, err := encodeUserContentWithPromptCacheBreakpoint(c, i == lastTextIndex)
 			if err != nil {
@@ -561,11 +562,39 @@ func encodeInputTextContentWithPromptCacheBreakpoint(c *llm.TextContent, breakpo
 
 func encodeReasoningContent(c *llm.ThinkingContent) responses.ResponseInputItemUnionParam {
 	return responses.ResponseInputItemUnionParam{
-		OfReasoning: &responses.ResponseReasoningItemParam{
-			ID:               "",
-			EncryptedContent: openai.String(c.Signature),
-		},
+		OfReasoning: openAIReasoningItemParam(c),
 	}
+}
+
+func openAIReasoningItemParam(c *llm.ThinkingContent) *responses.ResponseReasoningItemParam {
+	param := &responses.ResponseReasoningItemParam{
+		ID:               c.ID,
+		EncryptedContent: openai.String(c.Signature),
+	}
+	var summaryItems []string
+	if c.Metadata != nil {
+		_ = json.Unmarshal([]byte(c.Metadata[openAIReasoningSummaryMetadataKey]), &summaryItems)
+	}
+	if len(summaryItems) == 0 && c.Metadata[openAIReasoningContentMetadataKey] == "" {
+		summaryItems = []string{c.Thinking}
+	}
+	for _, text := range summaryItems {
+		param.Summary = append(param.Summary, responses.ResponseReasoningItemSummaryParam{
+			Type: "summary_text",
+			Text: text,
+		})
+	}
+	var reasoningItems []string
+	if c.Metadata != nil {
+		_ = json.Unmarshal([]byte(c.Metadata[openAIReasoningContentMetadataKey]), &reasoningItems)
+	}
+	for _, text := range reasoningItems {
+		param.Content = append(param.Content, responses.ResponseReasoningItemContentParam{
+			Type: "reasoning_text",
+			Text: text,
+		})
+	}
+	return param
 }
 
 func encodeInputImageContent(c *llm.ImageContent) (*responses.ResponseInputContentUnionParam, error) {

--- a/providers/openai/encode.go
+++ b/providers/openai/encode.go
@@ -568,8 +568,10 @@ func encodeReasoningContent(c *llm.ThinkingContent) responses.ResponseInputItemU
 
 func openAIReasoningItemParam(c *llm.ThinkingContent) *responses.ResponseReasoningItemParam {
 	param := &responses.ResponseReasoningItemParam{
-		ID:               c.ID,
-		EncryptedContent: openai.String(c.Signature),
+		ID: c.ID,
+	}
+	if c.Signature != "" {
+		param.EncryptedContent = openai.String(c.Signature)
 	}
 	var summaryItems []string
 	if c.Metadata != nil {

--- a/providers/openai/provider_test.go
+++ b/providers/openai/provider_test.go
@@ -183,6 +183,22 @@ func TestEncodeMessages(t *testing.T) {
 			want: `[{"arguments":"{\"city\": \"NYC\"}","call_id":"call_12345xyz","name":"get_weather","type":"function_call"}]`,
 		},
 		{
+			name: "foreign thinking is not replayed",
+			messages: []*llm.Message{
+				{
+					Role: llm.Assistant,
+					Content: []llm.Content{
+						&llm.ThinkingContent{
+							Thinking:  "Anthropic thought",
+							Signature: "anthropic-signature",
+						},
+						&llm.TextContent{Text: "answer"},
+					},
+				},
+			},
+			want: `[{"content":[{"text":"answer","type":"output_text"}],"role":"assistant","type":"message"}]`,
+		},
+		{
 			name: "tool result content",
 			messages: []*llm.Message{
 				{
@@ -382,6 +398,37 @@ func TestConvertResponse(t *testing.T) {
 	assert.Equal(t, 8, result.Usage.InputTokens)
 	assert.Equal(t, 8, result.Usage.OutputTokens)
 	assert.Equal(t, 2, result.Usage.CacheReadInputTokens)
+}
+
+func TestDecodeReasoningContentPreservesRawTextForReplay(t *testing.T) {
+	content, err := decodeReasoningContent(responses.ResponseReasoningItem{
+		ID:               "rs_1",
+		EncryptedContent: "encrypted",
+		Summary: []responses.ResponseReasoningItemSummary{{
+			Type: "summary_text",
+			Text: "summary",
+		}},
+		Content: []responses.ResponseReasoningItemContent{{
+			Type: "reasoning_text",
+			Text: "raw reasoning",
+		}},
+	})
+	assert.NoError(t, err)
+	assert.Len(t, content, 1)
+	thinking := content[0].(*llm.ThinkingContent)
+	assert.Equal(t, "raw reasoning", thinking.Thinking)
+	assert.Equal(t, `["summary"]`, thinking.Metadata[openAIReasoningSummaryMetadataKey])
+	assert.Equal(t, `["raw reasoning"]`, thinking.Metadata[openAIReasoningContentMetadataKey])
+
+	replayed, err := encodeMessages([]*llm.Message{{
+		Role:    llm.Assistant,
+		Content: content,
+	}})
+	assert.NoError(t, err)
+	data, err := json.Marshal(replayed)
+	assert.NoError(t, err)
+	assert.Contains(t, string(data), `"summary":[{"text":"summary","type":"summary_text"}]`)
+	assert.Contains(t, string(data), `"content":[{"text":"raw reasoning","type":"reasoning_text"}]`)
 }
 
 func TestConvertResponseWithDifferentModels(t *testing.T) {

--- a/providers/openai/provider_test.go
+++ b/providers/openai/provider_test.go
@@ -2,6 +2,7 @@ package openai
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/deepnoodle-ai/dive/llm"
@@ -429,6 +430,17 @@ func TestDecodeReasoningContentPreservesRawTextForReplay(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Contains(t, string(data), `"summary":[{"text":"summary","type":"summary_text"}]`)
 	assert.Contains(t, string(data), `"content":[{"text":"raw reasoning","type":"reasoning_text"}]`)
+}
+
+func TestOpenAIReasoningReplayOmitsEmptyEncryptedContent(t *testing.T) {
+	param := openAIReasoningItemParam(&llm.ThinkingContent{
+		ID:       "rs_without_encrypted_content",
+		Thinking: "summary",
+	})
+	data, err := json.Marshal(param)
+	assert.NoError(t, err)
+	assert.Contains(t, string(data), `"id":"rs_without_encrypted_content"`)
+	assert.False(t, strings.Contains(string(data), `"encrypted_content"`))
 }
 
 func TestConvertResponseWithDifferentModels(t *testing.T) {

--- a/providers/openai/stream_iterator.go
+++ b/providers/openai/stream_iterator.go
@@ -51,7 +51,10 @@ type outputItemState struct {
 	// SummaryStreamedByIndex tracks which reasoning summary parts were streamed
 	// incrementally (keyed by SummaryIndex), so the OutputItemDone handler
 	// only emits fallback events for summary parts that were not already streamed.
-	SummaryStreamedByIndex map[int]bool
+	SummaryStreamedByIndex       map[int]bool
+	ReasoningTextStreamedByIndex map[int]bool
+	ReasoningStarted             bool
+	ReasoningStopped             bool
 
 	// For message with text/reasoning content parts
 	// Keyed by ContentIndex
@@ -272,39 +275,47 @@ func (s *openaiStreamIterator) processOpenAIEvent(event responses.ResponseStream
 			summaryIdx := int(data.SummaryIndex)
 
 			// Mark the existing reasoning item state so OutputItemDone skips duplicate emission.
-			if itemState, ok := s.outputItemsState[outputIdx]; ok {
+			itemState, ok := s.outputItemsState[outputIdx]
+			if ok {
 				if itemState.SummaryStreamedByIndex == nil {
 					itemState.SummaryStreamedByIndex = make(map[int]bool)
 				}
 				itemState.SummaryStreamedByIndex[summaryIdx] = true
-				itemState.ContentParts[summaryIdx] = &contentPartState{
-					ContentIndex: summaryIdx,
-					PartType:     "thinking",
-					Text:         data.Part.Text,
-				}
 			} else {
 				// Create state if it doesn't exist yet.
-				s.outputItemsState[outputIdx] = &outputItemState{
+				itemState = &outputItemState{
 					OutputIndex: outputIdx,
 					ItemID:      data.ItemID,
 					ItemType:    "reasoning",
 					SummaryStreamedByIndex: map[int]bool{
 						summaryIdx: true,
 					},
-					ContentParts: map[int]*contentPartState{
-						summaryIdx: {ContentIndex: summaryIdx, PartType: "thinking", Text: data.Part.Text},
-					},
+					ContentParts: make(map[int]*contentPartState),
 				}
+				s.outputItemsState[outputIdx] = itemState
+			}
+			itemState.ContentParts[summaryIdx] = &contentPartState{
+				ContentIndex: summaryIdx,
+				PartType:     "thinking",
+				Text:         data.Part.Text,
 			}
 
-			diveEvents = append(diveEvents, &llm.Event{
-				Type:  llm.EventTypeContentBlockStart,
-				Index: &outputIdx,
-				ContentBlock: &llm.EventContentBlock{
-					Type:     llm.ContentTypeThinking,
-					Thinking: data.Part.Text,
-				},
-			})
+			if !itemState.ReasoningStarted {
+				itemState.ReasoningStarted = true
+				diveEvents = append(diveEvents, &llm.Event{
+					Type:  llm.EventTypeContentBlockStart,
+					Index: &outputIdx,
+					ContentBlock: &llm.EventContentBlock{
+						Type:     llm.ContentTypeThinking,
+						ID:       data.ItemID,
+						Thinking: data.Part.Text,
+					},
+				})
+			} else if data.Part.Text != "" {
+				diveEvents = append(diveEvents, thinkingDeltaEvent(outputIdx, summarySeparator(summaryIdx)+data.Part.Text))
+			} else if summaryIdx > 0 {
+				diveEvents = append(diveEvents, thinkingDeltaEvent(outputIdx, summarySeparator(summaryIdx)))
+			}
 		}
 
 	case responses.ResponseReasoningSummaryTextDeltaEvent:
@@ -314,7 +325,7 @@ func (s *openaiStreamIterator) processOpenAIEvent(event responses.ResponseStream
 		// Get or create the state for reasoning summary.
 		itemState, exists := s.outputItemsState[outputIdx]
 		if !exists {
-			s.outputItemsState[outputIdx] = &outputItemState{
+			itemState = &outputItemState{
 				OutputIndex: outputIdx,
 				ItemID:      data.ItemID,
 				ItemType:    "reasoning",
@@ -325,21 +336,31 @@ func (s *openaiStreamIterator) processOpenAIEvent(event responses.ResponseStream
 					summaryIdx: {ContentIndex: summaryIdx, PartType: "thinking"},
 				},
 			}
-			itemState = s.outputItemsState[outputIdx]
+			s.outputItemsState[outputIdx] = itemState
+		} else {
+			if itemState.SummaryStreamedByIndex == nil {
+				itemState.SummaryStreamedByIndex = make(map[int]bool)
+			}
+			itemState.SummaryStreamedByIndex[summaryIdx] = true
+		}
+		if itemState.ContentParts[summaryIdx] == nil {
+			itemState.ContentParts[summaryIdx] = &contentPartState{
+				ContentIndex: summaryIdx,
+				PartType:     "thinking",
+			}
+		}
 
+		if !itemState.ReasoningStarted {
+			itemState.ReasoningStarted = true
 			idxStart := outputIdx
 			diveEvents = append(diveEvents, &llm.Event{
 				Type:  llm.EventTypeContentBlockStart,
 				Index: &idxStart,
 				ContentBlock: &llm.EventContentBlock{
 					Type: llm.ContentTypeThinking,
+					ID:   data.ItemID,
 				},
 			})
-		} else {
-			if itemState.SummaryStreamedByIndex == nil {
-				itemState.SummaryStreamedByIndex = make(map[int]bool)
-			}
-			itemState.SummaryStreamedByIndex[summaryIdx] = true
 		}
 
 		// Accumulate the text.
@@ -347,34 +368,118 @@ func (s *openaiStreamIterator) processOpenAIEvent(event responses.ResponseStream
 			partState.Text += data.Delta
 		}
 
-		idxDelta := outputIdx
-		diveEvents = append(diveEvents, &llm.Event{
-			Type:  llm.EventTypeContentBlockDelta,
-			Index: &idxDelta,
-			Delta: &llm.EventDelta{
-				Type:     llm.EventDeltaTypeThinking,
-				Thinking: data.Delta,
-			},
-		})
+		diveEvents = append(diveEvents, thinkingDeltaEvent(outputIdx, data.Delta))
 
 	case responses.ResponseReasoningSummaryPartDoneEvent:
 		outputIdx := int(data.OutputIndex)
 		summaryIdx := int(data.SummaryIndex)
-		if itemState, exists := s.outputItemsState[outputIdx]; exists {
-			if itemState.SummaryStreamedByIndex == nil {
-				itemState.SummaryStreamedByIndex = make(map[int]bool)
+		itemState := s.outputItemsState[outputIdx]
+		if itemState == nil {
+			itemState = &outputItemState{
+				OutputIndex:            outputIdx,
+				ItemID:                 data.ItemID,
+				ItemType:               "reasoning",
+				SummaryStreamedByIndex: make(map[int]bool),
+				ContentParts:           make(map[int]*contentPartState),
 			}
-			itemState.SummaryStreamedByIndex[summaryIdx] = true
-			if partState, ok := itemState.ContentParts[summaryIdx]; ok {
-				partState.IsComplete = true
-				partState.Text = data.Part.Text
-			}
-			idxStop := outputIdx
-			diveEvents = append(diveEvents, &llm.Event{
-				Type:  llm.EventTypeContentBlockStop,
-				Index: &idxStop,
-			})
+			s.outputItemsState[outputIdx] = itemState
 		}
+		if itemState.SummaryStreamedByIndex == nil {
+			itemState.SummaryStreamedByIndex = make(map[int]bool)
+		}
+		if !itemState.SummaryStreamedByIndex[summaryIdx] {
+			if !itemState.ReasoningStarted {
+				itemState.ReasoningStarted = true
+				diveEvents = append(diveEvents, &llm.Event{
+					Type:  llm.EventTypeContentBlockStart,
+					Index: &outputIdx,
+					ContentBlock: &llm.EventContentBlock{
+						Type: llm.ContentTypeThinking,
+						ID:   data.ItemID,
+					},
+				})
+			}
+			diveEvents = append(diveEvents,
+				thinkingDeltaEvent(outputIdx, summarySeparator(summaryIdx)+data.Part.Text))
+		}
+		itemState.SummaryStreamedByIndex[summaryIdx] = true
+		if partState, ok := itemState.ContentParts[summaryIdx]; ok {
+			partState.IsComplete = true
+			partState.Text = data.Part.Text
+		}
+
+	case responses.ResponseReasoningTextDeltaEvent:
+		outputIdx := int(data.OutputIndex)
+		contentIdx := int(data.ContentIndex)
+		itemState := s.outputItemsState[outputIdx]
+		if itemState == nil {
+			itemState = &outputItemState{
+				OutputIndex:                  outputIdx,
+				ItemID:                       data.ItemID,
+				ItemType:                     "reasoning",
+				SummaryStreamedByIndex:       make(map[int]bool),
+				ReasoningTextStreamedByIndex: make(map[int]bool),
+				ContentParts:                 make(map[int]*contentPartState),
+			}
+			s.outputItemsState[outputIdx] = itemState
+		}
+		if itemState.ReasoningTextStreamedByIndex == nil {
+			itemState.ReasoningTextStreamedByIndex = make(map[int]bool)
+		}
+		firstReasoningText := len(itemState.ReasoningTextStreamedByIndex) == 0
+		itemState.ReasoningTextStreamedByIndex[contentIdx] = true
+		if !itemState.ReasoningStarted {
+			itemState.ReasoningStarted = true
+			diveEvents = append(diveEvents, &llm.Event{
+				Type:  llm.EventTypeContentBlockStart,
+				Index: &outputIdx,
+				ContentBlock: &llm.EventContentBlock{
+					Type: llm.ContentTypeThinking,
+					ID:   data.ItemID,
+				},
+			})
+		} else if firstReasoningText && len(itemState.SummaryStreamedByIndex) > 0 {
+			diveEvents = append(diveEvents, thinkingDeltaEvent(outputIdx, "\n\n"))
+		}
+		diveEvents = append(diveEvents, thinkingDeltaEvent(outputIdx, data.Delta))
+
+	case responses.ResponseReasoningTextDoneEvent:
+		outputIdx := int(data.OutputIndex)
+		contentIdx := int(data.ContentIndex)
+		itemState := s.outputItemsState[outputIdx]
+		if itemState == nil {
+			itemState = &outputItemState{
+				OutputIndex:                  outputIdx,
+				ItemID:                       data.ItemID,
+				ItemType:                     "reasoning",
+				SummaryStreamedByIndex:       make(map[int]bool),
+				ReasoningTextStreamedByIndex: make(map[int]bool),
+				ContentParts:                 make(map[int]*contentPartState),
+			}
+			s.outputItemsState[outputIdx] = itemState
+		}
+		if itemState.ReasoningTextStreamedByIndex == nil {
+			itemState.ReasoningTextStreamedByIndex = make(map[int]bool)
+		}
+		if !itemState.ReasoningTextStreamedByIndex[contentIdx] {
+			if !itemState.ReasoningStarted {
+				itemState.ReasoningStarted = true
+				diveEvents = append(diveEvents, &llm.Event{
+					Type:  llm.EventTypeContentBlockStart,
+					Index: &outputIdx,
+					ContentBlock: &llm.EventContentBlock{
+						Type: llm.ContentTypeThinking,
+						ID:   data.ItemID,
+					},
+				})
+			}
+			separator := ""
+			if contentIdx > 0 || len(itemState.SummaryStreamedByIndex) > 0 {
+				separator = "\n\n"
+			}
+			diveEvents = append(diveEvents, thinkingDeltaEvent(outputIdx, separator+data.Text))
+		}
+		itemState.ReasoningTextStreamedByIndex[contentIdx] = true
 
 	case responses.ResponseTextDoneEvent:
 		outputIdx := int(data.OutputIndex)
@@ -404,28 +509,79 @@ func (s *openaiStreamIterator) processOpenAIEvent(event responses.ResponseStream
 		if data.Item.Type == "reasoning" {
 			itemState := s.outputItemsState[outputIdx]
 			reasoning := data.Item.AsReasoning()
-			for i, part := range reasoning.Summary {
-				if itemState != nil && itemState.SummaryStreamedByIndex[i] {
-					continue // already streamed incrementally
+			if itemState == nil {
+				itemState = &outputItemState{
+					OutputIndex:                  outputIdx,
+					ItemID:                       reasoning.ID,
+					ItemType:                     "reasoning",
+					SummaryStreamedByIndex:       make(map[int]bool),
+					ReasoningTextStreamedByIndex: make(map[int]bool),
+					ContentParts:                 make(map[int]*contentPartState),
 				}
-				idxStart := outputIdx
+				s.outputItemsState[outputIdx] = itemState
+			}
+			if !itemState.ReasoningStarted &&
+				(len(reasoning.Summary) > 0 || len(reasoning.Content) > 0 || reasoning.EncryptedContent != "") {
+				itemState.ReasoningStarted = true
 				diveEvents = append(diveEvents, &llm.Event{
 					Type:  llm.EventTypeContentBlockStart,
-					Index: &idxStart,
+					Index: &outputIdx,
 					ContentBlock: &llm.EventContentBlock{
-						Type:     llm.ContentTypeThinking,
-						Thinking: part.Text,
+						Type: llm.ContentTypeThinking,
+						ID:   reasoning.ID,
 					},
 				})
-				idxDelta := outputIdx
+			}
+			preferReasoningText := len(reasoning.Content) > 0 && len(itemState.SummaryStreamedByIndex) == 0
+			for i, part := range reasoning.Summary {
+				if preferReasoningText {
+					break
+				}
+				if itemState.SummaryStreamedByIndex[i] {
+					continue // already streamed incrementally
+				}
+				diveEvents = append(diveEvents, thinkingDeltaEvent(outputIdx, summarySeparator(i)+part.Text))
+			}
+			for i, part := range reasoning.Content {
+				if itemState.ReasoningTextStreamedByIndex[i] {
+					continue
+				}
+				separator := ""
+				if i > 0 || len(itemState.SummaryStreamedByIndex) > 0 {
+					separator = "\n\n"
+				}
+				diveEvents = append(diveEvents, thinkingDeltaEvent(outputIdx, separator+part.Text))
+			}
+			metadata, err := openAIReasoningMetadata(
+				reasoningSummaryTexts(reasoning),
+				reasoningContentTexts(reasoning),
+			)
+			if err != nil {
+				return nil, err
+			}
+			if len(metadata) > 0 {
 				diveEvents = append(diveEvents, &llm.Event{
 					Type:  llm.EventTypeContentBlockDelta,
-					Index: &idxDelta,
+					Index: &outputIdx,
 					Delta: &llm.EventDelta{
-						Type:     llm.EventDeltaTypeThinking,
-						Thinking: part.Text,
+						Type:     llm.EventDeltaTypeMetadata,
+						Metadata: metadata,
 					},
 				})
+			}
+			if reasoning.EncryptedContent != "" {
+				idxSignature := outputIdx
+				diveEvents = append(diveEvents, &llm.Event{
+					Type:  llm.EventTypeContentBlockDelta,
+					Index: &idxSignature,
+					Delta: &llm.EventDelta{
+						Type:      llm.EventDeltaTypeSignature,
+						Signature: reasoning.EncryptedContent,
+					},
+				})
+			}
+			if itemState.ReasoningStarted && !itemState.ReasoningStopped {
+				itemState.ReasoningStopped = true
 				idxStop := outputIdx
 				diveEvents = append(diveEvents, &llm.Event{
 					Type:  llm.EventTypeContentBlockStop,
@@ -509,4 +665,38 @@ func (s *openaiStreamIterator) processOpenAIEvent(event responses.ResponseStream
 	}
 
 	return diveEvents, nil
+}
+
+func thinkingDeltaEvent(outputIdx int, thinking string) *llm.Event {
+	return &llm.Event{
+		Type:  llm.EventTypeContentBlockDelta,
+		Index: &outputIdx,
+		Delta: &llm.EventDelta{
+			Type:     llm.EventDeltaTypeThinking,
+			Thinking: thinking,
+		},
+	}
+}
+
+func summarySeparator(summaryIdx int) string {
+	if summaryIdx > 0 {
+		return "\n\n"
+	}
+	return ""
+}
+
+func reasoningSummaryTexts(reasoning responses.ResponseReasoningItem) []string {
+	texts := make([]string, 0, len(reasoning.Summary))
+	for _, part := range reasoning.Summary {
+		texts = append(texts, part.Text)
+	}
+	return texts
+}
+
+func reasoningContentTexts(reasoning responses.ResponseReasoningItem) []string {
+	texts := make([]string, 0, len(reasoning.Content))
+	for _, part := range reasoning.Content {
+		texts = append(texts, part.Text)
+	}
+	return texts
 }

--- a/providers/openai/stream_iterator_test.go
+++ b/providers/openai/stream_iterator_test.go
@@ -187,3 +187,86 @@ func TestStreamIteratorAccumulatorPricesDisjointUsage(t *testing.T) {
 	assert.Equal(t, want.CacheWrite, usage.Cost.CacheWrite)
 	assert.Equal(t, want.Total, usage.Cost.Total)
 }
+
+func TestStreamIteratorPreservesReplayableReasoning(t *testing.T) {
+	payloads := []string{
+		`{"type":"response.created","sequence_number":1,"response":{"id":"resp_1","model":"gpt-5.6-sol","status":"in_progress"}}`,
+		`{"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"rs_1","type":"reasoning","status":"in_progress","summary":[]}}`,
+		`{"type":"response.reasoning_summary_part.added","sequence_number":3,"item_id":"rs_1","output_index":0,"summary_index":0,"part":{"type":"summary_text","text":""}}`,
+		`{"type":"response.reasoning_summary_text.delta","sequence_number":4,"item_id":"rs_1","output_index":0,"summary_index":0,"delta":"why"}`,
+		`{"type":"response.reasoning_summary_part.done","sequence_number":5,"item_id":"rs_1","output_index":0,"summary_index":0,"part":{"type":"summary_text","text":"why"}}`,
+		`{"type":"response.output_item.done","sequence_number":6,"output_index":0,"item":{"id":"rs_1","type":"reasoning","status":"completed","encrypted_content":"encrypted-reasoning","summary":[{"type":"summary_text","text":"why"}]}}`,
+		`{"type":"response.completed","sequence_number":7,"response":{"id":"resp_1","model":"gpt-5.6-sol","status":"completed","usage":{"input_tokens":1,"output_tokens":2,"input_tokens_details":{"cached_tokens":0,"cache_write_tokens":0},"output_tokens_details":{"reasoning_tokens":1}}}}`,
+	}
+	events := make([]responses.ResponseStreamEventUnion, 0, len(payloads))
+	for _, payload := range payloads {
+		var event responses.ResponseStreamEventUnion
+		assert.NoError(t, json.Unmarshal([]byte(payload), &event))
+		events = append(events, event)
+	}
+
+	iterator := newOpenAIStreamIterator(&mockStreamSource{events: events}, &llm.Config{})
+	t.Cleanup(func() {
+		assert.NoError(t, iterator.Close())
+	})
+	accumulator := llm.NewResponseAccumulator()
+	for iterator.Next() {
+		assert.NoError(t, accumulator.AddEvent(iterator.Event()))
+	}
+	assert.NoError(t, iterator.Err())
+	assert.True(t, accumulator.IsComplete())
+
+	message := accumulator.Response().Message()
+	assert.Equal(t, 1, len(message.Content))
+	thinking, ok := message.Content[0].(*llm.ThinkingContent)
+	assert.True(t, ok)
+	assert.Equal(t, "rs_1", thinking.ID)
+	assert.Equal(t, "why", thinking.Thinking)
+	assert.Equal(t, "encrypted-reasoning", thinking.Signature)
+	assert.Equal(t, `["why"]`, thinking.Metadata[openAIReasoningSummaryMetadataKey])
+
+	replayed, err := encodeMessages([]*llm.Message{message})
+	assert.NoError(t, err)
+	replayedJSON, err := json.Marshal(replayed)
+	assert.NoError(t, err)
+	assert.Contains(t, string(replayedJSON), `"id":"rs_1"`)
+	assert.Contains(t, string(replayedJSON), `"encrypted_content":"encrypted-reasoning"`)
+	assert.Contains(t, string(replayedJSON), `"text":"why"`)
+}
+
+func TestStreamIteratorPreservesRawReasoningText(t *testing.T) {
+	payloads := []string{
+		`{"type":"response.created","sequence_number":1,"response":{"id":"resp_1","model":"gpt-5.6-sol","status":"in_progress"}}`,
+		`{"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"rs_raw","type":"reasoning","status":"in_progress","summary":[],"content":[]}}`,
+		`{"type":"response.reasoning_text.done","sequence_number":3,"item_id":"rs_raw","output_index":0,"content_index":0,"text":"raw reasoning"}`,
+		`{"type":"response.output_item.done","sequence_number":5,"output_index":0,"item":{"id":"rs_raw","type":"reasoning","status":"completed","encrypted_content":"encrypted-raw","summary":[],"content":[{"type":"reasoning_text","text":"raw reasoning"}]}}`,
+		`{"type":"response.completed","sequence_number":6,"response":{"id":"resp_1","model":"gpt-5.6-sol","status":"completed","usage":{"input_tokens":1,"output_tokens":2,"input_tokens_details":{"cached_tokens":0,"cache_write_tokens":0},"output_tokens_details":{"reasoning_tokens":1}}}}`,
+	}
+	events := make([]responses.ResponseStreamEventUnion, 0, len(payloads))
+	for _, payload := range payloads {
+		var event responses.ResponseStreamEventUnion
+		assert.NoError(t, json.Unmarshal([]byte(payload), &event))
+		events = append(events, event)
+	}
+
+	iterator := newOpenAIStreamIterator(&mockStreamSource{events: events}, &llm.Config{})
+	t.Cleanup(func() { assert.NoError(t, iterator.Close()) })
+	accumulator := llm.NewResponseAccumulator()
+	for iterator.Next() {
+		assert.NoError(t, accumulator.AddEvent(iterator.Event()))
+	}
+	assert.NoError(t, iterator.Err())
+
+	message := accumulator.Response().Message()
+	thinking := message.Content[0].(*llm.ThinkingContent)
+	assert.Equal(t, "rs_raw", thinking.ID)
+	assert.Equal(t, "raw reasoning", thinking.Thinking)
+	assert.Equal(t, "encrypted-raw", thinking.Signature)
+	assert.Equal(t, `["raw reasoning"]`, thinking.Metadata[openAIReasoningContentMetadataKey])
+
+	replayed, err := encodeMessages([]*llm.Message{message})
+	assert.NoError(t, err)
+	replayedJSON, err := json.Marshal(replayed)
+	assert.NoError(t, err)
+	assert.Contains(t, string(replayedJSON), `"content":[{"text":"raw reasoning","type":"reasoning_text"}]`)
+}

--- a/providers/openai/types.go
+++ b/providers/openai/types.go
@@ -16,6 +16,11 @@ const (
 	IncludeCodeInterpreterCallOutputs Include = "code_interpreter_call.outputs"
 )
 
+const (
+	openAIReasoningSummaryMetadataKey = "openai.reasoning_summary"
+	openAIReasoningContentMetadataKey = "openai.reasoning_content"
+)
+
 // // Request represents the OpenAI Responses API request structure
 // type Request struct {
 // 	Model              string            `json:"model"`

--- a/providers/openaicompletions/openai.go
+++ b/providers/openaicompletions/openai.go
@@ -427,7 +427,7 @@ func convertMessagesForProvider(messages []*llm.Message, providerName string) ([
 		var hasMedia bool
 		var hasStructuredContent bool
 		var reasoning []string
-		var reasoningDetails json.RawMessage
+		var reasoningDetailParts []json.RawMessage
 		for _, c := range msg.Content {
 			switch c := c.(type) {
 			case *llm.ToolUseContent:
@@ -471,11 +471,17 @@ func convertMessagesForProvider(messages []*llm.Message, providerName string) ([
 					hasStructuredContent = true
 				case providerName == "openrouter" &&
 					c.Metadata[openRouterReasoningDetailsMetadataKey] != "":
-					raw := json.RawMessage(c.Metadata[openRouterReasoningDetailsMetadataKey])
-					if !json.Valid(raw) {
+					var raw []json.RawMessage
+					if err := json.Unmarshal(
+						[]byte(c.Metadata[openRouterReasoningDetailsMetadataKey]),
+						&raw,
+					); err != nil {
 						return nil, fmt.Errorf("invalid OpenRouter reasoning details in assistant history")
 					}
-					reasoningDetails = append(reasoningDetails[:0], raw...)
+					for _, detail := range raw {
+						reasoningDetailParts = append(reasoningDetailParts,
+							append(json.RawMessage(nil), detail...))
+					}
 				case providerName == "openrouter" &&
 					c.Metadata[openRouterReasoningMetadataKey] == "true":
 					reasoning = append(reasoning, c.Thinking)
@@ -490,6 +496,13 @@ func convertMessagesForProvider(messages []*llm.Message, providerName string) ([
 		}
 		if hasMedia && role == "assistant" {
 			return nil, fmt.Errorf("image and document content is not supported in assistant messages by the chat completions API")
+		}
+		var reasoningDetails json.RawMessage
+		if len(reasoningDetailParts) > 0 {
+			reasoningDetails, err = json.Marshal(reasoningDetailParts)
+			if err != nil {
+				return nil, fmt.Errorf("marshal OpenRouter reasoning details: %w", err)
+			}
 		}
 
 		// A single message carries all tool calls, plus any accompanying text.
@@ -509,6 +522,7 @@ func convertMessagesForProvider(messages []*llm.Message, providerName string) ([
 			parts = nil
 			reasoning = nil
 			reasoningDetails = nil
+			reasoningDetailParts = nil
 			hasStructuredContent = false
 		}
 

--- a/providers/openaicompletions/openai.go
+++ b/providers/openaicompletions/openai.go
@@ -59,6 +59,12 @@ var (
 
 var _ llm.StreamingLLM = &Provider{}
 
+const (
+	mistralThinkingMetadataKey            = "mistral.thinking"
+	openRouterReasoningMetadataKey        = "openrouter.reasoning"
+	openRouterReasoningDetailsMetadataKey = "openrouter.reasoning_details"
+)
+
 // Provider implements an LLM provider using the OpenAI Chat Completions API.
 // This is used as the base for several providers including Grok, Groq, Mistral,
 // Ollama, and OpenRouter.
@@ -114,7 +120,7 @@ func (p *Provider) Generate(ctx context.Context, opts ...llm.Option) (*llm.Respo
 	if err := validateMessages(config.Messages); err != nil {
 		return nil, err
 	}
-	msgs, err := convertMessages(config.Messages)
+	msgs, err := convertMessagesForProvider(config.Messages, p.Name())
 	if err != nil {
 		return nil, fmt.Errorf("error converting messages: %w", err)
 	}
@@ -180,10 +186,7 @@ func (p *Provider) Generate(ctx context.Context, opts ...llm.Option) (*llm.Respo
 	}
 	choice := result.Choices[0]
 
-	var contentBlocks []llm.Content
-	if choice.Message.Content != "" {
-		contentBlocks = append(contentBlocks, &llm.TextContent{Text: choice.Message.Content})
-	}
+	contentBlocks := responseMessageContent(choice.Message, p.Name())
 
 	// Transform tool calls into content blocks (like Anthropic)
 	if len(choice.Message.ToolCalls) > 0 {
@@ -255,7 +258,7 @@ func (p *Provider) Stream(ctx context.Context, opts ...llm.Option) (llm.StreamIt
 	if err := validateMessages(config.Messages); err != nil {
 		return nil, err
 	}
-	msgs, err := convertMessages(config.Messages)
+	msgs, err := convertMessagesForProvider(config.Messages, p.Name())
 	if err != nil {
 		return nil, fmt.Errorf("error converting messages: %w", err)
 	}
@@ -318,6 +321,7 @@ func (p *Provider) Stream(ctx context.Context, opts ...llm.Option) (llm.StreamIt
 			thinkingIndex:        -1,
 			textIndex:            -1,
 			reportedCostCurrency: p.reportedCostCurrency,
+			providerName:         p.Name(),
 		}, nil
 	})
 	return stream, nil
@@ -397,6 +401,10 @@ func addPromptCacheBreakpoints(messages []Message, limit int) {
 }
 
 func convertMessages(messages []*llm.Message) ([]Message, error) {
+	return convertMessagesForProvider(messages, "")
+}
+
+func convertMessagesForProvider(messages []*llm.Message, providerName string) ([]Message, error) {
 	// Chat Completions has no operator-authority role, so operator reminders
 	// always render as tagged user messages (nil resolver = no native authority).
 	messages, err := llm.RenderReminders(messages, nil)
@@ -417,6 +425,9 @@ func convertMessages(messages []*llm.Message) ([]Message, error) {
 		var toolResults []*llm.ToolResultContent
 		var parts []ContentPart
 		var hasMedia bool
+		var hasStructuredContent bool
+		var reasoning []string
+		var reasoningDetails json.RawMessage
 		for _, c := range msg.Content {
 			switch c := c.(type) {
 			case *llm.ToolUseContent:
@@ -446,12 +457,33 @@ func convertMessages(messages []*llm.Message) ([]Message, error) {
 				}
 				parts = append(parts, part)
 				hasMedia = true
-			case *llm.ThinkingContent, *llm.RedactedThinkingContent:
-				// The Chat Completions API has no standard field for
-				// replaying assistant reasoning back to the server, so
-				// thinking content (which this provider's own stream
-				// iterator can produce from "reasoning" deltas) is
-				// skipped on encode rather than erroring.
+			case *llm.ThinkingContent:
+				switch {
+				case isMistralProvider(providerName) &&
+					c.Metadata[mistralThinkingMetadataKey] == "true":
+					parts = append(parts, ContentPart{
+						Type: "thinking",
+						Thinking: []ContentPart{{
+							Type: "text",
+							Text: c.Thinking,
+						}},
+					})
+					hasStructuredContent = true
+				case providerName == "openrouter" &&
+					c.Metadata[openRouterReasoningDetailsMetadataKey] != "":
+					raw := json.RawMessage(c.Metadata[openRouterReasoningDetailsMetadataKey])
+					if !json.Valid(raw) {
+						return nil, fmt.Errorf("invalid OpenRouter reasoning details in assistant history")
+					}
+					reasoningDetails = append(reasoningDetails[:0], raw...)
+				case providerName == "openrouter" &&
+					c.Metadata[openRouterReasoningMetadataKey] == "true":
+					reasoning = append(reasoning, c.Thinking)
+				}
+			case *llm.RedactedThinkingContent:
+				// Redacted thinking has no portable Chat Completions shape.
+				// Provider-specific encrypted blocks use namespaced metadata on
+				// ThinkingContent instead.
 			default:
 				return nil, fmt.Errorf("unsupported content type: %s", c.Type())
 			}
@@ -462,12 +494,22 @@ func convertMessages(messages []*llm.Message) ([]Message, error) {
 
 		// A single message carries all tool calls, plus any accompanying text.
 		if len(toolCalls) > 0 {
-			result = append(result, Message{
-				Role:      role,
-				Content:   joinTextParts(parts),
-				ToolCalls: toolCalls,
-			})
+			assistant := Message{
+				Role:             role,
+				ToolCalls:        toolCalls,
+				Reasoning:        strings.Join(reasoning, "\n\n"),
+				ReasoningDetails: reasoningDetails,
+			}
+			if hasStructuredContent {
+				assistant.ContentParts = parts
+			} else {
+				assistant.Content = joinTextParts(parts)
+			}
+			result = append(result, assistant)
 			parts = nil
+			reasoning = nil
+			reasoningDetails = nil
+			hasStructuredContent = false
 		}
 
 		// One "tool" message per tool result.
@@ -481,9 +523,21 @@ func convertMessages(messages []*llm.Message) ([]Message, error) {
 
 		// Remaining content: messages with media carry a content-part array;
 		// text-only messages keep the plain-string content shape.
-		if len(parts) > 0 {
-			if hasMedia {
-				result = append(result, Message{Role: role, ContentParts: parts})
+		if len(parts) > 0 || len(reasoning) > 0 || len(reasoningDetails) > 0 {
+			if hasMedia || hasStructuredContent {
+				result = append(result, Message{
+					Role:             role,
+					ContentParts:     parts,
+					Reasoning:        strings.Join(reasoning, "\n\n"),
+					ReasoningDetails: reasoningDetails,
+				})
+			} else if len(reasoning) > 0 || len(reasoningDetails) > 0 {
+				result = append(result, Message{
+					Role:             role,
+					Content:          joinTextParts(parts),
+					Reasoning:        strings.Join(reasoning, "\n\n"),
+					ReasoningDetails: reasoningDetails,
+				})
 			} else {
 				for _, p := range parts {
 					result = append(result, Message{Role: role, Content: p.Text})
@@ -492,6 +546,81 @@ func convertMessages(messages []*llm.Message) ([]Message, error) {
 		}
 	}
 	return result, nil
+}
+
+func isMistralProvider(providerName string) bool {
+	return strings.HasPrefix(providerName, "mistral-")
+}
+
+func responseMessageContent(message Message, providerName string) []llm.Content {
+	var content []llm.Content
+	if len(message.ReasoningDetails) > 0 {
+		thinking := message.Reasoning
+		if thinking == "" {
+			thinking = reasoningDetailsText(message.ReasoningDetails)
+		}
+		metadata := llm.ProviderMetadata{}
+		if providerName == "openrouter" {
+			metadata[openRouterReasoningDetailsMetadataKey] = string(message.ReasoningDetails)
+		}
+		content = append(content, &llm.ThinkingContent{
+			Thinking: thinking,
+			Metadata: metadata,
+		})
+	} else if message.Reasoning != "" {
+		metadata := llm.ProviderMetadata{}
+		if providerName == "openrouter" {
+			metadata[openRouterReasoningMetadataKey] = "true"
+		}
+		content = append(content, &llm.ThinkingContent{
+			Thinking: message.Reasoning,
+			Metadata: metadata,
+		})
+	}
+
+	if len(message.ContentParts) == 0 {
+		if message.Content != "" {
+			content = append(content, &llm.TextContent{Text: message.Content})
+		}
+		return content
+	}
+	for _, part := range message.ContentParts {
+		switch part.Type {
+		case "thinking":
+			content = append(content, &llm.ThinkingContent{
+				Thinking: joinThinkingParts(part.Thinking),
+				Metadata: llm.ProviderMetadata{mistralThinkingMetadataKey: "true"},
+			})
+		case "text":
+			content = append(content, &llm.TextContent{Text: part.Text})
+		}
+	}
+	return content
+}
+
+func joinThinkingParts(parts []ContentPart) string {
+	var text strings.Builder
+	for _, part := range parts {
+		text.WriteString(part.Text)
+	}
+	return text.String()
+}
+
+func reasoningDetailsText(raw json.RawMessage) string {
+	var details []map[string]any
+	if err := json.Unmarshal(raw, &details); err != nil {
+		return ""
+	}
+	var text []string
+	for _, detail := range details {
+		for _, key := range []string{"text", "summary"} {
+			if value, ok := detail[key].(string); ok && value != "" {
+				text = append(text, value)
+				break
+			}
+		}
+	}
+	return strings.Join(text, "\n\n")
 }
 
 // joinTextParts flattens text content parts into a single string for message

--- a/providers/openaicompletions/openai_test.go
+++ b/providers/openaicompletions/openai_test.go
@@ -775,6 +775,103 @@ func TestConvertMessagesSkipsThinkingContent(t *testing.T) {
 	assert.Equal(t, "The answer is 4.", result[0].Content)
 }
 
+func TestMistralThinkingChunksDecodeAndReplay(t *testing.T) {
+	var message Message
+	assert.NoError(t, json.Unmarshal([]byte(`{
+		"role":"assistant",
+		"content":[
+			{"type":"thinking","thinking":[{"type":"text","text":"First reason. "},{"type":"text","text":"Second reason."}]},
+			{"type":"text","text":"Final answer."}
+		]
+	}`), &message))
+
+	content := responseMessageContent(message, "mistral-mistral-small-latest")
+	assert.Len(t, content, 2)
+	thinking, ok := content[0].(*llm.ThinkingContent)
+	assert.True(t, ok)
+	assert.Equal(t, "First reason. Second reason.", thinking.Thinking)
+	assert.Equal(t, "true", thinking.Metadata[mistralThinkingMetadataKey])
+	answer, ok := content[1].(*llm.TextContent)
+	assert.True(t, ok)
+	assert.Equal(t, "Final answer.", answer.Text)
+
+	replayed, err := convertMessagesForProvider([]*llm.Message{{
+		Role:    llm.Assistant,
+		Content: content,
+	}}, "mistral-mistral-small-latest")
+	assert.NoError(t, err)
+	assert.Len(t, replayed, 1)
+	body, err := json.Marshal(replayed[0])
+	assert.NoError(t, err)
+	assert.Equal(t,
+		`{"role":"assistant","content":[{"type":"thinking","thinking":[{"type":"text","text":"First reason. Second reason."}]},{"type":"text","text":"Final answer."}]}`,
+		string(body))
+}
+
+func TestMistralDoesNotReplayAnotherProvidersThinking(t *testing.T) {
+	messages, err := convertMessagesForProvider([]*llm.Message{{
+		Role: llm.Assistant,
+		Content: []llm.Content{
+			&llm.ThinkingContent{Thinking: "anthropic reasoning", Signature: "anthropic-signature"},
+			&llm.TextContent{Text: "answer"},
+		},
+	}}, "mistral-mistral-small-latest")
+	assert.NoError(t, err)
+	assert.Len(t, messages, 1)
+	assert.Equal(t, "answer", messages[0].Content)
+	assert.Empty(t, messages[0].ContentParts)
+}
+
+func TestOpenRouterReasoningDetailsDecodeAndReplay(t *testing.T) {
+	var message Message
+	assert.NoError(t, json.Unmarshal([]byte(`{
+		"role":"assistant",
+		"content":"answer",
+		"reasoning":"summary",
+		"reasoning_details":[{"type":"reasoning.text","text":"summary","signature":"sig","format":"anthropic-claude-v1","index":0}]
+	}`), &message))
+
+	content := responseMessageContent(message, "openrouter")
+	assert.Len(t, content, 2)
+	thinking := content[0].(*llm.ThinkingContent)
+	assert.Equal(t, "summary", thinking.Thinking)
+	assert.True(t, json.Valid([]byte(thinking.Metadata[openRouterReasoningDetailsMetadataKey])))
+
+	replayed, err := convertMessagesForProvider([]*llm.Message{{
+		Role:    llm.Assistant,
+		Content: content,
+	}}, "openrouter")
+	assert.NoError(t, err)
+	assert.Len(t, replayed, 1)
+	assert.Equal(t, "answer", replayed[0].Content)
+	assert.Empty(t, replayed[0].Reasoning)
+	assert.Equal(t, message.ReasoningDetails, replayed[0].ReasoningDetails)
+}
+
+func TestResponseMessageContentPreservesPlainReasoning(t *testing.T) {
+	content := responseMessageContent(Message{
+		Content:   "answer",
+		Reasoning: "visible reasoning",
+	}, "openrouter")
+	assert.Len(t, content, 2)
+	thinking := content[0].(*llm.ThinkingContent)
+	assert.Equal(t, "visible reasoning", thinking.Thinking)
+	assert.Equal(t, "true", thinking.Metadata[openRouterReasoningMetadataKey])
+}
+
+func TestMessageIgnoresNullReasoningDetails(t *testing.T) {
+	var message Message
+	assert.NoError(t, json.Unmarshal([]byte(`{
+		"role":"assistant",
+		"content":"answer",
+		"reasoning_details":null
+	}`), &message))
+	assert.Nil(t, message.ReasoningDetails)
+	content := responseMessageContent(message, "openrouter")
+	assert.Len(t, content, 1)
+	assert.Equal(t, "answer", content[0].(*llm.TextContent).Text)
+}
+
 // TestGenerateUsageDetails verifies that cached prompt tokens and reasoning
 // tokens from a non-streaming response are carried into llm.Usage.
 func TestGenerateUsageDetails(t *testing.T) {

--- a/providers/openaicompletions/openai_test.go
+++ b/providers/openaicompletions/openai_test.go
@@ -848,6 +848,46 @@ func TestOpenRouterReasoningDetailsDecodeAndReplay(t *testing.T) {
 	assert.Equal(t, message.ReasoningDetails, replayed[0].ReasoningDetails)
 }
 
+func TestOpenRouterReplaysMultipleReasoningDetailBlocks(t *testing.T) {
+	messages, err := convertMessagesForProvider([]*llm.Message{{
+		Role: llm.Assistant,
+		Content: []llm.Content{
+			&llm.ThinkingContent{Metadata: llm.ProviderMetadata{
+				openRouterReasoningDetailsMetadataKey: `[{"type":"reasoning.text","text":"first"}]`,
+			}},
+			&llm.ThinkingContent{Metadata: llm.ProviderMetadata{
+				openRouterReasoningDetailsMetadataKey: `[{"type":"reasoning.text","text":"second"}]`,
+			}},
+			&llm.TextContent{Text: "answer"},
+		},
+	}}, "openrouter")
+	assert.NoError(t, err)
+	assert.Len(t, messages, 1)
+	var details []map[string]any
+	assert.NoError(t, json.Unmarshal(messages[0].ReasoningDetails, &details))
+	assert.Len(t, details, 2)
+	assert.Equal(t, "first", details[0]["text"])
+	assert.Equal(t, "second", details[1]["text"])
+}
+
+func TestMessageMarshalContentPartsPreservesOtherFields(t *testing.T) {
+	message := Message{
+		Role:         "assistant",
+		ContentParts: []ContentPart{{Type: "text", Text: "answer"}},
+		Name:         "named-assistant",
+		Reasoning:    "reasoning",
+		ReasoningDetails: json.RawMessage(
+			`[{"type":"reasoning.text","text":"reasoning"}]`,
+		),
+	}
+	data, err := json.Marshal(message)
+	assert.NoError(t, err)
+	assert.Contains(t, string(data), `"content":[{"type":"text","text":"answer"}]`)
+	assert.Contains(t, string(data), `"name":"named-assistant"`)
+	assert.Contains(t, string(data), `"reasoning":"reasoning"`)
+	assert.Contains(t, string(data), `"reasoning_details":[{"type":"reasoning.text","text":"reasoning"}]`)
+}
+
 func TestResponseMessageContentPreservesPlainReasoning(t *testing.T) {
 	content := responseMessageContent(Message{
 		Content:   "answer",

--- a/providers/openaicompletions/stream_iterator.go
+++ b/providers/openaicompletions/stream_iterator.go
@@ -34,9 +34,11 @@ type StreamIterator struct {
 	finalEvents []*llm.Event
 	// thinkingIndex and textIndex track the sequential content block index
 	// assigned to each block type, or -1 if not yet started.
-	thinkingIndex        int
-	textIndex            int
-	reportedCostCurrency string
+	thinkingIndex              int
+	textIndex                  int
+	reportedCostCurrency       string
+	providerName               string
+	openRouterReasoningDetails []json.RawMessage
 	// toolCallIndices maps OpenAI tool call indices to sequential block indices.
 	toolCallIndices map[int]int
 }
@@ -167,78 +169,43 @@ func (s *StreamIterator) next() ([]*llm.Event, error) {
 	}
 
 	if choice.Delta.Reasoning != "" {
-		if s.thinkingIndex < 0 {
-			s.thinkingIndex = s.nextBlockIndex
-			s.nextBlockIndex++
-			s.contentBlocks[s.thinkingIndex] = &ContentBlockAccumulator{Type: "thinking"}
-			events = append(events, &llm.Event{
-				Type:         llm.EventTypeContentBlockStart,
-				Index:        &s.thinkingIndex,
-				ContentBlock: &llm.EventContentBlock{Type: "thinking"},
-			})
+		metadata := llm.ProviderMetadata(nil)
+		if s.providerName == "openrouter" {
+			metadata = llm.ProviderMetadata{openRouterReasoningMetadataKey: "true"}
 		}
-		events = append(events, &llm.Event{
-			Type:  llm.EventTypeContentBlockDelta,
-			Index: &s.thinkingIndex,
-			Delta: &llm.EventDelta{
-				Type:     llm.EventDeltaTypeThinking,
-				Thinking: choice.Delta.Reasoning,
-			},
-		})
+		events = s.appendThinkingEvents(events, choice.Delta.Reasoning, metadata)
+	}
+	if s.providerName == "openrouter" && len(bytes.TrimSpace(choice.Delta.ReasoningDetails)) > 0 &&
+		!bytes.Equal(bytes.TrimSpace(choice.Delta.ReasoningDetails), []byte("null")) {
+		var err error
+		events, err = s.appendOpenRouterReasoningDetails(
+			events,
+			choice.Delta.ReasoningDetails,
+			choice.Delta.Reasoning == "",
+		)
+		if err != nil {
+			return nil, err
+		}
 	}
 
-	// Handle text content
+	// Mistral emits array-shaped content deltas while thinking. Preserve each
+	// ThinkChunk as thinking and each TextChunk as answer text.
+	for _, part := range choice.Delta.ContentParts {
+		switch part.Type {
+		case "thinking":
+			thinking := joinThinkingParts(part.Thinking)
+			if thinking != "" {
+				events = s.appendThinkingEvents(events, thinking,
+					llm.ProviderMetadata{mistralThinkingMetadataKey: "true"})
+			}
+		case "text":
+			events = s.appendTextEvents(events, part.Text)
+		}
+	}
+
+	// Handle ordinary string-shaped text content.
 	if choice.Delta.Content != "" {
-		// Apply and clear prefill if there is one
-		if s.prefill != "" {
-			if !strings.HasPrefix(choice.Delta.Content, s.prefill) &&
-				!strings.HasPrefix(s.prefill, choice.Delta.Content) {
-				choice.Delta.Content = s.prefill + choice.Delta.Content
-			}
-			s.prefill = ""
-		}
-		// If this is a new text block, stop any open blocks and start it
-		if s.textIndex < 0 {
-			// Stop any previous content blocks that are still open
-			for prevIndex, prev := range s.contentBlocks {
-				if !prev.IsComplete {
-					stopIndex := prevIndex
-					events = append(events, &llm.Event{
-						Type:  llm.EventTypeContentBlockStop,
-						Index: &stopIndex,
-					})
-					prev.IsComplete = true
-				}
-			}
-			// Stop any previous tool calls that are still open
-			for prevIndex, prev := range s.toolCalls {
-				if !prev.IsComplete {
-					stopIndex := prevIndex
-					events = append(events, &llm.Event{
-						Type:  llm.EventTypeContentBlockStop,
-						Index: &stopIndex,
-					})
-					prev.IsComplete = true
-				}
-			}
-			s.textIndex = s.nextBlockIndex
-			s.nextBlockIndex++
-			s.contentBlocks[s.textIndex] = &ContentBlockAccumulator{Type: "text"}
-			events = append(events, &llm.Event{
-				Type:         llm.EventTypeContentBlockStart,
-				Index:        &s.textIndex,
-				ContentBlock: &llm.EventContentBlock{Type: "text"},
-			})
-		}
-		// Generate a content_block_delta event
-		events = append(events, &llm.Event{
-			Type:  llm.EventTypeContentBlockDelta,
-			Index: &s.textIndex,
-			Delta: &llm.EventDelta{
-				Type: llm.EventDeltaTypeText,
-				Text: choice.Delta.Content,
-			},
-		})
+		events = s.appendTextEvents(events, choice.Delta.Content)
 	}
 
 	if len(choice.Delta.ToolCalls) > 0 {
@@ -367,6 +334,132 @@ func (s *StreamIterator) next() ([]*llm.Event, error) {
 	}
 
 	return events, nil
+}
+
+func (s *StreamIterator) appendThinkingEvents(events []*llm.Event, text string, metadata llm.ProviderMetadata) []*llm.Event {
+	if text == "" {
+		return events
+	}
+	events = s.ensureThinkingBlock(events, metadata)
+	return append(events, &llm.Event{
+		Type:  llm.EventTypeContentBlockDelta,
+		Index: &s.thinkingIndex,
+		Delta: &llm.EventDelta{
+			Type:     llm.EventDeltaTypeThinking,
+			Thinking: text,
+		},
+	})
+}
+
+func (s *StreamIterator) ensureThinkingBlock(events []*llm.Event, metadata llm.ProviderMetadata) []*llm.Event {
+	if s.thinkingIndex < 0 {
+		s.thinkingIndex = s.nextBlockIndex
+		s.nextBlockIndex++
+		s.contentBlocks[s.thinkingIndex] = &ContentBlockAccumulator{Type: "thinking"}
+		events = append(events, &llm.Event{
+			Type:  llm.EventTypeContentBlockStart,
+			Index: &s.thinkingIndex,
+			ContentBlock: &llm.EventContentBlock{
+				Type:     llm.ContentTypeThinking,
+				Metadata: metadata.Clone(),
+			},
+		})
+	}
+	return events
+}
+
+func (s *StreamIterator) appendOpenRouterReasoningDetails(
+	events []*llm.Event,
+	raw json.RawMessage,
+	includeVisibleText bool,
+) ([]*llm.Event, error) {
+	var details []json.RawMessage
+	if err := json.Unmarshal(raw, &details); err != nil {
+		return nil, err
+	}
+	if len(details) == 0 {
+		return events, nil
+	}
+	for _, detail := range details {
+		s.openRouterReasoningDetails = append(
+			s.openRouterReasoningDetails,
+			append(json.RawMessage(nil), detail...),
+		)
+	}
+	fullDetails, err := json.Marshal(s.openRouterReasoningDetails)
+	if err != nil {
+		return nil, err
+	}
+	metadata := llm.ProviderMetadata{
+		openRouterReasoningDetailsMetadataKey: string(fullDetails),
+	}
+	events = s.ensureThinkingBlock(events, metadata)
+	if includeVisibleText {
+		if text := reasoningDetailsText(raw); text != "" {
+			events = s.appendThinkingEvents(events, text, metadata)
+		}
+	}
+	events = append(events, &llm.Event{
+		Type:  llm.EventTypeContentBlockDelta,
+		Index: &s.thinkingIndex,
+		Delta: &llm.EventDelta{
+			Type:     llm.EventDeltaTypeMetadata,
+			Metadata: metadata,
+		},
+	})
+	return events, nil
+}
+
+func (s *StreamIterator) appendTextEvents(events []*llm.Event, text string) []*llm.Event {
+	if text == "" {
+		return events
+	}
+	// Apply and clear prefill if there is one.
+	if s.prefill != "" {
+		if !strings.HasPrefix(text, s.prefill) && !strings.HasPrefix(s.prefill, text) {
+			text = s.prefill + text
+		}
+		s.prefill = ""
+	}
+	// If this is a new text block, stop any open blocks and start it.
+	if s.textIndex < 0 {
+		for prevIndex, prev := range s.contentBlocks {
+			if !prev.IsComplete {
+				stopIndex := prevIndex
+				events = append(events, &llm.Event{
+					Type:  llm.EventTypeContentBlockStop,
+					Index: &stopIndex,
+				})
+				prev.IsComplete = true
+			}
+		}
+		for prevIndex, prev := range s.toolCalls {
+			if !prev.IsComplete {
+				stopIndex := prevIndex
+				events = append(events, &llm.Event{
+					Type:  llm.EventTypeContentBlockStop,
+					Index: &stopIndex,
+				})
+				prev.IsComplete = true
+			}
+		}
+		s.textIndex = s.nextBlockIndex
+		s.nextBlockIndex++
+		s.contentBlocks[s.textIndex] = &ContentBlockAccumulator{Type: "text"}
+		events = append(events, &llm.Event{
+			Type:         llm.EventTypeContentBlockStart,
+			Index:        &s.textIndex,
+			ContentBlock: &llm.EventContentBlock{Type: llm.ContentTypeText},
+		})
+	}
+	return append(events, &llm.Event{
+		Type:  llm.EventTypeContentBlockDelta,
+		Index: &s.textIndex,
+		Delta: &llm.EventDelta{
+			Type: llm.EventDeltaTypeText,
+			Text: text,
+		},
+	})
 }
 
 // flushFinalEvents returns the deferred message_delta and message_stop events,

--- a/providers/openaicompletions/stream_iterator.go
+++ b/providers/openaicompletions/stream_iterator.go
@@ -151,6 +151,7 @@ func (s *StreamIterator) next() ([]*llm.Event, error) {
 	}
 	choice := event.Choices[0]
 	var events []*llm.Event
+	var processErr error
 
 	// Emit message start event if this is the first event
 	if s.eventCount == 0 {
@@ -177,14 +178,13 @@ func (s *StreamIterator) next() ([]*llm.Event, error) {
 	}
 	if s.providerName == "openrouter" && len(bytes.TrimSpace(choice.Delta.ReasoningDetails)) > 0 &&
 		!bytes.Equal(bytes.TrimSpace(choice.Delta.ReasoningDetails), []byte("null")) {
-		var err error
-		events, err = s.appendOpenRouterReasoningDetails(
+		events, processErr = s.appendOpenRouterReasoningDetails(
 			events,
 			choice.Delta.ReasoningDetails,
 			choice.Delta.Reasoning == "",
 		)
-		if err != nil {
-			return nil, err
+		if processErr != nil {
+			return nil, processErr
 		}
 	}
 
@@ -199,16 +199,28 @@ func (s *StreamIterator) next() ([]*llm.Event, error) {
 					llm.ProviderMetadata{mistralThinkingMetadataKey: "true"})
 			}
 		case "text":
+			events, processErr = s.flushOpenRouterReasoningDetails(events)
+			if processErr != nil {
+				return nil, processErr
+			}
 			events = s.appendTextEvents(events, part.Text)
 		}
 	}
 
 	// Handle ordinary string-shaped text content.
 	if choice.Delta.Content != "" {
+		events, processErr = s.flushOpenRouterReasoningDetails(events)
+		if processErr != nil {
+			return nil, processErr
+		}
 		events = s.appendTextEvents(events, choice.Delta.Content)
 	}
 
 	if len(choice.Delta.ToolCalls) > 0 {
+		events, processErr = s.flushOpenRouterReasoningDetails(events)
+		if processErr != nil {
+			return nil, processErr
+		}
 		for _, toolCallDelta := range choice.Delta.ToolCalls {
 			// Map OpenAI tool call index to a sequential display index
 			index, known := s.toolCallIndices[toolCallDelta.Index]
@@ -292,6 +304,10 @@ func (s *StreamIterator) next() ([]*llm.Event, error) {
 	}
 
 	if choice.FinishReason != "" {
+		events, processErr = s.flushOpenRouterReasoningDetails(events)
+		if processErr != nil {
+			return nil, processErr
+		}
 		// Stop any open content blocks
 		for index, block := range s.contentBlocks {
 			blockIndex := index
@@ -341,9 +357,10 @@ func (s *StreamIterator) appendThinkingEvents(events []*llm.Event, text string, 
 		return events
 	}
 	events = s.ensureThinkingBlock(events, metadata)
+	index := s.thinkingIndex
 	return append(events, &llm.Event{
 		Type:  llm.EventTypeContentBlockDelta,
-		Index: &s.thinkingIndex,
+		Index: &index,
 		Delta: &llm.EventDelta{
 			Type:     llm.EventDeltaTypeThinking,
 			Thinking: text,
@@ -356,9 +373,10 @@ func (s *StreamIterator) ensureThinkingBlock(events []*llm.Event, metadata llm.P
 		s.thinkingIndex = s.nextBlockIndex
 		s.nextBlockIndex++
 		s.contentBlocks[s.thinkingIndex] = &ContentBlockAccumulator{Type: "thinking"}
+		index := s.thinkingIndex
 		events = append(events, &llm.Event{
 			Type:  llm.EventTypeContentBlockStart,
-			Index: &s.thinkingIndex,
+			Index: &index,
 			ContentBlock: &llm.EventContentBlock{
 				Type:     llm.ContentTypeThinking,
 				Metadata: metadata.Clone(),
@@ -386,28 +404,35 @@ func (s *StreamIterator) appendOpenRouterReasoningDetails(
 			append(json.RawMessage(nil), detail...),
 		)
 	}
+	events = s.ensureThinkingBlock(events, nil)
+	if includeVisibleText {
+		if text := reasoningDetailsText(raw); text != "" {
+			events = s.appendThinkingEvents(events, text, nil)
+		}
+	}
+	return events, nil
+}
+
+func (s *StreamIterator) flushOpenRouterReasoningDetails(events []*llm.Event) ([]*llm.Event, error) {
+	if len(s.openRouterReasoningDetails) == 0 || s.thinkingIndex < 0 {
+		return events, nil
+	}
 	fullDetails, err := json.Marshal(s.openRouterReasoningDetails)
 	if err != nil {
 		return nil, err
 	}
-	metadata := llm.ProviderMetadata{
-		openRouterReasoningDetailsMetadataKey: string(fullDetails),
-	}
-	events = s.ensureThinkingBlock(events, metadata)
-	if includeVisibleText {
-		if text := reasoningDetailsText(raw); text != "" {
-			events = s.appendThinkingEvents(events, text, metadata)
-		}
-	}
-	events = append(events, &llm.Event{
+	s.openRouterReasoningDetails = nil
+	index := s.thinkingIndex
+	return append(events, &llm.Event{
 		Type:  llm.EventTypeContentBlockDelta,
-		Index: &s.thinkingIndex,
+		Index: &index,
 		Delta: &llm.EventDelta{
-			Type:     llm.EventDeltaTypeMetadata,
-			Metadata: metadata,
+			Type: llm.EventDeltaTypeMetadata,
+			Metadata: llm.ProviderMetadata{
+				openRouterReasoningDetailsMetadataKey: string(fullDetails),
+			},
 		},
-	})
-	return events, nil
+	}), nil
 }
 
 func (s *StreamIterator) appendTextEvents(events []*llm.Event, text string) []*llm.Event {

--- a/providers/openaicompletions/stream_iterator_test.go
+++ b/providers/openaicompletions/stream_iterator_test.go
@@ -2,6 +2,7 @@ package openaicompletions
 
 import (
 	"bufio"
+	"encoding/json"
 	"io"
 	"strings"
 	"testing"
@@ -233,6 +234,86 @@ func TestStreamIteratorUsageOnFinishChunk(t *testing.T) {
 	response := accumulator.Response()
 	assert.Equal(t, 5, response.Usage.InputTokens)
 	assert.Equal(t, 2, response.Usage.OutputTokens)
+}
+
+func TestStreamIteratorPreservesMistralThinkingChunks(t *testing.T) {
+	body := strings.Join([]string{
+		`data: {"id":"chatcmpl-thinking","model":"mistral-small-latest","choices":[{"index":0,"delta":{"role":"assistant","content":[{"type":"thinking","thinking":[{"type":"text","text":"First "}]}]}}]}`,
+		``,
+		`data: {"id":"chatcmpl-thinking","model":"mistral-small-latest","choices":[{"index":0,"delta":{"content":[{"type":"thinking","thinking":[{"type":"text","text":"then"}]},{"type":"text","text":"Answer"}]}}]}`,
+		``,
+		`data: {"id":"chatcmpl-thinking","model":"mistral-small-latest","choices":[{"index":0,"delta":{"content":" done"}}]}`,
+		``,
+		`data: {"id":"chatcmpl-thinking","model":"mistral-small-latest","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}`,
+		``,
+		`data: [DONE]`,
+		``,
+	}, "\n")
+
+	iterator := newTestStreamIterator(body)
+	iterator.providerName = "mistral-mistral-small-latest"
+	t.Cleanup(func() { assert.NoError(t, iterator.Close()) })
+	_, accumulator := collectEvents(t, iterator)
+	response := accumulator.Response()
+	assert.Len(t, response.Content, 2)
+	thinking := response.Content[0].(*llm.ThinkingContent)
+	assert.Equal(t, "First then", thinking.Thinking)
+	assert.Equal(t, "true", thinking.Metadata[mistralThinkingMetadataKey])
+	answer := response.Content[1].(*llm.TextContent)
+	assert.Equal(t, "Answer done", answer.Text)
+
+	replayed, err := convertMessagesForProvider([]*llm.Message{response.Message().Copy()}, iterator.providerName)
+	assert.NoError(t, err)
+	assert.Len(t, replayed, 1)
+	assert.Len(t, replayed[0].ContentParts, 2)
+	assert.Equal(t, "thinking", replayed[0].ContentParts[0].Type)
+	assert.Equal(t, "First then", replayed[0].ContentParts[0].Thinking[0].Text)
+	assert.Equal(t, "Answer done", replayed[0].ContentParts[1].Text)
+}
+
+func TestStreamIteratorPreservesOpenRouterReasoningDetails(t *testing.T) {
+	body := strings.Join([]string{
+		`data: {"id":"chatcmpl-reasoning","model":"google/gemini-3.1-pro-preview","choices":[{"index":0,"delta":{"role":"assistant","reasoning_details":[{"type":"reasoning.text","text":"First ","id":"reasoning-1","format":"google-gemini-v1","index":0}]}}]}`,
+		``,
+		`data: {"id":"chatcmpl-reasoning","model":"google/gemini-3.1-pro-preview","choices":[{"index":0,"delta":{"reasoning_details":[{"type":"reasoning.text","text":"then","id":"reasoning-1","format":"google-gemini-v1","index":0}]}}]}`,
+		``,
+		`data: {"id":"chatcmpl-reasoning","model":"google/gemini-3.1-pro-preview","choices":[{"index":0,"delta":{"content":"Answer"}}]}`,
+		``,
+		`data: {"id":"chatcmpl-reasoning","model":"google/gemini-3.1-pro-preview","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}`,
+		``,
+		`data: [DONE]`,
+		``,
+	}, "\n")
+
+	iterator := newTestStreamIterator(body)
+	iterator.providerName = "openrouter"
+	t.Cleanup(func() { assert.NoError(t, iterator.Close()) })
+	_, accumulator := collectEvents(t, iterator)
+	response := accumulator.Response()
+	assert.Len(t, response.Content, 2)
+	thinking := response.Content[0].(*llm.ThinkingContent)
+	assert.Equal(t, "First then", thinking.Thinking)
+	var details []map[string]any
+	assert.NoError(t, json.Unmarshal(
+		[]byte(thinking.Metadata[openRouterReasoningDetailsMetadataKey]),
+		&details,
+	))
+	assert.Len(t, details, 2)
+	assert.Equal(t, "First ", details[0]["text"])
+	assert.Equal(t, "then", details[1]["text"])
+
+	replayed, err := convertMessagesForProvider(
+		[]*llm.Message{response.Message().Copy()},
+		iterator.providerName,
+	)
+	assert.NoError(t, err)
+	assert.Len(t, replayed, 1)
+	assert.Equal(t, "Answer", replayed[0].Content)
+	assert.Empty(t, replayed[0].Reasoning)
+	assert.Equal(t,
+		thinking.Metadata[openRouterReasoningDetailsMetadataKey],
+		string(replayed[0].ReasoningDetails),
+	)
 }
 
 // TestStreamIteratorUsageDetails verifies that cached prompt tokens and

--- a/providers/openaicompletions/stream_iterator_test.go
+++ b/providers/openaicompletions/stream_iterator_test.go
@@ -288,7 +288,7 @@ func TestStreamIteratorPreservesOpenRouterReasoningDetails(t *testing.T) {
 	iterator := newTestStreamIterator(body)
 	iterator.providerName = "openrouter"
 	t.Cleanup(func() { assert.NoError(t, iterator.Close()) })
-	_, accumulator := collectEvents(t, iterator)
+	events, accumulator := collectEvents(t, iterator)
 	response := accumulator.Response()
 	assert.Len(t, response.Content, 2)
 	thinking := response.Content[0].(*llm.ThinkingContent)
@@ -314,6 +314,21 @@ func TestStreamIteratorPreservesOpenRouterReasoningDetails(t *testing.T) {
 		thinking.Metadata[openRouterReasoningDetailsMetadataKey],
 		string(replayed[0].ReasoningDetails),
 	)
+	metadataDeltas := 0
+	for _, event := range events {
+		if event.Delta != nil && event.Delta.Type == llm.EventDeltaTypeMetadata {
+			metadataDeltas++
+		}
+	}
+	assert.Equal(t, 1, metadataDeltas)
+	iterator.thinkingIndex = 99
+	for _, event := range events {
+		if event.ContentBlock != nil && event.ContentBlock.Type == llm.ContentTypeThinking ||
+			event.Delta != nil && (event.Delta.Type == llm.EventDeltaTypeThinking ||
+				event.Delta.Type == llm.EventDeltaTypeMetadata) {
+			assert.Equal(t, 0, *event.Index)
+		}
+	}
 }
 
 // TestStreamIteratorUsageDetails verifies that cached prompt tokens and

--- a/providers/openaicompletions/types.go
+++ b/providers/openaicompletions/types.go
@@ -64,26 +64,16 @@ type Message struct {
 }
 
 func (m Message) MarshalJSON() ([]byte, error) {
+	type alias Message
 	if len(m.ContentParts) == 0 {
-		type alias Message
 		return json.Marshal(alias(m))
 	}
 	return json.Marshal(struct {
-		Role             string          `json:"role"`
-		Content          []ContentPart   `json:"content"`
-		Name             string          `json:"name,omitempty"`
-		ToolCallID       string          `json:"tool_call_id,omitempty"`
-		ToolCalls        []ToolCall      `json:"tool_calls,omitempty"`
-		Reasoning        string          `json:"reasoning,omitempty"`
-		ReasoningDetails json.RawMessage `json:"reasoning_details,omitempty"`
+		alias
+		Content []ContentPart `json:"content"`
 	}{
-		Role:             m.Role,
-		Content:          m.ContentParts,
-		Name:             m.Name,
-		ToolCallID:       m.ToolCallID,
-		ToolCalls:        m.ToolCalls,
-		Reasoning:        m.Reasoning,
-		ReasoningDetails: m.ReasoningDetails,
+		alias:   alias(m),
+		Content: m.ContentParts,
 	})
 }
 

--- a/providers/openaicompletions/types.go
+++ b/providers/openaicompletions/types.go
@@ -55,6 +55,12 @@ type Message struct {
 	Name         string        `json:"name,omitempty"`
 	ToolCallID   string        `json:"tool_call_id,omitempty"`
 	ToolCalls    []ToolCall    `json:"tool_calls,omitempty"`
+	// Reasoning is the OpenAI-compatible plaintext reasoning extension used by
+	// gateways such as OpenRouter.
+	Reasoning string `json:"reasoning,omitempty"`
+	// ReasoningDetails preserves OpenRouter's structured reasoning blocks
+	// verbatim for replay. It is intentionally opaque to this shared adapter.
+	ReasoningDetails json.RawMessage `json:"reasoning_details,omitempty"`
 }
 
 func (m Message) MarshalJSON() ([]byte, error) {
@@ -63,23 +69,35 @@ func (m Message) MarshalJSON() ([]byte, error) {
 		return json.Marshal(alias(m))
 	}
 	return json.Marshal(struct {
-		Role       string        `json:"role"`
-		Content    []ContentPart `json:"content"`
-		Name       string        `json:"name,omitempty"`
-		ToolCallID string        `json:"tool_call_id,omitempty"`
-		ToolCalls  []ToolCall    `json:"tool_calls,omitempty"`
-	}{m.Role, m.ContentParts, m.Name, m.ToolCallID, m.ToolCalls})
+		Role             string          `json:"role"`
+		Content          []ContentPart   `json:"content"`
+		Name             string          `json:"name,omitempty"`
+		ToolCallID       string          `json:"tool_call_id,omitempty"`
+		ToolCalls        []ToolCall      `json:"tool_calls,omitempty"`
+		Reasoning        string          `json:"reasoning,omitempty"`
+		ReasoningDetails json.RawMessage `json:"reasoning_details,omitempty"`
+	}{
+		Role:             m.Role,
+		Content:          m.ContentParts,
+		Name:             m.Name,
+		ToolCallID:       m.ToolCallID,
+		ToolCalls:        m.ToolCalls,
+		Reasoning:        m.Reasoning,
+		ReasoningDetails: m.ReasoningDetails,
+	})
 }
 
 // UnmarshalJSON accepts both content shapes: a plain string (the usual
 // response form) or a content-part array.
 func (m *Message) UnmarshalJSON(data []byte) error {
 	var aux struct {
-		Role       string          `json:"role"`
-		Content    json.RawMessage `json:"content"`
-		Name       string          `json:"name"`
-		ToolCallID string          `json:"tool_call_id"`
-		ToolCalls  []ToolCall      `json:"tool_calls"`
+		Role             string          `json:"role"`
+		Content          json.RawMessage `json:"content"`
+		Name             string          `json:"name"`
+		ToolCallID       string          `json:"tool_call_id"`
+		ToolCalls        []ToolCall      `json:"tool_calls"`
+		Reasoning        string          `json:"reasoning"`
+		ReasoningDetails json.RawMessage `json:"reasoning_details"`
 	}
 	if err := json.Unmarshal(data, &aux); err != nil {
 		return err
@@ -88,6 +106,13 @@ func (m *Message) UnmarshalJSON(data []byte) error {
 	m.Name = aux.Name
 	m.ToolCallID = aux.ToolCallID
 	m.ToolCalls = aux.ToolCalls
+	m.Reasoning = aux.Reasoning
+	reasoningDetails := bytes.TrimSpace(aux.ReasoningDetails)
+	if len(reasoningDetails) == 0 || bytes.Equal(reasoningDetails, []byte("null")) {
+		m.ReasoningDetails = nil
+	} else {
+		m.ReasoningDetails = append(m.ReasoningDetails[:0], reasoningDetails...)
+	}
 	m.Content = ""
 	m.ContentParts = nil
 	content := bytes.TrimSpace(aux.Content)
@@ -113,8 +138,11 @@ func (m *Message) UnmarshalJSON(data []byte) error {
 // ContentPart is one element of a multimodal content array in a Chat
 // Completions message.
 type ContentPart struct {
-	Type                  string                 `json:"type"` // "text", "image_url", or "file"
-	Text                  string                 `json:"text,omitempty"`
+	Type string `json:"type"` // "text", "thinking", "image_url", or "file"
+	Text string `json:"text,omitempty"`
+	// Thinking is populated for Mistral ThinkChunk parts. Each nested part is
+	// currently a text chunk, but the recursive shape matches the wire format.
+	Thinking              []ContentPart          `json:"thinking,omitempty"`
 	ImageURL              *ImageURLPart          `json:"image_url,omitempty"`
 	File                  *FilePart              `json:"file,omitempty"`
 	PromptCacheBreakpoint *PromptCacheBreakpoint `json:"prompt_cache_breakpoint,omitempty"`
@@ -265,10 +293,52 @@ type StreamChoice struct {
 }
 
 type StreamDelta struct {
-	Role      string          `json:"role"`
-	Content   string          `json:"content,omitempty"`
-	Reasoning string          `json:"reasoning,omitempty"`
-	ToolCalls []ToolCallDelta `json:"tool_calls,omitempty"`
+	Role string `json:"role"`
+	// Content holds the ordinary string form. ContentParts holds the typed
+	// array form used by Mistral while it streams thinking chunks.
+	Content          string          `json:"-"`
+	ContentParts     []ContentPart   `json:"-"`
+	Reasoning        string          `json:"reasoning,omitempty"`
+	ReasoningDetails json.RawMessage `json:"reasoning_details,omitempty"`
+	ToolCalls        []ToolCallDelta `json:"tool_calls,omitempty"`
+}
+
+// UnmarshalJSON accepts both Chat Completions delta.content shapes: the usual
+// string and Mistral's array of ThinkChunk/TextChunk objects.
+func (d *StreamDelta) UnmarshalJSON(data []byte) error {
+	var aux struct {
+		Role             string          `json:"role"`
+		Content          json.RawMessage `json:"content"`
+		Reasoning        string          `json:"reasoning"`
+		ReasoningDetails json.RawMessage `json:"reasoning_details"`
+		ToolCalls        []ToolCallDelta `json:"tool_calls"`
+	}
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+	d.Role = aux.Role
+	d.Reasoning = aux.Reasoning
+	reasoningDetails := bytes.TrimSpace(aux.ReasoningDetails)
+	if len(reasoningDetails) == 0 || bytes.Equal(reasoningDetails, []byte("null")) {
+		d.ReasoningDetails = nil
+	} else {
+		d.ReasoningDetails = append(d.ReasoningDetails[:0], reasoningDetails...)
+	}
+	d.ToolCalls = aux.ToolCalls
+	d.Content = ""
+	d.ContentParts = nil
+	content := bytes.TrimSpace(aux.Content)
+	if len(content) == 0 || bytes.Equal(content, []byte("null")) {
+		return nil
+	}
+	switch content[0] {
+	case '"':
+		return json.Unmarshal(content, &d.Content)
+	case '[':
+		return json.Unmarshal(content, &d.ContentParts)
+	default:
+		return fmt.Errorf("unexpected stream delta content shape: %s", content)
+	}
 }
 
 // ToolCallDelta represents a partial tool call in a streaming response


### PR DESCRIPTION
## Summary

- preserve opaque provider replay metadata through content cloning, JSON persistence, and streaming accumulation
- round-trip Gemini thought parts and positional signatures, including signed answer text and empty signature-only parts
- support Mistral structured thinking chunks and OpenRouter plaintext/structured reasoning in both streaming and non-streaming paths
- retain OpenAI Responses summaries, raw reasoning text, item IDs, and encrypted content for stateless replay
- keep foreign provider metadata out of Anthropic/Ollama and other provider wire formats

## Review findings

The audit confirmed the remembered Gemini deficiency and found adjacent gaps:

- Gemini exposed thought summaries but dropped them and non-tool signatures when the assistant message was replayed.
- Mistral structured thinking arrays were dropped in non-streaming responses, failed to decode while streaming, and were stripped from history.
- OpenRouter structured `reasoning_details` were not retained for replay.
- OpenAI Responses streaming lost reasoning item IDs and encrypted content, and raw `reasoning_text` events were ignored.
- Generic Chat Completions non-streaming responses ignored plaintext `reasoning`.

Anthropic already preserved its native thinking/redacted-thinking blocks; Ollama inherits that adapter. Grok inherits the corrected OpenAI Responses path.

## Validation

Automated gates:

- `make check`
- `go test -race ./...`
- `go vet ./...` and `go test -race ./...` in `providers/google`, `providers/openai`, and `providers/grok`
- tests across every release module, examples, and demos

Live qualification:

- Anthropic Claude Haiku 4.5: visible thinking plus a multi-turn tool/replay flow.
- Gemini 3.6 Flash: a streamed thought-text block was captured and replayed; a separate signed tool call was captured and accepted on replay with its tool result.
- OpenAI GPT-5.6 Luna: a streamed reasoning item with ID, text, encrypted content, and summary metadata was captured and accepted on replay.
- Grok 4.5: visible thinking plus a multi-turn tool/replay flow.
- OpenRouter Gemini 3.1 Pro Preview: visible thinking plus a multi-turn tool/replay flow through the shared Chat Completions adapter.
- Ollama Qwen 3.6: visible thinking across a local Bash tool loop using the inherited Anthropic adapter.
- Mistral: official current wire-shape fixtures cover non-streaming, streaming, and exact replay. No Mistral credential is configured locally, so the native hosted Mistral path was not live-qualified.

## Contract references

- [Gemini thought signatures](https://ai.google.dev/gemini-api/docs/generate-content/thought-signatures)
- [Mistral reasoning](https://docs.mistral.ai/studio-api/conversations/reasoning)
- [OpenRouter reasoning tokens](https://openrouter.ai/docs/guides/best-practices/reasoning-tokens)
- [OpenAI Responses reasoning items](https://platform.openai.com/docs/api-reference/responses-streaming/response/reasoning_summary_part)