### PR TITLE
Prepare v1.23.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [1.23.0] - 2026-08-12
+
 ### Added
 
 - **Grok 4.6** — `grok-4.6` added to the Grok catalog and pricing; now the

--- a/a2a/go.mod
+++ b/a2a/go.mod
@@ -6,7 +6,7 @@ toolchain go1.26.5
 
 require (
 	github.com/a2aproject/a2a-go/v2 v2.4.0
-	github.com/deepnoodle-ai/dive v1.22.0
+	github.com/deepnoodle-ai/dive v1.23.0
 	github.com/deepnoodle-ai/wonton v0.0.37
 )
 

--- a/demos/colosseum/go.mod
+++ b/demos/colosseum/go.mod
@@ -5,11 +5,11 @@ go 1.25.0
 toolchain go1.26.5
 
 require (
-	github.com/deepnoodle-ai/dive v1.22.0
-	github.com/deepnoodle-ai/dive/a2a v1.22.0
-	github.com/deepnoodle-ai/dive/providers/google v1.22.0
-	github.com/deepnoodle-ai/dive/providers/grok v1.22.0
-	github.com/deepnoodle-ai/dive/providers/openai v1.22.0
+	github.com/deepnoodle-ai/dive v1.23.0
+	github.com/deepnoodle-ai/dive/a2a v1.23.0
+	github.com/deepnoodle-ai/dive/providers/google v1.23.0
+	github.com/deepnoodle-ai/dive/providers/grok v1.23.0
+	github.com/deepnoodle-ai/dive/providers/openai v1.23.0
 	github.com/deepnoodle-ai/wonton v0.0.37
 )
 

--- a/demos/noodleville/go.mod
+++ b/demos/noodleville/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 toolchain go1.26.5
 
 require (
-	github.com/deepnoodle-ai/dive v1.22.0
+	github.com/deepnoodle-ai/dive v1.23.0
 	github.com/deepnoodle-ai/wonton v0.0.37
 )
 

