### PR TITLE
Add Claude Fable/Mythos 5.1 and correct three stale catalog prices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,36 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Added
+
+- **Claude Fable 5.1 and Mythos 5.1** — new `ModelClaudeFable51` and
+  `ModelClaudeMythos51` constants (1M context, $10/$50 per MTok). Fable 5.1
+  replaces Fable 5 in the CLI recommendations; Fable 5 and Mythos 5 remain
+  available.
+- **OpenRouter catalog picks up the current frontier ids** —
+  `anthropic/claude-fable-5.1`, `openai/gpt-5.6-sol` / `-terra` / `-luna`,
+  `google/gemini-3.7-flash`, and `x-ai/grok-4.6`.
+- **`ModelCodestral2508`** — the current Codestral release, and
+  `ModelCodestralLatest` now carries the Mistral CLI's coding recommendation.
+
+### Fixed
+
+- **Claude Sonnet 5 was priced 50% too high.** Its $2/$10 per MTok launch rate
+  became the standard price; Anthropic cancelled the increase to $3/$15 that
+  the catalog had pre-applied.
+- **Gemini 3.7 and 3.6 Flash were priced 2x too high.** Both now record the
+  $0.75/$3.75 per MTok rate billed today rather than the $1.50/$7.50 scheduled
+  for 2027-01-01. Catalogs record the price in effect, not a future one.
+- **Fable 5.1 and Mythos 5.1 cache reads bill at 0.025x base input**, not the
+  0.1x Dive derives for every other Claude model, so the $0.25 per MTok rate is
+  stated in the catalog instead of derived 4x too high.
+
+### Changed
+
+- **Mistral's Devstral models are marked deprecated.** Mistral has retired the
+  family, and `devstral-small-latest` no longer resolves upstream at all; the
+  constants remain for compatibility.
+
 ## [1.26.0] - 2026-08-22
 
 ### Fixed

--- a/docs/guides/llm-guide.md
+++ b/docs/guides/llm-guide.md
@@ -184,11 +184,14 @@ for compatibility with custom OpenAI-compatible endpoints.
 
 Newer Claude models prefer **adaptive thinking** — the model decides when and how
 much to think — with `effort` guiding depth. Opus 4.7, Opus 4.8, Sonnet 5, and
