### PR TITLE
Fix streaming usage double count on the input side

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **Streaming usage no longer double counts the input side.** Anthropic-shaped
+  streams repeat cumulative usage in both `message_start` and `message_delta`;
+  `ResponseAccumulator` now merges frames by supersession (new `Usage.Absorb`)
+  instead of summing, so input, cache, and cost figures are no longer ~2x on
+  streamed Anthropic/Ollama traffic. `Usage.Add` keeps its additive semantics
+  for cross-request aggregation.
+
 ## [1.23.0] - 2026-08-12
 
 ### Added

--- a/docs/bugs/streaming-usage-double-count.md
+++ b/docs/bugs/streaming-usage-double-count.md
@@ -1,10 +1,13 @@
 # Streaming usage is double counted on the input side
 
-**Status:** open
-**Severity:** high — corrupts every usage-derived number (cost, billing, context gauges) on streamed Anthropic traffic
+**Status:** fixed — [#261](https://github.com/deepnoodle-ai/dive/pull/261), unreleased. This document is kept as the historical record.
+**Severity:** high — corrupted every usage-derived number (cost, billing, context gauges) on streamed Anthropic traffic
 **Affected:** `llm/stream.go` (`ResponseAccumulator`), `providers/anthropic`, `providers/ollama`, `experimental/cmd/dive`
-**Confirmed on:** `v1.23.0`; present since April 2025 (see [History](#history))
+**Confirmed on:** `v1.23.0`; present from April 2025 until #261 (see [History](#history))
 **Originally reported by:** Mobius Cloud team, 2026-08-12
+
+The sections below describe the defect in the present tense as it existed
+before the fix.
 
 ## Summary
 
@@ -51,7 +54,7 @@ and becomes an `Add`.
 
 Feeding real Anthropic frames through the accumulator:
 
-```
+```text
 message_start {"input_tokens":14,"cache_creation_input_tokens":8012,"cache_read_input_tokens":120000,"output_tokens":4}
 message_delta {"input_tokens":14,"cache_creation_input_tokens":8012,"cache_read_input_tokens":120000,"output_tokens":7}
 ```
@@ -128,11 +131,14 @@ summing only `InputTokens` saw an absolute error of 14 tokens.
 provider, but drives each one through `generateFixture`, which decodes a **single non-streaming
 JSON body**. The streaming path it was meant to protect is never exercised.
 
-## Proposed fix
+## Fix
 
-Make the guard in the accumulator the primary fix rather than a per-provider patch. It covers
-Anthropic, Ollama, and the latent `openaicompletions` path in one place, and preserves the
-`message_start`-only fields that a provider-side strip would drop.
+Shipped in #261. The guard lives in the accumulator rather than in a per-provider patch: it
+covers Anthropic, Ollama, and the latent `openaicompletions` path in one place, and preserves
+the `message_start`-only fields that a provider-side strip would drop.
+
+`Usage.Absorb` (`llm/usage.go`) merges cumulative frames by per-field max, and
+`ResponseAccumulator.AddEvent` (`llm/stream.go`) calls it in place of `Usage.Add`:
 
 ```go
 // Usage frames from Anthropic and Google are cumulative for the whole message,
@@ -143,30 +149,40 @@ func (u *Usage) Absorb(other *Usage) {
     u.CacheCreationInputTokens = max(u.CacheCreationInputTokens, other.CacheCreationInputTokens)
     u.CacheReadInputTokens = max(u.CacheReadInputTokens, other.CacheReadInputTokens)
     u.ReasoningTokens = max(u.ReasoningTokens, other.ReasoningTokens)
-    // ServiceTier / Speed / modality details keep their existing merge rules
+    // ModalityTokens merge by per-bucket max; ServiceTier/Speed take the later
+    // non-empty value; boolean flags OR-merge; provider Cost replaces rather
+    // than sums. See llm/usage.go for the full rule set.
 }
 ```
 
 Per-field max rather than wholesale replacement matters: `message_start` carries fields that
 `message_delta` omits (`service_tier`, the `cache_creation` ephemeral 5m/1h breakdown), so a
-straight overwrite loses them. It also fixes the output drift for free.
+straight overwrite loses them. It also fixes the output drift for free. Choosing max over
+replacement means the rules hold whether or not `message_delta.usage` repeats every key — the
+originally reported dumps show exactly four keys in both frames, which suggests the capture
+script selected specific keys.
 
-**`Usage.Add` must keep its additive semantics** for the cross-generation aggregation in
-`Agent.chat` (`agent.go:1996`), which is correct.
+**`Usage.Add` keeps its additive semantics** for the cross-generation aggregation in
+`Agent.chat` (`agent.go:1996`), which was and remains correct.
 
-Before finalizing the merge rules, confirm against a raw uncaptured frame dump what
-`message_delta.usage` actually carries. The originally reported dumps show exactly four keys in
-both frames, which suggests the capture script selected specific keys.
+## Regression tests
 
-## Suggested regression tests
+Landed with the fix:
 
-1. **Accumulator, cumulative frames.** `message_start{input:14, cache_creation:8012, output:4}`
-   → `content_block_*` → `message_delta{input:14, cache_creation:8012, output:7}` →
-   `message_stop`. Assert `input:14, cache_creation:8012, output:7`.
-2. **Warm-cache variant** with `cache_read_input_tokens` non-zero in both frames.
-3. **Provider-level golden test** replaying a captured Anthropic SSE transcript, asserting
-   accumulated usage equals the final frame's values.
-4. **Extend `usage_invariant_test.go` to the streaming path** for every provider — the gap that
-   let this through.
-5. **Cross-provider invariant**: assert no `message_start` event carries non-zero usage, which
-   also pins the `openaicompletions` latent case.
+1. **Accumulator, cumulative frames** — `TestResponseAccumulatorCumulativeUsageFrames`
+   (`llm/stream_test.go`). Replays the reproduction frames with both the cache-write and
+   cache-read buckets non-zero, asserting the final frame's values.
+2. **Output-only `message_delta`** — `TestResponseAccumulatorOutputOnlyDeltaKeepsSeededInputUsage`
+   (`llm/stream_test.go`). Pins why max beats wholesale replacement.
+3. **Provider-level golden test** — `TestStreamCumulativeUsageNotDoubleCounted`
+   (`providers/anthropic/stream_usage_test.go`). Replays a captured SSE transcript through the
+   real provider via `httptest`.
+4. **`Usage.Absorb` unit tests** (`llm/usage_test.go`) covering the cost-replace, tier/speed,
+   modality, and nil-argument rules.
+
+Still open:
+
+1. **Extend `usage_invariant_test.go` to the streaming path** for every provider — the gap that
+   let this through. It still drives each provider through a single non-streaming JSON body.
+2. **Pin the `openaicompletions` latent case** with a stream whose usage arrives on a chunk that
+   also carries choices. `Absorb` makes it correct today, but nothing asserts it.

--- a/docs/bugs/streaming-usage-double-count.md
+++ b/docs/bugs/streaming-usage-double-count.md
@@ -1,0 +1,172 @@
+# Streaming usage is double counted on the input side
+
+**Status:** open
+**Severity:** high — corrupts every usage-derived number (cost, billing, context gauges) on streamed Anthropic traffic
+**Affected:** `llm/stream.go` (`ResponseAccumulator`), `providers/anthropic`, `providers/ollama`, `experimental/cmd/dive`
+**Confirmed on:** `v1.23.0`; present since April 2025 (see [History](#history))
+**Originally reported by:** Mobius Cloud team, 2026-08-12
+
+## Summary
+
+For streaming requests whose provider forwards Anthropic-shaped SSE frames,
+`ResponseAccumulator` counts `input_tokens`, `cache_creation_input_tokens`, and
+`cache_read_input_tokens` **exactly twice**.
+
+The accumulator seeds `Response.Usage` from `message_start`, then *adds* the usage carried by
+`message_delta`. Anthropic repeats the full cumulative usage object in both frames, so every
+input-side bucket lands twice.
+
+`output_tokens` is inflated by the small starting count `message_start` reports (typically 4),
+which is why the defect stays invisible in the number people usually sanity-check.
+Non-streaming calls are correct.
+
+## Root cause
+
+`llm/stream.go`, `ResponseAccumulator.AddEvent`:
+
+```go
+case EventTypeMessageStart:
+    if event.Message == nil {
+        return errors.New("invalid message start event")
+    }
+    r.response = event.Message   // seeds Usage from message_start
+    return nil
+```
+
+```go
+// Update usage information if provided
+if event.Usage != nil && r.response != nil {
+    r.response.Usage.Add(event.Usage)   // adds message_delta's usage on top
+```
+
+`Usage.Add` (`llm/usage.go:172`) is a field-wise sum. Anthropic's `message_delta.usage` is
+**cumulative for the whole message**, not incremental — the opposite of what `Add` assumes.
+
+The Anthropic provider decodes raw SSE straight into `llm.Event`
+(`providers/anthropic/stream_iterator.go`, a pure passthrough), so `message_start` usage arrives
+nested under `message` and becomes the seed, while `message_delta` usage arrives at the top level
+and becomes an `Add`.
+
+## Reproduction
+
+Feeding real Anthropic frames through the accumulator:
+
+```
+message_start {"input_tokens":14,"cache_creation_input_tokens":8012,"cache_read_input_tokens":120000,"output_tokens":4}
+message_delta {"input_tokens":14,"cache_creation_input_tokens":8012,"cache_read_input_tokens":120000,"output_tokens":7}
+```
+
+| bucket | true | accumulated |
+|---|---:|---:|
+| `input_tokens` | 14 | **28** |
+| `cache_creation_input_tokens` | 8,012 | **16,024** |
+| `cache_read_input_tokens` | 120,000 | **240,000** |
+| `output_tokens` | 7 | **11** |
+| `TotalInputTokens()` | 128,026 | **256,052** |
+
+Verified end to end by driving `dive.NewAgent` against an `httptest` server replaying the SSE
+transcript above through the real `providers/anthropic` provider.
+
+## Scope
+
+| Provider | Stream path | Affected |
+|---|---|---|
+| `anthropic` | passthrough SSE → `llm.Event` | **yes** |
+| `ollama` | embeds `*anthropic.Provider` (Anthropic-compatible Messages API) | **yes** |
+| `openaicompletions` (→ `mistral`, `openrouter`) | own iterator | **latent** — see below |
+| `openai` (Responses API, → `grok`) | own iterator; `message_start` carries no usage | no |
+| `google` | own iterator; usage emitted once on `message_delta` | no |
+
+`openaicompletions` is not structurally immune. Its `message_start` carries
+`Usage: s.usage.toLLMUsage()` (`stream_iterator.go:167`), populated at `:143` from the same
+chunk. It is safe only because OpenAI delivers usage in a trailing choices-empty chunk. A
+provider that emits usage on a chunk that *also* carries choices double counts identically —
+measured `input=200` against a true `100`. OpenRouter proxies many upstreams and is the most
+plausible route to this.
+
+## Impact on the Dive CLI
+
+Yes — the CLI is affected. `Agent.generateStreaming` (`agent.go:2093`) accumulates through the
+buggy path, and the resulting `Response.Usage` flows into the CLI via
+`agentEventCallback` → `lastUsage` → `usageUpdateEvent`.
+
+Using the reproduction above (`claude-sonnet-5`, list-price estimate):
+
+- **Token rows** (`render.go:191-193`, `app.go:2548-2557`) — input, cache read, cache write and
+  the total row all render at 2x.
+- **Context gauge** — `compaction.CalculateContextTokens` returns `TotalInputTokens()`, so it
+  reports 256,052 against a true 128,026. Compaction and budget guards trip at roughly half the
+  real context size.
+- **Cost** — `0.132339` against a true `0.066192`, i.e. 1.999x. Output is not doubled, which is
+  why it is marginally under exactly 2x.
+- **Percentages are correct.** Cache-hit % (`render.go:220-238`) renders 93% either way, because
+  numerator and denominator are doubled together. The same cancellation is why
+  `logCacheThrash` (`providers/anthropic/anthropic.go:464`) cannot detect this — it compares
+  write against read.
+
+## History
+
+The bug is old and was not introduced by the recent billing work.
+
+| Date | PR | Effect |
+|---|---|---|
+| 2025-04-03 | #21 | Added `r.response = event.Message`. Input/output double count begins. |
+| 2025-06-05 | #39 | Added cache-bucket accumulation. Cache double count — the costly part — begins. |
+| 2026-08-10 | #251 | Added `TotalInputTokens()`. Did not touch the accumulator. |
+| 2026-08-10 | #254 | Replaced five explicit `+=` lines with `Usage.Add()`. Semantics unchanged. |
+
+The same seed-then-add shape is present verbatim at `v1.15.0` and `v1.20.0`, and `CostOf`
+already priced cache buckets separately at `v1.20.0`.
+
+`TotalInputTokens()` (new in #251) is the likely reason this surfaced now: it is the first
+helper that rolls the doubled cache buckets into a single headline number. A caller previously
+summing only `InputTokens` saw an absolute error of 14 tokens.
+
+### Why tests missed it
+
+`experimental/cmd/dive/usage_invariant_test.go` asserts disjoint input buckets across every
+provider, but drives each one through `generateFixture`, which decodes a **single non-streaming
+JSON body**. The streaming path it was meant to protect is never exercised.
+
+## Proposed fix
+
+Make the guard in the accumulator the primary fix rather than a per-provider patch. It covers
+Anthropic, Ollama, and the latent `openaicompletions` path in one place, and preserves the
+`message_start`-only fields that a provider-side strip would drop.
+
+```go
+// Usage frames from Anthropic and Google are cumulative for the whole message,
+// not incremental: a later frame supersedes an earlier one field by field.
+func (u *Usage) Absorb(other *Usage) {
+    u.InputTokens = max(u.InputTokens, other.InputTokens)
+    u.OutputTokens = max(u.OutputTokens, other.OutputTokens)
+    u.CacheCreationInputTokens = max(u.CacheCreationInputTokens, other.CacheCreationInputTokens)
+    u.CacheReadInputTokens = max(u.CacheReadInputTokens, other.CacheReadInputTokens)
+    u.ReasoningTokens = max(u.ReasoningTokens, other.ReasoningTokens)
+    // ServiceTier / Speed / modality details keep their existing merge rules
+}
+```
+
+Per-field max rather than wholesale replacement matters: `message_start` carries fields that
+`message_delta` omits (`service_tier`, the `cache_creation` ephemeral 5m/1h breakdown), so a
+straight overwrite loses them. It also fixes the output drift for free.
+
+**`Usage.Add` must keep its additive semantics** for the cross-generation aggregation in
+`Agent.chat` (`agent.go:1996`), which is correct.
+
+Before finalizing the merge rules, confirm against a raw uncaptured frame dump what
+`message_delta.usage` actually carries. The originally reported dumps show exactly four keys in
+both frames, which suggests the capture script selected specific keys.
+
+## Suggested regression tests
+
+1. **Accumulator, cumulative frames.** `message_start{input:14, cache_creation:8012, output:4}`
+   → `content_block_*` → `message_delta{input:14, cache_creation:8012, output:7}` →
+   `message_stop`. Assert `input:14, cache_creation:8012, output:7`.
+2. **Warm-cache variant** with `cache_read_input_tokens` non-zero in both frames.
+3. **Provider-level golden test** replaying a captured Anthropic SSE transcript, asserting
+   accumulated usage equals the final frame's values.
+4. **Extend `usage_invariant_test.go` to the streaming path** for every provider — the gap that
+   let this through.
+5. **Cross-provider invariant**: assert no `message_start` event carries non-zero usage, which
+   also pins the `openaicompletions` latent case.

--- a/llm/stream.go
+++ b/llm/stream.go
@@ -209,12 +209,11 @@ func (r *ResponseAccumulator) AddEvent(event *Event) error {
 		r.finalizeContent()
 	}
 
-	// Update usage information if provided
+	// Update usage information if provided. Streaming usage frames carry
+	// cumulative totals for the whole message, not increments, so merge by
+	// supersession rather than summing.
 	if event.Usage != nil && r.response != nil {
-		r.response.Usage.Add(event.Usage)
-		if event.Usage.Speed != "" {
-			r.response.Usage.Speed = event.Usage.Speed
-		}
+		r.response.Usage.Absorb(event.Usage)
 	}
 
 	// Update context management information if provided

--- a/llm/stream_test.go
+++ b/llm/stream_test.go
@@ -102,6 +102,85 @@ func TestResponseAccumulatorUsageIncludesReasoningAndSpeed(t *testing.T) {
 	assert.Equal(t, usage.Speed, "fast")
 }
 
+func TestResponseAccumulatorCumulativeUsageFrames(t *testing.T) {
+	// Anthropic's message_delta repeats the full cumulative usage that
+	// message_start seeded; the accumulator must not count it twice.
+	acc := NewResponseAccumulator()
+	assert.NoError(t, acc.AddEvent(&Event{
+		Type: EventTypeMessageStart,
+		Message: &Response{
+			ID:   "msg_1",
+			Role: Assistant,
+			Usage: Usage{
+				InputTokens:              14,
+				CacheCreationInputTokens: 8012,
+				CacheReadInputTokens:     120000,
+				OutputTokens:             4,
+			},
+		},
+	}))
+	idx := 0
+	assert.NoError(t, acc.AddEvent(&Event{
+		Type:         EventTypeContentBlockStart,
+		Index:        &idx,
+		ContentBlock: &EventContentBlock{Type: ContentTypeText},
+	}))
+	assert.NoError(t, acc.AddEvent(&Event{
+		Type:  EventTypeContentBlockDelta,
+		Index: &idx,
+		Delta: &EventDelta{Type: EventDeltaTypeText, Text: "hello"},
+	}))
+	assert.NoError(t, acc.AddEvent(&Event{
+		Type:  EventTypeMessageDelta,
+		Delta: &EventDelta{StopReason: "end_turn"},
+		Usage: &Usage{
+			InputTokens:              14,
+			CacheCreationInputTokens: 8012,
+			CacheReadInputTokens:     120000,
+			OutputTokens:             7,
+		},
+	}))
+	assert.NoError(t, acc.AddEvent(&Event{Type: EventTypeMessageStop}))
+
+	usage := acc.Response().Usage
+	assert.Equal(t, usage.InputTokens, 14)
+	assert.Equal(t, usage.CacheCreationInputTokens, 8012)
+	assert.Equal(t, usage.CacheReadInputTokens, 120000)
+	assert.Equal(t, usage.OutputTokens, 7)
+	assert.Equal(t, usage.TotalInputTokens(), 128026)
+}
+
+func TestResponseAccumulatorOutputOnlyDeltaKeepsSeededInputUsage(t *testing.T) {
+	// Some message_delta frames carry only output_tokens; the input buckets
+	// seeded by message_start must survive the merge.
+	acc := NewResponseAccumulator()
+	assert.NoError(t, acc.AddEvent(&Event{
+		Type: EventTypeMessageStart,
+		Message: &Response{
+			ID:   "msg_1",
+			Role: Assistant,
+			Usage: Usage{
+				InputTokens:              14,
+				CacheCreationInputTokens: 8012,
+				CacheReadInputTokens:     120000,
+				OutputTokens:             1,
+			},
+		},
+	}))
+	assert.NoError(t, acc.AddEvent(&Event{
+		Type:  EventTypeMessageDelta,
+		Delta: &EventDelta{StopReason: "end_turn"},
+		Usage: &Usage{OutputTokens: 104},
+	}))
+	assert.NoError(t, acc.AddEvent(&Event{Type: EventTypeMessageStop}))
+
+	usage := acc.Response().Usage
+	assert.Equal(t, usage.InputTokens, 14)
+	assert.Equal(t, usage.CacheCreationInputTokens, 8012)
+	assert.Equal(t, usage.CacheReadInputTokens, 120000)
+	assert.Equal(t, usage.OutputTokens, 104)
+}
+
 func TestResponseAccumulatorPreservesOmittedThinkingSignature(t *testing.T) {
 	acc := NewResponseAccumulator()
 	idx0, idx1 := 0, 1

--- a/llm/usage.go
+++ b/llm/usage.go
@@ -168,6 +168,58 @@ func (u *Usage) Copy() *Usage {
 	return cp
 }
 
+// Absorb merges a cumulative usage frame into this usage object. Streaming
+// providers report running totals for the whole message rather than
+// increments (Anthropic documents message_delta usage as cumulative), so a
+// later frame supersedes an earlier one field by field. A zero token count
+// means the frame omitted that field, so token buckets merge by max rather
+// than wholesale replacement — message_delta frames that carry only
+// output_tokens must not erase the input buckets seeded by message_start.
+// Use Add for aggregating usage across separate requests.
+func (u *Usage) Absorb(other *Usage) {
+	if other == nil {
+		return
+	}
+	u.InputTokens = max(u.InputTokens, other.InputTokens)
+	u.OutputTokens = max(u.OutputTokens, other.OutputTokens)
+	u.CacheCreationInputTokens = max(u.CacheCreationInputTokens, other.CacheCreationInputTokens)
+	u.CacheReadInputTokens = max(u.CacheReadInputTokens, other.CacheReadInputTokens)
+	u.ToolUseInputTokens = max(u.ToolUseInputTokens, other.ToolUseInputTokens)
+	u.ReasoningTokens = max(u.ReasoningTokens, other.ReasoningTokens)
+	if len(other.ModalityTokens) > 0 {
+		if u.ModalityTokens == nil {
+			u.ModalityTokens = make(map[string]ModalityTokenUsage, len(other.ModalityTokens))
+		}
+		for modality, frame := range other.ModalityTokens {
+			current := u.ModalityTokens[modality]
+			current.InputTokens = max(current.InputTokens, frame.InputTokens)
+			current.OutputTokens = max(current.OutputTokens, frame.OutputTokens)
+			current.CacheCreationInputTokens = max(current.CacheCreationInputTokens, frame.CacheCreationInputTokens)
+			current.CacheReadInputTokens = max(current.CacheReadInputTokens, frame.CacheReadInputTokens)
+			u.ModalityTokens[modality] = current
+		}
+	}
+	if other.ServiceTier != "" {
+		u.ServiceTier = other.ServiceTier
+	}
+	if other.Speed != "" {
+		u.Speed = other.Speed
+	}
+	u.CacheCreationInputTokensUnavailable = u.CacheCreationInputTokensUnavailable || other.CacheCreationInputTokensUnavailable
+	u.InputModalityTokenDetailsIncomplete = u.InputModalityTokenDetailsIncomplete || other.InputModalityTokenDetailsIncomplete
+	u.OutputModalityTokenDetailsIncomplete = u.OutputModalityTokenDetailsIncomplete || other.OutputModalityTokenDetailsIncomplete
+	u.CacheReadModalityTokenDetailsIncomplete = u.CacheReadModalityTokenDetailsIncomplete || other.CacheReadModalityTokenDetailsIncomplete
+	u.CostEstimateUnavailable = u.CostEstimateUnavailable || other.CostEstimateUnavailable
+	if u.CostEstimateUnavailable {
+		u.Cost = nil
+	} else if other.Cost != nil {
+		// Cumulative frames supersede: the later provider-reported cost
+		// replaces the earlier one rather than summing with it.
+		costCopy := *other.Cost
+		u.Cost = &costCopy
+	}
+}
+
 // Add incremental usage to this usage object.
 func (u *Usage) Add(other *Usage) {
 	if other == nil {

--- a/llm/usage_test.go
+++ b/llm/usage_test.go
@@ -254,3 +254,58 @@ func TestUsageAddAndCopyPreserveBillingDetails(t *testing.T) {
 	assert.True(t, usage.CostEstimateUnavailable)
 	assert.Nil(t, usage.Cost)
 }
+
+func TestUsageAbsorbCumulativeFrames(t *testing.T) {
+	usage := Usage{
+		InputTokens:              14,
+		CacheCreationInputTokens: 8012,
+		CacheReadInputTokens:     120000,
+		OutputTokens:             4,
+		ServiceTier:              "standard",
+		ModalityTokens: map[string]ModalityTokenUsage{
+			"text": {InputTokens: 14, OutputTokens: 4},
+		},
+	}
+	usage.Absorb(&Usage{
+		InputTokens:              14,
+		CacheCreationInputTokens: 8012,
+		CacheReadInputTokens:     120000,
+		OutputTokens:             7,
+		Speed:                    "fast",
+		ModalityTokens: map[string]ModalityTokenUsage{
+			"text": {InputTokens: 14, OutputTokens: 7},
+		},
+	})
+
+	assert.Equal(t, 14, usage.InputTokens)
+	assert.Equal(t, 8012, usage.CacheCreationInputTokens)
+	assert.Equal(t, 120000, usage.CacheReadInputTokens)
+	assert.Equal(t, 7, usage.OutputTokens)
+	assert.Equal(t, 128026, usage.TotalInputTokens())
+	// message_start-only fields survive frames that omit them
+	assert.Equal(t, "standard", usage.ServiceTier)
+	assert.Equal(t, "fast", usage.Speed)
+	assert.Equal(t, 14, usage.ModalityTokens["text"].InputTokens)
+	assert.Equal(t, 7, usage.ModalityTokens["text"].OutputTokens)
+}
+
+func TestUsageAbsorbCostReplacesRatherThanSums(t *testing.T) {
+	usage := Usage{Cost: &Cost{Total: 0.5, Input: 0.3, Output: 0.2}}
+	usage.Absorb(&Usage{Cost: &Cost{Total: 0.9, Input: 0.3, Output: 0.6}})
+	assert.Equal(t, 0.9, usage.Cost.Total)
+	assert.Equal(t, 0.6, usage.Cost.Output)
+
+	// A frame without cost leaves the existing cost alone.
+	usage.Absorb(&Usage{OutputTokens: 10})
+	assert.Equal(t, 0.9, usage.Cost.Total)
+
+	usage.Absorb(&Usage{CostEstimateUnavailable: true})
+	assert.True(t, usage.CostEstimateUnavailable)
+	assert.Nil(t, usage.Cost)
+}
+
+func TestUsageAbsorbNilIsNoOp(t *testing.T) {
+	usage := Usage{InputTokens: 5}
+	usage.Absorb(nil)
+	assert.Equal(t, 5, usage.InputTokens)
+}

--- a/providers/anthropic/stream_usage_test.go
+++ b/providers/anthropic/stream_usage_test.go
@@ -1,0 +1,57 @@
+package anthropic
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/deepnoodle-ai/dive/llm"
+	"github.com/deepnoodle-ai/wonton/assert"
+)
+
+// Anthropic repeats the full cumulative usage object in message_delta that
+// message_start already carried. The accumulated usage must equal the final
+// frame's values, not the sum of both frames.
+const cumulativeUsageAnthropicStream = `data: {"type":"message_start","message":{"id":"msg_1","type":"message","role":"assistant","model":"test-model","content":[],"usage":{"input_tokens":14,"cache_creation_input_tokens":8012,"cache_read_input_tokens":120000,"output_tokens":4}}}
+
+data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}
+
+data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"ok"}}
+
+data: {"type":"content_block_stop","index":0}
+
+data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"input_tokens":14,"cache_creation_input_tokens":8012,"cache_read_input_tokens":120000,"output_tokens":7}}
+
+data: {"type":"message_stop"}
+
+`
+
+func TestStreamCumulativeUsageNotDoubleCounted(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = io.WriteString(w, cumulativeUsageAnthropicStream)
+	}))
+	defer server.Close()
+
+	provider := New(
+		WithAPIKey("test-key"),
+		WithEndpoint(server.URL),
+	)
+	iterator, err := provider.Stream(context.Background(),
+		llm.WithMessages(llm.NewUserTextMessage("hello")),
+	)
+	assert.NoError(t, err)
+	defer iterator.Close()
+
+	accumulator := consumeAnthropicStream(t, iterator)
+	assert.True(t, accumulator.IsComplete())
+
+	usage := accumulator.Response().Usage
+	assert.Equal(t, 14, usage.InputTokens)
+	assert.Equal(t, 8012, usage.CacheCreationInputTokens)
+	assert.Equal(t, 120000, usage.CacheReadInputTokens)
+	assert.Equal(t, 7, usage.OutputTokens)
+	assert.Equal(t, 128026, usage.TotalInputTokens())
+}


### PR DESCRIPTION
Closes #260

## Problem

For streaming requests whose provider forwards Anthropic-shaped SSE frames, `ResponseAccumulator` counted `input_tokens`, `cache_creation_input_tokens`, and `cache_read_input_tokens` exactly twice: it seeded `Response.Usage` from `message_start`, then `Add()`ed the usage carried by `message_delta` — but Anthropic's `message_delta.usage` is **cumulative for the whole message**, not incremental (confirmed against the streaming docs: *"The token counts shown in the `usage` field of the `message_delta` event are cumulative"*). Affected: `anthropic`, `ollama` (embeds the Anthropic provider), and latently `openaicompletions` when an upstream emits usage on a chunk that also carries choices. Non-streaming calls were correct.

Reproduced with real frame values: input 14→**28**, cache creation 8,012→**16,024**, cache read 120,000→**240,000**, `TotalInputTokens()` 128,026→**256,052**. Downstream this doubled CLI token rows, cost estimates (~2x), and the context gauge — compaction and budget guards tripped at roughly half the real context size.

## Fix

Fixed at the accumulator so every provider routed through it is covered in one place:

- **New `Usage.Absorb`** merges cumulative frames by per-field **max**: a later frame supersedes an earlier one, while frames that omit fields (the docs also show `message_delta` frames carrying *only* `output_tokens`) don't erase the input buckets seeded by `message_start`. This also fixes the output-token drift from `message_start`'s starting count.
- Merge rules beyond the token buckets: `ModalityTokens` max per bucket, provider-attached `Cost` **replaces** rather than sums, `ServiceTier`/`Speed` take the later non-empty value, boolean flags OR-merge. The accumulator's previous `Speed` special-case is now handled inside `Absorb`.
- **`Usage.Add` keeps its additive semantics** for cross-generation aggregation in `Agent.chat`, which was and remains correct.

## Tests

- Accumulator test replaying the reproduction frames (cold + warm cache buckets), asserting the final frame's values.
- Accumulator test for an output-only `message_delta`, pinning why max beats wholesale replacement.
- Provider-level golden test replaying a captured Anthropic SSE transcript through the real `providers/anthropic` provider via `httptest`.
- `Usage.Absorb` unit tests covering the cost-replace, tier/speed, modality, and flag rules.

All tests pass in the main module and in the `providers/google` / `providers/openai` submodules (which build against the local `llm` via replace directives).

## Notes

- Includes `docs/bugs/streaming-usage-double-count.md` (the writeup #260 links to), previously untracked.
- Follow-ups not in this PR: extending `usage_invariant_test.go` to the streaming path for every provider, and refreshing `providers/anthropic/reference.md`, which still documents the pre-2025 `message_delta` shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed double-counting of input, cached, output, and cost usage during streamed Anthropic and Ollama responses.
  * Preserved accurate token and billing information when usage updates contain only partial data.
  * Added regression coverage for cumulative streaming usage across supported providers.

* **Documentation**
  * Added an unreleased changelog entry and documentation describing the streaming usage correction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->