### PR TITLE
Prepare v1.24.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [1.24.0] - 2026-08-12
+
 ### Fixed
 
 - **Streaming usage no longer double counts the input side.** Anthropic-shaped

--- a/a2a/go.mod
+++ b/a2a/go.mod
@@ -6,7 +6,7 @@ toolchain go1.26.5
 
 require (
 	github.com/a2aproject/a2a-go/v2 v2.4.0
-	github.com/deepnoodle-ai/dive v1.23.0
+	github.com/deepnoodle-ai/dive v1.24.0
 	github.com/deepnoodle-ai/wonton v0.0.37
 )
 

--- a/demos/colosseum/go.mod
+++ b/demos/colosseum/go.mod
@@ -5,11 +5,11 @@ go 1.25.0
 toolchain go1.26.5
 
 require (
-	github.com/deepnoodle-ai/dive v1.23.0
-	github.com/deepnoodle-ai/dive/a2a v1.23.0
-	github.com/deepnoodle-ai/dive/providers/google v1.23.0
-	github.com/deepnoodle-ai/dive/providers/grok v1.23.0
-	github.com/deepnoodle-ai/dive/providers/openai v1.23.0
+	github.com/deepnoodle-ai/dive v1.24.0
+	github.com/deepnoodle-ai/dive/a2a v1.24.0
+	github.com/deepnoodle-ai/dive/providers/google v1.24.0
+	github.com/deepnoodle-ai/dive/providers/grok v1.24.0
+	github.com/deepnoodle-ai/dive/providers/openai v1.24.0
 	github.com/deepnoodle-ai/wonton v0.0.37
 )
 

--- a/demos/noodleville/go.mod
+++ b/demos/noodleville/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 toolchain go1.26.5
 
 require (
-	github.com/deepnoodle-ai/dive v1.23.0
+	github.com/deepnoodle-ai/dive v1.24.0
 	github.com/deepnoodle-ai/wonton v0.0.37
 )
 

--- a/docs/bugs/streaming-usage-double-count.md
+++ b/docs/bugs/streaming-usage-double-count.md
@@ -15,7 +15,7 @@ For streaming requests whose provider forwards Anthropic-shaped SSE frames,
 `ResponseAccumulator` counts `input_tokens`, `cache_creation_input_tokens`, and
 `cache_read_input_tokens` **exactly twice**.
 
-The accumulator seeds `Response.Usage` from `message_start`, then *adds* the usage carried by
+The accumulator seeds `Response.Usage` from `message_start`, then _adds_ the usage carried by
 `message_delta`. Anthropic repeats the full cumulative usage object in both frames, so every
 input-side bucket lands twice.
 