-the Fable and Mythos 5 / 5.1 models reject manual `budget_tokens`; Dive keeps
-older callers working by mapping `ReasoningBudget` to adaptive thinking on those
-models. Fable and Mythos always think and reject `thinking: {type: disabled}`,
-so Dive omits the parameter for them and rejects a forced `tool_choice`, which
-those models answer with a 400.
+the Fable and Mythos 5 / 5.1 models reject manual `budget_tokens`. On those
+models Dive keeps an existing `ReasoningBudget` caller working by emitting
+`thinking: {type: adaptive}` and omitting `budget_tokens` — the request stays
+valid, but the requested budget is dropped rather than translated, so the model
+decides the depth. Use `ReasoningEffort` to steer it instead. Fable and Mythos
+always think and reject `thinking: {type: disabled}`, so Dive omits the
+parameter for them; it also rejects a forced `tool_choice`, which Fable 5.1 and
+Mythos 5.1 answer with a 400.
 
 ```go
 ModelSettings: &dive.ModelSettings{

--- a/docs/guides/llm-guide.md
+++ b/docs/guides/llm-guide.md
@@ -183,9 +183,12 @@ for compatibility with custom OpenAI-compatible endpoints.
 ### Reasoning And Summarized Thinking On Claude
 
 Newer Claude models prefer **adaptive thinking** — the model decides when and how
-much to think — with `effort` guiding depth. Opus 4.7, Opus 4.8, Sonnet 5, Fable
-5, and Mythos 5 reject manual `budget_tokens`; Dive keeps older callers working
-by mapping `ReasoningBudget` to adaptive thinking on those models.
+much to think — with `effort` guiding depth. Opus 4.7, Opus 4.8, Sonnet 5, and
+the Fable and Mythos 5 / 5.1 models reject manual `budget_tokens`; Dive keeps
+older callers working by mapping `ReasoningBudget` to adaptive thinking on those
+models. Fable and Mythos always think and reject `thinking: {type: disabled}`,
+so Dive omits the parameter for them and rejects a forced `tool_choice`, which
+those models answer with a 400.
 
 ```go
 ModelSettings: &dive.ModelSettings{
@@ -196,7 +199,7 @@ ModelSettings: &dive.ModelSettings{
 ```
 
 `ThinkingDisplaySummarized` requests visible summarized thinking blocks. This is
-important on Sonnet 5, Fable 5, Mythos 5, Opus 4.7, and Opus 4.8, where Claude
+important on Sonnet 5, Fable 5/5.1, Mythos 5/5.1, Opus 4.7, and Opus 4.8, where Claude
 defaults to `omitted` display and returns an empty `thinking` field plus an
 encrypted signature. Dive preserves both normal `thinking` blocks and
 `redacted_thinking` blocks in responses; when continuing a tool-use turn, pass

--- a/providers/anthropic/capabilities.go
+++ b/providers/anthropic/capabilities.go
@@ -168,12 +168,18 @@ var modelCapabilityTable = []capabilityEntry{
 		thinkingOnByDefault: true,
 	}},
 	// Fable 5 and Mythos 5 always think and reject an explicit disable, so
-	// Dive omits the thinking parameter for them instead.
+	// Dive omits the thinking parameter for them instead. The 5.1 point
+	// releases behave identically here and deliberately share these entries by
+	// prefix: "claude-fable-5-1" matches "claude-fable-5", and likewise for
+	// Mythos. Their added restriction — forced tool_choice returns a 400 — is
+	// already covered, since requestThinkingBlocksForcedToolChoice rejects a
+	// forced choice for any model that always thinks and cannot be disabled.
 	{prefix: "claude-fable-5", caps: modelCapabilities{
 		efforts: effortsFull, adaptive: true, thinkingOnByDefault: true,
 	}},
-	// Mythos 5 is catalogued but not currently served (404), so its entry
-	// mirrors Fable 5 and is untested against the live API.
+	// Mythos 5 and 5.1 are catalogued but reachable only through Anthropic's
+	// limited-availability program, so these values mirror Fable and are
+	// untested against the live API.
 	{prefix: "claude-mythos-5", caps: modelCapabilities{
 		efforts: effortsFull, adaptive: true, thinkingOnByDefault: true,
 	}},

--- a/providers/anthropic/capabilities_test.go
+++ b/providers/anthropic/capabilities_test.go
@@ -140,3 +140,29 @@ func TestUnknownModelKeepsParametersUntouched(t *testing.T) {
 	req := buildReq(t, "my-proxy-claude", llm.WithTemperature(0.5))
 	assert.NotNil(t, req.Temperature)
 }
+
+// The 5.1 point releases have no entry of their own and inherit the Fable and
+// Mythos ones by prefix. Landing on *an* entry is not enough — a wrong match
+// would hand them explicitDisable or a manual budget, both of which the API
+// answers with a 400 — so pin the classification they actually resolve to.
+func TestFableAndMythos51InheritTheirFamilyEntries(t *testing.T) {
+	for _, model := range []string{ModelClaudeFable51, ModelClaudeMythos51} {
+		t.Run(model, func(t *testing.T) {
+			caps, known := lookupCapabilities(model)
+			assert.True(t, known)
+			assert.Equal(t, reasoningNative, caps.reasoningKind())
+			assert.True(t, caps.adaptive)
+			assert.True(t, caps.thinkingOnByDefault)
+			assert.False(t, caps.explicitDisable, "5.1 rejects thinking:{type:disabled}")
+			assert.False(t, caps.manualBudget, "5.1 rejects budget_tokens")
+			assert.False(t, caps.temperature, "5.1 rejects temperature")
+		})
+	}
+}
+
+// Forced tool_choice returns a 400 on Fable 5.1 and Mythos 5.1. Dive rejects it
+// before the request leaves, via the always-thinking classification above.
+func TestForcedToolChoiceRejectedOnFable51(t *testing.T) {
+	assert.True(t, requestThinkingBlocksForcedToolChoice(ModelClaudeFable51, nil))
+	assert.True(t, requestThinkingBlocksForcedToolChoice(ModelClaudeMythos51, nil))
+}

--- a/providers/anthropic/catalog.json
+++ b/providers/anthropic/catalog.json
@@ -152,14 +152,28 @@
       "description": "Complex agentic coding and long-horizon work"
     },
     {
+      "go_name": "ModelClaudeFable51",
+      "id": "claude-fable-5-1",
+      "kind": "text",
+      "context_window": 1000000,
+      "display_name": "Fable 5.1",
+      "recommended": true,
+      "cli_order": 2,
+      "description": "Most capable for demanding reasoning and long-horizon agentic work"
+    },
+    {
+      "go_name": "ModelClaudeMythos51",
+      "id": "claude-mythos-5-1",
+      "kind": "text",
+      "context_window": 1000000,
+      "display_name": "Mythos 5.1"
+    },
+    {
       "go_name": "ModelClaudeFable5",
       "id": "claude-fable-5",
       "kind": "text",
       "context_window": 1000000,
-      "display_name": "Fable 5",
-      "recommended": true,
-      "cli_order": 2,
-      "description": "Most capable for the hardest reasoning, at premium pricing"
+      "display_name": "Fable 5"
     },
     {
       "go_name": "ModelClaudeMythos5",
@@ -281,6 +295,23 @@
         "updated_at": "2026-08-09"
       },
       {
+        "model": "claude-fable-5-1",
+        "input_price_per_1m_tokens": "10.00",
+        "output_price_per_1m_tokens": "50.00",
+        "cache_read_price_per_1m_tokens": "0.25",
+        "currency": "USD",
+        "updated_at": "2026-09-01",
+        "note": "Cache hits bill at 0.025x base input on Fable 5.1 and Mythos 5.1, not the 0.1x every other Claude model uses, so the rate is stated rather than derived."
+      },
+      {
+        "model": "claude-mythos-5-1",
+        "input_price_per_1m_tokens": "10.00",
+        "output_price_per_1m_tokens": "50.00",
+        "cache_read_price_per_1m_tokens": "0.25",
+        "currency": "USD",
+        "updated_at": "2026-09-01"
+      },
+      {
         "model": "claude-fable-5",
         "input_price_per_1m_tokens": "10.00",
         "output_price_per_1m_tokens": "50.00",
@@ -296,11 +327,11 @@
       },
       {
         "model": "claude-sonnet-5",
-        "input_price_per_1m_tokens": "3.00",
-        "output_price_per_1m_tokens": "15.00",
+        "input_price_per_1m_tokens": "2.00",
+        "output_price_per_1m_tokens": "10.00",
         "currency": "USD",
-        "updated_at": "2026-06-30",
-        "note": "Sonnet 5 standard pricing. Introductory rates of $2/$10 per MTok are in effect through 2026-08-31; we use the long-term $3/$15 rates here to avoid a silent price cliff when the introductory period ends."
+        "updated_at": "2026-09-01",
+        "note": "$2/$10 per MTok launched as introductory pricing through 2026-08-31 and is now the standard price; Anthropic cancelled the scheduled increase to $3/$15."
       }
     ],
     "fast_text": [

--- a/providers/anthropic/cost_test.go
+++ b/providers/anthropic/cost_test.go
@@ -56,3 +56,27 @@ func TestWithCachePricing(t *testing.T) {
 	assert.Equal(t, 0.4, out.CacheReadPrice)
 	assert.Equal(t, 5.0, out.CacheWritePrice)
 }
+
+// Fable 5.1 and Mythos 5.1 bill cache hits at 0.025x base input, not the 0.1x
+// every other Claude model uses. The catalog states that rate outright; this
+// pins that withCachePricing leaves it alone instead of deriving over it.
+func TestFable51CacheReadPricingIsNotDerived(t *testing.T) {
+	for _, model := range []string{ModelClaudeFable51, ModelClaudeMythos51} {
+		t.Run(model, func(t *testing.T) {
+			p, ok := providers.PricingFor(model, false)
+			assert.True(t, ok, "pricing should be registered")
+			assert.Equal(t, 10.0, p.InputPrice)
+			assert.Equal(t, 50.0, p.OutputPrice)
+			assert.Equal(t, 0.25, p.CacheReadPrice)   // 0.025x input, not 1.0
+			assert.Equal(t, 12.50, p.CacheWritePrice) // 1.25x input, as everywhere
+		})
+	}
+}
+
+func TestSonnet5StandardPricing(t *testing.T) {
+	p, ok := providers.PricingFor(ModelClaudeSonnet5, false)
+	assert.True(t, ok, "Sonnet 5 pricing should be registered")
+	assert.Equal(t, 2.0, p.InputPrice)
+	assert.Equal(t, 10.0, p.OutputPrice)
+	assert.Equal(t, 0.2, p.CacheReadPrice)
+}

--- a/providers/anthropic/models_gen.go
+++ b/providers/anthropic/models_gen.go
@@ -20,6 +20,8 @@ const (
 	ModelClaudeOpus47           = "claude-opus-4-7"
 	ModelClaudeOpus48           = "claude-opus-4-8"
 	ModelClaudeOpus5            = "claude-opus-5"
+	ModelClaudeFable51          = "claude-fable-5-1"
+	ModelClaudeMythos51         = "claude-mythos-5-1"
 	ModelClaudeFable5           = "claude-fable-5"
 	ModelClaudeMythos5          = "claude-mythos-5"
 	ModelClaudeSonnet5          = "claude-sonnet-5"

--- a/providers/anthropic/pricing_gen.go
+++ b/providers/anthropic/pricing_gen.go
@@ -104,6 +104,23 @@ var TextModelPricing = map[string]llm.PricingInfo{
 		Currency:    "USD",
 		UpdatedAt:   "2026-08-09",
 	},
+	// Cache hits bill at 0.025x base input on Fable 5.1 and Mythos 5.1, not the 0.1x every other Claude model uses, so the rate is stated rather than derived.
+	ModelClaudeFable51: {
+		Model:          ModelClaudeFable51,
+		InputPrice:     10.00,
+		OutputPrice:    50.00,
+		CacheReadPrice: 0.25,
+		Currency:       "USD",
+		UpdatedAt:      "2026-09-01",
+	},
+	ModelClaudeMythos51: {
+		Model:          ModelClaudeMythos51,
+		InputPrice:     10.00,
+		OutputPrice:    50.00,
+		CacheReadPrice: 0.25,
+		Currency:       "USD",
+		UpdatedAt:      "2026-09-01",
+	},
 	ModelClaudeFable5: {
 		Model:       ModelClaudeFable5,
 		InputPrice:  10.00,
@@ -118,13 +135,13 @@ var TextModelPricing = map[string]llm.PricingInfo{
 		Currency:    "USD",
 		UpdatedAt:   "2026-06-09",
 	},
-	// Sonnet 5 standard pricing. Introductory rates of $2/$10 per MTok are in effect through 2026-08-31; we use the long-term $3/$15 rates here to avoid a silent price cliff when the introductory period ends.
+	// $2/$10 per MTok launched as introductory pricing through 2026-08-31 and is now the standard price; Anthropic cancelled the scheduled increase to $3/$15.
 	ModelClaudeSonnet5: {
 		Model:       ModelClaudeSonnet5,
-		InputPrice:  3.00,
-		OutputPrice: 15.00,
+		InputPrice:  2.00,
+		OutputPrice: 10.00,
 		Currency:    "USD",
-		UpdatedAt:   "2026-06-30",
+		UpdatedAt:   "2026-09-01",
 	},
 }
 

--- a/providers/anthropic/register.go
+++ b/providers/anthropic/register.go
@@ -34,6 +34,10 @@ func registerPricing() {
 // input price: cache reads bill at 0.1x, and cache writes at the default
 // 5-minute TTL bill at 1.25x. (The 1-hour TTL is 2x, but usage does not carry
 // a per-TTL split, so the default rate is used.)
+//
+// Only zero fields are filled, so a model whose published rate departs from the
+// multipliers states it in catalog.json instead: Fable 5.1 and Mythos 5.1 bill
+// cache reads at 0.025x, and deriving 0.1x there would overcharge by 4x.
 func withCachePricing(p llm.PricingInfo) llm.PricingInfo {
 	if p.CacheReadPrice == 0 {
 		p.CacheReadPrice = p.InputPrice * 0.10

--- a/providers/google/catalog.json
+++ b/providers/google/catalog.json
@@ -230,19 +230,21 @@
     "text": [
       {
         "model": "gemini-3.7-flash",
-        "input_price_per_1m_tokens": "1.50",
-        "output_price_per_1m_tokens": "7.50",
-        "cache_read_price_per_1m_tokens": "0.15",
+        "input_price_per_1m_tokens": "0.75",
+        "output_price_per_1m_tokens": "3.75",
+        "cache_read_price_per_1m_tokens": "0.075",
         "currency": "USD",
-        "updated_at": "2026-08-15"
+        "updated_at": "2026-09-01",
+        "note": "Rates billed today. Google lists a scheduled increase to $1.50/$7.50 ($0.15 cache read) on 2027-01-01; revisit then."
       },
       {
         "model": "gemini-3.6-flash",
-        "input_price_per_1m_tokens": "1.50",
-        "output_price_per_1m_tokens": "7.50",
-        "cache_read_price_per_1m_tokens": "0.15",
+        "input_price_per_1m_tokens": "0.75",
+        "output_price_per_1m_tokens": "3.75",
+        "cache_read_price_per_1m_tokens": "0.075",
         "currency": "USD",
-        "updated_at": "2026-07-21"
+        "updated_at": "2026-09-01",
+        "note": "Rates billed today. Google lists a scheduled increase to $1.50/$7.50 ($0.15 cache read) on 2027-01-01; revisit then."
       },
       {
         "model": "gemini-3.5-flash",

--- a/providers/google/cost_test.go
+++ b/providers/google/cost_test.go
@@ -10,8 +10,8 @@ import (
 
 func TestGoogleCacheReadPricingCoverage(t *testing.T) {
 	expected := map[string]float64{
-		ModelGemini37Flash:                 0.15,
-		ModelGemini36Flash:                 0.15,
+		ModelGemini37Flash:                 0.075,
+		ModelGemini36Flash:                 0.075,
 		ModelGemini35Flash:                 0.15,
 		ModelGemini35FlashLite:             0.03,
 		ModelGemini31ProPreview:            0.20,

--- a/providers/google/models_test.go
+++ b/providers/google/models_test.go
@@ -14,7 +14,7 @@ func TestLatestGeminiFlashModels(t *testing.T) {
 		inputPrice  float64
 		outputPrice float64
 	}{
-		{ModelGemini37Flash, "gemini-3.7-flash", 1.50, 7.50},
+		{ModelGemini37Flash, "gemini-3.7-flash", 0.75, 3.75},
 		{ModelGemini35FlashLite, "gemini-3.5-flash-lite", 0.30, 2.50},
 	}
 

--- a/providers/google/pricing_gen.go
+++ b/providers/google/pricing_gen.go
@@ -6,21 +6,23 @@ import "github.com/deepnoodle-ai/dive/llm"
 
 // TextModelPricing is generated from catalog.json.
 var TextModelPricing = map[string]llm.PricingInfo{
+	// Rates billed today. Google lists a scheduled increase to $1.50/$7.50 ($0.15 cache read) on 2027-01-01; revisit then.
 	ModelGemini37Flash: {
 		Model:          ModelGemini37Flash,
-		InputPrice:     1.50,
-		OutputPrice:    7.50,
-		CacheReadPrice: 0.15,
+		InputPrice:     0.75,
+		OutputPrice:    3.75,
+		CacheReadPrice: 0.075,
 		Currency:       "USD",
-		UpdatedAt:      "2026-08-15",
+		UpdatedAt:      "2026-09-01",
 	},
+	// Rates billed today. Google lists a scheduled increase to $1.50/$7.50 ($0.15 cache read) on 2027-01-01; revisit then.
 	ModelGemini36Flash: {
 		Model:          ModelGemini36Flash,
-		InputPrice:     1.50,
-		OutputPrice:    7.50,
-		CacheReadPrice: 0.15,
+		InputPrice:     0.75,
+		OutputPrice:    3.75,
+		CacheReadPrice: 0.075,
 		Currency:       "USD",
-		UpdatedAt:      "2026-07-21",
+		UpdatedAt:      "2026-09-01",
 	},
 	ModelGemini35Flash: {
 		Model:                    ModelGemini35Flash,

--- a/providers/mistral/catalog.json
+++ b/providers/mistral/catalog.json
@@ -88,13 +88,15 @@
       "go_name": "ModelDevstral2",
       "id": "devstral-2512",
       "kind": "text",
-      "context_window": 128000
+      "context_window": 128000,
+      "deprecated": "Mistral has retired the Devstral family; use ModelCodestralLatest for coding."
     },
     {
       "go_name": "ModelDevstralSmall2",
       "id": "labs-devstral-small-2512",
       "kind": "text",
-      "context_window": 128000
+      "context_window": 128000,
+      "deprecated": "Mistral has retired the Devstral family; use ModelCodestralLatest for coding."
     },
     {
       "go_name": "ModelDevstralSmallLatest",
@@ -102,14 +104,24 @@
       "kind": "text",
       "context_window": 128000,
       "display_name": "Devstral Small",
+      "deprecated": "Mistral no longer serves or documents this alias; use ModelCodestralLatest for coding."
+    },
+    {
+      "go_name": "ModelCodestralLatest",
+      "id": "codestral-latest",
+      "kind": "text",
+      "context_window": 128000,
+      "display_name": "Codestral",
       "recommended": true,
       "cli_order": 3,
       "description": "Optimized for coding tasks"
     },
     {
-      "go_name": "ModelCodestralLatest",
-      "id": "codestral-latest",
-      "kind": "text"
+      "go_name": "ModelCodestral2508",
+      "id": "codestral-2508",
+      "kind": "text",
+      "context_window": 128000,
+      "display_name": "Codestral 25.08"
     },
     {
       "go_name": "ModelCodestral2501",

--- a/providers/mistral/models_gen.go
+++ b/providers/mistral/models_gen.go
@@ -3,18 +3,22 @@
 package mistral
 
 const (
-	ModelMistralMedium       = "mistral-medium-latest"
-	ModelMistralLarge3       = "mistral-large-2512"
-	ModelMistralLarge        = "mistral-large-latest"
-	ModelMistralLarge2411    = "mistral-large-2411"
-	ModelMistralSmall        = "mistral-small-latest"
-	ModelMinistral3_14B      = "ministral-14b-2512"
-	ModelMinistral3_8B       = "ministral-8b-2512"
-	ModelMinistral3_3B       = "ministral-3b-2512"
-	ModelDevstral2           = "devstral-2512"
-	ModelDevstralSmall2      = "labs-devstral-small-2512"
+	ModelMistralMedium    = "mistral-medium-latest"
+	ModelMistralLarge3    = "mistral-large-2512"
+	ModelMistralLarge     = "mistral-large-latest"
+	ModelMistralLarge2411 = "mistral-large-2411"
+	ModelMistralSmall     = "mistral-small-latest"
+	ModelMinistral3_14B   = "ministral-14b-2512"
+	ModelMinistral3_8B    = "ministral-8b-2512"
+	ModelMinistral3_3B    = "ministral-3b-2512"
+	// Deprecated: Mistral has retired the Devstral family; use ModelCodestralLatest for coding.
+	ModelDevstral2 = "devstral-2512"
+	// Deprecated: Mistral has retired the Devstral family; use ModelCodestralLatest for coding.
+	ModelDevstralSmall2 = "labs-devstral-small-2512"
+	// Deprecated: Mistral no longer serves or documents this alias; use ModelCodestralLatest for coding.
 	ModelDevstralSmallLatest = "devstral-small-latest"
 	ModelCodestralLatest     = "codestral-latest"
+	ModelCodestral2508       = "codestral-2508"
 	ModelCodestral2501       = "codestral-2501"
 	ModelCodestralMamba      = "open-codestral-mamba"
 	ModelMistral7B           = "open-mistral-7b"

--- a/providers/openrouter/catalog.json
+++ b/providers/openrouter/catalog.json
@@ -16,6 +16,13 @@
   ],
   "models": [
     {
+      "go_name": "ModelClaudeFable51",
+      "id": "anthropic/claude-fable-5.1",
+      "kind": "text",
+      "context_window": 1000000,
+      "display_name": "Fable 5.1"
+    },
+    {
       "go_name": "ModelClaudeFable5",
       "id": "anthropic/claude-fable-5",
       "kind": "text",
@@ -97,6 +104,27 @@
       "id": "anthropic/claude-sonnet-4",
       "kind": "text",
       "context_window": 1000000
+    },
+    {
+      "go_name": "ModelGPT56Sol",
+      "id": "openai/gpt-5.6-sol",
+      "kind": "text",
+      "context_window": 1050000,
+      "display_name": "GPT-5.6 Sol"
+    },
+    {
+      "go_name": "ModelGPT56Terra",
+      "id": "openai/gpt-5.6-terra",
+      "kind": "text",
+      "context_window": 1050000,
+      "display_name": "GPT-5.6 Terra"
+    },
+    {
+      "go_name": "ModelGPT56Luna",
+      "id": "openai/gpt-5.6-luna",
+      "kind": "text",
+      "context_window": 1050000,
+      "display_name": "GPT-5.6 Luna"
     },
     {
       "go_name": "ModelGPT55",
@@ -188,6 +216,13 @@
       "display_name": "o4-mini"
     },
     {
+      "go_name": "ModelGemini37Flash",
+      "id": "google/gemini-3.7-flash",
+      "kind": "text",
+      "context_window": 1048576,
+      "display_name": "Gemini 3.7 Flash"
+    },
+    {
       "go_name": "ModelGemini31ProPreview",
       "id": "google/gemini-3.1-pro-preview",
       "kind": "text",
@@ -222,6 +257,13 @@
       "kind": "text",
       "context_window": 1000000,
       "display_name": "Gemini 2.5 Flash"
+    },
+    {
+      "go_name": "ModelGrok46",
+      "id": "x-ai/grok-4.6",
+      "kind": "text",
+      "context_window": 500000,
+      "display_name": "Grok 4.6"
     },
     {
       "go_name": "ModelGrok45",

--- a/providers/openrouter/models_gen.go
+++ b/providers/openrouter/models_gen.go
@@ -3,6 +3,7 @@
 package openrouter
 
 const (
+	ModelClaudeFable51      = "anthropic/claude-fable-5.1"
 	ModelClaudeFable5       = "anthropic/claude-fable-5"
 	ModelClaudeSonnet5      = "anthropic/claude-sonnet-5"
 	ModelClaudeOpus5        = "anthropic/claude-opus-5"
@@ -15,6 +16,9 @@ const (
 	ModelClaudeHaiku45      = "anthropic/claude-haiku-4.5"
 	ModelClaudeOpus41       = "anthropic/claude-opus-4.1"
 	ModelClaudeSonnet4      = "anthropic/claude-sonnet-4"
+	ModelGPT56Sol           = "openai/gpt-5.6-sol"
+	ModelGPT56Terra         = "openai/gpt-5.6-terra"
+	ModelGPT56Luna          = "openai/gpt-5.6-luna"
 	ModelGPT55              = "openai/gpt-5.5"
 	ModelGPT54              = "openai/gpt-5.4"
 	ModelGPT54Mini          = "openai/gpt-5.4-mini"
@@ -28,12 +32,14 @@ const (
 	ModelO3                 = "openai/o3"
 	ModelO3Pro              = "openai/o3-pro"
 	ModelO4Mini             = "openai/o4-mini"
+	ModelGemini37Flash      = "google/gemini-3.7-flash"
 	ModelGemini31ProPreview = "google/gemini-3.1-pro-preview"
 	// Deprecated: Model was shut down March 9, 2026.
 	ModelGemini3ProPreview   = "google/gemini-3-pro-preview"
 	ModelGemini3FlashPreview = "google/gemini-3-flash-preview"
 	ModelGemini25Pro         = "google/gemini-2.5-pro"
 	ModelGemini25Flash       = "google/gemini-2.5-flash"
+	ModelGrok46              = "x-ai/grok-4.6"
 	ModelGrok45              = "x-ai/grok-4.5"
 	ModelGrok43              = "x-ai/grok-4.3"
 	ModelGrokBuild01         = "x-ai/grok-build-0.1"


### PR DESCRIPTION
Worked the [provider watch](https://github.com/deepnoodle-ai/dive/issues/269) signals that affect models Dive users actually reach. Every price below was verified against the provider's own pricing page today.

## New models

| Provider | Added |
| --- | --- |
| Anthropic | `claude-fable-5-1`, `claude-mythos-5-1` (1M context, $10/$50 per MTok) |
| OpenRouter | `anthropic/claude-fable-5.1`, `openai/gpt-5.6-sol` / `-terra` / `-luna`, `google/gemini-3.7-flash`, `x-ai/grok-4.6` |
| Mistral | `codestral-2508` |

Fable 5.1 takes Fable 5's CLI recommendation slot and `codestral-latest` takes Devstral's; Fable 5 and Mythos 5 stay catalogued.

Neither 5.1 id needs its own `modelCapabilityTable` entry — they inherit the Fable and Mythos ones by prefix, which is the right classification (always thinking, no explicit disable, no manual budget, no temperature) and already makes Dive reject the forced `tool_choice` that both models answer with a 400. Tests pin that resolution, since landing on *an* entry is not the same as landing on the right one.

## Pricing fixes

Three of these were real over-charges in `Usage.Cost`:

- **Sonnet 5 billed 50% high.** The catalog pre-applied a scheduled increase to $3/$15 to avoid a "silent price cliff" on 2026-09-01. Anthropic has since cancelled that increase and made $2/$10 the standard price, so the cliff never came and the pre-application was simply wrong for two months.
- **Gemini 3.7 and 3.6 Flash billed 2x high** — the same defect from the other direction, recording the $1.50/$7.50 rate scheduled for 2027-01-01 instead of the $0.75/$3.75 billed today. Now the rate in effect, with the future increase noted in the row rather than pre-applied.
- **Fable 5.1 / Mythos 5.1 cache reads bill at 0.025x base input**, not the 0.1x every other Claude model uses. `registerPricing` derives the 0.1x default, so the $0.25 per MTok rate is stated in `catalog.json` instead of being derived 4x too high.

The consistent rule these settle on: a catalog records the price in effect, not a scheduled future one.

## Deprecations

Mistral has retired the entire Devstral family, and `devstral-small-latest` — which the CLI was recommending — no longer appears in any upstream listing at all (this is the watcher's one `model_not_found_upstream`). The constants stay for compatibility, now marked `Deprecated`.

## Deliberately not done

The watcher also flags Google's `gemini-3.5-transcribe` / `-live` / `gemini-omni-1.1-flash`, Vertex's `gpt-oss-*`, Mistral's `mistral-ocr-4*`, and a long tail of OpenRouter `:batch` variants. Those are transcription, OCR, and batch surfaces Dive has no adapter for, so they stay out.

I also left `scripts/provider_watch_baseline.json.gz` alone. Refreshing it would accept all ~200 observed changes, including the ones above that nothing has acted on — that seems like your call, not a side effect of this PR.

## Verification

`make check` passes (catalog check, watcher tests, release-notes tests, fmt, vet, test), plus `go vet` and `go test` in every sub-module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VrkvCYYhsCJjeKfMcuaNLf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Claude Fable 5.1, Mythos 5.1, Codestral 2508, and new OpenRouter models, including GPT-5.6 variants, Gemini 3.7 Flash, and Grok 4.6.
  * Added reasoning behavior support and documentation for Claude Fable 5.1 and Mythos 5.1.
* **Pricing Updates**
  * Corrected pricing for Claude Sonnet 5 and Gemini Flash models.
  * Added model-specific cache pricing for Claude Fable 5.1 and Mythos 5.1.
* **Deprecations**
  * Marked Mistral Devstral models as deprecated and updated coding model recommendations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->