### PR TITLE
Prepare v1.27.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [1.27.0] - 2026-09-02
+
 ### Added
 
 - **Gemini 3.8 Flash** — new `google.ModelGemini38Flash` (1M context,

--- a/a2a/go.mod
+++ b/a2a/go.mod
@@ -6,7 +6,7 @@ toolchain go1.26.8
 
 require (
 	github.com/a2aproject/a2a-go/v2 v2.5.0
-	github.com/deepnoodle-ai/dive v1.26.0
+	github.com/deepnoodle-ai/dive v1.27.0
 	github.com/deepnoodle-ai/wonton v0.0.39
 )
 

--- a/demos/colosseum/go.mod
+++ b/demos/colosseum/go.mod
@@ -5,11 +5,11 @@ go 1.26.0
 toolchain go1.26.8
 
 require (
-	github.com/deepnoodle-ai/dive v1.26.0
-	github.com/deepnoodle-ai/dive/a2a v1.26.0
-	github.com/deepnoodle-ai/dive/providers/google v1.26.0
-	github.com/deepnoodle-ai/dive/providers/grok v1.26.0
-	github.com/deepnoodle-ai/dive/providers/openai v1.26.0
+	github.com/deepnoodle-ai/dive v1.27.0
+	github.com/deepnoodle-ai/dive/a2a v1.27.0
+	github.com/deepnoodle-ai/dive/providers/google v1.27.0
+	github.com/deepnoodle-ai/dive/providers/grok v1.27.0
+	github.com/deepnoodle-ai/dive/providers/openai v1.27.0
 	github.com/deepnoodle-ai/wonton v0.0.39
 )
 

--- a/demos/noodleville/go.mod
+++ b/demos/noodleville/go.mod
@@ -5,7 +5,7 @@ go 1.26.0
 toolchain go1.26.8
 
 require (
-	github.com/deepnoodle-ai/dive v1.26.0
+	github.com/deepnoodle-ai/dive v1.27.0
 	github.com/deepnoodle-ai/wonton v0.0.39
 )
 

--- a/docs/releases/v1.27.0.md
+++ b/docs/releases/v1.27.0.md
@@ -1,0 +1,92 @@
+## Highlights
+
+**This release requires Go 1.26.** All eleven modules moved their `go`
+directive from 1.25.0 to 1.26.0, so consumers on Go 1.25 need to upgrade before
+taking v1.27.0. `google.golang.org/api` v0.297.0 is what forced the floor, and
+raising it unblocked a dependency refresh across every module that had been
+held back — openai-go to v3.55.0, genai to v1.71.0, mcp-go to v1.0.0, glob to
+v1.0.0. The pinned toolchain also moved to go1.26.8, which clears six Go
+standard library advisories that were reachable from Dive's own code and that
+nothing was tracking, because Dependabot does not scan the toolchain pin.
+
+**Three model prices in the catalog were wrong, and two of them were
+overcharging.** If you read `Usage.Cost`, your numbers were high: Claude Sonnet
+5 by 50%, Gemini 3.7 and 3.6 Flash by 2x. Both defects came from the same
+habit of pre-applying a scheduled price change — Anthropic then cancelled its
+increase, and Google's is not until 2027. The catalog now records the price in
+effect and notes future changes in the row instead of applying them early.
+Fable 5.1 and Mythos 5.1 cache reads are stated rather than derived, since they
+bill at 0.025x base input rather than the 0.1x every other Claude model uses.
+
+**A 403 from Grok stopped reporting why.** openai-go v3.51 quit parsing the
+bare-string `error` member that xAI returns, so a response like "your team has
+used all available credits" surfaced as a raw `json.UnmarshalTypeError` — no
+status code, no message, and no retry classification. A response middleware now
+normalizes that shape before the SDK sees it. Standard-shaped error bodies are
+untouched.
+
+**Gemini 3.8 Flash is the new `google.DefaultModel`**, alongside new constants
+for Claude Fable 5.1 and Mythos 5.1, Gemini's transcribe and omni ids, and
+Codestral 2508. If you rely on the default rather than naming a model, this
+release changes which one you get; 3.7 Flash stays catalogued and is one
+constant away. Mistral's Devstral family is marked deprecated — Mistral retired
+it upstream, and `devstral-small-latest` no longer resolves at all.
+
+## Pull requests
+
+- Add Gemini 3.8 Flash, move to Go 1.26, and refresh every dependency and toolchain (#276)
+- Add Claude Fable/Mythos 5.1 and correct three stale catalog prices (#274)
+
+## Changelog
+
+### Added
+
+- **Gemini 3.8 Flash** — new `google.ModelGemini38Flash` (1M context,
+  $0.75/$3.75 per MTok). It becomes `google.DefaultModel` and takes Gemini 3.7
+  Flash's CLI recommendation slot; 3.7 Flash remains catalogued. OpenRouter
+  picks up `google/gemini-3.8-flash`.
+- **Gemini 3.5 Transcribe, Transcribe Live, and Omni 1.1 Flash** —
+  `ModelGemini35Transcribe`, `ModelGemini35TranscribeLive`, and
+  `ModelGeminiOmni11Flash` for Google's new speech-to-text and video models.
+- **Claude Fable 5.1 and Mythos 5.1** — new `ModelClaudeFable51` and
+  `ModelClaudeMythos51` constants (1M context, $10/$50 per MTok). Fable 5.1
+  replaces Fable 5 in the CLI recommendations; Fable 5 and Mythos 5 remain
+  available.
+- **OpenRouter catalog picks up the current frontier ids** —
+  `anthropic/claude-fable-5.1`, `openai/gpt-5.6-sol` / `-terra` / `-luna`,
+  `google/gemini-3.7-flash`, and `x-ai/grok-4.6`.
+- **`ModelCodestral2508`** — the current Codestral release, and
+  `ModelCodestralLatest` now carries the Mistral CLI's coding recommendation.
+
+### Fixed
+
+- **Claude Sonnet 5 was priced 50% too high.** Its $2/$10 per MTok launch rate
+  became the standard price; Anthropic cancelled the increase to $3/$15 that
+  the catalog had pre-applied.
+- **Gemini 3.7 and 3.6 Flash were priced 2x too high.** Both now record the
+  $0.75/$3.75 per MTok rate billed today rather than the $1.50/$7.50 scheduled
+  for 2027-01-01. Catalogs record the price in effect, not a future one.
+- **Fable 5.1 and Mythos 5.1 cache reads bill at 0.025x base input**, not the
+  0.1x Dive derives for every other Claude model, so the $0.25 per MTok rate is
+  stated in the catalog instead of derived 4x too high.
+- **OpenAI-compatible error bodies with a bare-string `error` member keep their
+  status code and message.** openai-go v3.51 stopped parsing the xAI/Grok shape
+  `{"code":...,"error":"<message>"}` into an SDK error at all, surfacing a raw
+  `json.UnmarshalTypeError` instead; a 403 for exhausted credits lost both its
+  status and its reason, and no longer classified for retry.
+
+### Changed
+
+- **Dive now requires Go 1.26.** All 11 modules moved from `go 1.25.0` to
+  `go 1.26.0`, and the pinned toolchain from go1.26.5 to go1.26.8, which clears
+  six Go standard library advisories (`net/http`, `crypto/tls`, `net/url`,
+  `encoding/asn1`, `encoding/xml`, `html/template`). `govulncheck` now reports
+  zero vulnerabilities across every module.
+- **Dependencies refreshed across every module.** Notably
+  `google.golang.org/genai` v1.68.0 → v1.71.0, `google.golang.org/api` v0.293.0
+  → v0.297.0, `openai/openai-go/v3` v3.50.0 → v3.55.0 (the v3.51 hold is
+  lifted), `mark3labs/mcp-go` v0.58.0 → v1.0.0, `gobwas/glob` v0.2.3 → v1.0.0,
+  `wonton` v0.0.38 → v0.0.39, and OpenTelemetry v1.45.0 → v1.46.0.
+- **Mistral's Devstral models are marked deprecated.** Mistral has retired the
+  family, and `devstral-small-latest` no longer resolves upstream at all; the
+  constants remain for compatibility.

--- a/examples/go.mod
+++ b/examples/go.mod
@@ -5,13 +5,13 @@ go 1.26.0
 toolchain go1.26.8
 
 require (
-	github.com/deepnoodle-ai/dive v1.26.0
-	github.com/deepnoodle-ai/dive/a2a v1.26.0
-	github.com/deepnoodle-ai/dive/experimental/mcp v1.26.0
-	github.com/deepnoodle-ai/dive/otel v1.26.0
-	github.com/deepnoodle-ai/dive/providers/google v1.26.0
-	github.com/deepnoodle-ai/dive/providers/grok v1.26.0
-	github.com/deepnoodle-ai/dive/providers/openai v1.26.0
+	github.com/deepnoodle-ai/dive v1.27.0
+	github.com/deepnoodle-ai/dive/a2a v1.27.0
+	github.com/deepnoodle-ai/dive/experimental/mcp v1.27.0
+	github.com/deepnoodle-ai/dive/otel v1.27.0
+	github.com/deepnoodle-ai/dive/providers/google v1.27.0
+	github.com/deepnoodle-ai/dive/providers/grok v1.27.0
+	github.com/deepnoodle-ai/dive/providers/openai v1.27.0
 	github.com/deepnoodle-ai/wonton v0.0.39
 	github.com/fatih/color v1.19.0
 	github.com/mark3labs/mcp-go v1.0.0

--- a/experimental/cmd/dive/go.mod
+++ b/experimental/cmd/dive/go.mod
@@ -5,10 +5,10 @@ go 1.26.0
 toolchain go1.26.8
 
 require (
-	github.com/deepnoodle-ai/dive v1.26.0
-	github.com/deepnoodle-ai/dive/providers/google v1.26.0
-	github.com/deepnoodle-ai/dive/providers/grok v1.26.0
-	github.com/deepnoodle-ai/dive/providers/openai v1.26.0
+	github.com/deepnoodle-ai/dive v1.27.0
+	github.com/deepnoodle-ai/dive/providers/google v1.27.0
+	github.com/deepnoodle-ai/dive/providers/grok v1.27.0
+	github.com/deepnoodle-ai/dive/providers/openai v1.27.0
 	github.com/deepnoodle-ai/wonton v0.0.39
 	github.com/mattn/go-runewidth v0.0.29
 	google.golang.org/genai v1.71.0

--- a/experimental/mcp/go.mod
+++ b/experimental/mcp/go.mod
@@ -5,7 +5,7 @@ go 1.26.0
 toolchain go1.26.8
 
 require (
-	github.com/deepnoodle-ai/dive v1.26.0
+	github.com/deepnoodle-ai/dive v1.27.0
 	github.com/deepnoodle-ai/wonton v0.0.39
 	github.com/mark3labs/mcp-go v1.0.0
 )

--- a/otel/go.mod
+++ b/otel/go.mod
@@ -5,7 +5,7 @@ go 1.26.0
 toolchain go1.26.8
 
 require (
-	github.com/deepnoodle-ai/dive v1.26.0
+	github.com/deepnoodle-ai/dive v1.27.0
 	go.opentelemetry.io/otel v1.46.0
 	go.opentelemetry.io/otel/metric v1.46.0
 	go.opentelemetry.io/otel/sdk v1.45.0

--- a/providers/google/go.mod
+++ b/providers/google/go.mod
@@ -5,7 +5,7 @@ go 1.26.0
 toolchain go1.26.8
 
 require (
-	github.com/deepnoodle-ai/dive v1.26.0
+	github.com/deepnoodle-ai/dive v1.27.0
 	github.com/deepnoodle-ai/wonton v0.0.39
 	google.golang.org/genai v1.71.0
 )

--- a/providers/grok/go.mod
+++ b/providers/grok/go.mod
@@ -5,8 +5,8 @@ go 1.26.0
 toolchain go1.26.8
 
 require (
-	github.com/deepnoodle-ai/dive v1.26.0
-	github.com/deepnoodle-ai/dive/providers/openai v1.26.0
+	github.com/deepnoodle-ai/dive v1.27.0
+	github.com/deepnoodle-ai/dive/providers/openai v1.27.0
 	github.com/deepnoodle-ai/wonton v0.0.39
 	github.com/openai/openai-go/v3 v3.55.0
 	golang.org/x/image v0.45.0

--- a/providers/openai/go.mod
+++ b/providers/openai/go.mod
@@ -5,7 +5,7 @@ go 1.26.0
 toolchain go1.26.8
 
 require (
-	github.com/deepnoodle-ai/dive v1.26.0
+	github.com/deepnoodle-ai/dive v1.27.0
 	github.com/deepnoodle-ai/wonton v0.0.39
 	github.com/openai/openai-go/v3 v3.55.0
 	golang.org/x/image v0.45.0


### PR DESCRIPTION
Release prep for v1.27.0, following `docs/releasing.md` steps 1–4. No library code changes — changelog, module requirement sync, and release notes only.

## Version choice

**Minor, not patch.** Two things in this release are more than a bugfix: the Go floor moves to 1.26 (consumers on 1.25 cannot take it), and four providers gain new model constants — including a new `google.DefaultModel`, which changes behavior for anyone using the default rather than naming a model.

## What's here

- **`CHANGELOG.md`** — `[Unreleased]` cut to `[1.27.0] - 2026-09-02` with a fresh empty `[Unreleased]` above it. Both merged PRs since v1.26.0 (#274, #276) are accounted for in the section; nothing was added or reworded.
- **`go.mod` × 11** — `make release-prep VERSION=v1.27.0` rewrote every `github.com/deepnoodle-ai/dive*` requirement from v1.26.0 to v1.27.0, including the untagged `demos/` modules. These are invisible to CI because every sub-module resolves through a `replace`, but they break anyone who resolves the tag.
- **`docs/releases/v1.27.0.md`** — `make release-notes VERSION=v1.27.0` for the mechanical sections; Highlights written from the merged PR bodies.

## The Highlights, in brief

Four paragraphs, ordered by what a consumer has to act on:

1. **Go 1.26 required** — the upgrade gate, plus the dependency refresh it unblocked and the six stdlib advisories the go1.26.8 toolchain pin clears.
2. **Two pricing overcharges** — `Usage.Cost` read 50% high for Sonnet 5 and 2x high for Gemini 3.7/3.6 Flash. This is the item most likely to have silently affected someone's numbers, so it is stated as a correction rather than a catalog update.
3. **Grok 403s lost their reason** — the openai-go v3.51 bare-string `error` regression, and the middleware that normalizes it.
4. **`google.DefaultModel` is now Gemini 3.8 Flash** — a behavior change for anyone on the default, with the note that 3.7 Flash is one constant away.

## Verification

- `make check` passes (catalog check, watcher tests, release-notes tests, prettier, vet, full suite).
- `python3 scripts/sync_module_versions.py v1.27.0 --check` and `release_notes.py v1.27.0 --check` both pass — the latter is what `make release-publish` gates on, so the Highlights placeholder is confirmed gone.
- All 10 sub-modules build.

## After merge

Steps 5–6 are not done here and need someone with push access to the tags:

```sh
git tag v1.27.0
make tag-modules VERSION=v1.27.0   # re-checks the requirement sync, refuses if stale
git push origin --tags
make release-publish VERSION=v1.27.0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CQTB7XXytad5uouhda4CHp


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Released version 1.27.0 with a Go 1.26 requirement.
* **Improvements**
  * Corrected model pricing information.
  * Improved normalization of errors from OpenAI-compatible providers.
  * Added new model constants and catalog entries.
  * Updated the default Gemini model.
* **Deprecations**
  * Deprecated support for Mistral Devstral.
* **Maintenance**
  * Updated bundled modules and examples to version 1.27.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->