### PR TITLE
CLI: Persist interactive input history

### DIFF
--- a/experimental/cmd/dive/app.go
+++ b/experimental/cmd/dive/app.go
@@ -363,7 +363,8 @@ type App struct {
 	needNewTextMessage bool              // set after tool calls to create new text message
 
 	// Command history
-	history []string
+	history      []string
+	historyStore *inputHistoryStore
 
 	// UI state
 	frame               uint64
@@ -1398,7 +1399,7 @@ func (a *App) submitInput(value string) {
 
 	a.setInputText("") // Clear input
 	a.historyIndex = -1
-	a.history = append(a.history, trimmed)
+	a.recordInputHistory(trimmed)
 
 	// Handle commands
 	if strings.HasPrefix(trimmed, "/") {
@@ -1411,6 +1412,16 @@ func (a *App) submitInput(value string) {
 	includeStartupAttachment := !a.firstUserSent
 	a.firstUserSent = true
 	go a.processMessageAsync(trimmed, attachments, includeStartupAttachment)
+}
+
+func (a *App) recordInputHistory(input string) {
+	a.history = limitInputHistory(append(a.history, input))
+	if a.historyStore == nil {
+		return
+	}
+	if err := a.historyStore.Save(a.history); err != nil {
+		a.setFlash("Could not save input history: %v", err)
+	}
 }
 
 // processMessageAsync handles message processing in background.

--- a/experimental/cmd/dive/history.go
+++ b/experimental/cmd/dive/history.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+const maxInputHistoryEntries = 1000
+
+type inputHistoryFile struct {
+	Entries []string `json:"entries"`
+}
+
+// inputHistoryStore persists interactive input independently of conversation
+// sessions, so recalled prompts remain available after restarting the CLI.
+type inputHistoryStore struct {
+	path string
+}
+
+func defaultInputHistoryStore() (*inputHistoryStore, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil, fmt.Errorf("find home directory: %w", err)
+	}
+	return &inputHistoryStore{path: filepath.Join(home, ".dive", "history.json")}, nil
+}
+
+func (s *inputHistoryStore) Load() ([]string, error) {
+	data, err := os.ReadFile(s.path)
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("read input history: %w", err)
+	}
+
+	var file inputHistoryFile
+	if err := json.Unmarshal(data, &file); err != nil {
+		return nil, fmt.Errorf("parse input history: %w", err)
+	}
+	return limitInputHistory(file.Entries), nil
+}
+
+func (s *inputHistoryStore) Save(entries []string) error {
+	data, err := json.MarshalIndent(inputHistoryFile{Entries: limitInputHistory(entries)}, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encode input history: %w", err)
+	}
+	data = append(data, '\n')
+
+	dir := filepath.Dir(s.path)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return fmt.Errorf("create input history directory: %w", err)
+	}
+
+	tmp, err := os.CreateTemp(dir, filepath.Base(s.path)+".tmp-*")
+	if err != nil {
+		return fmt.Errorf("create input history file: %w", err)
+	}
+	tmpPath := tmp.Name()
+	committed := false
+	defer func() {
+		if !committed {
+			_ = os.Remove(tmpPath)
+		}
+	}()
+
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("write input history: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close input history: %w", err)
+	}
+	if err := os.Rename(tmpPath, s.path); err != nil {
+		return fmt.Errorf("save input history: %w", err)
+	}
+	committed = true
+	return nil
+}
+
+func limitInputHistory(entries []string) []string {
+	if len(entries) <= maxInputHistoryEntries {
+		return append([]string(nil), entries...)
+	}
+	return append([]string(nil), entries[len(entries)-maxInputHistoryEntries:]...)
+}

