### PR TITLE
Prepare v1.25.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [1.25.0] - 2026-08-15
+
 ### Added
 
 - **The `dive` CLI now loads a `.env` file from the current directory on

--- a/a2a/go.mod
+++ b/a2a/go.mod
@@ -6,7 +6,7 @@ toolchain go1.26.5
 
 require (
 	github.com/a2aproject/a2a-go/v2 v2.4.0
-	github.com/deepnoodle-ai/dive v1.24.0
+	github.com/deepnoodle-ai/dive v1.25.0
 	github.com/deepnoodle-ai/wonton v0.0.37
 )
 

--- a/demos/colosseum/go.mod
+++ b/demos/colosseum/go.mod
@@ -5,11 +5,11 @@ go 1.25.0
 toolchain go1.26.5
 
 require (
-	github.com/deepnoodle-ai/dive v1.24.0
-	github.com/deepnoodle-ai/dive/a2a v1.24.0
-	github.com/deepnoodle-ai/dive/providers/google v1.24.0
-	github.com/deepnoodle-ai/dive/providers/grok v1.24.0
-	github.com/deepnoodle-ai/dive/providers/openai v1.24.0
+	github.com/deepnoodle-ai/dive v1.25.0
+	github.com/deepnoodle-ai/dive/a2a v1.25.0
+	github.com/deepnoodle-ai/dive/providers/google v1.25.0
+	github.com/deepnoodle-ai/dive/providers/grok v1.25.0
+	github.com/deepnoodle-ai/dive/providers/openai v1.25.0
 	github.com/deepnoodle-ai/wonton v0.0.37
 )
 

--- a/demos/noodleville/go.mod
+++ b/demos/noodleville/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 toolchain go1.26.5
 
 require (
-	github.com/deepnoodle-ai/dive v1.24.0
+	github.com/deepnoodle-ai/dive v1.25.0
 	github.com/deepnoodle-ai/wonton v0.0.37
 )
 

