### PR TITLE
Prepare v1.26.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [1.26.0] - 2026-08-22
+
 ### Fixed
 
 - **OpenAI Responses assistant messages keep their `phase`.** The phase

--- a/a2a/go.mod
+++ b/a2a/go.mod
@@ -6,7 +6,7 @@ toolchain go1.26.5
 
 require (
 	github.com/a2aproject/a2a-go/v2 v2.5.0
-	github.com/deepnoodle-ai/dive v1.25.1
+	github.com/deepnoodle-ai/dive v1.26.0
 	github.com/deepnoodle-ai/wonton v0.0.38
 )
 

--- a/demos/colosseum/go.mod
+++ b/demos/colosseum/go.mod
@@ -5,11 +5,11 @@ go 1.25.0
 toolchain go1.26.5
 
 require (
-	github.com/deepnoodle-ai/dive v1.25.1
-	github.com/deepnoodle-ai/dive/a2a v1.25.1
-	github.com/deepnoodle-ai/dive/providers/google v1.25.1
-	github.com/deepnoodle-ai/dive/providers/grok v1.25.1
-	github.com/deepnoodle-ai/dive/providers/openai v1.25.1
+	github.com/deepnoodle-ai/dive v1.26.0
+	github.com/deepnoodle-ai/dive/a2a v1.26.0
+	github.com/deepnoodle-ai/dive/providers/google v1.26.0
+	github.com/deepnoodle-ai/dive/providers/grok v1.26.0
+	github.com/deepnoodle-ai/dive/providers/openai v1.26.0
 	github.com/deepnoodle-ai/wonton v0.0.38
 )
 

--- a/demos/noodleville/go.mod
+++ b/demos/noodleville/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 toolchain go1.26.5
 
 require (
-	github.com/deepnoodle-ai/dive v1.25.1
+	github.com/deepnoodle-ai/dive v1.26.0
 	github.com/deepnoodle-ai/wonton v0.0.38
 )
 

