### PR TITLE
Prepare v1.22.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [1.22.0] - 2026-08-11
+
 ### Fixed
 
 - **Provider reasoning blocks now survive response copying, streaming, and

--- a/a2a/go.mod
+++ b/a2a/go.mod
@@ -6,7 +6,7 @@ toolchain go1.26.5
 
 require (
 	github.com/a2aproject/a2a-go/v2 v2.4.0
-	github.com/deepnoodle-ai/dive v1.21.0
+	github.com/deepnoodle-ai/dive v1.22.0
 	github.com/deepnoodle-ai/wonton v0.0.37
 )
 

--- a/demos/colosseum/go.mod
+++ b/demos/colosseum/go.mod
@@ -5,11 +5,11 @@ go 1.25.0
 toolchain go1.26.5
 
 require (
-	github.com/deepnoodle-ai/dive v1.21.0
-	github.com/deepnoodle-ai/dive/a2a v1.21.0
-	github.com/deepnoodle-ai/dive/providers/google v1.21.0
-	github.com/deepnoodle-ai/dive/providers/grok v1.21.0
-	github.com/deepnoodle-ai/dive/providers/openai v1.21.0
+	github.com/deepnoodle-ai/dive v1.22.0
+	github.com/deepnoodle-ai/dive/a2a v1.22.0
+	github.com/deepnoodle-ai/dive/providers/google v1.22.0
+	github.com/deepnoodle-ai/dive/providers/grok v1.22.0
+	github.com/deepnoodle-ai/dive/providers/openai v1.22.0
 	github.com/deepnoodle-ai/wonton v0.0.37
 )
 

--- a/demos/noodleville/go.mod
+++ b/demos/noodleville/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 toolchain go1.26.5
 
 require (
-	github.com/deepnoodle-ai/dive v1.21.0
+	github.com/deepnoodle-ai/dive v1.22.0
 	github.com/deepnoodle-ai/wonton v0.0.37
 )
 