--- a/docs/releases/v1.25.0.md
+++ b/docs/releases/v1.25.0.md
@@ -1,0 +1,49 @@
+## Highlights
+
+The `dive` CLI now loads a `.env` file from the current directory on startup,
+so provider API keys like `MISTRAL_API_KEY` work as soon as they're in a local
+`.env` — no more exporting them into the shell first. Existing environment
+variables still win over `.env` values, and a missing file is not an error.
+
+Two new default models: Google's `gemini-3.7-flash` is now the Google default
+(same list price as `gemini-3.6-flash`, which stays available), and Mistral's
+`mistral-medium-latest` is now the Mistral default, replacing
+`mistral-large-latest` per Mistral's own announcement. Gemini 3.7 Flash's
+thinking parameters differ from the rest of the 3.x flash family — it rejects
+`MINIMAL` effort and caps `thinkingBudget` at 32768 instead of 65535 — and
+that's now reflected in `providers/google/capabilities.go`.
+
+While adding Mistral Medium, we also caught stale list pricing on two existing
+Mistral models: `mistral-large-latest` was overpriced (corrected from
+$2.00/$6.00 to $0.50/$1.50 per 1M tokens) and `mistral-small-latest` was
+underpriced (corrected from $0.10/$0.30 to $0.15/$0.60). Cost estimates for
+those two models will shift on upgrade to match Mistral's current pricing
+page. No other migration is needed.
+
+## Pull requests
+
+- Add Gemini 3.7 Flash and Mistral Medium 3.5 to the catalogs (#264)
+- Load .env in the experimental dive CLI on startup (#263)
+
+## Changelog
+
+### Added
+
+- **The `dive` CLI now loads a `.env` file from the current directory on
+  startup** (via `wonton/env`), so provider API keys like `MISTRAL_API_KEY`
+  no longer need to be exported into the shell manually. Existing
+  environment variables take precedence; a missing `.env` is not an error.
+- **Gemini 3.7 Flash** — `gemini-3.7-flash` added to the Google catalog and
+  pricing; now the Google default. Google publishes identical list pricing to
+  `gemini-3.6-flash`, which remains available. Its thinking parameters were
+  verified live against Vertex AI: unlike the rest of the 3.x flash family it
+  rejects `MINIMAL` effort and its `thinkingBudget` ceiling is 32768, not
+  65535 (see `providers/google/capabilities.go`).
+- **Mistral Medium 3.5** — `mistral-medium-latest` added to the Mistral
+  catalog and pricing ($1.50/$7.50 per 1M tokens, 256k context); now the
+  Mistral default, replacing `mistral-large-latest` per Mistral's own "becomes
+  the default model in Le Chat" announcement. `mistral-large-latest` and
+  `mistral-small-latest` also had their published list prices corrected —
+  Large fell to $0.50/$1.50 (from a stale $2.00/$6.00) and Small rose to
+  $0.15/$0.60 (from a stale $0.10/$0.30) — both now match Mistral's current
+  pricing page rather than late-2025 figures.

--- a/examples/go.mod
+++ b/examples/go.mod
@@ -5,13 +5,13 @@ go 1.25.5
 toolchain go1.26.5
 
 require (
-	github.com/deepnoodle-ai/dive v1.24.0
-	github.com/deepnoodle-ai/dive/a2a v1.24.0
-	github.com/deepnoodle-ai/dive/experimental/mcp v1.24.0
-	github.com/deepnoodle-ai/dive/otel v1.24.0
-	github.com/deepnoodle-ai/dive/providers/google v1.24.0
-	github.com/deepnoodle-ai/dive/providers/grok v1.24.0
-	github.com/deepnoodle-ai/dive/providers/openai v1.24.0
+	github.com/deepnoodle-ai/dive v1.25.0
+	github.com/deepnoodle-ai/dive/a2a v1.25.0
+	github.com/deepnoodle-ai/dive/experimental/mcp v1.25.0
+	github.com/deepnoodle-ai/dive/otel v1.25.0
+	github.com/deepnoodle-ai/dive/providers/google v1.25.0
+	github.com/deepnoodle-ai/dive/providers/grok v1.25.0
+	github.com/deepnoodle-ai/dive/providers/openai v1.25.0
 	github.com/deepnoodle-ai/wonton v0.0.37
 	github.com/fatih/color v1.19.0
 	github.com/mark3labs/mcp-go v0.57.0

--- a/experimental/cmd/dive/go.mod
+++ b/experimental/cmd/dive/go.mod
@@ -5,10 +5,10 @@ go 1.25.0
 toolchain go1.26.5
 
 require (
-	github.com/deepnoodle-ai/dive v1.24.0
-	github.com/deepnoodle-ai/dive/providers/google v1.24.0
-	github.com/deepnoodle-ai/dive/providers/grok v1.24.0
-	github.com/deepnoodle-ai/dive/providers/openai v1.24.0
+	github.com/deepnoodle-ai/dive v1.25.0
+	github.com/deepnoodle-ai/dive/providers/google v1.25.0
+	github.com/deepnoodle-ai/dive/providers/grok v1.25.0
+	github.com/deepnoodle-ai/dive/providers/openai v1.25.0
 	github.com/deepnoodle-ai/wonton v0.0.37
 	github.com/mattn/go-runewidth v0.0.27
 	google.golang.org/genai v1.67.0

--- a/experimental/mcp/go.mod
+++ b/experimental/mcp/go.mod
@@ -5,7 +5,7 @@ go 1.25.5
 toolchain go1.26.5
 
 require (
-	github.com/deepnoodle-ai/dive v1.24.0
+	github.com/deepnoodle-ai/dive v1.25.0
 	github.com/deepnoodle-ai/wonton v0.0.37
 	github.com/mark3labs/mcp-go v0.57.0
 )

--- a/otel/go.mod
+++ b/otel/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 toolchain go1.26.5
 
 require (
-	github.com/deepnoodle-ai/dive v1.24.0
+	github.com/deepnoodle-ai/dive v1.25.0
 	go.opentelemetry.io/otel v1.45.0
 	go.opentelemetry.io/otel/metric v1.45.0
 	go.opentelemetry.io/otel/sdk v1.45.0

--- a/providers/google/go.mod
+++ b/providers/google/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 toolchain go1.26.5
 
 require (
-	github.com/deepnoodle-ai/dive v1.24.0
+	github.com/deepnoodle-ai/dive v1.25.0
 	github.com/deepnoodle-ai/wonton v0.0.37
 	google.golang.org/genai v1.67.0
 )

--- a/providers/grok/go.mod
+++ b/providers/grok/go.mod
@@ -5,8 +5,8 @@ go 1.25.0
 toolchain go1.26.5
 
 require (
-	github.com/deepnoodle-ai/dive v1.24.0
-	github.com/deepnoodle-ai/dive/providers/openai v1.24.0
+	github.com/deepnoodle-ai/dive v1.25.0
+	github.com/deepnoodle-ai/dive/providers/openai v1.25.0
 	github.com/deepnoodle-ai/wonton v0.0.37
 	github.com/openai/openai-go/v3 v3.50.0
 	golang.org/x/image v0.44.0

--- a/providers/openai/go.mod
+++ b/providers/openai/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 toolchain go1.26.5
 
 require (
-	github.com/deepnoodle-ai/dive v1.24.0
+	github.com/deepnoodle-ai/dive v1.25.0
 	github.com/deepnoodle-ai/wonton v0.0.37
 	github.com/openai/openai-go/v3 v3.50.0
 	golang.org/x/image v0.44.0


### PR DESCRIPTION
## Summary
- Cuts `CHANGELOG.md`: renames `[Unreleased]` to `[1.25.0] - 2026-08-15`, leaves a fresh empty `Unreleased` above it.
- Syncs all sub-module `go.mod` requirements (`github.com/deepnoodle-ai/dive`) from v1.24.0 to v1.25.0 via `make release-prep`.
- Adds `docs/releases/v1.25.0.md` with Highlights, the pull request list (#263, #264), and the changelog section.

Covers everything merged since v1.24.0:
- Load .env in the experimental dive CLI on startup (#263)
- Add Gemini 3.7 Flash and Mistral Medium 3.5 to the catalogs (#264)

## Test plan
- [x] `go build ./...`
- [x] `go test ./...`
- [x] `python3 scripts/release_notes.py v1.25.0 --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The CLI now loads environment variables from `.env` files.
  * Added Gemini 3.7 Flash and Mistral Medium as available model defaults.
  * Added limits for Gemini thinking parameters.
* **Bug Fixes**
  * Corrected pricing information for Mistral models.
* **Documentation**
  * Added release notes for version 1.25.0, including model catalog updates and related changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->