--- a/experimental/cmd/dive/history_test.go
+++ b/experimental/cmd/dive/history_test.go
@@ -61,6 +61,23 @@ func TestInputHistoryStore_LoadRejectsInvalidJSON(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestAppRecordInputHistoryReplacesInvalidHistory(t *testing.T) {
+	path := filepath.Join(t.TempDir(), ".dive", "history.json")
+	assert.NoError(t, os.MkdirAll(filepath.Dir(path), 0o700))
+	assert.NoError(t, os.WriteFile(path, []byte("not json"), 0o600))
+
+	app := newTestApp()
+	app.historyStore = &inputHistoryStore{path: path}
+	_, err := app.historyStore.Load()
+	assert.Error(t, err)
+
+	app.recordInputHistory("replacement prompt")
+
+	entries, err := app.historyStore.Load()
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"replacement prompt"}, entries)
+}
+
 func TestAppRecordInputHistoryPersistsAcrossApps(t *testing.T) {
 	store := &inputHistoryStore{path: filepath.Join(t.TempDir(), ".dive", "history.json")}
 	first := newTestApp()

--- a/experimental/cmd/dive/history_test.go
+++ b/experimental/cmd/dive/history_test.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/deepnoodle-ai/wonton/assert"
+	"github.com/deepnoodle-ai/wonton/tui"
+)
+
+func TestInputHistoryStore_SaveAndLoad(t *testing.T) {
+	store := &inputHistoryStore{path: filepath.Join(t.TempDir(), ".dive", "history.json")}
+	entries := []string{"first prompt", "a prompt\nwith multiple lines"}
+
+	assert.NoError(t, store.Save(entries))
+
+	raw, err := os.ReadFile(store.path)
+	assert.NoError(t, err)
+	var file inputHistoryFile
+	assert.NoError(t, json.Unmarshal(raw, &file))
+	assert.Equal(t, entries, file.Entries)
+
+	info, err := os.Stat(store.path)
+	assert.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o600), info.Mode().Perm())
+
+	loaded, err := store.Load()
+	assert.NoError(t, err)
+	assert.Equal(t, entries, loaded)
+}
+
+func TestLimitInputHistoryKeepsNewestEntries(t *testing.T) {
+	entries := make([]string, maxInputHistoryEntries+1)
+	entries[0] = "oldest"
+	entries[len(entries)-1] = "newest"
+
+	limited := limitInputHistory(entries)
+
+	assert.Equal(t, maxInputHistoryEntries, len(limited))
+	assert.Equal(t, "", limited[0])
+	assert.Equal(t, "newest", limited[len(limited)-1])
+}
+
+func TestInputHistoryStore_LoadMissingFile(t *testing.T) {
+	store := &inputHistoryStore{path: filepath.Join(t.TempDir(), ".dive", "history.json")}
+
+	entries, err := store.Load()
+
+	assert.NoError(t, err)
+	assert.Equal(t, 0, len(entries))
+}
+
+func TestInputHistoryStore_LoadRejectsInvalidJSON(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "history.json")
+	assert.NoError(t, os.WriteFile(path, []byte("not json"), 0o600))
+
+	_, err := (&inputHistoryStore{path: path}).Load()
+
+	assert.Error(t, err)
+}
+
+func TestAppRecordInputHistoryPersistsAcrossApps(t *testing.T) {
+	store := &inputHistoryStore{path: filepath.Join(t.TempDir(), ".dive", "history.json")}
+	first := newTestApp()
+	first.historyStore = store
+	first.recordInputHistory("first prompt")
+	first.recordInputHistory("second prompt")
+
+	entries, err := store.Load()
+	assert.NoError(t, err)
+
+	second := newTestApp()
+	second.history = entries
+	assert.True(t, second.handleInputNavKey(tui.KeyEvent{Key: tui.KeyArrowUp}))
+	assert.Equal(t, "second prompt", second.inputText)
+	assert.True(t, second.handleInputNavKey(tui.KeyEvent{Key: tui.KeyArrowUp}))
+	assert.Equal(t, "first prompt", second.inputText)
+}

--- a/experimental/cmd/dive/main.go
+++ b/experimental/cmd/dive/main.go
@@ -441,11 +441,13 @@ func runInteractive(ctx *cli.Context) error {
 	app.contextDemos = contextDemos
 	if historyStore, err := defaultInputHistoryStore(); err != nil {
 		fmt.Fprintf(os.Stderr, "Warning: failed to configure input history: %v\n", err)
-	} else if history, err := historyStore.Load(); err != nil {
-		fmt.Fprintf(os.Stderr, "Warning: failed to load input history: %v\n", err)
 	} else {
 		app.historyStore = historyStore
-		app.history = history
+		if history, err := historyStore.Load(); err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: failed to load input history: %v\n", err)
+		} else {
+			app.history = history
+		}
 	}
 
 	attachment, err := loadStartupInstructionAttachment(cwd)

--- a/experimental/cmd/dive/main.go
+++ b/experimental/cmd/dive/main.go
@@ -439,6 +439,14 @@ func runInteractive(ctx *cli.Context) error {
 	app.currentSession = currentSession
 	app.operatorReminders = operatorReminders
 	app.contextDemos = contextDemos
+	if historyStore, err := defaultInputHistoryStore(); err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: failed to configure input history: %v\n", err)
+	} else if history, err := historyStore.Load(); err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: failed to load input history: %v\n", err)
+	} else {
+		app.historyStore = historyStore
+		app.history = history
+	}
 
 	attachment, err := loadStartupInstructionAttachment(cwd)
 	if err != nil {


### PR DESCRIPTION
## Summary
- persist submitted interactive prompts in `~/.dive/history.json`
- load history across CLI sessions and retain the newest 1,000 entries
- use private, atomic JSON writes and show non-fatal load/save errors

## Testing
- `MODEL_API_KEY= META_API_KEY= go test ./...` (from `experimental/cmd/dive`)
- `go build .` (from `experimental/cmd/dive`)

The environment variables are cleared for the test command to avoid an existing default-model test sensitivity.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Interactive mode now remembers submitted input between sessions.
  * Input history is stored locally and supports navigating previously entered commands.
  * History is limited to the 1,000 most recent entries.
  * Invalid saved history can be replaced with new input history.

* **Bug Fixes**
  * History loading and saving issues now appear as warnings or errors without preventing interactive startup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->