### PR TITLE
Add dangerous permission bypass flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Added
+
+- **The experimental `dive` CLI can skip tool approval prompts with
+  `--dangerously-skip-permissions`.** The default approval flow is unchanged;
+  use the bypass only in an externally sandboxed environment.
+
 ## [1.25.1] - 2026-08-15
 
 ### Fixed

--- a/experimental/cmd/dive/main.go
+++ b/experimental/cmd/dive/main.go
@@ -163,6 +163,7 @@ func main() {
 				Default(100000).
 				Env("DIVE_COMPACTION_THRESHOLD").
 				Help("Token threshold for automatic context compaction"),
+			dangerouslySkipPermissionsFlag(),
 		).
 		Run(runMain)
 
@@ -331,7 +332,7 @@ func runInteractive(ctx *cli.Context) error {
 
 	// Set up tool permission hook using the permission package
 	permConfig := &permission.Config{
-		Mode:  permission.ModeDefault,
+		Mode:  permissionMode(ctx),
 		Rules: defaultPermissionRules(tools),
 	}
 	permManager := permission.NewManager(permConfig, tuiDialog)
@@ -442,6 +443,21 @@ func runInteractive(ctx *cli.Context) error {
 	monNotifier.app = app
 
 	return app.Run()
+}
+
+const dangerouslySkipPermissions = "dangerously-skip-permissions"
+
+func dangerouslySkipPermissionsFlag() cli.Flag {
+	return cli.Bool(dangerouslySkipPermissions).
+		Default(false).
+		Help("Run all tools without approval prompts; only use in an externally sandboxed environment")
+}
+
+func permissionMode(ctx *cli.Context) permission.Mode {
+	if ctx.Bool(dangerouslySkipPermissions) {
+		return permission.ModeBypassPermissions
+	}
+	return permission.ModeDefault
 }
 
 //go:embed system_prompt.txt

--- a/experimental/cmd/dive/main_test.go
+++ b/experimental/cmd/dive/main_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/deepnoodle-ai/dive"
 	"github.com/deepnoodle-ai/dive/llm"
+	"github.com/deepnoodle-ai/dive/permission"
 	"github.com/deepnoodle-ai/dive/toolkit"
 	"github.com/deepnoodle-ai/wonton/assert"
 	"github.com/deepnoodle-ai/wonton/cli"
@@ -137,6 +138,41 @@ func TestDefaultPermissionRules_AllowsReadOnlyToolsByDefault(t *testing.T) {
 	assert.False(t, allowed["Write"], "Write should not be auto-allowed")
 	assert.False(t, allowed["Edit"], "Edit should not be auto-allowed")
 	assert.False(t, allowed["Bash"], "Bash should not be auto-allowed")
+}
+
+func TestPermissionMode(t *testing.T) {
+	tests := []struct {
+		name     string
+		args     []string
+		expected permission.Mode
+	}{
+		{
+			name:     "defaults to approval prompts",
+			expected: permission.ModeDefault,
+		},
+		{
+			name:     "bypasses approval prompts",
+			args:     []string{"--" + dangerouslySkipPermissions},
+			expected: permission.ModeBypassPermissions,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			app := cli.New("test")
+			var actual permission.Mode
+			app.Main().
+				Flags(dangerouslySkipPermissionsFlag()).
+				Run(func(ctx *cli.Context) error {
+					actual = permissionMode(ctx)
+					return nil
+				})
+
+			result := app.Test(t, cli.TestArgs(tt.args...))
+			assert.True(t, result.Success(), result.Stderr)
+			assert.Equal(t, tt.expected, actual)
+		})
+	}
 }
 
 func TestNewCLIModelSettingsThinkingFlags(t *testing.T) {


### PR DESCRIPTION
## Summary

- add `--dangerously-skip-permissions` to the experimental `dive` CLI
- activate the existing `permission.ModeBypassPermissions` mode when the flag is present while preserving the default approval flow
- document the flag in the unreleased changelog and cover both permission modes

## Why

Externally sandboxed or otherwise pre-authorized runs need an explicit way to execute tool calls without stopping for interactive approval prompts.

## Validation

- `go test ./...`
- `cd experimental/cmd/dive && go test -race ./...`
- `cd experimental/cmd/dive && go run . --help` confirms the public flag
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an experimental `dive` CLI option to bypass tool approval prompts.
  * The option displays a warning and is intended only for externally sandboxed environments.
  * Default approval prompts remain unchanged when the option is not enabled.

* **Documentation**
  * Added an Unreleased changelog entry describing the new option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->