### PR TITLE
Add Grok 4.6 to the Grok catalog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Added
+
+- **Grok 4.6** — `grok-4.6` added to the Grok catalog and pricing; now the
+  Grok default, with the same 500k context as `grok-4.5` but higher cached-
+  and long-context pricing. Its reasoning-effort ladder is narrower than
+  `grok-4.5`'s (`low`/`medium`/`high`/`xhigh`, no `none` or `minimal`). Also
+  adds `grok-imagine-image-2.0` ($0.04/image).
+
 ## [1.22.0] - 2026-08-11
 
 ### Fixed

--- a/demos/colosseum/provider/registry.go
+++ b/demos/colosseum/provider/registry.go
@@ -69,7 +69,7 @@ var registry = []*Spec{
 		Aliases: []string{"xai"},
 		EnvKeys: []string{"XAI_API_KEY", "GROK_API_KEY"},
 		Cheap:   grok.ModelGrok41FastNonReasoning,
-		Premium: grok.ModelGrok45,
+		Premium: grok.ModelGrok46,
 		newLLM:  func(m string) llm.LLM { return grok.New(grok.WithModel(m)) },
 	},
 }

--- a/docs/guides/grok.md
+++ b/docs/guides/grok.md
@@ -11,18 +11,19 @@ the server-side tool plumbing described below.
 ```go
 import "github.com/deepnoodle-ai/dive/providers/grok"
 
-model := grok.New() // defaults to grok-4.5
+model := grok.New() // defaults to grok-4.6
 ```
 
 **Env:** `XAI_API_KEY` (preferred) or `GROK_API_KEY`.
-**Models:** See `providers/grok/models.go`. `grok-4.5` is the current default;
-`grok-4.5-latest` and `grok-build-latest` are aliases, and `grok-build-0.1`
-remains available as the coding model.
+**Models:** See `providers/grok/models_gen.go`. `grok-4.6` is the current
+default; `grok-4.5` remains available, and `grok-build-0.1` remains available
+as the coding model.
 
-`grok-4.5` supports text and image inputs, tool/function calling, structured
+`grok-4.6` supports text and image inputs, tool/function calling, structured
 outputs, and reasoning. Its context window is 500k tokens; list pricing is
 $2.00 per 1M input tokens, $0.50 per 1M cached input tokens, and $6.00 per 1M
-output tokens.
+output tokens below a 200k-token prompt, rising to $4.00 / $1.00 / $12.00
+above it.
 
 ## Prompt caching
 

--- a/examples/grok_code_execution_example/main.go
+++ b/examples/grok_code_execution_example/main.go
@@ -32,7 +32,7 @@ func main() {
 		IncludeOutputs: true,
 	})
 
