### PR TITLE
Prepare v1.25.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [1.25.1] - 2026-08-15
+
 ### Fixed
 
 - **Google text generation works on Vertex AI again.** Since v1.21.0 the

--- a/a2a/go.mod
+++ b/a2a/go.mod
@@ -6,7 +6,7 @@ toolchain go1.26.5
 
 require (
 	github.com/a2aproject/a2a-go/v2 v2.4.0
-	github.com/deepnoodle-ai/dive v1.25.0
+	github.com/deepnoodle-ai/dive v1.25.1
 	github.com/deepnoodle-ai/wonton v0.0.37
 )
 

--- a/demos/colosseum/go.mod
+++ b/demos/colosseum/go.mod
@@ -5,11 +5,11 @@ go 1.25.0
 toolchain go1.26.5
 
 require (
-	github.com/deepnoodle-ai/dive v1.25.0
-	github.com/deepnoodle-ai/dive/a2a v1.25.0
-	github.com/deepnoodle-ai/dive/providers/google v1.25.0
-	github.com/deepnoodle-ai/dive/providers/grok v1.25.0
-	github.com/deepnoodle-ai/dive/providers/openai v1.25.0
+	github.com/deepnoodle-ai/dive v1.25.1
+	github.com/deepnoodle-ai/dive/a2a v1.25.1
+	github.com/deepnoodle-ai/dive/providers/google v1.25.1
+	github.com/deepnoodle-ai/dive/providers/grok v1.25.1
+	github.com/deepnoodle-ai/dive/providers/openai v1.25.1
 	github.com/deepnoodle-ai/wonton v0.0.37
 )
 

--- a/demos/noodleville/go.mod
+++ b/demos/noodleville/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 toolchain go1.26.5
 
 require (
-	github.com/deepnoodle-ai/dive v1.25.0
+	github.com/deepnoodle-ai/dive v1.25.1
 	github.com/deepnoodle-ai/wonton v0.0.37
 )
 

