### PR TITLE
Preserve OpenAI message phase and close out partial streams cleanly across providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
   is still open. A response that ends without an item's done event now closes
   every block it left open — text, reasoning, or tool call — before
   `message_delta`, matching the other providers' event order.
+- **OpenAI-compatible chat completions streams always terminate cleanly.** A
+  stream that reaches `[DONE]` or EOF without a `finish_reason` — as seen
+  through Mistral and OpenRouter — now closes its open text and tool-call
+  blocks and emits `message_delta` and `message_stop`, instead of ending with
+  the message still open.
 
 ## [1.25.1] - 2026-08-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - **OpenAI streaming closes a text block on its output item's done event**
   rather than on `output_text.done`, so metadata that arrives only with the
   done event — such as a late `phase` label — reaches consumers while the block
-  is still open.
+  is still open. A response that ends without an item's done event now closes
+  every block it left open — text, reasoning, or tool call — before
+  `message_delta`, matching the other providers' event order.
 
 ## [1.25.1] - 2026-08-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **OpenAI Responses assistant messages keep their `phase`.** The phase
+  (`commentary` or `final_answer`) now decodes onto each text block as
+  `openai.phase` provider metadata and is replayed on follow-up requests, so
+  runtimes that persist and resend history manually no longer silently drop it.
+  Unlabeled messages stay unphased.
+
 ### Added
 
 - **The experimental `dive` CLI can skip tool approval prompts with

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,12 +13,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
   `openai.phase` provider metadata and is replayed on follow-up requests, so
   runtimes that persist and resend history manually no longer silently drop it.
   Unlabeled messages stay unphased.
+- **Compaction keeps provider metadata on truncated content.** Shrinking an
+  oversized text or `tool_use` block no longer strips replay state such as a
+  Google thought signature or an OpenAI message phase.
 
 ### Added
 
 - **The experimental `dive` CLI can skip tool approval prompts with
   `--dangerously-skip-permissions`.** The default approval flow is unchanged;
   use the bypass only in an externally sandboxed environment.
+
+### Changed
+
+- **OpenAI streaming closes a text block on its output item's done event**
+  rather than on `output_text.done`, so metadata that arrives only with the
+  done event — such as a late `phase` label — reaches consumers while the block
+  is still open.
 
 ## [1.25.1] - 2026-08-15
 

--- a/experimental/compaction/compaction.go
+++ b/experimental/compaction/compaction.go
@@ -544,15 +544,18 @@ func reducible(c llm.Content) bool {
 // reduceBlock returns a smaller version of c — text-bearing blocks truncated by
 // `excess` bytes, tool_use inputs and image/document payloads culled to a
 // placeholder. Always a fresh struct, so the original block is never mutated.
+// Provider metadata is carried over: a shrunken block is still replayed, and
+// dropping it would strip replay state such as an OpenAI message phase or a
+// Google thought signature.
 func reduceBlock(c llm.Content, excess int) llm.Content {
 	switch cc := c.(type) {
 	case *llm.TextContent:
-		return &llm.TextContent{Text: truncateText(cc.Text, len(cc.Text)-excess), CacheControl: cc.CacheControl, Citations: cc.Citations}
+		return &llm.TextContent{Text: truncateText(cc.Text, len(cc.Text)-excess), CacheControl: cc.CacheControl, Citations: cc.Citations, Metadata: cc.Metadata.Clone()}
 	case *llm.ToolResultContent:
 		txt := toolResultText(cc)
 		return &llm.ToolResultContent{ToolUseID: cc.ToolUseID, Content: truncateText(txt, len(txt)-excess), IsError: cc.IsError, CacheControl: cc.CacheControl}
 	case *llm.ToolUseContent:
-		return &llm.ToolUseContent{ID: cc.ID, Name: cc.Name, Input: culledToolInput}
+		return &llm.ToolUseContent{ID: cc.ID, Name: cc.Name, Input: culledToolInput, Metadata: cc.Metadata.Clone()}
 	case *llm.ImageContent:
 		return &llm.TextContent{Text: "[image content omitted for summarization]"}
 	case *llm.DocumentContent:

--- a/experimental/compaction/compaction_test.go
+++ b/experimental/compaction/compaction_test.go
@@ -481,3 +481,33 @@ func TestTruncateText(t *testing.T) {
 	assert.True(t, len(out) <= 200)
 	assert.True(t, strings.Contains(out, "truncated"))
 }
+
+// TestReduceBlockKeepsProviderMetadata guards replay state on shrunken blocks:
+// truncating a text block or culling a tool_use input must not strip metadata
+// the provider requires on the next request, such as an OpenAI message phase or
+// a Google thought signature.
+func TestReduceBlockKeepsProviderMetadata(t *testing.T) {
+	text := &llm.TextContent{
+		Text:     strings.Repeat("a", 1000),
+		Metadata: llm.ProviderMetadata{"openai.phase": "final_answer"},
+	}
+	reducedText, isText := reduceBlock(text, 800).(*llm.TextContent)
+	assert.True(t, isText)
+	assert.True(t, len(reducedText.Text) < len(text.Text))
+	assert.Equal(t, "final_answer", reducedText.Metadata["openai.phase"])
+
+	// The reduced block owns its metadata rather than aliasing the original.
+	reducedText.Metadata["openai.phase"] = "commentary"
+	assert.Equal(t, "final_answer", text.Metadata["openai.phase"])
+
+	toolUse := &llm.ToolUseContent{
+		ID:       "t1",
+		Name:     "search",
+		Input:    json.RawMessage(`{"query":"` + strings.Repeat("b", 1000) + `"}`),
+		Metadata: llm.ProviderMetadata{"google.thought_signature": "sig"},
+	}
+	reducedToolUse, isToolUse := reduceBlock(toolUse, 800).(*llm.ToolUseContent)
+	assert.True(t, isToolUse)
+	assert.True(t, len(reducedToolUse.Input) < len(toolUse.Input))
+	assert.Equal(t, "sig", reducedToolUse.Metadata["google.thought_signature"])
+}

--- a/llm/message_test.go
+++ b/llm/message_test.go
@@ -173,3 +173,44 @@ func TestMessage_MarshalUnmarshalJSON(t *testing.T) {
 		assert.Equal(t, ContentTypeText, decoded.Content[1].Type())
 	})
 }
+
+// TestMessageJSONRoundTripPreservesProviderMetadata covers the durable-runtime
+// path: provider replay state attached to a content block must survive being
+// persisted and reloaded, and a Copy must own its metadata rather than alias it.
+func TestMessageJSONRoundTripPreservesProviderMetadata(t *testing.T) {
+	original := &Message{
+		Role: Assistant,
+		Content: []Content{
+			&TextContent{
+				Text:     "Checking that now.",
+				Metadata: ProviderMetadata{"example.phase": "commentary"},
+			},
+			&ToolUseContent{
+				ID:       "call_1",
+				Name:     "lookup",
+				Input:    json.RawMessage(`{}`),
+				Metadata: ProviderMetadata{"example.signature": "opaque"},
+			},
+			&ThinkingContent{
+				Thinking: "reasoning",
+				Metadata: ProviderMetadata{"example.replay": "opaque"},
+			},
+		},
+	}
+
+	data, err := json.Marshal(original)
+	assert.NoError(t, err)
+
+	var reloaded Message
+	assert.NoError(t, json.Unmarshal(data, &reloaded))
+	assert.Equal(t, 3, len(reloaded.Content))
+	assert.Equal(t, "commentary", reloaded.Content[0].(*TextContent).Metadata["example.phase"])
+	assert.Equal(t, "opaque", reloaded.Content[1].(*ToolUseContent).Metadata["example.signature"])
+	assert.Equal(t, "opaque", reloaded.Content[2].(*ThinkingContent).Metadata["example.replay"])
+
+	copied := reloaded.Copy()
+	text := copied.Content[0].(*TextContent)
+	assert.Equal(t, "commentary", text.Metadata["example.phase"])
+	text.Metadata["example.phase"] = "final_answer"
+	assert.Equal(t, "commentary", reloaded.Content[0].(*TextContent).Metadata["example.phase"])
+}

--- a/providers/google/stream_iterator_test.go
+++ b/providers/google/stream_iterator_test.go
@@ -404,3 +404,60 @@ func TestStreamIteratorStreamError(t *testing.T) {
 	}
 	assert.Error(t, iterator.Err())
 }
+
+// TestStreamIteratorClosesDanglingBlocks verifies that a stream which simply
+// ends — no FinishReason, no usage chunk — still closes the block it left
+// open and terminates with message_delta then message_stop, so consumers see
+// a balanced block lifecycle whatever kind of block was streaming last.
+func TestStreamIteratorClosesDanglingBlocks(t *testing.T) {
+	partChunk := func(part *genai.Part) *genai.GenerateContentResponse {
+		return &genai.GenerateContentResponse{
+			Candidates: []*genai.Candidate{{
+				Content: &genai.Content{Role: "model", Parts: []*genai.Part{part}},
+			}},
+		}
+	}
+	tests := []struct {
+		name    string
+		chunk   *genai.GenerateContentResponse
+		content llm.ContentType
+	}{
+		{name: "text", chunk: partChunk(&genai.Part{Text: "Hi"}), content: llm.ContentTypeText},
+		{name: "thinking", chunk: partChunk(&genai.Part{Text: "hmm", Thought: true}), content: llm.ContentTypeThinking},
+		{name: "function call", chunk: partChunk(&genai.Part{FunctionCall: &genai.FunctionCall{Name: "calc", Args: map[string]any{"a": 1}}}), content: llm.ContentTypeToolUse},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			iterator := NewStreamIteratorFromSeq(context.Background(),
+				chunkSeq(tc.chunk), "gemini-2.5-pro")
+			defer iterator.Close()
+			events, accumulator := collectStreamEvents(t, iterator)
+
+			var types []llm.EventType
+			starts, stops, stopIndex, deltaIndex := 0, 0, -1, -1
+			for i, event := range events {
+				types = append(types, event.Type)
+				switch event.Type {
+				case llm.EventTypeContentBlockStart:
+					starts++
+				case llm.EventTypeContentBlockStop:
+					stops++
+					stopIndex = i
+				case llm.EventTypeMessageDelta:
+					deltaIndex = i
+				}
+			}
+			assert.Equal(t, 1, starts)
+			assert.Equal(t, 1, stops)
+			assert.True(t, deltaIndex >= 0, "expected a message_delta event")
+			assert.True(t, stopIndex < deltaIndex, "content_block_stop must precede message_delta, got %v", types)
+			assert.Equal(t, llm.EventTypeMessageStop, types[len(types)-1])
+
+			// The partial block still reaches consumers as a well-formed message.
+			assert.True(t, accumulator.IsComplete())
+			message := accumulator.Response().Message()
+			assert.Equal(t, 1, len(message.Content))
+			assert.Equal(t, tc.content, message.Content[0].Type())
+		})
+	}
+}

