### PR TITLE
Fix Vertex AI generation: stop sending the service-tier sentinel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **Google text generation works on Vertex AI again.** Since v1.21.0 the
+  provider sent `serviceTier: "unspecified"` when no tier was requested, which
+  Vertex AI rejects with a 400 on every `Generate` and `Stream` call; the field
+  is now omitted unless a tier is explicitly set. The Gemini Developer API
+  backend was unaffected.
+
 ## [1.25.0] - 2026-08-15
 
 ### Added

--- a/providers/google/cost_test.go
+++ b/providers/google/cost_test.go
@@ -194,3 +194,19 @@ func TestPopulateGoogleCostFailsClosed(t *testing.T) {
 		})
 	}
 }
+
+// TestPopulateGoogleCostUnspecifiedTierParity pins that an empty tier and
+// genai.ServiceTierUnspecified produce identical usage. The fix for the Vertex
+// service-tier regression stops the "unspecified" sentinel from ever entering
+// the pricing context, and this equivalence is what makes that change invisible
+// to the cost path — it must stay true if the tier guards are ever rewritten.
+func TestPopulateGoogleCostUnspecifiedTierParity(t *testing.T) {
+	compute := func(tier genai.ServiceTier) *llm.Usage {
+		usage := &llm.Usage{InputTokens: 100_000, OutputTokens: 1_000_000}
+		populateGoogleCost(ModelGemini25Pro, nil, usage, googlePricingContext{serviceTier: tier})
+		return usage
+	}
+	assert.Equal(t, compute(""), compute(genai.ServiceTierUnspecified))
+	assert.NotNil(t, compute("").Cost)
+	assert.Equal(t, "", compute("").ServiceTier)
+}

--- a/providers/google/google.go
+++ b/providers/google/google.go
@@ -302,7 +302,11 @@ func (p *Provider) applyRequestConfig(req *Request, config *llm.Config) error {
 	req.System = config.SystemPrompt
 	switch strings.ToLower(config.ServiceTier) {
 	case "", "default":
-		req.ServiceTier = genai.ServiceTierUnspecified
+		// Leave ServiceTier at its zero value. genai.ServiceTierUnspecified is
+		// the non-empty string "unspecified", which serializes into the request
+		// body; Vertex AI rejects it with a 400, and the Developer API gains
+		// nothing from it. Omitting the field is the only spelling both
+		// backends accept.
 	case string(genai.ServiceTierStandard):
 		req.ServiceTier = genai.ServiceTierStandard
 	case string(genai.ServiceTierFlex), string(genai.ServiceTierPriority):

--- a/providers/google/google_test.go
+++ b/providers/google/google_test.go
@@ -207,7 +207,10 @@ func TestProviderServiceTierValidation(t *testing.T) {
 			if strings.EqualFold(tier, "standard") {
 				assert.Equal(t, genai.ServiceTierStandard, request.ServiceTier)
 			} else {
-				assert.Equal(t, genai.ServiceTierUnspecified, request.ServiceTier)
+				// The zero value, not genai.ServiceTierUnspecified: that
+				// constant is the non-empty string "unspecified", which
+				// serializes onto the wire and Vertex AI rejects with a 400.
+				assert.Equal(t, genai.ServiceTier(""), request.ServiceTier)
 			}
 		})
 	}