--- a/docs/releases/v1.26.0.md
+++ b/docs/releases/v1.26.0.md
@@ -1,0 +1,67 @@
+## Highlights
+
+Streaming through the OpenAI-shaped providers now always ends cleanly. A
+response that stopped short — a cancelled turn, a truncated stream, or a
+chat-completions stream that hit `[DONE]` or EOF without a `finish_reason` —
+used to leave its content blocks open and never emit `message_delta` or
+`message_stop`, so `ResponseAccumulator` never saw the response as complete.
+Both the OpenAI Responses iterator and the OpenAI-compatible chat completions
+iterator (what Mistral and OpenRouter run through) now close whatever they left
+open — text, reasoning, or tool call — before the terminal events, in the same
+order Anthropic and Google already used. Grok inherits the fix; Google was
+checked, was already correct, and now has a test guarding that.
+
+Two fixes for anyone who persists conversation history and replays it manually.
+OpenAI Responses assistant messages keep their `phase` label (`commentary` or
+`final_answer`): it decodes onto each text block as `openai.phase` provider
+metadata and is sent back on follow-up requests instead of being quietly
+dropped. And compaction no longer strips provider metadata when it truncates an
+oversized text or `tool_use` block, so replay state like a Google thought
+signature or an OpenAI phase survives a compacted turn.
+
+The experimental `dive` CLI gains `--dangerously-skip-permissions` for runs that
+are already sandboxed elsewhere. The default approval flow is unchanged.
+
+Dependencies were refreshed across all eleven modules, including wonton
+v0.0.38. `github.com/openai/openai-go/v3` is deliberately held at v3.50.0 —
+v3.52.0 restructures the MCP tool-call error type and needs a real migration of
+its own. Upgrading to this release requires no changes on your side.
+
+## Pull requests
+
+- Preserve OpenAI message phase and close out partial streams cleanly across providers (#271)
+- Bump wonton from v0.0.37 to v0.0.38 and refresh dependencies across modules (#270)
+- Add dangerous permission bypass flag (#268)
+
+## Changelog
+
+### Fixed
+
+- **OpenAI Responses assistant messages keep their `phase`.** The phase
+  (`commentary` or `final_answer`) now decodes onto each text block as
+  `openai.phase` provider metadata and is replayed on follow-up requests, so
+  runtimes that persist and resend history manually no longer silently drop it.
+  Unlabeled messages stay unphased.
+- **Compaction keeps provider metadata on truncated content.** Shrinking an
+  oversized text or `tool_use` block no longer strips replay state such as a
+  Google thought signature or an OpenAI message phase.
+
+### Added
+
+- **The experimental `dive` CLI can skip tool approval prompts with
+  `--dangerously-skip-permissions`.** The default approval flow is unchanged;
+  use the bypass only in an externally sandboxed environment.
+
+### Changed
+
+- **OpenAI streaming closes a text block on its output item's done event**
+  rather than on `output_text.done`, so metadata that arrives only with the
+  done event — such as a late `phase` label — reaches consumers while the block
+  is still open. A response that ends without an item's done event now closes
+  every block it left open — text, reasoning, or tool call — before
+  `message_delta`, matching the other providers' event order.
+- **OpenAI-compatible chat completions streams always terminate cleanly.** A
+  stream that reaches `[DONE]` or EOF without a `finish_reason` — as seen
+  through Mistral and OpenRouter — now closes its open text and tool-call
+  blocks and emits `message_delta` and `message_stop`, instead of ending with
+  the message still open.

--- a/examples/go.mod
+++ b/examples/go.mod
@@ -5,13 +5,13 @@ go 1.25.5
 toolchain go1.26.5
 
 require (
-	github.com/deepnoodle-ai/dive v1.25.1
-	github.com/deepnoodle-ai/dive/a2a v1.25.1
-	github.com/deepnoodle-ai/dive/experimental/mcp v1.25.1
-	github.com/deepnoodle-ai/dive/otel v1.25.1
-	github.com/deepnoodle-ai/dive/providers/google v1.25.1
-	github.com/deepnoodle-ai/dive/providers/grok v1.25.1
-	github.com/deepnoodle-ai/dive/providers/openai v1.25.1
+	github.com/deepnoodle-ai/dive v1.26.0
+	github.com/deepnoodle-ai/dive/a2a v1.26.0
+	github.com/deepnoodle-ai/dive/experimental/mcp v1.26.0
+	github.com/deepnoodle-ai/dive/otel v1.26.0
+	github.com/deepnoodle-ai/dive/providers/google v1.26.0
+	github.com/deepnoodle-ai/dive/providers/grok v1.26.0
+	github.com/deepnoodle-ai/dive/providers/openai v1.26.0
 	github.com/deepnoodle-ai/wonton v0.0.38
 	github.com/fatih/color v1.19.0
 	github.com/mark3labs/mcp-go v0.58.0

--- a/experimental/cmd/dive/go.mod
+++ b/experimental/cmd/dive/go.mod
@@ -5,10 +5,10 @@ go 1.25.0
 toolchain go1.26.5
 
 require (
-	github.com/deepnoodle-ai/dive v1.25.1
-	github.com/deepnoodle-ai/dive/providers/google v1.25.1
-	github.com/deepnoodle-ai/dive/providers/grok v1.25.1
-	github.com/deepnoodle-ai/dive/providers/openai v1.25.1
+	github.com/deepnoodle-ai/dive v1.26.0
+	github.com/deepnoodle-ai/dive/providers/google v1.26.0
+	github.com/deepnoodle-ai/dive/providers/grok v1.26.0
+	github.com/deepnoodle-ai/dive/providers/openai v1.26.0
 	github.com/deepnoodle-ai/wonton v0.0.38
 	github.com/mattn/go-runewidth v0.0.28
 	google.golang.org/genai v1.68.0

--- a/experimental/mcp/go.mod
+++ b/experimental/mcp/go.mod
@@ -5,7 +5,7 @@ go 1.25.5
 toolchain go1.26.5
 
 require (
-	github.com/deepnoodle-ai/dive v1.25.1
+	github.com/deepnoodle-ai/dive v1.26.0
 	github.com/deepnoodle-ai/wonton v0.0.38
 	github.com/mark3labs/mcp-go v0.58.0
 )

--- a/otel/go.mod
+++ b/otel/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 toolchain go1.26.5
 
 require (
-	github.com/deepnoodle-ai/dive v1.25.1
+	github.com/deepnoodle-ai/dive v1.26.0
 	go.opentelemetry.io/otel v1.45.0
 	go.opentelemetry.io/otel/metric v1.45.0
 	go.opentelemetry.io/otel/sdk v1.45.0

--- a/providers/google/go.mod
+++ b/providers/google/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 toolchain go1.26.5
 
 require (
-	github.com/deepnoodle-ai/dive v1.25.1
+	github.com/deepnoodle-ai/dive v1.26.0
 	github.com/deepnoodle-ai/wonton v0.0.38
 	google.golang.org/genai v1.68.0
 )

--- a/providers/grok/go.mod
+++ b/providers/grok/go.mod
@@ -5,8 +5,8 @@ go 1.25.0
 toolchain go1.26.5
 
 require (
-	github.com/deepnoodle-ai/dive v1.25.1
-	github.com/deepnoodle-ai/dive/providers/openai v1.25.1
+	github.com/deepnoodle-ai/dive v1.26.0
+	github.com/deepnoodle-ai/dive/providers/openai v1.26.0
 	github.com/deepnoodle-ai/wonton v0.0.38
 	github.com/openai/openai-go/v3 v3.50.0
 	golang.org/x/image v0.45.0

--- a/providers/openai/go.mod
+++ b/providers/openai/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 toolchain go1.26.5
 
 require (
-	github.com/deepnoodle-ai/dive v1.25.1
+	github.com/deepnoodle-ai/dive v1.26.0
 	github.com/deepnoodle-ai/wonton v0.0.38
 	github.com/openai/openai-go/v3 v3.50.0
 	golang.org/x/image v0.45.0


### PR DESCRIPTION
Release prep for v1.26.0. Nothing is published by merging this — the tag and
the GitHub release come afterward.

## What's in the release

Three PRs since v1.25.1:

- **#271** — OpenAI Responses keeps the assistant message `phase`; OpenAI and
  OpenAI-compatible streams close their open blocks and emit terminal events
  even when the stream ends early; compaction stops stripping provider
  metadata off truncated blocks.
- **#270** — dependency refresh across all eleven modules (wonton v0.0.38),
  with `openai-go/v3` deliberately held at v3.50.0.
- **#268** — `--dangerously-skip-permissions` on the experimental `dive` CLI.

## Why 1.26.0 and not 1.25.2

v1.25.1 was a patch with no new API. This release adds a CLI flag and changes
the order of streaming events for OpenAI-shaped providers, so it takes the
minor bump.

## What this PR changes

- `CHANGELOG.md` — `[Unreleased]` becomes `[1.26.0] - 2026-08-22`, with a fresh
  empty `[Unreleased]` above it.
- Eleven `go.mod` files — the `github.com/deepnoodle-ai/dive` requirement (and
  the sub-module requirements) bumped to v1.26.0. Local `replace` directives
  hide a stale requirement from CI but break anyone resolving the tag, which is
  why this runs before tagging.
- `docs/releases/v1.26.0.md` — the release notes that get posted verbatim. The
  Highlights section is the part worth reviewing.

## Verification

- `make check` (release-notes tests, prettier, `go vet`, `go test`) — pass
- `go build ./...` and `go test ./...` in all ten sub-modules — pass
- `sync_module_versions.py --check` and `release_notes.py --check` — pass


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the `--dangerously-skip-permissions` command-line option.
  - Improved handling of interrupted OpenAI-compatible streaming responses.
  - Preserved OpenAI phase and provider metadata during replay and compaction.

- **Documentation**
  - Added release notes for version 1.26.0, including feature updates and improvements.

- **Chores**
  - Updated project components and examples to use version 1.26.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->