--- a/docs/releases/v1.23.0.md
+++ b/docs/releases/v1.23.0.md
@@ -1,0 +1,30 @@
+## Highlights
+
+xAI replaced Grok 4.5 with **Grok 4.6** as its flagship model — same 500k
+context window, but cached- and long-context input now cost roughly double.
+Dive's Grok provider now defaults to `grok-4.6`; `grok-4.5` remains available
+if you need to pin to it. This release also picks up xAI's companion image
+model, `grok-imagine-image-2.0`.
+
+Grok 4.6 also narrows the reasoning-effort range compared to 4.5: it accepts
+`low`/`medium`/`high`/`xhigh` but rejects `none` and `minimal` outright, per
+xAI's published docs. Dive's capability table now reflects that, so requests
+with an unsupported effort get resolved/clamped correctly instead of
+erroring against the live API.
+
+No action is required to pick up the new default — existing code that calls
+`grok.New()` without pinning a model will start using `grok-4.6` on upgrade.
+
+## Pull requests
+
+- Add Grok 4.6 to the Grok catalog (#258)
+
+## Changelog
+
+### Added
+
+- **Grok 4.6** — `grok-4.6` added to the Grok catalog and pricing; now the
+  Grok default, with the same 500k context as `grok-4.5` but higher cached-
+  and long-context pricing. Its reasoning-effort ladder is narrower than
+  `grok-4.5`'s (`low`/`medium`/`high`/`xhigh`, no `none` or `minimal`). Also
+  adds `grok-imagine-image-2.0` ($0.04/image).

--- a/examples/go.mod
+++ b/examples/go.mod
@@ -5,13 +5,13 @@ go 1.25.5
 toolchain go1.26.5
 
 require (
-	github.com/deepnoodle-ai/dive v1.22.0
-	github.com/deepnoodle-ai/dive/a2a v1.22.0
-	github.com/deepnoodle-ai/dive/experimental/mcp v1.22.0
-	github.com/deepnoodle-ai/dive/otel v1.22.0
-	github.com/deepnoodle-ai/dive/providers/google v1.22.0
-	github.com/deepnoodle-ai/dive/providers/grok v1.22.0
-	github.com/deepnoodle-ai/dive/providers/openai v1.22.0
+	github.com/deepnoodle-ai/dive v1.23.0
+	github.com/deepnoodle-ai/dive/a2a v1.23.0
+	github.com/deepnoodle-ai/dive/experimental/mcp v1.23.0
+	github.com/deepnoodle-ai/dive/otel v1.23.0
+	github.com/deepnoodle-ai/dive/providers/google v1.23.0
+	github.com/deepnoodle-ai/dive/providers/grok v1.23.0
+	github.com/deepnoodle-ai/dive/providers/openai v1.23.0
 	github.com/deepnoodle-ai/wonton v0.0.37
 	github.com/fatih/color v1.19.0
 	github.com/mark3labs/mcp-go v0.57.0

--- a/experimental/cmd/dive/go.mod
+++ b/experimental/cmd/dive/go.mod
@@ -5,10 +5,10 @@ go 1.25.0
 toolchain go1.26.5
 
 require (
-	github.com/deepnoodle-ai/dive v1.22.0
-	github.com/deepnoodle-ai/dive/providers/google v1.22.0
-	github.com/deepnoodle-ai/dive/providers/grok v1.22.0
-	github.com/deepnoodle-ai/dive/providers/openai v1.22.0
+	github.com/deepnoodle-ai/dive v1.23.0
+	github.com/deepnoodle-ai/dive/providers/google v1.23.0
+	github.com/deepnoodle-ai/dive/providers/grok v1.23.0
+	github.com/deepnoodle-ai/dive/providers/openai v1.23.0
 	github.com/deepnoodle-ai/wonton v0.0.37
 	github.com/mattn/go-runewidth v0.0.27
 	google.golang.org/genai v1.67.0

--- a/experimental/mcp/go.mod
+++ b/experimental/mcp/go.mod
@@ -5,7 +5,7 @@ go 1.25.5
 toolchain go1.26.5
 
 require (
-	github.com/deepnoodle-ai/dive v1.22.0
+	github.com/deepnoodle-ai/dive v1.23.0
 	github.com/deepnoodle-ai/wonton v0.0.37
 	github.com/mark3labs/mcp-go v0.57.0
 )

--- a/otel/go.mod
+++ b/otel/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 toolchain go1.26.5
 
 require (
-	github.com/deepnoodle-ai/dive v1.22.0
+	github.com/deepnoodle-ai/dive v1.23.0
 	go.opentelemetry.io/otel v1.45.0
 	go.opentelemetry.io/otel/metric v1.45.0
 	go.opentelemetry.io/otel/sdk v1.45.0

--- a/providers/google/go.mod
+++ b/providers/google/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 toolchain go1.26.5
 
 require (
-	github.com/deepnoodle-ai/dive v1.22.0
+	github.com/deepnoodle-ai/dive v1.23.0
 	github.com/deepnoodle-ai/wonton v0.0.37
 	google.golang.org/genai v1.67.0
 )

--- a/providers/grok/go.mod
+++ b/providers/grok/go.mod
@@ -5,8 +5,8 @@ go 1.25.0
 toolchain go1.26.5
 
 require (
-	github.com/deepnoodle-ai/dive v1.22.0
-	github.com/deepnoodle-ai/dive/providers/openai v1.22.0
+	github.com/deepnoodle-ai/dive v1.23.0
+	github.com/deepnoodle-ai/dive/providers/openai v1.23.0
 	github.com/deepnoodle-ai/wonton v0.0.37
 	github.com/openai/openai-go/v3 v3.50.0
 	golang.org/x/image v0.44.0

--- a/providers/openai/go.mod
+++ b/providers/openai/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 toolchain go1.26.5
 
 require (
-	github.com/deepnoodle-ai/dive v1.22.0
+	github.com/deepnoodle-ai/dive v1.23.0
 	github.com/deepnoodle-ai/wonton v0.0.37
 	github.com/openai/openai-go/v3 v3.50.0
 	golang.org/x/image v0.44.0


### PR DESCRIPTION
## Summary
- Cuts `CHANGELOG.md`'s `[Unreleased]` section to `[1.23.0] - 2026-08-12` (Grok 4.6 addition, #258 — the only change since v1.22.0).
- `make release-prep VERSION=v1.23.0` syncs every sub-module's `github.com/deepnoodle-ai/dive*` requirement from v1.22.0 to v1.23.0.
- Adds `docs/releases/v1.23.0.md` via `make release-notes VERSION=v1.23.0`, with Highlights written by hand.

## Test plan
- [x] `make release-notes-test`
- [x] `go build ./...` / `go test ./...` at repo root

Once this merges, tag from `main`:
```sh
git tag v1.23.0
make tag-modules VERSION=v1.23.0
git push origin --tags
make release-publish VERSION=v1.23.0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)