@@ -59,31 +59,31 @@ message_start {"input_tokens":14,"cache_creation_input_tokens":8012,"cache_read_
 message_delta {"input_tokens":14,"cache_creation_input_tokens":8012,"cache_read_input_tokens":120000,"output_tokens":7}
 ```
 
-| bucket | true | accumulated |
-|---|---:|---:|
-| `input_tokens` | 14 | **28** |
-| `cache_creation_input_tokens` | 8,012 | **16,024** |
-| `cache_read_input_tokens` | 120,000 | **240,000** |
-| `output_tokens` | 7 | **11** |
-| `TotalInputTokens()` | 128,026 | **256,052** |
+| bucket                        |    true | accumulated |
+| ----------------------------- | ------: | ----------: |
+| `input_tokens`                |      14 |      **28** |
+| `cache_creation_input_tokens` |   8,012 |  **16,024** |
+| `cache_read_input_tokens`     | 120,000 | **240,000** |
+| `output_tokens`               |       7 |      **11** |
+| `TotalInputTokens()`          | 128,026 | **256,052** |
 
 Verified end to end by driving `dive.NewAgent` against an `httptest` server replaying the SSE
 transcript above through the real `providers/anthropic` provider.
 
 ## Scope
 
-| Provider | Stream path | Affected |
-|---|---|---|
-| `anthropic` | passthrough SSE → `llm.Event` | **yes** |
-| `ollama` | embeds `*anthropic.Provider` (Anthropic-compatible Messages API) | **yes** |
-| `openaicompletions` (→ `mistral`, `openrouter`) | own iterator | **latent** — see below |
-| `openai` (Responses API, → `grok`) | own iterator; `message_start` carries no usage | no |
-| `google` | own iterator; usage emitted once on `message_delta` | no |
+| Provider                                        | Stream path                                                      | Affected               |
+| ----------------------------------------------- | ---------------------------------------------------------------- | ---------------------- |
+| `anthropic`                                     | passthrough SSE → `llm.Event`                                    | **yes**                |
+| `ollama`                                        | embeds `*anthropic.Provider` (Anthropic-compatible Messages API) | **yes**                |
+| `openaicompletions` (→ `mistral`, `openrouter`) | own iterator                                                     | **latent** — see below |
+| `openai` (Responses API, → `grok`)              | own iterator; `message_start` carries no usage                   | no                     |
+| `google`                                        | own iterator; usage emitted once on `message_delta`              | no                     |
 
 `openaicompletions` is not structurally immune. Its `message_start` carries
 `Usage: s.usage.toLLMUsage()` (`stream_iterator.go:167`), populated at `:143` from the same
 chunk. It is safe only because OpenAI delivers usage in a trailing choices-empty chunk. A
-provider that emits usage on a chunk that *also* carries choices double counts identically —
+provider that emits usage on a chunk that _also_ carries choices double counts identically —
 measured `input=200` against a true `100`. OpenRouter proxies many upstreams and is the most
 plausible route to this.
 
@@ -111,12 +111,12 @@ Using the reproduction above (`claude-sonnet-5`, list-price estimate):
 
 The bug is old and was not introduced by the recent billing work.
 
-| Date | PR | Effect |
-|---|---|---|
-| 2025-04-03 | #21 | Added `r.response = event.Message`. Input/output double count begins. |
-| 2025-06-05 | #39 | Added cache-bucket accumulation. Cache double count — the costly part — begins. |
-| 2026-08-10 | #251 | Added `TotalInputTokens()`. Did not touch the accumulator. |
-| 2026-08-10 | #254 | Replaced five explicit `+=` lines with `Usage.Add()`. Semantics unchanged. |
+| Date       | PR   | Effect                                                                          |
+| ---------- | ---- | ------------------------------------------------------------------------------- |
+| 2025-04-03 | #21  | Added `r.response = event.Message`. Input/output double count begins.           |
+| 2025-06-05 | #39  | Added cache-bucket accumulation. Cache double count — the costly part — begins. |
+| 2026-08-10 | #251 | Added `TotalInputTokens()`. Did not touch the accumulator.                      |
+| 2026-08-10 | #254 | Replaced five explicit `+=` lines with `Usage.Add()`. Semantics unchanged.      |
 
 The same seed-then-add shape is present verbatim at `v1.15.0` and `v1.20.0`, and `CostOf`
 already priced cache buckets separately at `v1.20.0`.

--- a/docs/releases/v1.24.0.md
+++ b/docs/releases/v1.24.0.md
@@ -1,0 +1,31 @@
+## Highlights
+
+Streamed usage was double counted on the input side. Anthropic repeats the full
+cumulative usage object in both `message_start` and `message_delta`, and the
+accumulator summed the two frames instead of letting the later one supersede.
+The fix sits in `ResponseAccumulator`, so `anthropic`, `ollama`, and the latent
+`openaicompletions` path are covered together. Non-streaming calls were
+unaffected, as were `openai`, `grok`, and `google` streams.
+
+Your numbers will move on upgrade: input and cache tokens for streamed
+Anthropic traffic drop to roughly half of what Dive reported before, and cost
+estimates with them. Compaction and budget guards were tripping at about half
+the real context window and now fire where you configured them, so revisit any
+threshold tuned against the old reading. No migration otherwise — `Usage.Absorb`
+is new for merging cumulative frames, and `Usage.Add` keeps its additive
+semantics for aggregating across requests.
+
+## Pull requests
+
+- Fix streaming usage double count on the input side (#261)
+
+## Changelog
+
+### Fixed
+
+- **Streaming usage no longer double counts the input side.** Anthropic-shaped
+  streams repeat cumulative usage in both `message_start` and `message_delta`;
+  `ResponseAccumulator` now merges frames by supersession (new `Usage.Absorb`)
+  instead of summing, so input, cache, and cost figures are no longer ~2x on
+  streamed Anthropic/Ollama traffic. `Usage.Add` keeps its additive semantics
+  for cross-request aggregation.

--- a/examples/go.mod
+++ b/examples/go.mod
@@ -5,13 +5,13 @@ go 1.25.5
 toolchain go1.26.5
 
 require (
-	github.com/deepnoodle-ai/dive v1.23.0
-	github.com/deepnoodle-ai/dive/a2a v1.23.0
-	github.com/deepnoodle-ai/dive/experimental/mcp v1.23.0
-	github.com/deepnoodle-ai/dive/otel v1.23.0
-	github.com/deepnoodle-ai/dive/providers/google v1.23.0
-	github.com/deepnoodle-ai/dive/providers/grok v1.23.0
-	github.com/deepnoodle-ai/dive/providers/openai v1.23.0
+	github.com/deepnoodle-ai/dive v1.24.0
+	github.com/deepnoodle-ai/dive/a2a v1.24.0
+	github.com/deepnoodle-ai/dive/experimental/mcp v1.24.0
+	github.com/deepnoodle-ai/dive/otel v1.24.0
+	github.com/deepnoodle-ai/dive/providers/google v1.24.0
+	github.com/deepnoodle-ai/dive/providers/grok v1.24.0
+	github.com/deepnoodle-ai/dive/providers/openai v1.24.0
 	github.com/deepnoodle-ai/wonton v0.0.37
 	github.com/fatih/color v1.19.0
 	github.com/mark3labs/mcp-go v0.57.0

--- a/experimental/cmd/dive/go.mod
+++ b/experimental/cmd/dive/go.mod
@@ -5,10 +5,10 @@ go 1.25.0
 toolchain go1.26.5
 
 require (
-	github.com/deepnoodle-ai/dive v1.23.0
-	github.com/deepnoodle-ai/dive/providers/google v1.23.0
-	github.com/deepnoodle-ai/dive/providers/grok v1.23.0
-	github.com/deepnoodle-ai/dive/providers/openai v1.23.0
+	github.com/deepnoodle-ai/dive v1.24.0
+	github.com/deepnoodle-ai/dive/providers/google v1.24.0
+	github.com/deepnoodle-ai/dive/providers/grok v1.24.0
+	github.com/deepnoodle-ai/dive/providers/openai v1.24.0
 	github.com/deepnoodle-ai/wonton v0.0.37
 	github.com/mattn/go-runewidth v0.0.27
 	google.golang.org/genai v1.67.0

--- a/experimental/mcp/go.mod
+++ b/experimental/mcp/go.mod
@@ -5,7 +5,7 @@ go 1.25.5
 toolchain go1.26.5
 
 require (
-	github.com/deepnoodle-ai/dive v1.23.0
+	github.com/deepnoodle-ai/dive v1.24.0
 	github.com/deepnoodle-ai/wonton v0.0.37
 	github.com/mark3labs/mcp-go v0.57.0
 )

--- a/otel/go.mod
+++ b/otel/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 toolchain go1.26.5
 
 require (
-	github.com/deepnoodle-ai/dive v1.23.0
+	github.com/deepnoodle-ai/dive v1.24.0
 	go.opentelemetry.io/otel v1.45.0
 	go.opentelemetry.io/otel/metric v1.45.0
 	go.opentelemetry.io/otel/sdk v1.45.0

--- a/providers/google/go.mod
+++ b/providers/google/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 toolchain go1.26.5
 
 require (
-	github.com/deepnoodle-ai/dive v1.23.0
+	github.com/deepnoodle-ai/dive v1.24.0
 	github.com/deepnoodle-ai/wonton v0.0.37
 	google.golang.org/genai v1.67.0
 )

--- a/providers/grok/go.mod
+++ b/providers/grok/go.mod
@@ -5,8 +5,8 @@ go 1.25.0
 toolchain go1.26.5
 
 require (
-	github.com/deepnoodle-ai/dive v1.23.0
-	github.com/deepnoodle-ai/dive/providers/openai v1.23.0
+	github.com/deepnoodle-ai/dive v1.24.0
+	github.com/deepnoodle-ai/dive/providers/openai v1.24.0
 	github.com/deepnoodle-ai/wonton v0.0.37
 	github.com/openai/openai-go/v3 v3.50.0
 	golang.org/x/image v0.44.0

--- a/providers/openai/go.mod
+++ b/providers/openai/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 toolchain go1.26.5
 
 require (
-	github.com/deepnoodle-ai/dive v1.23.0
+	github.com/deepnoodle-ai/dive v1.24.0
 	github.com/deepnoodle-ai/wonton v0.0.37
 	github.com/openai/openai-go/v3 v3.50.0
 	golang.org/x/image v0.44.0


### PR DESCRIPTION
Release prep for v1.24.0, following `docs/releasing.md` steps 1–4.

- **Changelog** — `## [Unreleased]` cut to `## [1.24.0] - 2026-08-12`, fresh empty `Unreleased` above it.
- **Module requirements** — `make release-prep VERSION=v1.24.0` across all eight tagged sub-modules plus the untagged `demos/`.
- **Release notes** — `docs/releases/v1.24.0.md`, Highlights written.

One PR in this release: #261 (streaming usage double count). Its changelog entry was already in `Unreleased`.

Also runs prettier over `docs/bugs/streaming-usage-double-count.md`, which landed unformatted in #261 and was failing `make fmt-check` on main.

`make check` passes.

After merge: `git tag v1.24.0 && make tag-modules VERSION=v1.24.0 && git push origin --tags`, then `make release-publish VERSION=v1.24.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)