### PR TITLE
Load .env in the experimental dive CLI on startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Added
+
+- **The `dive` CLI now loads a `.env` file from the current directory on
+  startup** (via `wonton/env`), so provider API keys like `MISTRAL_API_KEY`
+  no longer need to be exported into the shell manually. Existing
+  environment variables take precedence; a missing `.env` is not an error.
+
 ## [1.24.0] - 2026-08-12
 
 ### Fixed

--- a/experimental/cmd/dive/main.go
+++ b/experimental/cmd/dive/main.go
@@ -30,10 +30,13 @@ import (
 	"github.com/deepnoodle-ai/dive/toolkit/firecrawl"
 	"github.com/deepnoodle-ai/dive/toolkit/orchestration"
 	"github.com/deepnoodle-ai/wonton/cli"
+	"github.com/deepnoodle-ai/wonton/env"
 	"github.com/deepnoodle-ai/wonton/fetch"
 )
 
 func main() {
+	loadDotEnv()
+
 	app := cli.New("dive").
 		Description("Interactive AI assistant for coding tasks").
 		Version("0.1.0")
@@ -169,6 +172,16 @@ func main() {
 		}
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(cli.GetExitCode(err))
+	}
+}
+
+// loadDotEnv loads variables from a ".env" file in the current directory
+// into the process environment, without overwriting variables already set.
+// A missing file is not an error; other failures (e.g. a malformed file)
+// are reported but don't prevent startup.
+func loadDotEnv() {
+	if err := env.LoadEnvFile(); err != nil && !os.IsNotExist(err) {
+		fmt.Fprintf(os.Stderr, "Warning: failed to load .env file: %v\n", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- The `dive` CLI now loads a `.env` file from the current directory at startup via `wonton/env.LoadEnvFile`, so provider API keys (e.g. `MISTRAL_API_KEY`) work without exporting them into the shell first.
- Existing environment variables take precedence over `.env` values; a missing `.env` file is not an error, other read failures are reported to stderr as a warning without aborting startup.

## Test plan
- [x] `go build ./...` (root module)
- [x] `cd experimental/cmd/dive && go build ./... && go test ./...`
- [x] Manually verified: built the CLI, placed a `.env` with `MISTRAL_API_KEY=...` in a scratch directory (with the real var unset), ran `dive models --available` from that directory, and confirmed Mistral now appears in the available-providers list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The `dive` CLI now automatically loads environment variables from a `.env` file at startup.
  * Existing environment variables take precedence over values in `.env`.
  * Missing `.env` files are handled silently, while other loading issues display a warning without blocking startup.

* **Documentation**
  * Added changelog documentation for `.env` loading behavior and environment-variable precedence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->