--- a/docs/releases/v1.22.0.md
+++ b/docs/releases/v1.22.0.md
@@ -1,0 +1,30 @@
+## Highlights
+
+**Provider-native reasoning can now cross the full agent lifecycle without
+being lost.** This release is aimed at multi-turn agents, tool loops, and
+durable conversations: thinking content, signatures, and replay-only metadata
+survive streaming aggregation, response copying, JSON storage, and request
+reconstruction. That closes the gap where a first turn succeeded but replaying
+its assistant message could drop provider state or mix thought text into answer
+content.
+
+For users, upgrading is enough when messages flow through Dive's `llm.Content`
+types. Applications that transform messages into their own schema should
+preserve content metadata and signatures as opaque values; they are
+provider-specific and may be required for the next turn. Foreign metadata is
+filtered when a message is sent through a different provider.
+
+## Pull requests
+
+- Preserve reasoning blocks across provider adapters (#256)
+
+## Changelog
+
+### Fixed
+
+- **Provider reasoning blocks now survive response copying, streaming, and
+  multi-turn replay.** Gemini preserves thought parts and positional thought
+  signatures (including signed text and empty parts); Mistral preserves its
+  structured thinking chunks; OpenRouter retains plaintext and structured
+  `reasoning_details`; and OpenAI Responses retains summaries, raw reasoning
+  text, reasoning item IDs, and encrypted content from streamed responses.

--- a/examples/go.mod
+++ b/examples/go.mod
@@ -5,13 +5,13 @@ go 1.25.5
 toolchain go1.26.5
 
 require (
-	github.com/deepnoodle-ai/dive v1.21.0
-	github.com/deepnoodle-ai/dive/a2a v1.21.0
-	github.com/deepnoodle-ai/dive/experimental/mcp v1.21.0
-	github.com/deepnoodle-ai/dive/otel v1.21.0
-	github.com/deepnoodle-ai/dive/providers/google v1.21.0
-	github.com/deepnoodle-ai/dive/providers/grok v1.21.0
-	github.com/deepnoodle-ai/dive/providers/openai v1.21.0
+	github.com/deepnoodle-ai/dive v1.22.0
+	github.com/deepnoodle-ai/dive/a2a v1.22.0
+	github.com/deepnoodle-ai/dive/experimental/mcp v1.22.0
+	github.com/deepnoodle-ai/dive/otel v1.22.0
+	github.com/deepnoodle-ai/dive/providers/google v1.22.0
+	github.com/deepnoodle-ai/dive/providers/grok v1.22.0
+	github.com/deepnoodle-ai/dive/providers/openai v1.22.0
 	github.com/deepnoodle-ai/wonton v0.0.37
 	github.com/fatih/color v1.19.0
 	github.com/mark3labs/mcp-go v0.57.0

--- a/experimental/cmd/dive/go.mod
+++ b/experimental/cmd/dive/go.mod
@@ -5,10 +5,10 @@ go 1.25.0
 toolchain go1.26.5
 
 require (
-	github.com/deepnoodle-ai/dive v1.21.0
-	github.com/deepnoodle-ai/dive/providers/google v1.21.0
-	github.com/deepnoodle-ai/dive/providers/grok v1.21.0
-	github.com/deepnoodle-ai/dive/providers/openai v1.21.0
+	github.com/deepnoodle-ai/dive v1.22.0
+	github.com/deepnoodle-ai/dive/providers/google v1.22.0
+	github.com/deepnoodle-ai/dive/providers/grok v1.22.0
+	github.com/deepnoodle-ai/dive/providers/openai v1.22.0
 	github.com/deepnoodle-ai/wonton v0.0.37
 	github.com/mattn/go-runewidth v0.0.27
 	google.golang.org/genai v1.67.0

--- a/experimental/mcp/go.mod
+++ b/experimental/mcp/go.mod
@@ -5,7 +5,7 @@ go 1.25.5
 toolchain go1.26.5
 
 require (
-	github.com/deepnoodle-ai/dive v1.21.0
+	github.com/deepnoodle-ai/dive v1.22.0
 	github.com/deepnoodle-ai/wonton v0.0.37
 	github.com/mark3labs/mcp-go v0.57.0
 )

--- a/otel/go.mod
+++ b/otel/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 toolchain go1.26.5
 
 require (
-	github.com/deepnoodle-ai/dive v1.21.0
+	github.com/deepnoodle-ai/dive v1.22.0
 	go.opentelemetry.io/otel v1.45.0
 	go.opentelemetry.io/otel/metric v1.45.0
 	go.opentelemetry.io/otel/sdk v1.45.0

--- a/providers/google/go.mod
+++ b/providers/google/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 toolchain go1.26.5
 
 require (
-	github.com/deepnoodle-ai/dive v1.21.0
+	github.com/deepnoodle-ai/dive v1.22.0
 	github.com/deepnoodle-ai/wonton v0.0.37
 	google.golang.org/genai v1.67.0
 )

--- a/providers/grok/go.mod
+++ b/providers/grok/go.mod
@@ -5,8 +5,8 @@ go 1.25.0
 toolchain go1.26.5
 
 require (
-	github.com/deepnoodle-ai/dive v1.21.0
-	github.com/deepnoodle-ai/dive/providers/openai v1.21.0
+	github.com/deepnoodle-ai/dive v1.22.0
+	github.com/deepnoodle-ai/dive/providers/openai v1.22.0
 	github.com/deepnoodle-ai/wonton v0.0.37
 	github.com/openai/openai-go/v3 v3.50.0
 	golang.org/x/image v0.44.0

--- a/providers/openai/go.mod
+++ b/providers/openai/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 toolchain go1.26.5
 
 require (
-	github.com/deepnoodle-ai/dive v1.21.0
+	github.com/deepnoodle-ai/dive v1.22.0
 	github.com/deepnoodle-ai/wonton v0.0.37
 	github.com/openai/openai-go/v3 v3.50.0
 	golang.org/x/image v0.44.0


### PR DESCRIPTION
## Summary

- cut the existing Unreleased changelog as `v1.22.0` and leave a fresh Unreleased section
- point all eight tagged sub-modules and both demo modules at `v1.22.0`
- add reviewed GitHub release notes for the provider-reasoning replay work merged since `v1.21.0`

## Why v1.22.0

Provider reasoning is now preserved across copying, streaming, persistence, and multi-turn replay. That expands the portable `llm.Content` contract and fixes observable behavior across several providers, so a minor release is the appropriate boundary rather than a patch.

## Validation

- `make check` with external provider credentials unset
- `go vet ./...` and `go test -race ./...` in the root module, all eight tagged modules, and both demo modules
- `python3 scripts/release_notes.py v1.22.0 --check`
- `python3 scripts/sync_module_versions.py v1.22.0 --check`
- Prettier check for `docs/releases/v1.22.0.md`
- `git diff --check`

This PR prepares the release but does not publish it. After merge, the release sequence is:

```sh
git tag v1.22.0
make tag-modules VERSION=v1.22.0
git push origin --tags
make release-publish VERSION=v1.22.0
```