--- a/providers/google/service_tier_test.go
+++ b/providers/google/service_tier_test.go
@@ -1,0 +1,124 @@
+package google
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/deepnoodle-ai/dive/llm"
+	"github.com/deepnoodle-ai/wonton/assert"
+	"google.golang.org/genai"
+)
+
+// TestBuildGenAIGenerateConfigServiceTier pins the field-level contract: an
+// unset tier must leave GenerateContentConfig.ServiceTier at its zero value so
+// the genai SDK's omitempty drops it from the request body, while an explicit
+// tier is carried through. This is the assertion that would have caught the
+// v1.21.0 regression where the "unspecified" sentinel reached the wire and
+// Vertex AI rejected every generation call with a 400.
+func TestBuildGenAIGenerateConfigServiceTier(t *testing.T) {
+	genConfig, err := buildGenAIGenerateConfig(&Request{Model: "gemini-3.7-flash"})
+	assert.NoError(t, err)
+	assert.Equal(t, genai.ServiceTier(""), genConfig.ServiceTier)
+
+	genConfig, err = buildGenAIGenerateConfig(&Request{
+		Model:       "gemini-3.7-flash",
+		ServiceTier: genai.ServiceTierStandard,
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, genai.ServiceTierStandard, genConfig.ServiceTier)
+}
+
+// TestGoogleServiceTierOmittedOnWire is the end-to-end confirmation across the
+// whole request chain: when the caller asks for no service tier, the marshalled
+// request body must not mention serviceTier at all, on either backend. Omission
+// is the only setting both backends accept — the genai SDK's lowercase enum
+// spellings are rejected by Vertex AI, and Vertex's SERVICE_TIER_* proto names
+// are rejected by the Developer API. Same-package tests inject a
+// test-server-backed genai client so no real network call or credential is
+// needed; supplying HTTPClient explicitly keeps the Vertex path off ADC.
+func TestGoogleServiceTierOmittedOnWire(t *testing.T) {
+	newServer := func(captured *[]byte) *httptest.Server {
+		return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			body, _ := io.ReadAll(r.Body)
+			*captured = body
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(minimalGenerateResponse))
+		}))
+	}
+
+	t.Run("vertex backend", func(t *testing.T) {
+		var capturedBody []byte
+		server := newServer(&capturedBody)
+		defer server.Close()
+
+		client, err := genai.NewClient(context.Background(), &genai.ClientConfig{
+			Backend:     genai.BackendVertexAI,
+			Project:     "test-project",
+			Location:    "global",
+			HTTPClient:  &http.Client{},
+			HTTPOptions: genai.HTTPOptions{BaseURL: server.URL},
+		})
+		assert.NoError(t, err)
+
+		p := New(WithModel("gemini-3.7-flash"), WithVertexAI("global"),
+			WithProjectID("test-project"), WithMaxRetries(0))
+		p.client = client
+
+		_, err = p.Generate(context.Background(),
+			llm.WithMessages(llm.NewUserTextMessage("hi")))
+		assert.NoError(t, err)
+		assert.True(t, len(capturedBody) > 0, "expected the request body to be captured")
+		assert.False(t, strings.Contains(string(capturedBody), `"serviceTier"`),
+			"serviceTier must be omitted from the Vertex request body, got: %s", capturedBody)
+	})
+
+	t.Run("developer api backend", func(t *testing.T) {
+		var capturedBody []byte
+		server := newServer(&capturedBody)
+		defer server.Close()
+
+		client, err := genai.NewClient(context.Background(), &genai.ClientConfig{
+			APIKey:      "test-key",
+			HTTPOptions: genai.HTTPOptions{BaseURL: server.URL},
+		})
+		assert.NoError(t, err)
+
+		p := New(WithModel("gemini-3.7-flash"), WithMaxRetries(0))
+		p.client = client
+
+		_, err = p.Generate(context.Background(),
+			llm.WithMessages(llm.NewUserTextMessage("hi")))
+		assert.NoError(t, err)
+		assert.True(t, len(capturedBody) > 0, "expected the request body to be captured")
+		assert.False(t, strings.Contains(string(capturedBody), `"serviceTier"`),
+			"serviceTier must be omitted from the Developer API request body, got: %s", capturedBody)
+	})
+
+	// Guard against overcorrecting: an explicitly requested tier must still be
+	// serialized (the Developer API accepts the SDK's lowercase spellings).
+	t.Run("explicit standard is sent", func(t *testing.T) {
+		var capturedBody []byte
+		server := newServer(&capturedBody)
+		defer server.Close()
+
+		client, err := genai.NewClient(context.Background(), &genai.ClientConfig{
+			APIKey:      "test-key",
+			HTTPOptions: genai.HTTPOptions{BaseURL: server.URL},
+		})
+		assert.NoError(t, err)
+
+		p := New(WithModel("gemini-3.7-flash"), WithMaxRetries(0))
+		p.client = client
+
+		_, err = p.Generate(context.Background(),
+			llm.WithMessages(llm.NewUserTextMessage("hi")),
+			llm.WithServiceTier("standard"))
+		assert.NoError(t, err)
+		assert.True(t, strings.Contains(string(capturedBody), `"serviceTier":"standard"`),
+			"an explicitly requested tier must reach the wire, got: %s", capturedBody)
+	})
+}


### PR DESCRIPTION
## Summary

Since #254 (v1.21.0), `applyRequestConfig` wrote `genai.ServiceTierUnspecified` when the caller requested **no** service tier. That constant is the non-empty string `"unspecified"`, so it defeated the `buildGenAIGenerateConfig` non-empty guard, serialized into the request body, and **Vertex AI rejected every `Generate` and `Stream` call with a 400**:

```
provider api error (status 400): Invalid value at 'service_tier'
  (type.googleapis.com/google.cloud.aiplatform.v1beta1.ServiceTier), "unspecified"
```

The Gemini Developer API backend accepts the value, which is why this went unnoticed — the two backends use disjoint enum spellings, and omitting the field is the only setting both accept (measured live against both endpoints; reported by the Mobius Cloud team while verifying Gemini 3.7 Flash).

## Fix

Leave `req.ServiceTier` at its zero value for the unset/default case and let the existing guard omit the field — restoring pre-v1.21.0 wire behavior while keeping #254's validation and pricing plumbing.

Cost path is unchanged: `googleServiceTierName` has no `Unspecified` case and the unsupported-tier guard already opens with `!= ""`, so `""` and `"unspecified"` were always equivalent there. A parity test now pins that equivalence.

## Tests

- `TestBuildGenAIGenerateConfigServiceTier` — unset tier leaves `GenerateContentConfig.ServiceTier` empty; explicit tier carries through (the assertion that would have caught this).
- `TestGoogleServiceTierOmittedOnWire` — httptest round-trips through a real genai client on **both** backends, asserting `serviceTier` is absent from the marshalled body when unset and present when explicitly requested. First test in the package to exercise the Vertex request body.
- `TestPopulateGoogleCostUnspecifiedTierParity` — identical `Usage` for `""` vs `"unspecified"`.
- `TestProviderServiceTierValidation` updated: `""`/`"default"` now assert the zero value instead of pinning the sentinel.

## Not in scope (follow-up)

An explicitly requested `"standard"` tier still 400s on Vertex — the genai SDK's lowercase constants aren't the `SERVICE_TIER_*` proto names Vertex expects, and the SDK translates nothing. Options are rejecting early on the Vertex backend or translating per backend; either way this deserves an upstream issue against `google.golang.org/genai`. Note any rejection keyed on `p.vertexAI` alone would miss clients flipped onto Vertex via `GOOGLE_GENAI_USE_VERTEXAI=1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)