### PR TITLE
Stop pinning the model's exact wording in the Anthropic hello-world test

### DIFF
--- a/providers/anthropic/anthropic_test.go
+++ b/providers/anthropic/anthropic_test.go
@@ -28,11 +28,12 @@ func TestHelloWorld(t *testing.T) {
 		llm.NewUserTextMessage("respond with \"hello\""),
 	))
 	assert.NoError(t, err)
-	// Casing and trailing punctuation on a one-word reply are the model's
-	// choice, not the provider's behavior: Opus 5 answers "Hello" where 4.8
-	// answered "hello". Normalize rather than pin the exact string.
-	normalized := strings.ToLower(strings.Trim(response.Message().Text(), " .!"))
-	assert.Equal(t, normalized, "hello")
+	// How much the model says around the requested word is its choice, not the
+	// provider's behavior: Sonnet 5 has answered "hello", "Hello", and "Hello!
+	// How can I help you today?" to this prompt. What the round trip owes us is
+	// assistant text containing the word, so check that and nothing more. This
+	// matches the openaicompletions TestHelloWorld.
+	assert.Contains(t, strings.ToLower(response.Message().Text()), "hello")
 }
 
 func TestStreamCountTo10(t *testing.T) {


### PR DESCRIPTION
`TestHelloWorld` failed on `main` in CI:

```
    anthropic_test.go:35:
        mismatch (-want +got):
          string(
        -     "hello",
        +     "hello! how can i help you today?",
          )
--- FAIL: TestHelloWorld (1.40s)
```

Nothing in the provider changed. The test sends `respond with "hello"` to the live Anthropic API and pinned the reply to exactly `hello` after normalizing case and trailing punctuation. Sonnet 5 answered with an offer of help this time, which it is entirely free to do.

## Why not normalize harder

This test has already been patched once for exactly this. The current comment reads:

> Casing and trailing punctuation on a one-word reply are the model's choice, not the provider's behavior: Opus 5 answers "Hello" where 4.8 answered "hello". Normalize rather than pin the exact string.

That diagnosis was right and the fix was too narrow. Stripping ` .!` handles the variations seen at the time, but the underlying problem is asserting on a live model's exact output at all — the wording is the model's choice and not part of the provider contract, so every new variation is another red build on `main`. Trimming a trailing clause instead of trailing punctuation would just move the goalposts to the next surprise.

## The fix

Assert what the round trip actually owes us — assistant text containing the word we asked for:

```go
assert.Contains(t, strings.ToLower(response.Message().Text()), "hello")
```

This is not a new convention. `providers/openaicompletions` already landed on the same form in its own `TestHelloWorld`, with the same reasoning in its comment, so this makes the Anthropic test consistent with the sibling rather than the outlier.

The test still catches everything it was there to catch: auth, request construction, the HTTP round trip, response decoding, and that the assistant text reaches the caller. It just no longer fails when the model is chatty.

## Scope

`TestStreamCountTo10` in the same file still pins `1 2 3 4 5 6 7 8 9 10`, and I left it alone — its prompt constrains the output format explicitly ("respond with the integers only"), and it has not been flaking. Worth revisiting if it ever does, but not on the back of this failure.

## Verification

`go vet ./providers/anthropic/` clean, and `go test ./providers/anthropic/ -run TestHelloWorld` passes live against the API with `ANTHROPIC_API_KEY` set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CQTB7XXytad5uouhda4CHp
