### PR TITLE
Add Gemini 3.7 Flash and Mistral Medium 3.5 to the catalogs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
   startup** (via `wonton/env`), so provider API keys like `MISTRAL_API_KEY`
   no longer need to be exported into the shell manually. Existing
   environment variables take precedence; a missing `.env` is not an error.
+- **Gemini 3.7 Flash** — `gemini-3.7-flash` added to the Google catalog and
+  pricing; now the Google default. Google publishes identical list pricing to
+  `gemini-3.6-flash`, which remains available. Its thinking parameters were
+  verified live against Vertex AI: unlike the rest of the 3.x flash family it
+  rejects `MINIMAL` effort and its `thinkingBudget` ceiling is 32768, not
+  65535 (see `providers/google/capabilities.go`).
+- **Mistral Medium 3.5** — `mistral-medium-latest` added to the Mistral
+  catalog and pricing ($1.50/$7.50 per 1M tokens, 256k context); now the
+  Mistral default, replacing `mistral-large-latest` per Mistral's own "becomes
+  the default model in Le Chat" announcement. `mistral-large-latest` and
+  `mistral-small-latest` also had their published list prices corrected —
+  Large fell to $0.50/$1.50 (from a stale $2.00/$6.00) and Small rose to
+  $0.15/$0.60 (from a stale $0.10/$0.30) — both now match Mistral's current
+  pricing page rather than late-2025 figures.
 
 ## [1.24.0] - 2026-08-12
 

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ fmt.Println(response.OutputText())
 Use the LLM interface for direct model access without the agent loop:
 
 ```go
-model := google.New(google.WithModel(google.ModelGemini36Flash))
+model := google.New(google.WithModel(google.ModelGemini37Flash))
 response, err := model.Generate(ctx,
     llm.WithMessages(llm.NewUserMessage(
         llm.NewTextContent("What is in this image?"),

--- a/examples/google_example/main.go
+++ b/examples/google_example/main.go
@@ -11,7 +11,7 @@ import (
 
 func main() {
 	// Create the Google provider
-	provider := google.New(google.WithModel(google.ModelGemini36Flash))
+	provider := google.New(google.WithModel(google.ModelGemini37Flash))
 
 	ctx := context.Background()
 
@@ -47,7 +47,7 @@ func main() {
 	}
 	fmt.Println()
 
-	// Example 3: With system prompt. Gemini 3.6 Flash uses fixed sampling
+	// Example 3: With system prompt. Gemini 3.7 Flash uses fixed sampling
 	// controls, so requests should not set a temperature.
 	fmt.Println("=== With System Prompt ===")
 	response, err = provider.Generate(ctx,

--- a/experimental/cmd/dive/main.go
+++ b/experimental/cmd/dive/main.go
@@ -1246,7 +1246,7 @@ func getDefaultModel() string {
 		return anthropic.DefaultModel
 	}
 	if os.Getenv("GOOGLE_API_KEY") != "" || os.Getenv("GEMINI_API_KEY") != "" {
-		return "gemini-3.6-flash"
+		return "gemini-3.7-flash"
 	}
 	if os.Getenv("OPENAI_API_KEY") != "" {
 		return "gpt-5.6-sol"

--- a/experimental/cmd/dive/main.go
+++ b/experimental/cmd/dive/main.go
@@ -1255,7 +1255,7 @@ func getDefaultModel() string {
 		return defaultGrokModel
 	}
 	if os.Getenv("MISTRAL_API_KEY") != "" {
-		return "mistral-small-latest"
+		return defaultMistralModel
 	}
 	return anthropic.DefaultModel
 }

--- a/experimental/cmd/dive/main_test.go
+++ b/experimental/cmd/dive/main_test.go
@@ -49,7 +49,7 @@ func TestGetDefaultModel(t *testing.T) {
 			envVars: map[string]string{
 				"GOOGLE_API_KEY": "test",
 			},
-			expected: "gemini-3.6-flash",
+			expected: "gemini-3.7-flash",
 		},
 		{
 			name: "openai key present",

--- a/experimental/cmd/dive/main_test.go
+++ b/experimental/cmd/dive/main_test.go
@@ -65,6 +65,13 @@ func TestGetDefaultModel(t *testing.T) {
 			},
 			expected: "grok-4.6",
 		},
+		{
+			name: "mistral key present",
+			envVars: map[string]string{
+				"MISTRAL_API_KEY": "test",
+			},
+			expected: "mistral-medium-latest",
+		},
 	}
 
 	for _, tt := range tests {

--- a/experimental/cmd/dive/models_test.go
+++ b/experimental/cmd/dive/models_test.go
@@ -11,7 +11,7 @@ func TestLatestGeminiFlashModels(t *testing.T) {
 		model string
 		label string
 	}{
-		{"gemini-3.6-flash", "Gemini 3.6 Flash"},
+		{"gemini-3.7-flash", "Gemini 3.7 Flash"},
 		{"gemini-3.5-flash-lite", "Gemini 3.5 Flash-Lite"},
 	}
 
@@ -27,7 +27,7 @@ func TestLatestGeminiFlashModels(t *testing.T) {
 
 func TestGoogleProviderCatalogIncludesLatestFlashModels(t *testing.T) {
 	want := map[string]bool{
-		"gemini-3.6-flash":      false,
+		"gemini-3.7-flash":      false,
 		"gemini-3.5-flash-lite": false,
 	}
 	for _, provider := range providerCatalog {

--- a/experimental/cmd/dive/providers.go
+++ b/experimental/cmd/dive/providers.go
@@ -7,6 +7,7 @@ import (
 	"github.com/deepnoodle-ai/dive/llm"
 	"github.com/deepnoodle-ai/dive/providers"
 	"github.com/deepnoodle-ai/dive/providers/grok"
+	"github.com/deepnoodle-ai/dive/providers/mistral"
 
 	// Import providers to trigger their init() registration
 	_ "github.com/deepnoodle-ai/dive/providers/anthropic"
@@ -21,6 +22,9 @@ import (
 
 // defaultGrokModel is the default model used when a Grok API key is detected.
 var defaultGrokModel = grok.DefaultModel
+
+// defaultMistralModel is the default model used when a Mistral API key is detected.
+var defaultMistralModel = mistral.DefaultModel
 
 // createModel creates an LLM provider using the global registry.
 // Providers are registered via init() when imported above.

--- a/providers/google/capabilities.go
+++ b/providers/google/capabilities.go
@@ -34,8 +34,10 @@ type modelCapabilities struct {
 	// disable thinking has to degrade instead.
 	canDisableThinking bool
 
-	// unverified marks a model that is catalogued but could not be reached — it
-	// answered 404 "no longer available". Lookup reports it as unknown so its
+	// unverified marks a model whose thinking parameters have not been
+	// confirmed against the live API — either a retired model that now
+	// answers 404 "no longer available", or a newly catalogued model that
+	// has not been probed yet. Lookup reports it as unknown so its
 	// parameters pass through untouched rather than being guessed at.
 	unverified bool
 }
@@ -76,7 +78,17 @@ type capabilityEntry struct {
 // generation — gemini-3.5-flash can turn thinking off and gemini-3.5-flash-lite
 // cannot, and the 2.5 generation has no thinking level at all.
 var modelCapabilityTable = []capabilityEntry{
-	// --- 3.x: thinking levels, budgets in [1, 65535]. ---
+	// --- 3.x: thinking levels, budgets in [1, 65535] unless noted. ---
+	// 3.7 Flash rejects MINIMAL ("Thinking level is unsupported:
+	// THINKING_LEVEL_MINIMAL") and its budget ceiling is lower than the rest
+	// of the family — 32768, not 65535 ("thinking_budget is out of range;
+	// supported values are integers from 1 to 32768"). Verified live against
+	// Vertex AI on 2026-08-15; unlike the rest of this table it was not
+	// probed against the public Gemini API.
+	{prefix: "gemini-3.7-flash", caps: modelCapabilities{
+		efforts: effortsLowThroughHigh, minBudget: 1, maxBudget: 32768,
+		canDisableThinking: true,
+	}},
 	{prefix: "gemini-3.6-flash", caps: modelCapabilities{
 		efforts: effortsThroughHigh, minBudget: 1, maxBudget: 65535,
 	}},

--- a/providers/google/catalog.json
+++ b/providers/google/catalog.json
@@ -25,15 +25,22 @@
   ],
   "models": [
     {
+      "go_name": "ModelGemini37Flash",
+      "id": "gemini-3.7-flash",
+      "kind": "text",
+      "context_window": 1000000,
+      "display_name": "Gemini 3.7 Flash",
+      "default": true,
+      "recommended": true,
+      "cli_order": 1,
+      "description": "Most capable Flash model for agentic workflows and multimodal reasoning"
+    },
+    {
       "go_name": "ModelGemini36Flash",
       "id": "gemini-3.6-flash",
       "kind": "text",
       "context_window": 1000000,
-      "display_name": "Gemini 3.6 Flash",
-      "default": true,
-      "recommended": true,
-      "cli_order": 1,
-      "description": "Fast agentic and multimodal model with strong coding performance"
+      "display_name": "Gemini 3.6 Flash"
     },
     {
       "go_name": "ModelGemini35Flash",
@@ -221,6 +228,14 @@
   ],
   "pricing": {
     "text": [
+      {
+        "model": "gemini-3.7-flash",
+        "input_price_per_1m_tokens": "1.50",
+        "output_price_per_1m_tokens": "7.50",
+        "cache_read_price_per_1m_tokens": "0.15",
+        "currency": "USD",
+        "updated_at": "2026-08-15"
+      },
       {
         "model": "gemini-3.6-flash",
         "input_price_per_1m_tokens": "1.50",

--- a/providers/google/cost_test.go
+++ b/providers/google/cost_test.go
@@ -10,6 +10,7 @@ import (
 
 func TestGoogleCacheReadPricingCoverage(t *testing.T) {
 	expected := map[string]float64{
+		ModelGemini37Flash:                 0.15,
 		ModelGemini36Flash:                 0.15,
 		ModelGemini35Flash:                 0.15,
 		ModelGemini35FlashLite:             0.03,

--- a/providers/google/models_gen.go
+++ b/providers/google/models_gen.go
@@ -3,6 +3,7 @@
 package google
 
 const (
+	ModelGemini37Flash                 = "gemini-3.7-flash"
 	ModelGemini36Flash                 = "gemini-3.6-flash"
 	ModelGemini35Flash                 = "gemini-3.5-flash"
 	ModelGemini35FlashLite             = "gemini-3.5-flash-lite"
@@ -37,4 +38,4 @@ const (
 )
 
 // DefaultModel is generated from the catalog's default model.
-var DefaultModel = ModelGemini36Flash
+var DefaultModel = ModelGemini37Flash

--- a/providers/google/models_test.go
+++ b/providers/google/models_test.go
@@ -14,7 +14,7 @@ func TestLatestGeminiFlashModels(t *testing.T) {
 		inputPrice  float64
 		outputPrice float64
 	}{
-		{ModelGemini36Flash, "gemini-3.6-flash", 1.50, 7.50},
+		{ModelGemini37Flash, "gemini-3.7-flash", 1.50, 7.50},
 		{ModelGemini35FlashLite, "gemini-3.5-flash-lite", 0.30, 2.50},
 	}
 
@@ -33,7 +33,7 @@ func TestLatestGeminiFlashModelsOmitTemperature(t *testing.T) {
 	temperature := 0.8
 	provider := New()
 
-	for _, model := range []string{ModelGemini36Flash, ModelGemini35FlashLite} {
+	for _, model := range []string{ModelGemini37Flash, ModelGemini35FlashLite} {
 		t.Run(model, func(t *testing.T) {
 			logger := &recordingWarningLogger{}
 			var request Request

--- a/providers/google/pricing_gen.go
+++ b/providers/google/pricing_gen.go
@@ -6,6 +6,14 @@ import "github.com/deepnoodle-ai/dive/llm"
 
 // TextModelPricing is generated from catalog.json.
 var TextModelPricing = map[string]llm.PricingInfo{
+	ModelGemini37Flash: {
+		Model:          ModelGemini37Flash,
+		InputPrice:     1.50,
+		OutputPrice:    7.50,
+		CacheReadPrice: 0.15,
+		Currency:       "USD",
+		UpdatedAt:      "2026-08-15",
+	},
 	ModelGemini36Flash: {
 		Model:          ModelGemini36Flash,
 		InputPrice:     1.50,

--- a/providers/google/thinking_test.go
+++ b/providers/google/thinking_test.go
@@ -72,6 +72,24 @@ func TestMinimalClampsOnProModels(t *testing.T) {
 	assert.Equal(t, genai.ThinkingLevelLow, thinking.ThinkingLevel)
 }
 
+func TestMinimalClampsOnGemini37Flash(t *testing.T) {
+	// Verified live: 3.7 Flash answers "Thinking level is unsupported:
+	// THINKING_LEVEL_MINIMAL" even though the rest of the 3.x flash family
+	// accepts it — clamp up to LOW like the Pro models do.
+	thinking := buildThinking(t, ModelGemini37Flash,
+		llm.WithReasoningEffort(llm.ReasoningEffortMinimal))
+	assert.NotNil(t, thinking)
+	assert.Equal(t, genai.ThinkingLevelLow, thinking.ThinkingLevel)
+}
+
+func TestGemini37FlashBudgetCeilingIsLowerThanTheFamily(t *testing.T) {
+	// Verified live: 3.7 Flash reports "supported values are integers from 1
+	// to 32768", not the 65535 ceiling the rest of the 3.x flash family uses.
+	thinking := buildThinking(t, ModelGemini37Flash, llm.WithReasoningBudget(1_000_000))
+	assert.NotNil(t, thinking)
+	assert.Equal(t, int32(32768), *thinking.ThinkingBudget)
+}
+
 func TestReasoningBudgetMapsToThinkingBudget(t *testing.T) {
 	thinking := buildThinking(t, ModelGemini36Flash, llm.WithReasoningBudget(4096))
 	assert.NotNil(t, thinking)

--- a/providers/google/usage_pricing.go
+++ b/providers/google/usage_pricing.go
@@ -13,6 +13,7 @@ import (
 // generated catalog. Retired, live, TTS, and image-generation rows require
 // different billing shapes and intentionally remain unpriced here.
 var verifiedGoogleTextPricing = map[string]struct{}{
+	ModelGemini37Flash:                 {},
 	ModelGemini36Flash:                 {},
 	ModelGemini35Flash:                 {},
 	ModelGemini35FlashLite:             {},

--- a/providers/mistral/catalog.json
+++ b/providers/mistral/catalog.json
@@ -30,6 +30,17 @@
   ],
   "models": [
     {
+      "go_name": "ModelMistralMedium",
+      "id": "mistral-medium-latest",
+      "default": true,
+      "kind": "text",
+      "context_window": 256000,
+      "display_name": "Mistral Medium",
+      "recommended": true,
+      "cli_order": 1,
+      "description": "Flagship merged model for long-horizon agentic tasks and coding"
+    },
+    {
       "go_name": "ModelMistralLarge3",
       "id": "mistral-large-2512",
       "kind": "text",
@@ -38,13 +49,9 @@
     {
       "go_name": "ModelMistralLarge",
       "id": "mistral-large-latest",
-      "default": true,
       "kind": "text",
       "context_window": 128000,
-      "display_name": "Mistral Large",
-      "recommended": true,
-      "cli_order": 1,
-      "description": "Flagship model"
+      "display_name": "Mistral Large"
     },
     {
       "go_name": "ModelMistralLarge2411",
@@ -134,6 +141,13 @@
   "pricing": {
     "text": [
       {
+        "model": "mistral-medium-latest",
+        "input_price_per_1m_tokens": "1.5",
+        "output_price_per_1m_tokens": "7.5",
+        "currency": "USD",
+        "updated_at": "2026-08-15"
+      },
+      {
         "model": "mistral-large-2411",
         "input_price_per_1m_tokens": "2.0",
         "output_price_per_1m_tokens": "6.0",
@@ -142,17 +156,17 @@
       },
       {
         "model": "mistral-large-latest",
-        "input_price_per_1m_tokens": "2.0",
-        "output_price_per_1m_tokens": "6.0",
+        "input_price_per_1m_tokens": "0.5",
+        "output_price_per_1m_tokens": "1.5",
         "currency": "USD",
-        "updated_at": "2025-10-15"
+        "updated_at": "2026-08-15"
       },
       {
         "model": "mistral-small-latest",
-        "input_price_per_1m_tokens": "0.1",
-        "output_price_per_1m_tokens": "0.3",
+        "input_price_per_1m_tokens": "0.15",
+        "output_price_per_1m_tokens": "0.6",
         "currency": "USD",
-        "updated_at": "2025-10-15"
+        "updated_at": "2026-08-15"
       },
       {
         "model": "codestral-latest",

--- a/providers/mistral/models_gen.go
+++ b/providers/mistral/models_gen.go
@@ -3,6 +3,7 @@
 package mistral
 
 const (
+	ModelMistralMedium       = "mistral-medium-latest"
 	ModelMistralLarge3       = "mistral-large-2512"
 	ModelMistralLarge        = "mistral-large-latest"
 	ModelMistralLarge2411    = "mistral-large-2411"
@@ -22,4 +23,4 @@ const (
 )
 
 // DefaultModel is generated from the catalog's default model.
-var DefaultModel = ModelMistralLarge
+var DefaultModel = ModelMistralMedium

--- a/providers/mistral/pricing_gen.go
+++ b/providers/mistral/pricing_gen.go
@@ -6,6 +6,13 @@ import "github.com/deepnoodle-ai/dive/llm"
 
 // TextModelPricing is generated from catalog.json.
 var TextModelPricing = map[string]llm.PricingInfo{
+	ModelMistralMedium: {
+		Model:       ModelMistralMedium,
+		InputPrice:  1.5,
+		OutputPrice: 7.5,
+		Currency:    "USD",
+		UpdatedAt:   "2026-08-15",
+	},
 	ModelMistralLarge2411: {
 		Model:       ModelMistralLarge2411,
 		InputPrice:  2.0,
@@ -15,17 +22,17 @@ var TextModelPricing = map[string]llm.PricingInfo{
 	},
 	ModelMistralLarge: {
 		Model:       ModelMistralLarge,
-		InputPrice:  2.0,
-		OutputPrice: 6.0,
+		InputPrice:  0.5,
+		OutputPrice: 1.5,
 		Currency:    "USD",
-		UpdatedAt:   "2025-10-15",
+		UpdatedAt:   "2026-08-15",
 	},
 	ModelMistralSmall: {
 		Model:       ModelMistralSmall,
-		InputPrice:  0.1,
-		OutputPrice: 0.3,
+		InputPrice:  0.15,
+		OutputPrice: 0.6,
 		Currency:    "USD",
-		UpdatedAt:   "2025-10-15",
+		UpdatedAt:   "2026-08-15",
 	},
 	ModelCodestralLatest: {
 		Model:       ModelCodestralLatest,


### PR DESCRIPTION
## Summary

- **Gemini 3.7 Flash** (`gemini-3.7-flash`) added to the Google catalog and pricing; now the Google default (`gemini-3.6-flash` remains available at the same list price). Thinking parameters were verified live against Vertex AI (project `nvoken`): unlike the rest of the 3.x flash family, 3.7 Flash rejects `MINIMAL` effort (`"Thinking level is unsupported: THINKING_LEVEL_MINIMAL"`) and its `thinkingBudget` ceiling is 32768, not 65535 (`"supported values are integers from 1 to 32768"`).
- **Mistral Medium 3.5** (`mistral-medium-latest`, 256k context, $1.50/$7.50 per 1M tokens) added to the Mistral catalog; now the Mistral default, replacing `mistral-large-latest` per Mistral's own "becomes the default model in Le Chat" announcement.
- Fixed stale Mistral list pricing found along the way: `mistral-large-latest` was $2.00/$6.00 (now $0.50/$1.50) and `mistral-small-latest` was $0.10/$0.30 (now $0.15/$0.60) — neither matched Mistral's current pricing page.

## Test plan

- [x] `go build ./...` and `go test ./...` pass in the root module, `providers/google`, `experimental/cmd/dive`, `examples`, `a2a`, `otel`, `demos/colosseum`, `demos/noodleville`
- [x] `python3 scripts/generate_provider_catalogs.py --check` confirms generated files match `catalog.json`
- [x] Live-probed `gemini-3.7-flash`'s `thinkingLevel`/`thinkingBudget` bounds against Vertex AI and added regression tests (`TestMinimalClampsOnGemini37Flash`, `TestGemini37FlashBudgetCeilingIsLowerThanTheFamily`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Google Gemini 3.7 Flash with configurable reasoning, context support, and automatic cost estimation.
  * Added Mistral Medium with a 256,000-token context window and made it the default Mistral model.
  * Updated Mistral Large and Small pricing.
  * Updated Google and Mistral model catalogs, pricing, and defaults.

* **Documentation**
  * Updated Google usage examples to use Gemini 3.7 Flash.

* **Chores**
  * Added release notes covering new models, pricing, context limits, and provider-specific reasoning constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->