-	provider := grok.New() // defaults to grok-4.5
+	provider := grok.New() // defaults to grok-4.6
 
 	response, err := provider.Generate(context.Background(),
 		llm.WithMessages(llm.NewUserTextMessage(prompt)),

--- a/examples/grok_search_example/main.go
+++ b/examples/grok_search_example/main.go
@@ -40,7 +40,7 @@ func main() {
 		log.Fatal(err)
 	}
 
-	provider := grok.New() // defaults to grok-4.5
+	provider := grok.New() // defaults to grok-4.6
 
 	response, err := provider.Generate(context.Background(),
 		llm.WithMessages(llm.NewUserTextMessage(prompt)),

--- a/experimental/cmd/dive/main_test.go
+++ b/experimental/cmd/dive/main_test.go
@@ -63,7 +63,7 @@ func TestGetDefaultModel(t *testing.T) {
 			envVars: map[string]string{
 				"XAI_API_KEY": "test",
 			},
-			expected: "grok-4.5",
+			expected: "grok-4.6",
 		},
 	}
 

--- a/providers/grok/catalog.json
+++ b/providers/grok/catalog.json
@@ -28,15 +28,22 @@
   ],
   "models": [
     {
-      "go_name": "ModelGrok45",
-      "id": "grok-4.5",
+      "go_name": "ModelGrok46",
+      "id": "grok-4.6",
       "default": true,
       "kind": "text",
       "context_window": 500000,
-      "display_name": "Grok 4.5",
+      "display_name": "Grok 4.6",
       "recommended": true,
       "cli_order": 1,
       "description": "xAI flagship reasoning model with vision input"
+    },
+    {
+      "go_name": "ModelGrok45",
+      "id": "grok-4.5",
+      "kind": "text",
+      "context_window": 500000,
+      "display_name": "Grok 4.5"
     },
     {
       "go_name": "ModelGrok43",
@@ -196,6 +203,13 @@
       "context_window": 131072
     },
     {
+      "go_name": "ModelImagineImage20",
+      "id": "grok-imagine-image-2.0",
+      "kind": "image",
+      "context_window": 65536,
+      "display_name": "Grok Imagine Image 2.0"
+    },
+    {
       "go_name": "ModelImagineVideo",
       "id": "grok-imagine-video",
       "kind": "video",
@@ -210,6 +224,18 @@
   ],
   "pricing": {
     "text": [
+      {
+        "model": "grok-4.6",
+        "input_price_per_1m_tokens": "2.00",
+        "output_price_per_1m_tokens": "6.00",
+        "cache_read_price_per_1m_tokens": "0.50",
+        "long_context_threshold_tokens": 200000,
+        "long_context_input_price_per_1m_tokens": "4.00",
+        "long_context_cache_read_price_per_1m_tokens": "1.00",
+        "long_context_output_price_per_1m_tokens": "12.00",
+        "currency": "USD",
+        "updated_at": "2026-08-12"
+      },
       {
         "model": "grok-4.5",
         "input_price_per_1m_tokens": "2.00",
@@ -366,6 +392,12 @@
         "price_per_image": "0.05",
         "currency": "USD",
         "updated_at": "2026-05-28"
+      },
+      {
+        "model": "grok-imagine-image-2.0",
+        "price_per_image": "0.04",
+        "currency": "USD",
+        "updated_at": "2026-08-12"
       }
     ],
     "embedding": []

--- a/providers/grok/cost_test.go
+++ b/providers/grok/cost_test.go
@@ -55,6 +55,7 @@ func TestRetiredSlugsAreCostedAtTheirRedirectTarget(t *testing.T) {
 
 func TestPublishedGrokCacheReadPricingCoverage(t *testing.T) {
 	want := map[string]float64{
+		ModelGrok46:                 0.50,
 		ModelGrok45:                 0.30,
 		ModelGrok43:                 0.20,
 		ModelGrok420Reasoning:       0.20,

--- a/providers/grok/grok_test.go
+++ b/providers/grok/grok_test.go
@@ -32,7 +32,7 @@ func TestProvider_Name(t *testing.T) {
 }
 
 func TestProvider_DefaultModel(t *testing.T) {
-	assert.Equal(t, ModelGrok45, DefaultModel)
+	assert.Equal(t, ModelGrok46, DefaultModel)
 }
 
 func TestGenerateInheritsDisjointUsageConversion(t *testing.T) {

--- a/providers/grok/models_gen.go
+++ b/providers/grok/models_gen.go
@@ -3,6 +3,7 @@
 package grok
 
 const (
+	ModelGrok46              = "grok-4.6"
 	ModelGrok45              = "grok-4.5"
 	ModelGrok43              = "grok-4.3"
 	ModelGrok420Reasoning    = "grok-4.20-0309-reasoning"
@@ -35,9 +36,10 @@ const (
 	ModelImagineImagePro     = "grok-imagine-image-pro"
 	ModelImagineImage        = "grok-imagine-image"
 	ModelImagineImageQuality = "grok-imagine-image-quality"
+	ModelImagineImage20      = "grok-imagine-image-2.0"
 	ModelImagineVideo        = "grok-imagine-video"
 	ModelImagineVideo15      = "grok-imagine-video-1.5"
 )
 
 // DefaultModel is generated from the catalog's default model.
-var DefaultModel = ModelGrok45
+var DefaultModel = ModelGrok46

--- a/providers/grok/pricing_gen.go
+++ b/providers/grok/pricing_gen.go
@@ -6,6 +6,18 @@ import "github.com/deepnoodle-ai/dive/llm"
 
 // TextModelPricing is generated from catalog.json.
 var TextModelPricing = map[string]llm.PricingInfo{
+	ModelGrok46: {
+		Model:                     ModelGrok46,
+		InputPrice:                2.00,
+		OutputPrice:               6.00,
+		LongContextInputPrice:     4.00,
+		LongContextCacheReadPrice: 1.00,
+		LongContextOutputPrice:    12.00,
+		CacheReadPrice:            0.50,
+		LongContextThreshold:      200000,
+		Currency:                  "USD",
+		UpdatedAt:                 "2026-08-12",
+	},
 	ModelGrok45: {
 		Model:                     ModelGrok45,
 		InputPrice:                2.00,
@@ -163,5 +175,11 @@ var ImageModelPricing = map[string]llm.ImagePricingInfo{
 		Price:     0.05,
 		Currency:  "USD",
 		UpdatedAt: "2026-05-28",
+	},
+	ModelImagineImage20: {
+		Model:     ModelImagineImage20,
+		Price:     0.04,
+		Currency:  "USD",
+		UpdatedAt: "2026-08-12",
 	},
 }

--- a/providers/modelcaps/tables.go
+++ b/providers/modelcaps/tables.go
@@ -143,6 +143,18 @@ var grokTable = Table{
 		Temperature: true,
 	}},
 
+	// grok-4.6 narrows further still: xAI's docs list only low, medium,
+	// high (the default), and xhigh — neither none nor minimal.
+	{Prefix: "grok-4.6", Caps: Capabilities{
+		Efforts: []llm.ReasoningEffort{
+			llm.ReasoningEffortLow,
+			llm.ReasoningEffortMedium,
+			llm.ReasoningEffortHigh,
+			llm.ReasoningEffortXHigh,
+		},
+		Temperature: true,
+	}},
+
 	{Prefix: "grok-4.3", Caps: Capabilities{Efforts: grokBelowMax, Temperature: true}},
 	{Prefix: "grok-4", Caps: Capabilities{Efforts: grokBelowMax, Temperature: true}},
 	{Prefix: "grok-3", Caps: Capabilities{Efforts: grokBelowMax, Temperature: true}},


### PR DESCRIPTION
## Summary
- xAI shipped Grok 4.6, replacing Grok 4.5 as the flagship (same 500k context, higher cached/long-context pricing) — found via a live run of `scripts/provider_watch.py audit` against xAI's docs, before the weekly `provider-watch` workflow caught it.
- Adds `grok-4.6` (new default/recommended) and `grok-imagine-image-2.0` to `providers/grok/catalog.json` with pricing, regenerated via `make provider-catalog-generate`.
- Adds a `modelcaps` entry for `grok-4.6`'s narrower reasoning-effort ladder (`low`/`medium`/`high`/`xhigh` — no `none` or `minimal`, per xAI's release notes).
- Updates dependents that pinned the old default: tests in `providers/grok` and `experimental/cmd/dive`, the `demos/colosseum` provider registry, two `examples/grok_*` comments, `docs/guides/grok.md`, and `CHANGELOG.md`.

## Test plan
- [x] `make provider-catalog-check`
- [x] `go build ./...` / `go vet ./...` / `go test ./...` at repo root
- [x] `go test ./...` in `providers/grok`, `providers/modelcaps`, `experimental/cmd/dive`, `demos/colosseum`
- [x] `gofmt -l` clean on all touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for Grok 4.6, now the default recommended Grok model.
  - Added the Grok Imagine Image 2.0 image-generation model.
  - Added support for Grok 4.6’s 500k context window and low, medium, high, and xhigh reasoning levels.
- **Documentation**
  - Updated Grok setup guidance, model availability, and pricing details.
  - Updated examples and release information to reflect Grok 4.6.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->