--- a/docs/releases/v1.25.1.md
+++ b/docs/releases/v1.25.1.md
@@ -1,0 +1,34 @@
+## Highlights
+
+Patch release fixing a critical regression: since v1.21.0, the Google provider
+has been unable to complete any text generation call — `Generate` or
+`Stream`, any model — on the Vertex AI backend. Every request came back with
+a 400 from Vertex rejecting an internal `serviceTier: "unspecified"` sentinel
+that dive was writing onto the wire whenever no tier was requested, which is
+the overwhelmingly common case. The Gemini Developer API backend accepted the
+same value, which is why this went unnoticed for four releases: Vertex and
+Developer API traffic looked identical in code but diverged on the wire.
+
+The fix leaves the service tier field unset unless a caller explicitly
+requests one, restoring the pre-v1.21.0 request shape. No action is needed
+beyond upgrading — cost tracking, tier reporting, and traffic-type behavior
+are all unchanged.
+
+If you run Gemini through Vertex AI (including Application Default
+Credentials with no `GOOGLE_API_KEY`/`GEMINI_API_KEY` set), upgrade to
+v1.25.1 immediately; this backend has been non-functional for generation
+since v1.21.0.
+
+## Pull requests
+
+- Stop sending the service-tier sentinel that broke all Vertex AI generation (#266)
+
+## Changelog
+
+### Fixed
+
+- **Google text generation works on Vertex AI again.** Since v1.21.0 the
+  provider sent `serviceTier: "unspecified"` when no tier was requested, which
+  Vertex AI rejects with a 400 on every `Generate` and `Stream` call; the field
+  is now omitted unless a tier is explicitly set. The Gemini Developer API
+  backend was unaffected.

--- a/examples/go.mod
+++ b/examples/go.mod
@@ -5,13 +5,13 @@ go 1.25.5
 toolchain go1.26.5
 
 require (
-	github.com/deepnoodle-ai/dive v1.25.0
-	github.com/deepnoodle-ai/dive/a2a v1.25.0
-	github.com/deepnoodle-ai/dive/experimental/mcp v1.25.0
-	github.com/deepnoodle-ai/dive/otel v1.25.0
-	github.com/deepnoodle-ai/dive/providers/google v1.25.0
-	github.com/deepnoodle-ai/dive/providers/grok v1.25.0
-	github.com/deepnoodle-ai/dive/providers/openai v1.25.0
+	github.com/deepnoodle-ai/dive v1.25.1
+	github.com/deepnoodle-ai/dive/a2a v1.25.1
+	github.com/deepnoodle-ai/dive/experimental/mcp v1.25.1
+	github.com/deepnoodle-ai/dive/otel v1.25.1
+	github.com/deepnoodle-ai/dive/providers/google v1.25.1
+	github.com/deepnoodle-ai/dive/providers/grok v1.25.1
+	github.com/deepnoodle-ai/dive/providers/openai v1.25.1
 	github.com/deepnoodle-ai/wonton v0.0.37
 	github.com/fatih/color v1.19.0
 	github.com/mark3labs/mcp-go v0.57.0

--- a/experimental/cmd/dive/go.mod
+++ b/experimental/cmd/dive/go.mod
@@ -5,10 +5,10 @@ go 1.25.0
 toolchain go1.26.5
 
 require (
-	github.com/deepnoodle-ai/dive v1.25.0
-	github.com/deepnoodle-ai/dive/providers/google v1.25.0
-	github.com/deepnoodle-ai/dive/providers/grok v1.25.0
-	github.com/deepnoodle-ai/dive/providers/openai v1.25.0
+	github.com/deepnoodle-ai/dive v1.25.1
+	github.com/deepnoodle-ai/dive/providers/google v1.25.1
+	github.com/deepnoodle-ai/dive/providers/grok v1.25.1
+	github.com/deepnoodle-ai/dive/providers/openai v1.25.1
 	github.com/deepnoodle-ai/wonton v0.0.37
 	github.com/mattn/go-runewidth v0.0.27
 	google.golang.org/genai v1.67.0

--- a/experimental/mcp/go.mod
+++ b/experimental/mcp/go.mod
@@ -5,7 +5,7 @@ go 1.25.5
 toolchain go1.26.5
 
 require (
-	github.com/deepnoodle-ai/dive v1.25.0
+	github.com/deepnoodle-ai/dive v1.25.1
 	github.com/deepnoodle-ai/wonton v0.0.37
 	github.com/mark3labs/mcp-go v0.57.0
 )

--- a/otel/go.mod
+++ b/otel/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 toolchain go1.26.5
 
 require (
-	github.com/deepnoodle-ai/dive v1.25.0
+	github.com/deepnoodle-ai/dive v1.25.1
 	go.opentelemetry.io/otel v1.45.0
 	go.opentelemetry.io/otel/metric v1.45.0
 	go.opentelemetry.io/otel/sdk v1.45.0

--- a/providers/google/go.mod
+++ b/providers/google/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 toolchain go1.26.5
 
 require (
-	github.com/deepnoodle-ai/dive v1.25.0
+	github.com/deepnoodle-ai/dive v1.25.1
 	github.com/deepnoodle-ai/wonton v0.0.37
 	google.golang.org/genai v1.67.0
 )

--- a/providers/grok/go.mod
+++ b/providers/grok/go.mod
@@ -5,8 +5,8 @@ go 1.25.0
 toolchain go1.26.5
 
 require (
-	github.com/deepnoodle-ai/dive v1.25.0
-	github.com/deepnoodle-ai/dive/providers/openai v1.25.0
+	github.com/deepnoodle-ai/dive v1.25.1
+	github.com/deepnoodle-ai/dive/providers/openai v1.25.1
 	github.com/deepnoodle-ai/wonton v0.0.37
 	github.com/openai/openai-go/v3 v3.50.0
 	golang.org/x/image v0.44.0

--- a/providers/openai/go.mod
+++ b/providers/openai/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 toolchain go1.26.5
 
 require (
-	github.com/deepnoodle-ai/dive v1.25.0
+	github.com/deepnoodle-ai/dive v1.25.1
 	github.com/deepnoodle-ai/wonton v0.0.37
 	github.com/openai/openai-go/v3 v3.50.0
 	golang.org/x/image v0.44.0


### PR DESCRIPTION
## Summary
- Cuts `CHANGELOG.md`: renames `[Unreleased]` to `[1.25.1] - 2026-08-15`, leaves a fresh empty `Unreleased` above it.
- Syncs all sub-module `go.mod` requirements (`github.com/deepnoodle-ai/dive`) from v1.25.0 to v1.25.1 via `make release-prep`.
- Adds `docs/releases/v1.25.1.md` with Highlights, the pull request list (#266), and the changelog section.

Patch release — the only change since v1.25.0 is a critical bug fix, no new features:
- Stop sending the service-tier sentinel that broke all Vertex AI generation (#266)

## Test plan
- [x] `go build ./...`
- [x] `go test ./...`
- [x] `go build ./...` in each of the 8 tagged sub-modules
- [x] `python3 scripts/release_notes.py v1.25.1 --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)