--- a/providers/openai/decode.go
+++ b/providers/openai/decode.go
@@ -92,12 +92,17 @@ func decodeResponseItem(item responses.ResponseOutputItemUnion) ([]llm.Content, 
 
 func decodeMessageContent(outputMsg responses.ResponseOutputMessage) ([]llm.Content, error) {
 	var contentBlocks []llm.Content
+	phase := string(outputMsg.Phase)
 	for _, content := range outputMsg.Content {
 		switch content.Type {
 		case "output_text":
 			outputText := content.AsOutputText()
 			textContent := &llm.TextContent{
 				Text: outputText.Text,
+				// Each text block records the phase of the output message it
+				// came from, so a response mixing commentary with a final
+				// answer replays each block under its own phase.
+				Metadata: openAIPhaseMetadata(phase),
 			}
 			// Convert OpenAI annotations to web_search_result_location citations
 			if len(outputText.Annotations) > 0 {
@@ -278,6 +283,16 @@ func decodeReasoningContent(reasoning responses.ResponseReasoningItem) ([]llm.Co
 			Metadata:  metadata,
 		},
 	}, nil
+}
+
+// openAIPhaseMetadata returns metadata carrying an assistant output message's
+// phase, or nil when OpenAI did not label the message. Each call returns a
+// fresh map so blocks decoded from one message do not share state.
+func openAIPhaseMetadata(phase string) llm.ProviderMetadata {
+	if phase == "" {
+		return nil
+	}
+	return llm.ProviderMetadata{openAIPhaseMetadataKey: phase}
 }
 
 func openAIReasoningMetadata(summaryItems, reasoningItems []string) (llm.ProviderMetadata, error) {

--- a/providers/openai/encode.go
+++ b/providers/openai/encode.go
@@ -269,7 +269,14 @@ func encodeAssistantTextContent(c *llm.TextContent) (responses.ResponseInputItem
 			},
 		},
 	}
-	return responses.ResponseInputItemParamOfOutputMessage(content, "", ""), nil
+	item := responses.ResponseInputItemParamOfOutputMessage(content, "", "")
+	// Replay the phase OpenAI assigned to this block's output message. A block
+	// with no phase metadata came from an unlabeled message or another
+	// provider, and stays unphased rather than being assigned a guess.
+	if phase := c.Metadata[openAIPhaseMetadataKey]; phase != "" && item.OfOutputMessage != nil {
+		item.OfOutputMessage.Phase = responses.ResponseOutputMessagePhase(phase)
+	}
+	return item, nil
 }
 
 func encodeAssistantImageContent(c *llm.ImageContent) (responses.ResponseInputItemUnionParam, error) {

--- a/providers/openai/phase_test.go
+++ b/providers/openai/phase_test.go
@@ -163,7 +163,7 @@ func TestUserMessagesNeverCarryPhase(t *testing.T) {
 	assert.NotContains(t, replayJSON(t, userMessage), `"phase"`)
 }
 
-func streamPhaseEvents(t *testing.T, addedPhase, donePhase string) *llm.Message {
+func streamPhase(t *testing.T, addedPhase, donePhase string) (*llm.Message, []*llm.Event) {
 	t.Helper()
 	payloads := []string{
 		`{"type":"response.created","sequence_number":1,"response":{"id":"resp_1","model":"gpt-5.6-sol","status":"in_progress"}}`,
@@ -185,12 +185,23 @@ func streamPhaseEvents(t *testing.T, addedPhase, donePhase string) *llm.Message 
 	t.Cleanup(func() { assert.NoError(t, iterator.Close()) })
 
 	accumulator := llm.NewResponseAccumulator()
+	var streamed []*llm.Event
 	for iterator.Next() {
-		assert.NoError(t, accumulator.AddEvent(iterator.Event()))
+		event := iterator.Event()
+		streamed = append(streamed, event)
+		assert.NoError(t, accumulator.AddEvent(event))
 	}
 	assert.NoError(t, iterator.Err())
 	assert.True(t, accumulator.IsComplete())
-	return accumulator.Response().Message()
+	return accumulator.Response().Message(), streamed
+}
+
+// streamPhaseEvents returns only the accumulated message for tests that do not
+// inspect the event stream itself.
+func streamPhaseEvents(t *testing.T, addedPhase, donePhase string) *llm.Message {
+	t.Helper()
+	message, _ := streamPhase(t, addedPhase, donePhase)
+	return message
 }
 
 // TestStreamingPhaseFromOutputItemDone proves that reading phase only from the
@@ -230,4 +241,74 @@ func TestStreamingWithoutPhaseStaysUnphased(t *testing.T) {
 	text := message.Content[0].(*llm.TextContent)
 	assert.Equal(t, 0, len(text.Metadata))
 	assert.NotContains(t, replayJSON(t, message), `"phase"`)
+}
+
+// phaseOfDelta returns the phase carried by a metadata delta, or "" for any
+// other event, so ordering assertions can read the stream positionally.
+func phaseOfDelta(event *llm.Event) string {
+	if event.Type != llm.EventTypeContentBlockDelta || event.Delta == nil {
+		return ""
+	}
+	if event.Delta.Type != llm.EventDeltaTypeMetadata {
+		return ""
+	}
+	return event.Delta.Metadata[openAIPhaseMetadataKey]
+}
+
+// TestStreamingLatePhaseArrivesBeforeBlockStop guards the event contract for
+// consumers that rebuild messages from the stream: a phase OpenAI only reveals
+// on the done event must reach the text block while it is still open, or those
+// consumers finalize the block and drop it.
+func TestStreamingLatePhaseArrivesBeforeBlockStop(t *testing.T) {
+	_, events := streamPhase(t, "", `,"phase":"commentary"`)
+
+	phaseIndex, stopIndex := -1, -1
+	for i, event := range events {
+		if phaseOfDelta(event) == "commentary" {
+			assert.Equal(t, -1, phaseIndex, "phase delta must be emitted once")
+			phaseIndex = i
+		}
+		if event.Type == llm.EventTypeContentBlockStop {
+			assert.Equal(t, -1, stopIndex, "text block must stop once")
+			stopIndex = i
+		}
+	}
+	assert.True(t, phaseIndex >= 0, "expected a phase metadata delta")
+	assert.True(t, stopIndex >= 0, "expected a content block stop")
+	assert.True(t, phaseIndex < stopIndex, "phase delta must precede content_block_stop")
+}
+
+// TestStreamingEarlyPhaseSkipsRedundantDelta locks in that a message labeled on
+// the added event announces its phase once, on the block's start event.
+func TestStreamingEarlyPhaseSkipsRedundantDelta(t *testing.T) {
+	_, events := streamPhase(t, `,"phase":"final_answer"`, `,"phase":"final_answer"`)
+
+	var starts, deltas int
+	for _, event := range events {
+		if event.Type == llm.EventTypeContentBlockStart && event.ContentBlock != nil {
+			if event.ContentBlock.Metadata[openAIPhaseMetadataKey] == "final_answer" {
+				starts++
+			}
+		}
+		if phaseOfDelta(event) != "" {
+			deltas++
+		}
+	}
+	assert.Equal(t, 1, starts)
+	assert.Equal(t, 0, deltas)
+}
+
+// TestStreamingRelabeledPhaseEmitsSingleDelta covers a message relabeled between
+// added and done: the correction reaches consumers as one in-block delta.
+func TestStreamingRelabeledPhaseEmitsSingleDelta(t *testing.T) {
+	message, events := streamPhase(t, `,"phase":"commentary"`, `,"phase":"final_answer"`)
+
+	var phases []string
+	for _, event := range events {
+		if phase := phaseOfDelta(event); phase != "" {
+			phases = append(phases, phase)
+		}
+	}
+	assert.Equal(t, []string{"final_answer"}, phases)
+	assert.Equal(t, "final_answer", message.Content[0].(*llm.TextContent).Metadata[openAIPhaseMetadataKey])
 }

--- a/providers/openai/phase_test.go
+++ b/providers/openai/phase_test.go
@@ -1,0 +1,233 @@
+package openai
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/deepnoodle-ai/dive/llm"
+	"github.com/deepnoodle-ai/wonton/assert"
+	"github.com/openai/openai-go/v3/responses"
+)
+
+// decodeOutputMessage decodes a single-message response carrying the given
+// phase fragment, which callers supply as either `"phase":"...",` or empty.
+func decodeOutputMessage(t *testing.T, phaseField string) *llm.Response {
+	t.Helper()
+	var response responses.Response
+	payload := `{
+		"id": "resp_1",
+		"model": "gpt-5.6-sol",
+		"status": "completed",
+		"output": [{
+			"id": "msg_1",
+			"type": "message",
+			"role": "assistant",
+			"status": "completed",
+			` + phaseField + `
+			"content": [{"type": "output_text", "text": "Checking that now.", "annotations": []}]
+		}]
+	}`
+	assert.NoError(t, json.Unmarshal([]byte(payload), &response))
+	decoded, err := decodeAssistantResponse(&response)
+	assert.NoError(t, err)
+	return decoded
+}
+
+func replayJSON(t *testing.T, messages ...*llm.Message) string {
+	t.Helper()
+	replayed, err := encodeMessages(messages)
+	assert.NoError(t, err)
+	data, err := json.Marshal(replayed)
+	assert.NoError(t, err)
+	return string(data)
+}
+
+func TestOutputMessagePhaseRoundTrip(t *testing.T) {
+	for _, phase := range []string{"commentary", "final_answer"} {
+		t.Run(phase, func(t *testing.T) {
+			decoded := decodeOutputMessage(t, `"phase":"`+phase+`",`)
+
+			text, ok := decoded.Content[0].(*llm.TextContent)
+			assert.True(t, ok)
+			assert.Equal(t, phase, text.Metadata[openAIPhaseMetadataKey])
+
+			assert.Contains(t, replayJSON(t, decoded.Message()), `"phase":"`+phase+`"`)
+		})
+	}
+}
+
+// TestOutputMessagePhaseSurvivesPersistence covers the durable-runtime path:
+// the decoded message is serialized, reloaded, and only then replayed.
+func TestOutputMessagePhaseSurvivesPersistence(t *testing.T) {
+	decoded := decodeOutputMessage(t, `"phase":"commentary",`)
+
+	stored, err := json.Marshal(decoded.Message())
+	assert.NoError(t, err)
+
+	var reloaded llm.Message
+	assert.NoError(t, json.Unmarshal(stored, &reloaded))
+
+	text, ok := reloaded.Content[0].(*llm.TextContent)
+	assert.True(t, ok)
+	assert.Equal(t, "commentary", text.Metadata[openAIPhaseMetadataKey])
+
+	assert.Contains(t, replayJSON(t, &reloaded), `"phase":"commentary"`)
+}
+
+func TestOutputMessagePhaseSurvivesCopy(t *testing.T) {
+	decoded := decodeOutputMessage(t, `"phase":"final_answer",`)
+
+	copied := decoded.Message().Copy()
+	text, ok := copied.Content[0].(*llm.TextContent)
+	assert.True(t, ok)
+	assert.Equal(t, "final_answer", text.Metadata[openAIPhaseMetadataKey])
+
+	// The copy must own its metadata rather than aliasing the original.
+	text.Metadata[openAIPhaseMetadataKey] = "commentary"
+	original := decoded.Content[0].(*llm.TextContent)
+	assert.Equal(t, "final_answer", original.Metadata[openAIPhaseMetadataKey])
+}
+
+// TestOutputMessageWithoutPhaseStaysUnphased locks in that Dive never invents a
+// phase for a message OpenAI left unlabeled.
+func TestOutputMessageWithoutPhaseStaysUnphased(t *testing.T) {
+	decoded := decodeOutputMessage(t, "")
+
+	text, ok := decoded.Content[0].(*llm.TextContent)
+	assert.True(t, ok)
+	assert.Equal(t, 0, len(text.Metadata))
+
+	assert.NotContains(t, replayJSON(t, decoded.Message()), `"phase"`)
+}
+
+// TestMixedPhasesPreservedPerOutputMessage covers a response whose output items
+// carry different phases: commentary, a tool call, then the final answer. Each
+// replayed message must keep the phase of the item it came from.
+func TestMixedPhasesPreservedPerOutputMessage(t *testing.T) {
+	var response responses.Response
+	assert.NoError(t, json.Unmarshal([]byte(`{
+		"id": "resp_1",
+		"model": "gpt-5.6-sol",
+		"status": "completed",
+		"output": [
+			{"id":"rs_1","type":"reasoning","status":"completed","summary":[],"encrypted_content":"enc"},
+			{"id":"msg_1","type":"message","role":"assistant","status":"completed","phase":"commentary",
+			 "content":[{"type":"output_text","text":"Checking that now.","annotations":[]}]},
+			{"id":"fc_1","type":"function_call","call_id":"call_1","name":"lookup","arguments":"{}","status":"completed"},
+			{"id":"msg_2","type":"message","role":"assistant","status":"completed","phase":"final_answer",
+			 "content":[{"type":"output_text","text":"The answer is 42.","annotations":[]}]}
+		]
+	}`), &response))
+
+	decoded, err := decodeAssistantResponse(&response)
+	assert.NoError(t, err)
+
+	phases := map[string]string{}
+	for _, content := range decoded.Content {
+		if text, ok := content.(*llm.TextContent); ok {
+			phases[text.Text] = text.Metadata[openAIPhaseMetadataKey]
+		}
+	}
+	assert.Equal(t, "commentary", phases["Checking that now."])
+	assert.Equal(t, "final_answer", phases["The answer is 42."])
+
+	// Both phases must reach the wire, each attached to its own output message.
+	var replayed []map[string]any
+	assert.NoError(t, json.Unmarshal([]byte(replayJSON(t, decoded.Message())), &replayed))
+
+	byPhase := map[string]string{}
+	for _, item := range replayed {
+		if item["type"] != "message" {
+			continue
+		}
+		content := item["content"].([]any)[0].(map[string]any)
+		byPhase[item["phase"].(string)] = content["text"].(string)
+	}
+	assert.Equal(t, 2, len(byPhase))
+	assert.Equal(t, "Checking that now.", byPhase["commentary"])
+	assert.Equal(t, "The answer is 42.", byPhase["final_answer"])
+}
+
+// TestUserMessagesNeverCarryPhase guards the rule that phase belongs only to
+// assistant output messages, even if a user block somehow carries the metadata.
+func TestUserMessagesNeverCarryPhase(t *testing.T) {
+	userMessage := &llm.Message{
+		Role: llm.User,
+		Content: []llm.Content{
+			&llm.TextContent{
+				Text:     "hello",
+				Metadata: llm.ProviderMetadata{openAIPhaseMetadataKey: "commentary"},
+			},
+		},
+	}
+	assert.NotContains(t, replayJSON(t, userMessage), `"phase"`)
+}
+
+func streamPhaseEvents(t *testing.T, addedPhase, donePhase string) *llm.Message {
+	t.Helper()
+	payloads := []string{
+		`{"type":"response.created","sequence_number":1,"response":{"id":"resp_1","model":"gpt-5.6-sol","status":"in_progress"}}`,
+		`{"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"msg_1","type":"message","role":"assistant","status":"in_progress"` + addedPhase + `,"content":[]}}`,
+		`{"type":"response.content_part.added","sequence_number":3,"item_id":"msg_1","output_index":0,"content_index":0,"part":{"type":"output_text","text":"","annotations":[]}}`,
+		`{"type":"response.output_text.delta","sequence_number":4,"item_id":"msg_1","output_index":0,"content_index":0,"delta":"Checking that now."}`,
+		`{"type":"response.output_text.done","sequence_number":5,"item_id":"msg_1","output_index":0,"content_index":0,"text":"Checking that now."}`,
+		`{"type":"response.output_item.done","sequence_number":6,"output_index":0,"item":{"id":"msg_1","type":"message","role":"assistant","status":"completed"` + donePhase + `,"content":[{"type":"output_text","text":"Checking that now.","annotations":[]}]}}`,
+		`{"type":"response.completed","sequence_number":7,"response":{"id":"resp_1","model":"gpt-5.6-sol","status":"completed","usage":{"input_tokens":1,"output_tokens":2,"input_tokens_details":{"cached_tokens":0,"cache_write_tokens":0},"output_tokens_details":{"reasoning_tokens":0}}}}`,
+	}
+	events := make([]responses.ResponseStreamEventUnion, 0, len(payloads))
+	for _, payload := range payloads {
+		var event responses.ResponseStreamEventUnion
+		assert.NoError(t, json.Unmarshal([]byte(payload), &event))
+		events = append(events, event)
+	}
+
+	iterator := newOpenAIStreamIterator(&mockStreamSource{events: events}, &llm.Config{})
+	t.Cleanup(func() { assert.NoError(t, iterator.Close()) })
+
+	accumulator := llm.NewResponseAccumulator()
+	for iterator.Next() {
+		assert.NoError(t, accumulator.AddEvent(iterator.Event()))
+	}
+	assert.NoError(t, iterator.Err())
+	assert.True(t, accumulator.IsComplete())
+	return accumulator.Response().Message()
+}
+
+// TestStreamingPhaseFromOutputItemDone proves that reading phase only from the
+// added event is insufficient: OpenAI may label the message just on done.
+func TestStreamingPhaseFromOutputItemDone(t *testing.T) {
+	message := streamPhaseEvents(t, "", `,"phase":"commentary"`)
+
+	text, ok := message.Content[0].(*llm.TextContent)
+	assert.True(t, ok)
+	assert.Equal(t, "Checking that now.", text.Text)
+	assert.Equal(t, "commentary", text.Metadata[openAIPhaseMetadataKey])
+
+	assert.Contains(t, replayJSON(t, message), `"phase":"commentary"`)
+}
+
+func TestStreamingPhaseFromOutputItemAdded(t *testing.T) {
+	message := streamPhaseEvents(t, `,"phase":"final_answer"`, "")
+
+	text, ok := message.Content[0].(*llm.TextContent)
+	assert.True(t, ok)
+	assert.Equal(t, "final_answer", text.Metadata[openAIPhaseMetadataKey])
+
+	assert.Contains(t, replayJSON(t, message), `"phase":"final_answer"`)
+}
+
+// TestStreamingDonePhaseWins covers a message relabeled between added and done.
+func TestStreamingDonePhaseWins(t *testing.T) {
+	message := streamPhaseEvents(t, `,"phase":"commentary"`, `,"phase":"final_answer"`)
+
+	text := message.Content[0].(*llm.TextContent)
+	assert.Equal(t, "final_answer", text.Metadata[openAIPhaseMetadataKey])
+}
+
+func TestStreamingWithoutPhaseStaysUnphased(t *testing.T) {
+	message := streamPhaseEvents(t, "", "")
+
+	text := message.Content[0].(*llm.TextContent)
+	assert.Equal(t, 0, len(text.Metadata))
+	assert.NotContains(t, replayJSON(t, message), `"phase"`)
+}

--- a/providers/openai/provider_integration_test.go
+++ b/providers/openai/provider_integration_test.go
@@ -5,6 +5,7 @@ package openai
 import (
 	"context"
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"os"
 	"strings"
@@ -294,4 +295,70 @@ func setupIntegrationProvider(t *testing.T) *Provider {
 		WithModel("gpt-4o"),
 		WithMaxTokens(1000),
 	)
+}
+
+// TestIntegration_PhaseReplayedAcrossStatelessTurns qualifies faithful manual
+// continuation: the assistant turn from a live GPT-5.6 call is persisted,
+// reloaded, and resent as history without `previous_response_id`. Every phase
+// OpenAI assigned must reach the wire unchanged on the follow-up request.
+func TestIntegration_PhaseReplayedAcrossStatelessTurns(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	apiKey := os.Getenv("OPENAI_API_KEY")
+	if apiKey == "" {
+		t.Skip("OPENAI_API_KEY not set, skipping integration test")
+	}
+	provider := New(
+		WithAPIKey(apiKey),
+		WithModel(string(ModelGPT56Sol)),
+		WithMaxTokens(2000),
+	)
+
+	first, err := provider.Generate(
+		context.Background(),
+		llm.WithUserTextMessage("In two sentences, what is the capital of France?"),
+		llm.WithReasoningEffort(llm.ReasoningEffortLow),
+	)
+	assert.NoError(t, err)
+
+	// Persist and reload the assistant turn the way a durable runtime would.
+	stored, err := json.Marshal(first.Message())
+	assert.NoError(t, err)
+	var reloaded llm.Message
+	assert.NoError(t, json.Unmarshal(stored, &reloaded))
+
+	var phases []string
+	for _, content := range reloaded.Content {
+		if text, ok := content.(*llm.TextContent); ok {
+			if phase := text.Metadata[openAIPhaseMetadataKey]; phase != "" {
+				phases = append(phases, phase)
+			}
+		}
+	}
+	if len(phases) == 0 {
+		t.Skip("model returned no phased output messages; nothing to qualify")
+	}
+
+	// The replayed request must carry every phase the model assigned.
+	replayed, err := encodeMessages([]*llm.Message{&reloaded})
+	assert.NoError(t, err)
+	replayedJSON, err := json.Marshal(replayed)
+	assert.NoError(t, err)
+	for _, phase := range phases {
+		assert.Contains(t, string(replayedJSON), `"phase":"`+phase+`"`)
+	}
+
+	// And OpenAI must accept that history on a stateless follow-up turn.
+	second, err := provider.Generate(
+		context.Background(),
+		llm.WithMessages(
+			llm.NewUserTextMessage("In two sentences, what is the capital of France?"),
+			&reloaded,
+			llm.NewUserTextMessage("Now name its largest airport."),
+		),
+		llm.WithReasoningEffort(llm.ReasoningEffortLow),
+	)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, second.Message().Text())
 }

--- a/providers/openai/provider_integration_test.go
+++ b/providers/openai/provider_integration_test.go
@@ -8,12 +8,14 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"slices"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/deepnoodle-ai/dive/llm"
 	"github.com/deepnoodle-ai/wonton/assert"
+	"github.com/deepnoodle-ai/wonton/schema"
 )
 
 func TestIntegration_SimpleTextGeneration(t *testing.T) {
@@ -298,9 +300,12 @@ func setupIntegrationProvider(t *testing.T) *Provider {
 }
 
 // TestIntegration_PhaseReplayedAcrossStatelessTurns qualifies faithful manual
-// continuation: the assistant turn from a live GPT-5.6 call is persisted,
-// reloaded, and resent as history without `previous_response_id`. Every phase
-// OpenAI assigned must reach the wire unchanged on the follow-up request.
+// continuation. A tool-inducing prompt makes the model emit a `commentary`
+// preamble alongside its tool calls; that turn is persisted, reloaded, and
+// resent as history without `previous_response_id`, together with the tool
+// results. Every phase OpenAI assigned must reach the wire unchanged, OpenAI
+// must accept the replayed history, and the concluding turn must arrive as
+// `final_answer`.
 func TestIntegration_PhaseReplayedAcrossStatelessTurns(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
@@ -312,12 +317,26 @@ func TestIntegration_PhaseReplayedAcrossStatelessTurns(t *testing.T) {
 	provider := New(
 		WithAPIKey(apiKey),
 		WithModel(string(ModelGPT56Sol)),
-		WithMaxTokens(2000),
+		WithMaxTokens(3000),
 	)
 
-	first, err := provider.Generate(
-		context.Background(),
-		llm.WithUserTextMessage("In two sentences, what is the capital of France?"),
+	weather := llm.NewToolDefinition().
+		WithName("get_weather").
+		WithDescription("Get the current weather for a city.").
+		WithSchema(&schema.Schema{
+			Type:     "object",
+			Required: []string{"city"},
+			Properties: map[string]*schema.Property{
+				"city": {Type: "string", Description: "City name"},
+			},
+		})
+
+	prompt := "Check the weather in Paris and in Tokyo, telling me what you're " +
+		"doing as you go, then compare them."
+
+	first, err := provider.Generate(context.Background(),
+		llm.WithUserTextMessage(prompt),
+		llm.WithTools(weather),
 		llm.WithReasoningEffort(llm.ReasoningEffortLow),
 	)
 	assert.NoError(t, err)
@@ -328,19 +347,13 @@ func TestIntegration_PhaseReplayedAcrossStatelessTurns(t *testing.T) {
 	var reloaded llm.Message
 	assert.NoError(t, json.Unmarshal(stored, &reloaded))
 
-	var phases []string
-	for _, content := range reloaded.Content {
-		if text, ok := content.(*llm.TextContent); ok {
-			if phase := text.Metadata[openAIPhaseMetadataKey]; phase != "" {
-				phases = append(phases, phase)
-			}
-		}
-	}
+	phases := phasesOf(&reloaded)
+	t.Logf("turn 1 phases from %s: %v", ModelGPT56Sol, phases)
 	if len(phases) == 0 {
 		t.Skip("model returned no phased output messages; nothing to qualify")
 	}
 
-	// The replayed request must carry every phase the model assigned.
+	// Every phase the model assigned must survive into the replayed request.
 	replayed, err := encodeMessages([]*llm.Message{&reloaded})
 	assert.NoError(t, err)
 	replayedJSON, err := json.Marshal(replayed)
@@ -349,16 +362,55 @@ func TestIntegration_PhaseReplayedAcrossStatelessTurns(t *testing.T) {
 		assert.Contains(t, string(replayedJSON), `"phase":"`+phase+`"`)
 	}
 
-	// And OpenAI must accept that history on a stateless follow-up turn.
-	second, err := provider.Generate(
-		context.Background(),
+	// Answer whatever tool calls came back, so the conversation can conclude.
+	var toolResults []llm.Content
+	for _, content := range reloaded.Content {
+		if toolUse, ok := content.(*llm.ToolUseContent); ok {
+			toolResults = append(toolResults, &llm.ToolResultContent{
+				ToolUseID: toolUse.ID,
+				Content:   "18C, partly cloudy",
+			})
+		}
+	}
+	if len(toolResults) == 0 {
+		t.Skip("model made no tool calls; cannot continue the turn statelessly")
+	}
+
+	// OpenAI must accept the replayed history on a stateless follow-up turn.
+	second, err := provider.Generate(context.Background(),
 		llm.WithMessages(
-			llm.NewUserTextMessage("In two sentences, what is the capital of France?"),
+			llm.NewUserTextMessage(prompt),
 			&reloaded,
-			llm.NewUserTextMessage("Now name its largest airport."),
+			&llm.Message{Role: llm.User, Content: toolResults},
 		),
+		llm.WithTools(weather),
 		llm.WithReasoningEffort(llm.ReasoningEffortLow),
 	)
 	assert.NoError(t, err)
 	assert.NotEmpty(t, second.Message().Text())
+
+	secondPhases := phasesOf(second.Message())
+	t.Logf("turn 2 phases from %s: %v", ModelGPT56Sol, secondPhases)
+
+	// Across the exchange the model should exercise both phases: a commentary
+	// preamble before the tool calls, and a final answer once they resolve.
+	allPhases := append(append([]string{}, phases...), secondPhases...)
+	assert.True(t, slices.Contains(allPhases, "commentary"),
+		"expected a commentary phase across the exchange, got %v", allPhases)
+	assert.True(t, slices.Contains(allPhases, "final_answer"),
+		"expected a final_answer phase across the exchange, got %v", allPhases)
+}
+
+// phasesOf returns the phase recorded on each of a message's text blocks, in
+// order, skipping blocks OpenAI left unlabeled.
+func phasesOf(message *llm.Message) []string {
+	var phases []string
+	for _, content := range message.Content {
+		if text, ok := content.(*llm.TextContent); ok {
+			if phase := text.Metadata[openAIPhaseMetadataKey]; phase != "" {
+				phases = append(phases, phase)
+			}
+		}
+	}
+	return phases
 }

--- a/providers/openai/stream_iterator.go
+++ b/providers/openai/stream_iterator.go
@@ -59,6 +59,22 @@ type outputItemState struct {
 	// For message with text/reasoning content parts
 	// Keyed by ContentIndex
 	ContentParts map[int]*contentPartState
+
+	// Phase is the phase OpenAI assigned to a message item. It may be absent
+	// when the item is added and only appear on the done event, so the done
+	// event is treated as authoritative.
+	Phase string
+}
+
+// hasTextPart reports whether this item streamed an output_text part, meaning
+// the accumulator holds a text content block at this item's index.
+func (s *outputItemState) hasTextPart() bool {
+	for _, part := range s.ContentParts {
+		if part.PartType == "output_text" {
+			return true
+		}
+	}
+	return false
 }
 
 type contentPartState struct {
@@ -184,6 +200,10 @@ func (s *openaiStreamIterator) processOpenAIEvent(event responses.ResponseStream
 			ContentParts: make(map[int]*contentPartState),
 		}
 
+		if data.Item.Type == "message" {
+			s.outputItemsState[outputIdx].Phase = string(data.Item.Phase)
+		}
+
 		if data.Item.Type == "function_call" {
 			fnCall := data.Item.AsFunctionCall()
 			s.outputItemsState[outputIdx].ToolCallName = fnCall.Name
@@ -225,12 +245,17 @@ func (s *openaiStreamIterator) processOpenAIEvent(event responses.ResponseStream
 			return diveEvents, nil
 		}
 
+		contentBlock := &llm.EventContentBlock{Type: diveContentType}
+		if diveContentType == llm.ContentTypeText {
+			// Surface the phase to live consumers as soon as it is known. When
+			// OpenAI only labels the message on the done event, the metadata
+			// delta emitted there fills it in.
+			contentBlock.Metadata = openAIPhaseMetadata(itemState.Phase)
+		}
 		diveEvents = append(diveEvents, &llm.Event{
-			Type:  llm.EventTypeContentBlockStart,
-			Index: &outputIdx,
-			ContentBlock: &llm.EventContentBlock{
-				Type: diveContentType,
-			},
+			Type:         llm.EventTypeContentBlockStart,
+			Index:        &outputIdx,
+			ContentBlock: contentBlock,
 		})
 
 	case responses.ResponseTextDeltaEvent:
@@ -587,6 +612,28 @@ func (s *openaiStreamIterator) processOpenAIEvent(event responses.ResponseStream
 					Type:  llm.EventTypeContentBlockStop,
 					Index: &idxStop,
 				})
+			}
+		}
+
+		// The done event carries the authoritative phase for a message item:
+		// OpenAI may omit it when the item is added and only label it here.
+		if data.Item.Type == "message" {
+			if itemState, ok := s.outputItemsState[outputIdx]; ok {
+				if phase := string(data.Item.Phase); phase != "" {
+					itemState.Phase = phase
+				}
+				metadata := openAIPhaseMetadata(itemState.Phase)
+				if metadata != nil && itemState.hasTextPart() {
+					idxPhase := outputIdx
+					diveEvents = append(diveEvents, &llm.Event{
+						Type:  llm.EventTypeContentBlockDelta,
+						Index: &idxPhase,
+						Delta: &llm.EventDelta{
+							Type:     llm.EventDeltaTypeMetadata,
+							Metadata: metadata,
+						},
+					})
+				}
 			}
 		}
 

--- a/providers/openai/stream_iterator.go
+++ b/providers/openai/stream_iterator.go
@@ -48,6 +48,10 @@ type outputItemState struct {
 	ToolCallName      string
 	ToolCallID        string // The 'call_id' (e.g. call_xxxx)
 	ToolArgumentsJson string
+	// ToolCallStopped records that the function call's content_block_stop was
+	// emitted, so the block closes exactly once whether the item's done event
+	// or the end of the response closes it.
+	ToolCallStopped bool
 
 	// SummaryStreamedByIndex tracks which reasoning summary parts were streamed
 	// incrementally (keyed by SummaryIndex), so the OutputItemDone handler
@@ -72,11 +76,21 @@ type outputItemState struct {
 	PhaseEmitted string
 }
 
-// hasTextPart reports whether this item streamed an output_text part, meaning
-// the accumulator holds a text content block at this item's index.
-// closeTextBlocks emits content_block_stop for every text block this item
-// opened and has not closed yet, at the item's own event index.
-func (s *outputItemState) closeTextBlocks(outputIdx int) []*llm.Event {
+// closeOpenBlocks emits content_block_stop, at the item's own event index, for
+// every block this item opened and has not closed yet: its text parts, its
+// reasoning block, or its function call. Each block closes exactly once, so
+// the item's done event and an early end of the response can both call this
+// and consumers always receive a balanced block lifecycle.
+func (s *outputItemState) closeOpenBlocks() []*llm.Event {
+	var events []*llm.Event
+	stop := func() {
+		idxStop := s.OutputIndex
+		events = append(events, &llm.Event{
+			Type:  llm.EventTypeContentBlockStop,
+			Index: &idxStop,
+		})
+	}
+
 	contentIndexes := make([]int, 0, len(s.ContentParts))
 	for contentIdx, part := range s.ContentParts {
 		if part.PartType == "output_text" && !part.BlockStopped {
@@ -84,19 +98,25 @@ func (s *outputItemState) closeTextBlocks(outputIdx int) []*llm.Event {
 		}
 	}
 	sort.Ints(contentIndexes)
-
-	events := make([]*llm.Event, 0, len(contentIndexes))
 	for _, contentIdx := range contentIndexes {
 		s.ContentParts[contentIdx].BlockStopped = true
-		idxStop := outputIdx
-		events = append(events, &llm.Event{
-			Type:  llm.EventTypeContentBlockStop,
-			Index: &idxStop,
-		})
+		stop()
+	}
+
+	if s.ReasoningStarted && !s.ReasoningStopped {
+		s.ReasoningStopped = true
+		stop()
+	}
+
+	if s.ItemType == "function_call" && !s.ToolCallStopped {
+		s.ToolCallStopped = true
+		stop()
 	}
 	return events
 }
 
+// hasTextPart reports whether this item streamed an output_text part, meaning
+// the accumulator holds a text content block at this item's index.
 func (s *outputItemState) hasTextPart() bool {
 	for _, part := range s.ContentParts {
 		if part.PartType == "output_text" {
@@ -639,14 +659,6 @@ func (s *openaiStreamIterator) processOpenAIEvent(event responses.ResponseStream
 					},
 				})
 			}
-			if itemState.ReasoningStarted && !itemState.ReasoningStopped {
-				itemState.ReasoningStopped = true
-				idxStop := outputIdx
-				diveEvents = append(diveEvents, &llm.Event{
-					Type:  llm.EventTypeContentBlockStop,
-					Index: &idxStop,
-				})
-			}
 		}
 
 		// The done event carries the authoritative phase for a message item:
@@ -676,21 +688,11 @@ func (s *openaiStreamIterator) processOpenAIEvent(event responses.ResponseStream
 			}
 		}
 
-		// Close the text blocks this item opened, after any metadata the done
+		// Close every block this item opened, after any metadata the done
 		// event contributed to them.
 		if itemState, ok := s.outputItemsState[outputIdx]; ok {
-			diveEvents = append(diveEvents, itemState.closeTextBlocks(outputIdx)...)
-		}
-
-		if item, ok := s.outputItemsState[outputIdx]; ok && !item.IsComplete {
-			item.IsComplete = true
-			if item.ItemType == "function_call" {
-				idxFnStop := outputIdx
-				diveEvents = append(diveEvents, &llm.Event{
-					Type:  llm.EventTypeContentBlockStop,
-					Index: &idxFnStop,
-				})
-			}
+			diveEvents = append(diveEvents, itemState.closeOpenBlocks()...)
+			itemState.IsComplete = true
 		}
 
 	case responses.ResponseCompletedEvent:
@@ -708,6 +710,7 @@ func (s *openaiStreamIterator) processOpenAIEvent(event responses.ResponseStream
 		}
 		stopReason := determineStopReason(&data.Response)
 
+		diveEvents = append(diveEvents, s.closeDanglingBlocks()...)
 		diveEvents = append(diveEvents, &llm.Event{
 			Type: llm.EventTypeMessageDelta,
 			Delta: &llm.EventDelta{
@@ -715,7 +718,6 @@ func (s *openaiStreamIterator) processOpenAIEvent(event responses.ResponseStream
 			},
 			Usage: s.finalUsage,
 		})
-		diveEvents = append(diveEvents, s.closeDanglingTextBlocks()...)
 		diveEvents = append(diveEvents, &llm.Event{Type: llm.EventTypeMessageStop})
 		s.isClosed = true
 
@@ -738,6 +740,7 @@ func (s *openaiStreamIterator) processOpenAIEvent(event responses.ResponseStream
 		}
 		stopReason := determineStopReason(&data.Response)
 
+		diveEvents = append(diveEvents, s.closeDanglingBlocks()...)
 		diveEvents = append(diveEvents, &llm.Event{
 			Type: llm.EventTypeMessageDelta,
 			Delta: &llm.EventDelta{
@@ -745,7 +748,6 @@ func (s *openaiStreamIterator) processOpenAIEvent(event responses.ResponseStream
 			},
 			Usage: s.finalUsage,
 		})
-		diveEvents = append(diveEvents, s.closeDanglingTextBlocks()...)
 		diveEvents = append(diveEvents, &llm.Event{Type: llm.EventTypeMessageStop})
 		s.isClosed = true
 
@@ -795,10 +797,13 @@ func reasoningContentTexts(reasoning responses.ResponseReasoningItem) []string {
 	return texts
 }
 
-// closeDanglingTextBlocks closes any text block left open because the response
-// ended without the output_item.done event that normally closes it, so the
-// event stream always hands consumers a balanced block lifecycle.
-func (s *openaiStreamIterator) closeDanglingTextBlocks() []*llm.Event {
+// closeDanglingBlocks closes every block — text, reasoning, or function call —
+// left open because the response ended without the output_item.done event that
+// normally closes it, so the event stream always hands consumers a balanced
+// block lifecycle. It runs before message_delta, keeping the
+// content_block_stop → message_delta → message_stop order the other providers
+// emit.
+func (s *openaiStreamIterator) closeDanglingBlocks() []*llm.Event {
 	outputIndexes := make([]int, 0, len(s.outputItemsState))
 	for outputIdx := range s.outputItemsState {
 		outputIndexes = append(outputIndexes, outputIdx)
@@ -807,7 +812,7 @@ func (s *openaiStreamIterator) closeDanglingTextBlocks() []*llm.Event {
 
 	var events []*llm.Event
 	for _, outputIdx := range outputIndexes {
-		events = append(events, s.outputItemsState[outputIdx].closeTextBlocks(outputIdx)...)
+		events = append(events, s.outputItemsState[outputIdx].closeOpenBlocks()...)
 	}
 	return events
 }

--- a/providers/openai/stream_iterator.go
+++ b/providers/openai/stream_iterator.go
@@ -3,6 +3,7 @@ package openai
 import (
 	"fmt"
 	"io"
+	"sort"
 	"sync"
 
 	"github.com/deepnoodle-ai/dive/llm"
@@ -64,10 +65,38 @@ type outputItemState struct {
 	// when the item is added and only appear on the done event, so the done
 	// event is treated as authoritative.
 	Phase string
+
+	// PhaseEmitted is the phase already carried to consumers on the text
+	// block's start event, so the done event only emits a metadata delta when
+	// OpenAI relabeled the message after the block opened.
+	PhaseEmitted string
 }
 
 // hasTextPart reports whether this item streamed an output_text part, meaning
 // the accumulator holds a text content block at this item's index.
+// closeTextBlocks emits content_block_stop for every text block this item
+// opened and has not closed yet, at the item's own event index.
+func (s *outputItemState) closeTextBlocks(outputIdx int) []*llm.Event {
+	contentIndexes := make([]int, 0, len(s.ContentParts))
+	for contentIdx, part := range s.ContentParts {
+		if part.PartType == "output_text" && !part.BlockStopped {
+			contentIndexes = append(contentIndexes, contentIdx)
+		}
+	}
+	sort.Ints(contentIndexes)
+
+	events := make([]*llm.Event, 0, len(contentIndexes))
+	for _, contentIdx := range contentIndexes {
+		s.ContentParts[contentIdx].BlockStopped = true
+		idxStop := outputIdx
+		events = append(events, &llm.Event{
+			Type:  llm.EventTypeContentBlockStop,
+			Index: &idxStop,
+		})
+	}
+	return events
+}
+
 func (s *outputItemState) hasTextPart() bool {
 	for _, part := range s.ContentParts {
 		if part.PartType == "output_text" {
@@ -83,6 +112,10 @@ type contentPartState struct {
 	PartType     string // E.g., "output_text", "reasoning"
 	Text         string // Accumulated text for output_text or reasoning
 	IsComplete   bool
+
+	// BlockStopped records that this part's content_block_stop was emitted, so
+	// the item's done event closes each block exactly once.
+	BlockStopped bool
 }
 
 func newOpenAIStreamIterator(sdkStream StreamSource, config *llm.Config) *openaiStreamIterator {
@@ -251,6 +284,7 @@ func (s *openaiStreamIterator) processOpenAIEvent(event responses.ResponseStream
 			// OpenAI only labels the message on the done event, the metadata
 			// delta emitted there fills it in.
 			contentBlock.Metadata = openAIPhaseMetadata(itemState.Phase)
+			itemState.PhaseEmitted = itemState.Phase
 		}
 		diveEvents = append(diveEvents, &llm.Event{
 			Type:         llm.EventTypeContentBlockStart,
@@ -513,10 +547,10 @@ func (s *openaiStreamIterator) processOpenAIEvent(event responses.ResponseStream
 			if part, ok2 := item.ContentParts[contentIdx]; ok2 {
 				part.Text = data.Text
 				part.IsComplete = true
-				diveEvents = append(diveEvents, &llm.Event{
-					Type:  llm.EventTypeContentBlockStop,
-					Index: &outputIdx,
-				})
+				// The block is closed by the item's done event rather than
+				// here: OpenAI sends output_text.done first, and closing now
+				// would push any metadata the done event carries (such as a
+				// late phase label) outside the block lifecycle.
 			}
 		}
 
@@ -622,19 +656,30 @@ func (s *openaiStreamIterator) processOpenAIEvent(event responses.ResponseStream
 				if phase := string(data.Item.Phase); phase != "" {
 					itemState.Phase = phase
 				}
-				metadata := openAIPhaseMetadata(itemState.Phase)
-				if metadata != nil && itemState.hasTextPart() {
-					idxPhase := outputIdx
-					diveEvents = append(diveEvents, &llm.Event{
-						Type:  llm.EventTypeContentBlockDelta,
-						Index: &idxPhase,
-						Delta: &llm.EventDelta{
-							Type:     llm.EventDeltaTypeMetadata,
-							Metadata: metadata,
-						},
-					})
+				// A delta is only needed when the block's start event could not
+				// announce this phase, which keeps the stream free of redundant
+				// metadata for the common case of a message labeled up front.
+				if itemState.Phase != itemState.PhaseEmitted && itemState.hasTextPart() {
+					if metadata := openAIPhaseMetadata(itemState.Phase); metadata != nil {
+						itemState.PhaseEmitted = itemState.Phase
+						idxPhase := outputIdx
+						diveEvents = append(diveEvents, &llm.Event{
+							Type:  llm.EventTypeContentBlockDelta,
+							Index: &idxPhase,
+							Delta: &llm.EventDelta{
+								Type:     llm.EventDeltaTypeMetadata,
+								Metadata: metadata,
+							},
+						})
+					}
 				}
 			}
+		}
+
+		// Close the text blocks this item opened, after any metadata the done
+		// event contributed to them.
+		if itemState, ok := s.outputItemsState[outputIdx]; ok {
+			diveEvents = append(diveEvents, itemState.closeTextBlocks(outputIdx)...)
 		}
 
 		if item, ok := s.outputItemsState[outputIdx]; ok && !item.IsComplete {
@@ -670,6 +715,7 @@ func (s *openaiStreamIterator) processOpenAIEvent(event responses.ResponseStream
 			},
 			Usage: s.finalUsage,
 		})
+		diveEvents = append(diveEvents, s.closeDanglingTextBlocks()...)
 		diveEvents = append(diveEvents, &llm.Event{Type: llm.EventTypeMessageStop})
 		s.isClosed = true
 
@@ -699,6 +745,7 @@ func (s *openaiStreamIterator) processOpenAIEvent(event responses.ResponseStream
 			},
 			Usage: s.finalUsage,
 		})
+		diveEvents = append(diveEvents, s.closeDanglingTextBlocks()...)
 		diveEvents = append(diveEvents, &llm.Event{Type: llm.EventTypeMessageStop})
 		s.isClosed = true
 
@@ -746,4 +793,21 @@ func reasoningContentTexts(reasoning responses.ResponseReasoningItem) []string {
 		texts = append(texts, part.Text)
 	}
 	return texts
+}
+
+// closeDanglingTextBlocks closes any text block left open because the response
+// ended without the output_item.done event that normally closes it, so the
+// event stream always hands consumers a balanced block lifecycle.
+func (s *openaiStreamIterator) closeDanglingTextBlocks() []*llm.Event {
+	outputIndexes := make([]int, 0, len(s.outputItemsState))
+	for outputIdx := range s.outputItemsState {
+		outputIndexes = append(outputIndexes, outputIdx)
+	}
+	sort.Ints(outputIndexes)
+
+	var events []*llm.Event
+	for _, outputIdx := range outputIndexes {
+		events = append(events, s.outputItemsState[outputIdx].closeTextBlocks(outputIdx)...)
+	}
+	return events
 }

--- a/providers/openai/stream_iterator_test.go
+++ b/providers/openai/stream_iterator_test.go
@@ -270,3 +270,46 @@ func TestStreamIteratorPreservesRawReasoningText(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Contains(t, string(replayedJSON), `"content":[{"text":"raw reasoning","type":"reasoning_text"}]`)
 }
+
+// TestStreamIteratorClosesTextBlockWithoutItemDone covers a response that ends
+// without the output_item.done event that normally closes a text block, which
+// must still leave consumers with a balanced block lifecycle.
+func TestStreamIteratorClosesTextBlockWithoutItemDone(t *testing.T) {
+	payloads := []string{
+		`{"type":"response.created","sequence_number":1,"response":{"id":"resp_1","model":"gpt-5.6-sol","status":"in_progress"}}`,
+		`{"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"msg_1","type":"message","role":"assistant","status":"in_progress","content":[]}}`,
+		`{"type":"response.content_part.added","sequence_number":3,"item_id":"msg_1","output_index":0,"content_index":0,"part":{"type":"output_text","text":"","annotations":[]}}`,
+		`{"type":"response.output_text.delta","sequence_number":4,"item_id":"msg_1","output_index":0,"content_index":0,"delta":"Partial"}`,
+		`{"type":"response.incomplete","sequence_number":5,"response":{"id":"resp_1","model":"gpt-5.6-sol","status":"incomplete","incomplete_details":{"reason":"max_output_tokens"},"usage":{"input_tokens":1,"output_tokens":2,"input_tokens_details":{"cached_tokens":0,"cache_write_tokens":0},"output_tokens_details":{"reasoning_tokens":0}}}}`,
+	}
+	events := make([]responses.ResponseStreamEventUnion, 0, len(payloads))
+	for _, payload := range payloads {
+		var event responses.ResponseStreamEventUnion
+		assert.NoError(t, json.Unmarshal([]byte(payload), &event))
+		events = append(events, event)
+	}
+
+	iterator := newOpenAIStreamIterator(&mockStreamSource{events: events}, &llm.Config{})
+	defer iterator.Close()
+
+	var starts, stops, stopBeforeMessageStop int
+	var sawMessageStop bool
+	for iterator.Next() {
+		switch iterator.Event().Type {
+		case llm.EventTypeContentBlockStart:
+			starts++
+		case llm.EventTypeContentBlockStop:
+			stops++
+			if !sawMessageStop {
+				stopBeforeMessageStop++
+			}
+		case llm.EventTypeMessageStop:
+			sawMessageStop = true
+		}
+	}
+	assert.NoError(t, iterator.Err())
+
+	assert.Equal(t, 1, starts)
+	assert.Equal(t, 1, stops)
+	assert.Equal(t, 1, stopBeforeMessageStop)
+}

--- a/providers/openai/stream_iterator_test.go
+++ b/providers/openai/stream_iterator_test.go
@@ -271,45 +271,99 @@ func TestStreamIteratorPreservesRawReasoningText(t *testing.T) {
 	assert.Contains(t, string(replayedJSON), `"content":[{"text":"raw reasoning","type":"reasoning_text"}]`)
 }
 
-// TestStreamIteratorClosesTextBlockWithoutItemDone covers a response that ends
-// without the output_item.done event that normally closes a text block, which
-// must still leave consumers with a balanced block lifecycle.
-func TestStreamIteratorClosesTextBlockWithoutItemDone(t *testing.T) {
-	payloads := []string{
-		`{"type":"response.created","sequence_number":1,"response":{"id":"resp_1","model":"gpt-5.6-sol","status":"in_progress"}}`,
-		`{"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"msg_1","type":"message","role":"assistant","status":"in_progress","content":[]}}`,
-		`{"type":"response.content_part.added","sequence_number":3,"item_id":"msg_1","output_index":0,"content_index":0,"part":{"type":"output_text","text":"","annotations":[]}}`,
-		`{"type":"response.output_text.delta","sequence_number":4,"item_id":"msg_1","output_index":0,"content_index":0,"delta":"Partial"}`,
-		`{"type":"response.incomplete","sequence_number":5,"response":{"id":"resp_1","model":"gpt-5.6-sol","status":"incomplete","incomplete_details":{"reason":"max_output_tokens"},"usage":{"input_tokens":1,"output_tokens":2,"input_tokens_details":{"cached_tokens":0,"cache_write_tokens":0},"output_tokens_details":{"reasoning_tokens":0}}}}`,
-	}
+// parseStreamPayloads decodes raw SSE event payloads into SDK stream events.
+func parseStreamPayloads(t *testing.T, payloads ...string) []responses.ResponseStreamEventUnion {
+	t.Helper()
 	events := make([]responses.ResponseStreamEventUnion, 0, len(payloads))
 	for _, payload := range payloads {
 		var event responses.ResponseStreamEventUnion
 		assert.NoError(t, json.Unmarshal([]byte(payload), &event))
 		events = append(events, event)
 	}
+	return events
+}
 
-	iterator := newOpenAIStreamIterator(&mockStreamSource{events: events}, &llm.Config{})
-	defer iterator.Close()
+// TestStreamIteratorClosesDanglingBlocks covers a response that ends without
+// the output_item.done event that normally closes a block. Whichever kind of
+// block was left open — text, function call, or reasoning — the iterator must
+// close it exactly once, and before message_delta, so consumers always see a
+// balanced block lifecycle in the same order the other providers emit.
+func TestStreamIteratorClosesDanglingBlocks(t *testing.T) {
+	created := `{"type":"response.created","sequence_number":1,"response":{"id":"resp_1","model":"gpt-5.6-sol","status":"in_progress"}}`
+	incomplete := `{"type":"response.incomplete","sequence_number":9,"response":{"id":"resp_1","model":"gpt-5.6-sol","status":"incomplete","incomplete_details":{"reason":"max_output_tokens"},"usage":{"input_tokens":1,"output_tokens":2,"input_tokens_details":{"cached_tokens":0,"cache_write_tokens":0},"output_tokens_details":{"reasoning_tokens":0}}}}`
 
-	var starts, stops, stopBeforeMessageStop int
-	var sawMessageStop bool
-	for iterator.Next() {
-		switch iterator.Event().Type {
-		case llm.EventTypeContentBlockStart:
-			starts++
-		case llm.EventTypeContentBlockStop:
-			stops++
-			if !sawMessageStop {
-				stopBeforeMessageStop++
-			}
-		case llm.EventTypeMessageStop:
-			sawMessageStop = true
-		}
+	cases := []struct {
+		name     string
+		payloads []string
+		content  llm.ContentType
+	}{
+		{
+			name: "text",
+			payloads: []string{
+				`{"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"msg_1","type":"message","role":"assistant","status":"in_progress","content":[]}}`,
+				`{"type":"response.content_part.added","sequence_number":3,"item_id":"msg_1","output_index":0,"content_index":0,"part":{"type":"output_text","text":"","annotations":[]}}`,
+				`{"type":"response.output_text.delta","sequence_number":4,"item_id":"msg_1","output_index":0,"content_index":0,"delta":"Partial"}`,
+			},
+			content: llm.ContentTypeText,
+		},
+		{
+			name: "function_call",
+			payloads: []string{
+				`{"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"fc_1","type":"function_call","call_id":"call_1","name":"lookup","arguments":"","status":"in_progress"}}`,
+				`{"type":"response.function_call_arguments.delta","sequence_number":3,"item_id":"fc_1","output_index":0,"delta":"{\"q\":\"x\"}"}`,
+			},
+			content: llm.ContentTypeToolUse,
+		},
+		{
+			name: "reasoning",
+			payloads: []string{
+				`{"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"rs_1","type":"reasoning","summary":[],"status":"in_progress"}}`,
+				`{"type":"response.reasoning_summary_part.added","sequence_number":3,"item_id":"rs_1","output_index":0,"summary_index":0,"part":{"type":"summary_text","text":""}}`,
+				`{"type":"response.reasoning_summary_text.delta","sequence_number":4,"item_id":"rs_1","output_index":0,"summary_index":0,"delta":"Thinking"}`,
+			},
+			content: llm.ContentTypeThinking,
+		},
 	}
-	assert.NoError(t, iterator.Err())
 
-	assert.Equal(t, 1, starts)
-	assert.Equal(t, 1, stops)
-	assert.Equal(t, 1, stopBeforeMessageStop)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			payloads := append(append([]string{created}, tc.payloads...), incomplete)
+			iterator := newOpenAIStreamIterator(&mockStreamSource{events: parseStreamPayloads(t, payloads...)}, &llm.Config{})
+			defer iterator.Close()
+
+			accumulator := llm.NewResponseAccumulator()
+			var types []llm.EventType
+			for iterator.Next() {
+				event := iterator.Event()
+				types = append(types, event.Type)
+				assert.NoError(t, accumulator.AddEvent(event))
+			}
+			assert.NoError(t, iterator.Err())
+
+			var starts, stops int
+			stopIndex, deltaIndex := -1, -1
+			for i, eventType := range types {
+				switch eventType {
+				case llm.EventTypeContentBlockStart:
+					starts++
+				case llm.EventTypeContentBlockStop:
+					stops++
+					stopIndex = i
+				case llm.EventTypeMessageDelta:
+					deltaIndex = i
+				}
+			}
+			assert.Equal(t, 1, starts)
+			assert.Equal(t, 1, stops)
+			assert.True(t, deltaIndex >= 0, "expected a message_delta event")
+			assert.True(t, stopIndex < deltaIndex, "content_block_stop must precede message_delta, got %v", types)
+			assert.Equal(t, llm.EventTypeMessageStop, types[len(types)-1])
+
+			// The partial block still reaches consumers as a well-formed message.
+			assert.True(t, accumulator.IsComplete())
+			message := accumulator.Response().Message()
+			assert.Equal(t, 1, len(message.Content))
+			assert.Equal(t, tc.content, message.Content[0].Type())
+		})
+	}
 }

--- a/providers/openai/types.go
+++ b/providers/openai/types.go
@@ -19,6 +19,14 @@ const (
 const (
 	openAIReasoningSummaryMetadataKey = "openai.reasoning_summary"
 	openAIReasoningContentMetadataKey = "openai.reasoning_content"
+
+	// openAIPhaseMetadataKey carries the phase OpenAI assigned to the assistant
+	// output message a text block came from ("commentary" for intermediate
+	// updates, "final_answer" for the answer). Callers that replay history
+	// manually must resend it unchanged; dropping it degrades gpt-5.3-codex and
+	// later. Absent means OpenAI did not label the message, and Dive never
+	// infers one.
+	openAIPhaseMetadataKey = "openai.phase"
 )
 
 // // Request represents the OpenAI Responses API request structure

--- a/providers/openaicompletions/stream_iterator.go
+++ b/providers/openaicompletions/stream_iterator.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"io"
+	"sort"
 	"strings"
 	"sync"
 
@@ -32,6 +33,11 @@ type StreamIterator struct {
 	// usage chunk (stream_options.include_usage) has been consumed, so the
 	// message_delta carries the real token usage.
 	finalEvents []*llm.Event
+	// terminated records that the terminal message_delta and message_stop
+	// events have been returned, whether built from a finish_reason or
+	// synthesized at [DONE]/EOF, so a stream that signals its end more than
+	// once (finish_reason, then [DONE], then EOF) terminates exactly once.
+	terminated bool
 	// thinkingIndex and textIndex track the sequential content block index
 	// assigned to each block type, or -1 if not yet started.
 	thinkingIndex              int
@@ -100,10 +106,10 @@ func (s *StreamIterator) next() ([]*llm.Event, error) {
 	line, err := s.reader.ReadBytes('\n')
 	if err != nil {
 		// If the stream ends before a trailing usage chunk or [DONE] marker
-		// arrives, flush any deferred final events so the message still
-		// terminates with message_delta and message_stop.
+		// arrives, terminate the message here so it still ends with
+		// content_block_stop, message_delta, and message_stop.
 		if err == io.EOF {
-			if events := s.flushFinalEvents(); len(events) > 0 {
+			if events := s.endStream(); len(events) > 0 {
 				return events, nil
 			}
 		}
@@ -127,7 +133,7 @@ func (s *StreamIterator) next() ([]*llm.Event, error) {
 	line = bytes.TrimPrefix(line, []byte("data: "))
 	// Check for stream end
 	if bytes.Equal(bytes.TrimSpace(line), []byte("[DONE]")) {
-		return s.flushFinalEvents(), nil
+		return s.endStream(), nil
 	}
 	// Unmarshal the event
 	var event StreamResponse
@@ -225,28 +231,8 @@ func (s *StreamIterator) next() ([]*llm.Event, error) {
 			// Map OpenAI tool call index to a sequential display index
 			index, known := s.toolCallIndices[toolCallDelta.Index]
 			if !known {
-				// Stop any previous content blocks that are still open
-				for prevIndex, prev := range s.contentBlocks {
-					if !prev.IsComplete {
-						stopIndex := prevIndex
-						events = append(events, &llm.Event{
-							Type:  llm.EventTypeContentBlockStop,
-							Index: &stopIndex,
-						})
-						prev.IsComplete = true
-					}
-				}
-				// Stop any previous tool calls that are still open
-				for prevIndex, prev := range s.toolCalls {
-					if !prev.IsComplete {
-						stopIndex := prevIndex
-						events = append(events, &llm.Event{
-							Type:  llm.EventTypeContentBlockStop,
-							Index: &stopIndex,
-						})
-						prev.IsComplete = true
-					}
-				}
+				// Stop any previous content blocks and tool calls still open
+				events = s.closeOpenBlocks(events)
 				index = s.nextBlockIndex
 				s.nextBlockIndex++
 				s.toolCallIndices[toolCallDelta.Index] = index
@@ -308,28 +294,7 @@ func (s *StreamIterator) next() ([]*llm.Event, error) {
 		if processErr != nil {
 			return nil, processErr
 		}
-		// Stop any open content blocks
-		for index, block := range s.contentBlocks {
-			blockIndex := index
-			if !block.IsComplete {
-				events = append(events, &llm.Event{
-					Type:  llm.EventTypeContentBlockStop,
-					Index: &blockIndex,
-				})
-				block.IsComplete = true
-			}
-		}
-		// Stop any open tool calls
-		for index, toolCall := range s.toolCalls {
-			blockIndex := index
-			if !toolCall.IsComplete {
-				events = append(events, &llm.Event{
-					Type:  llm.EventTypeContentBlockStop,
-					Index: &blockIndex,
-				})
-				toolCall.IsComplete = true
-			}
-		}
+		events = s.closeOpenBlocks(events)
 		// Build the message_delta event with the stop reason, but defer it
 		// (along with message_stop) until the trailing usage chunk, [DONE]
 		// marker, or EOF, so the message_delta carries the real token usage.
@@ -448,26 +413,7 @@ func (s *StreamIterator) appendTextEvents(events []*llm.Event, text string) []*l
 	}
 	// If this is a new text block, stop any open blocks and start it.
 	if s.textIndex < 0 {
-		for prevIndex, prev := range s.contentBlocks {
-			if !prev.IsComplete {
-				stopIndex := prevIndex
-				events = append(events, &llm.Event{
-					Type:  llm.EventTypeContentBlockStop,
-					Index: &stopIndex,
-				})
-				prev.IsComplete = true
-			}
-		}
-		for prevIndex, prev := range s.toolCalls {
-			if !prev.IsComplete {
-				stopIndex := prevIndex
-				events = append(events, &llm.Event{
-					Type:  llm.EventTypeContentBlockStop,
-					Index: &stopIndex,
-				})
-				prev.IsComplete = true
-			}
-		}
+		events = s.closeOpenBlocks(events)
 		s.textIndex = s.nextBlockIndex
 		s.nextBlockIndex++
 		s.contentBlocks[s.textIndex] = &ContentBlockAccumulator{Type: "text"}
@@ -487,13 +433,42 @@ func (s *StreamIterator) appendTextEvents(events []*llm.Event, text string) []*l
 	})
 }
 
+// closeOpenBlocks appends a content_block_stop for every content block and
+// tool call still open, in block-index order, and marks each complete so it
+// closes exactly once.
+func (s *StreamIterator) closeOpenBlocks(events []*llm.Event) []*llm.Event {
+	indexes := make([]int, 0, len(s.contentBlocks)+len(s.toolCalls))
+	for index, block := range s.contentBlocks {
+		if !block.IsComplete {
+			block.IsComplete = true
+			indexes = append(indexes, index)
+		}
+	}
+	for index, toolCall := range s.toolCalls {
+		if !toolCall.IsComplete {
+			toolCall.IsComplete = true
+			indexes = append(indexes, index)
+		}
+	}
+	sort.Ints(indexes)
+	for _, index := range indexes {
+		stopIndex := index
+		events = append(events, &llm.Event{
+			Type:  llm.EventTypeContentBlockStop,
+			Index: &stopIndex,
+		})
+	}
+	return events
+}
+
 // flushFinalEvents returns the deferred message_delta and message_stop events,
 // stamping the message_delta with the most recent usage. Returns nil if there
 // are no deferred events (or they were already flushed).
 func (s *StreamIterator) flushFinalEvents() []*llm.Event {
-	if len(s.finalEvents) == 0 {
+	if s.terminated || len(s.finalEvents) == 0 {
 		return nil
 	}
+	s.terminated = true
 	events := s.finalEvents
 	s.finalEvents = nil
 	for _, event := range events {
@@ -502,6 +477,34 @@ func (s *StreamIterator) flushFinalEvents() []*llm.Event {
 		}
 	}
 	return events
+}
+
+// endStream returns the terminal events for a stream that has signaled its end
+// with [DONE] or EOF. Final events deferred by a finish_reason are flushed with
+// the latest usage. When no finish_reason ever arrived, every block still open
+// is closed and a message_delta (carrying usage, with no stop reason) and
+// message_stop are synthesized, so consumers always receive a balanced block
+// lifecycle in the content_block_stop → message_delta → message_stop order the
+// other providers emit. Returns nil once the stream has terminated, or when no
+// message was ever started.
+func (s *StreamIterator) endStream() []*llm.Event {
+	if events := s.flushFinalEvents(); len(events) > 0 {
+		return events
+	}
+	if s.terminated || s.eventCount == 0 {
+		return nil
+	}
+	s.terminated = true
+	events := s.closeOpenBlocks(nil)
+	usage := s.llmUsage()
+	return append(events,
+		&llm.Event{
+			Type:  llm.EventTypeMessageDelta,
+			Delta: &llm.EventDelta{},
+			Usage: &usage,
+		},
+		&llm.Event{Type: llm.EventTypeMessageStop},
+	)
 }
 
 func (s *StreamIterator) llmUsage() llm.Usage {

--- a/providers/openaicompletions/stream_iterator_test.go
+++ b/providers/openaicompletions/stream_iterator_test.go
@@ -358,3 +358,56 @@ func TestStreamIteratorUsageDetails(t *testing.T) {
 	assert.Equal(t, 100, response.Usage.TotalInputTokens())
 	assert.Equal(t, 30, response.Usage.ReasoningTokens)
 }
+
+// TestStreamIteratorClosesDanglingBlocks verifies that a stream ending without
+// a finish_reason — at the [DONE] marker or at EOF — still closes every block it
+// opened and terminates with message_delta then message_stop, so consumers of
+// text and tool-call streams alike see a balanced block lifecycle.
+func TestStreamIteratorClosesDanglingBlocks(t *testing.T) {
+	textChunk := `data: {"id":"chatcmpl-6","object":"chat.completion.chunk","model":"mistral-large","choices":[{"index":0,"delta":{"role":"assistant","content":"Hi"}}]}`
+	toolChunk := `data: {"id":"chatcmpl-6","object":"chat.completion.chunk","model":"mistral-large","choices":[{"index":0,"delta":{"role":"assistant","tool_calls":[{"index":0,"id":"call_1","type":"function","function":{"name":"calculator","arguments":"{\"a\":1}"}}]}}]}`
+
+	tests := []struct {
+		name    string
+		body    string
+		content llm.ContentType
+	}{
+		{name: "text at [DONE]", body: textChunk + "\n\ndata: [DONE]\n\n", content: llm.ContentTypeText},
+		{name: "text at EOF", body: textChunk + "\n\n", content: llm.ContentTypeText},
+		{name: "tool call at [DONE]", body: toolChunk + "\n\ndata: [DONE]\n\n", content: llm.ContentTypeToolUse},
+		{name: "tool call at EOF", body: toolChunk + "\n\n", content: llm.ContentTypeToolUse},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			iterator := newTestStreamIterator(tc.body)
+			defer iterator.Close()
+			events, accumulator := collectEvents(t, iterator)
+
+			var types []llm.EventType
+			starts, stops, stopIndex, deltaIndex := 0, 0, -1, -1
+			for i, event := range events {
+				types = append(types, event.Type)
+				switch event.Type {
+				case llm.EventTypeContentBlockStart:
+					starts++
+				case llm.EventTypeContentBlockStop:
+					stops++
+					stopIndex = i
+				case llm.EventTypeMessageDelta:
+					deltaIndex = i
+				}
+			}
+			assert.Equal(t, 1, starts)
+			assert.Equal(t, 1, stops)
+			assert.True(t, deltaIndex >= 0, "expected a message_delta event")
+			assert.True(t, stopIndex < deltaIndex, "content_block_stop must precede message_delta, got %v", types)
+			assert.Equal(t, llm.EventTypeMessageStop, types[len(types)-1])
+
+			// The partial block still reaches consumers as a well-formed message.
+			assert.True(t, accumulator.IsComplete())
+			message := accumulator.Response().Message()
+			assert.Equal(t, 1, len(message.Content))
+			assert.Equal(t, tc.content, message.Content[0].Type())
+		})
+	}
+}


### PR DESCRIPTION
This started as a fix for one reported bug — OpenAI's `phase` label on assistant messages was being dropped — and grew to cover a few closely related streaming problems the fix exposed. Everything here is about making sure what a model sends us survives the round trip intact: into memory, into storage, and back out on the next request or to whoever is watching the stream.

## 1. OpenAI's message "phase" is no longer lost

When a model on OpenAI's Responses API replies, it can label each message as `commentary` ("checking that now…") or `final_answer`. OpenAI's SDK docs say to send those labels back on follow-up requests and warn that dropping them can make the model perform worse. We were dropping them.

I reproduced that first — the report's non-streaming test failed on `main` exactly as described. The fix keeps the label on each text block as a small piece of provider metadata (`openai.phase`), using the same channel that already carries OpenAI reasoning state and Google thought signatures. It's read when we decode a response, written back when we replay history, and tracked while streaming.

Two design notes:

- The label lives on each text block rather than as a new `Phase` field on the shared `llm.Message` type. That's enough because we already send one output message per text block when replaying, so a commentary message, a tool call, and a final answer go back out as three separate messages, each with its own label. It also keeps an OpenAI-specific idea out of the provider-neutral core.
- Refusal content and output-message IDs/status are left alone on purpose. Refusals have no metadata field and we don't replay them anyway, so adding one would be dead weight. Echoing provider-issued message IDs back is a behavior change with its own risk and isn't needed for the label to survive — worth a separate look.

## 2. Streaming delivers the phase while the block is still open

OpenAI sometimes only tells us the phase at the end of an output item, after the text has finished streaming. Previously we had already closed the text block by then, so the label arrived too late for anyone listening to the stream. Now a text block stays open until its item is done, the phase is announced inside the block's lifetime, and we don't announce it twice if it was already known up front.

## 3. Streams that end early now close out cleanly — every provider

Pulling on that thread showed that a stream which ends abruptly — OpenAI sending `response.incomplete`, or a connection simply stopping — could leave blocks "open" with no closing event, or close them in the wrong order. Anyone consuming the stream then sees an unbalanced sequence. I audited every provider:

- **OpenAI Responses** (also used by Grok): any text, reasoning, or tool-call block still open when the response ends is now closed, and closed *before* the final `message_delta`, which is the order the other providers already use.
- **OpenAI-compatible chat completions** (used by Mistral and OpenRouter): a stream that hit `[DONE]` or end-of-input without a `finish_reason` used to emit nothing at all to finish the message — no closing events, no `message_delta`, no `message_stop`. It now closes open text and tool-call blocks and ends the message properly, exactly once.
- **Google / Gemini**: already correct. It finalizes when the stream ends rather than waiting for a finish reason, and tool calls arrive whole, so nothing can dangle. I added a test so that stays true.
- **Anthropic** (also used by Ollama): passes the API's events straight through, so there's nothing for us to close.

## 4. Compaction keeps provider metadata

When compaction shrinks an oversized text or `tool_use` block, it used to rebuild the block without its metadata — silently throwing away things like the phase label above or a Google thought signature. It now keeps them.

## Testing

- `providers/openai/phase_test.go` — 11 cases covering decode → persist → encode for both phases, streaming, a mixed commentary/tool-call/final-answer response, `Copy`, unlabeled messages, and making sure nothing leaks into other providers. Confirmed these fail without the fix rather than assuming.
- `TestStreamIteratorClosesDanglingBlocks` in the OpenAI, chat-completions, and Google stream iterator tests — one block start, one block stop, the stop before `message_delta`, `message_stop` last, and the partial content still arriving as a well-formed message. The OpenAI and chat-completions versions fail without their fixes; the Google one passes unchanged.
- A compaction test for the metadata fix and a provider-neutral persistence test in `llm/message_test.go`.
- `provider_integration_test.go` gains a live multi-turn check against GPT-5.6 (`-tags integration`, needs `OPENAI_API_KEY`) that persists a real turn, reloads it, and confirms OpenAI accepts the replayed history. I have not run this one against the live API — it needs a key and a billed call — so please run it before relying on it.

All test suites are green across every module (root, `providers/openai`, `providers/google`, `providers/grok`), plus `go vet` and `gofmt`. One heads-up: `TestToolUse` in `openaicompletions` is a live call against gpt-4o that occasionally answers with text instead of a tool call; it flaked once during my runs and passed 3/3 on retry. It doesn't touch any code in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F1eYPGBnNesvpcJiSAouxm

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Preserved OpenAI assistant message phases, including `commentary` and `final_answer`, across responses, streaming, persistence, and follow-up requests.
  * Maintained phase information for individual messages while leaving user messages and unlabeled assistant messages unchanged.

* **Bug Fixes**
  * Ensured completed streaming phases take precedence over earlier partial phase updates.

* **Tests**
  * Added coverage for phase replay, serialization, copying, streaming behavior, and provider metadata preservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
