### PR TITLE
Improve experimental CLI settings, rendering, and Bash output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Added
 
+- **The CLI remembers model, thinking effort, thinking display, and usage detail in `~/.dive/settings.json`.** Resolution is flag > env > settings file > default; `/model`, `/effort`, `/thinking`, and `/usage full|brief` switch mid-session and persist, `/status` shows the effective configuration, and the status line always shows model and effort.
+- **The CLI status line is one row by default.** Model, effort, directory, branch, context %, and session total cost share a line; the token breakdown table only renders inline with `show_detailed_usage` (`--show-detailed-usage` / `/usage full`), while `/usage` still shows the full report on demand.
 - **The CLI renders the conversation in a managed, scrollable screen.** The
   transcript reflows on resize and scrolls with the wheel, PgUp/PgDn,
   Ctrl+Home/End, and Home/End.
@@ -43,6 +45,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Changed
 
+- **The CLI now uses one cohesive terminal color system.** Markdown, dialogs, inputs, tools, todos, usage reports, and progress states share brighter ocean-cyan accents and cool slate neutrals; periwinkle marks literals, while amber, green, and red are reserved for warning, success, and failure. Wonton v0.2.1 supplies explicit input-text styling.
+- **The CLI startup display is now compact three-line text.** Version, model with thinking effort, and workspace replace the bordered field list; exceptional scope, context, and resume details remain beneath it.
+- **The Bash tool now returns one plain-text stdout/stderr stream in emission order.** Successful output is unwrapped (including an empty string); nonzero exits use `<error>Exit code N\n…</error>`, and combined-output truncation always carries a marker. Each call remains a fresh shell: cwd, environment, options, and exit status reset, while filesystem changes persist.
 - **BREAKING: the managed screen is the CLI's default.** `--screen` and
   `DIVE_SCREEN` are gone; `--inline` (or `DIVE_INLINE=1`) selects the old
   renderer. `dive < file` and `dive | cat` are now refused, pointing at `--print`.
@@ -54,11 +59,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Fixed
 
+- **CLI history navigation no longer gets trapped by recalled slash commands.** Command and file autocomplete stay closed while browsing history, edits return the recalled entry to normal completion behavior, and all autocomplete matches remain reachable through an eight-row sliding window.
+- **CLI model switches now update downstream work, not just the status label.** Newly spawned subagents inherit the current model, effort, and thinking settings; compaction uses the switched model and recalculates automatic thresholds while preserving explicit thresholds.
+- **The CLI footer keeps one explicit blank row below the status line instead of two.** Multiline user messages also trim pasted trailing spaces and tabs for display without changing the content sent to the model.
 - **The `--resume` session picker is one line per session.** The workspace path
   moves under the list, empty sessions are dropped, and long titles are cut on
   whole characters rather than mid-rune.
 - **Dim text in the CLI is readable on a dark background.** Secondary greys and
   hints sat near 2.9:1 contrast.
+- **`/compact` no longer freezes the UI.** The summarizer runs in the background
+  with a compacting spinner; input for new turns is held until it finishes. The
+  result shows as a scrollback notice and in the turn-summary slot, replacing
+  the footer stats.
 - **`/clear` no longer panics without a session store.**
 - **Encrypted reasoning is requested whenever the model reasons** — the
   `reasoning.encrypted_content` include was sent only when the caller named a

--- a/a2a/go.mod
+++ b/a2a/go.mod
@@ -7,7 +7,7 @@ toolchain go1.26.8
 require (
 	github.com/a2aproject/a2a-go/v2 v2.5.0
 	github.com/deepnoodle-ai/dive v1.27.0
-	github.com/deepnoodle-ai/wonton v0.1.0
+	github.com/deepnoodle-ai/wonton v0.2.1
 )
 
 require (

--- a/a2a/go.sum
+++ b/a2a/go.sum
@@ -1,7 +1,7 @@
 github.com/a2aproject/a2a-go/v2 v2.5.0 h1:ZdcFoxv+nZTUV0i2ue5hES76YCANFPG9vjqd7vK8yWM=
 github.com/a2aproject/a2a-go/v2 v2.5.0/go.mod h1:NcRp/ZHxgMzDj12/BteIC2gOjljuEBKaGRfEdJ2lNSI=
-github.com/deepnoodle-ai/wonton v0.1.0 h1:59gaXJPwulv/cj/mR+bOpdyGrMvUEQ32oFf59zVk4f8=
-github.com/deepnoodle-ai/wonton v0.1.0/go.mod h1:G3fVZXXX/Oo01ATag//PH/6khtBNlDmxznXjORuG9gE=
+github.com/deepnoodle-ai/wonton v0.2.1 h1:GvfNIQT2B6NrEgXZHuxhUwjeMTm7Ms6YuZN17Oq2m4o=
+github.com/deepnoodle-ai/wonton v0.2.1/go.mod h1:G3fVZXXX/Oo01ATag//PH/6khtBNlDmxznXjORuG9gE=
 github.com/gobwas/glob v1.0.0 h1:p+FKbLEIsK1yZ39/OINwFvqNb5oyPY4H8xcy6uYu8dg=
 github.com/gobwas/glob v1.0.0/go.mod h1:oWCdo522i2P1n/hMXGNWs7yoV4wy/ciZuUIbvKj5rkc=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=

--- a/demos/colosseum/go.mod
+++ b/demos/colosseum/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/deepnoodle-ai/dive/providers/google v1.27.0
 	github.com/deepnoodle-ai/dive/providers/grok v1.27.0
 	github.com/deepnoodle-ai/dive/providers/openai v1.27.0
-	github.com/deepnoodle-ai/wonton v0.1.0
+	github.com/deepnoodle-ai/wonton v0.2.1
 )
 
 require (

--- a/demos/colosseum/go.sum
+++ b/demos/colosseum/go.sum
@@ -8,8 +8,8 @@ github.com/a2aproject/a2a-go/v2 v2.5.0 h1:ZdcFoxv+nZTUV0i2ue5hES76YCANFPG9vjqd7v
 github.com/a2aproject/a2a-go/v2 v2.5.0/go.mod h1:NcRp/ZHxgMzDj12/BteIC2gOjljuEBKaGRfEdJ2lNSI=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
-github.com/deepnoodle-ai/wonton v0.1.0 h1:59gaXJPwulv/cj/mR+bOpdyGrMvUEQ32oFf59zVk4f8=
-github.com/deepnoodle-ai/wonton v0.1.0/go.mod h1:G3fVZXXX/Oo01ATag//PH/6khtBNlDmxznXjORuG9gE=
+github.com/deepnoodle-ai/wonton v0.2.1 h1:GvfNIQT2B6NrEgXZHuxhUwjeMTm7Ms6YuZN17Oq2m4o=
+github.com/deepnoodle-ai/wonton v0.2.1/go.mod h1:G3fVZXXX/Oo01ATag//PH/6khtBNlDmxznXjORuG9gE=
 github.com/felixge/httpsnoop v1.1.0 h1:3YtUj32ZZkqZtt3sZZsClsymw/QDuVfpNhoA31zeORc=
 github.com/felixge/httpsnoop v1.1.0/go.mod h1:Zqxgdd+1Rkcz8euOqdr7lqgCRJztwr5hp9vDSi5UZCE=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=

--- a/demos/noodleville/go.mod
+++ b/demos/noodleville/go.mod
@@ -6,7 +6,7 @@ toolchain go1.26.8
 
 require (
 	github.com/deepnoodle-ai/dive v1.27.0
-	github.com/deepnoodle-ai/wonton v0.1.0
+	github.com/deepnoodle-ai/wonton v0.2.1
 )
 
 require (

--- a/demos/noodleville/go.sum
+++ b/demos/noodleville/go.sum
@@ -1,5 +1,5 @@
-github.com/deepnoodle-ai/wonton v0.1.0 h1:59gaXJPwulv/cj/mR+bOpdyGrMvUEQ32oFf59zVk4f8=
-github.com/deepnoodle-ai/wonton v0.1.0/go.mod h1:G3fVZXXX/Oo01ATag//PH/6khtBNlDmxznXjORuG9gE=
+github.com/deepnoodle-ai/wonton v0.2.1 h1:GvfNIQT2B6NrEgXZHuxhUwjeMTm7Ms6YuZN17Oq2m4o=
+github.com/deepnoodle-ai/wonton v0.2.1/go.mod h1:G3fVZXXX/Oo01ATag//PH/6khtBNlDmxznXjORuG9gE=
 github.com/gobwas/glob v1.0.0 h1:p+FKbLEIsK1yZ39/OINwFvqNb5oyPY4H8xcy6uYu8dg=
 github.com/gobwas/glob v1.0.0/go.mod h1:oWCdo522i2P1n/hMXGNWs7yoV4wy/ciZuUIbvKj5rkc=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=

--- a/docs/guides/tools.md
+++ b/docs/guides/tools.md
@@ -75,6 +75,16 @@ toolkit.NewBashTool(toolkit.BashToolOptions{
 })
 ```
 
+The result is one text block with stdout and stderr interleaved in emission
+order. Exit 0 returns that text verbatim (including an empty string). A nonzero
+exit returns `<error>Exit code N\n...merged output...</error>`. Large combined
+output is truncated with an explicit marker.
+
+Each invocation starts a fresh shell. `cd`, exported environment variables,
+shell options, and exit status do not carry into the next call; an explicit
+`working_directory` applies to that call only. Filesystem and other external
+changes made by a command do persist.
+
 ## Web
 
 ### WebSearch

--- a/docs/plans/2026-09-03-cli-parity-roadmap.md
+++ b/docs/plans/2026-09-03-cli-parity-roadmap.md
@@ -1,0 +1,107 @@
+# Dive experimental CLI parity roadmap
+
+**Status:** Proposed
+**Date:** 2026-09-03
+**Scope:** Daily coding-agent CLI equivalence, not feature-for-feature imitation
+
+## Outcome
+
+Dive should feel complete for the normal loop: start in a repository, understand the active model and safety boundary, steer work without fighting the input, recover or branch a session, inspect changes, and automate the same agent from a pipe. The settings/status work in the current working tree closes the most visible paper cuts. The next priorities are session continuity, live interaction control, and explicit safety controls.
+
+This baseline was checked against the current official [Codex developer commands](https://learn.chatgpt.com/docs/developer-commands?surface=cli), [Codex configuration reference](https://learn.chatgpt.com/docs/config-file/config-reference), [Claude Code CLI reference](https://code.claude.com/docs/en/cli-reference), [Claude Code interactive mode](https://code.claude.com/docs/en/interactive-mode), and [Claude Code settings](https://code.claude.com/docs/en/settings). Options change quickly, so this comparison is dated rather than presented as timeless.
+
+## Current baseline
+
+| Workflow | Dive now | Parity baseline | Assessment |
+|---|---|---|---|
+| Model and effort | Flags/env plus persistent user/project settings; `/model`, `/effort`, `/thinking`, `/status` | Both peers expose model selection; Codex exposes reasoning effort with `/model`, while Claude exposes `/model` and `/effort` | Closed by current patch |
+| Compact status | Model, effort, repository/branch, context %, and session total cost on one row; detailed usage opt-in | Both peers keep primary state visible and offer status/context inspection | Closed by current patch |
+| Session recovery | `--resume` opens a picker | Continue latest, resume by id/name, fork, rename, and session management | Major gap |
+| Input while working | New submission is ignored while processing | Queue a follow-up, steer the active turn, interrupt predictably | Major gap |
+| Prompt history | Up/down history persisted locally | Persistent history plus reverse search and pasted-input recall | Partial |
+| Shell escape | Shell exists as an agent tool | Direct `!` shell mode that does not spend a model turn | Gap |
+| Permissions/workspace | Permission prompts and one dangerous bypass flag | Named permission modes, approval policy, sandbox choice, allowed tools, and additional directories | Major gap |
+| Change inspection | Tool calls are visible and expandable | Built-in diff, review, initialization, and project-instruction workflows | Gap |
+| Non-interactive use | `--print` with text or one JSON result | stdin plus prompt composition, JSONL streaming, schemas, stable exit codes, turn/budget limits | Major gap |
+| Subagents/background work | Agent, monitor, and stop tools exist | Built-in agent/background-job visibility and control | Partial |
+| Extensibility/health | Skills load at startup | MCP/plugin management, diagnostics, auth/login, hooks, feedback/update flows | Gap |
+| Display control | Managed screen, `--inline`, mouse and scrollback commands | Status-line customization, themes/accessibility, alternate-screen controls | Partial |
+
+## Idea inventory
+
+The divergent pass produced twelve candidate improvements, grouped by the job they solve.
+
+### Orientation and configuration
+
+1. Add `/config` to inspect every effective value, source, and settings path, with `dive config get|set|unset` for scripts.
+2. Add a model/effort capability check so unsupported combinations are marked before the request instead of failing at the provider.
+3. Add session-only modifiers to `/model`, `/effort`, `/thinking`, and `/usage`; persistence remains the default.
+
+### Session continuity
+
+4. Replace the boolean resume shape with `dive resume [id|name]`, add `dive continue`, and keep the picker when no target is supplied.
+5. Add `/rename`, `/fork`, `/new`, `/sessions`, and archive/delete actions with confirmation where destructive.
+
+### Fast operator loop
+
+6. Queue Enter submissions while the model works; use a separate shortcut to steer the active turn and make Escape/Ctrl+C interruption states explicit.
+7. Add `!command` shell mode with working-directory continuity, streamed output, and a clear distinction from model-visible shell calls.
+8. Add Ctrl+R reverse history search scoped to the repository by default, with an all-projects toggle.
+9. Add `/diff`, `/review`, and `/init`; make changed-file context cheap to inspect without asking the model to rediscover it.
+
+### Safety and workspace boundaries
+
+10. Expose `--permission-mode`, `--sandbox`, `--allowed-tool`, `--disallowed-tool`, and repeatable `--add-dir`, plus `/permissions` for the live effective policy.
+
+### Automation and extensibility
+
+11. Define a stable non-interactive contract: an `exec` subcommand (or a fully specified `--print` alias), combined stdin + prompt input, JSONL streaming, structured-output schemas, max turns/budget, output-last-message, and documented exit codes.
+12. Add `mcp`, plugin, doctor, and update commands, followed by background-job and subagent status views.
+
+## Evaluation
+
+| Candidate | User impact | Delivery effort | Risk reduced | Priority |
+|---|---:|---:|---:|---:|
+| Session recovery and branching (#4–5) | Very high | Medium | High | 1 |
+| Queue, steer, interrupt, shell, history (#6–8) | Very high | Medium-high | Medium | 2 |
+| Explicit permissions and workspace scope (#10) | High | Medium | Very high | 3 |
+| Non-interactive contract (#11) | High | High | High | 4 |
+| Diff/review/init (#9) | High | Medium | Medium | 5 |
+| Config inspection and capability validation (#1–3) | Medium | Low-medium | Medium | 6 |
+| MCP/plugins/doctor/background UI (#12) | Medium | High | Medium | 7 |
+
+The ordering favors daily friction and recovery first. Automation is important, but its schema and streaming contract deserve a separate design pass rather than being added piecemeal to `--print`.
+
+## Selected next bets
+
+### 1. Session continuity contract
+
+Make resume addressable and composable before adding more session features. The minimum coherent slice is `dive continue`, `dive resume [query]`, `/rename`, and `/fork`. Store the effective model/effort with the session so resuming explains whether the session value or today's default won. Acceptance: a user can recover the last repository session non-interactively, fork it without altering the source, and see the selected session before the first new turn.
+
+### 2. Live interaction control
+
+Treat typing during work as intentional input. Enter queues a follow-up; a documented shortcut steers the active turn; Escape interrupts once and Ctrl+C retains its exit confirmation. Add `!` shell mode and Ctrl+R in the same input-state refactor because all three depend on explicit composer modes. Acceptance: no submitted text disappears, queued versus steering text is visibly labeled, interruption never exits accidentally, and direct shell commands do not enter model history unless requested.
+
+### 3. Explicit safety boundary
+
+Surface the policy the runtime already applies. Add named permission modes and additional-directory grants, show the effective sandbox/approval state in `/status` or `/permissions`, and keep the dangerous bypass visually unmistakable. Acceptance: users can tell what can be read, written, or executed before the first tool call; flags override settings; project configuration cannot silently broaden a managed/user boundary.
+
+## Sequencing
+
+- Ship the current settings and TUI cleanup first; it is a contained foundation and its tests are already local.
+- Design session identity and persistence before implementing `/fork`, so names, repository filtering, model inheritance, and deletion semantics share one contract.
+- Refactor the composer into explicit idle, working, queued, steering, shell, and interrupting states; then layer shortcuts on it.
+- Expose safety flags from the existing permission machinery, then add tests proving precedence and path boundaries end to end.
+- Write a separate automation spec before changing `--print`; preserve compatibility while introducing streaming and structured output.
+
+## Equivalence exit criteria
+
+Dive is equivalent for the intended daily workflow when a user can:
+
+1. See and persist model, effort, thinking, usage detail, repository, branch, context, cost, and permission state.
+2. Continue, target, rename, fork, archive, and safely delete sessions.
+3. Queue, steer, interrupt, search history, and run direct shell commands without losing input.
+4. Inspect the diff and request a review without spending turns reconstructing basic repository state.
+5. Run the same agent non-interactively with streamed machine-readable events, bounded execution, and stable failure semantics.
+
+MCP marketplaces, themes, remote execution, cloud task management, and every peer-specific command are follow-on differentiators, not prerequisites for this milestone.

--- a/docs/plans/2026-09-03-cli-settings-persistence.md
+++ b/docs/plans/2026-09-03-cli-settings-persistence.md
@@ -1,0 +1,88 @@
+# CLI persistent settings + status-line diet
+
+**Status:** Implemented and validated
+**Author:** Dive
+**Date:** 2026-09-03
+**Workflow:** This note records the implementation behavior and review decisions.
+
+## Context
+
+Dive's CLI resolved `model`, `thinking-effort`, and `show-thinking` from flags/env only, with a hardcoded `medium` effort default. `/model` switched per-session and forgot on exit. The status line rendered a 3–5 row token breakdown (`tokensPanelView`) every frame, and two render papercuts (inconsistent footer padding and pasted-whitespace highlighting in the user bubble) made it feel unfinished next to Codex/Claude Code.
+
+## Goals
+
+- `/model`, `/effort`, `/thinking` persist across sessions by default and report where the effective value came from (`flag > env > settings > default/autodetect`).
+- Status line is one row by default: `model · effort in dir on branch · ctx% · $total`; full breakdown available via `/usage` and opt-in live via `/usage full`.
+- Fix: keep exactly one explicit blank row under the footer instead of variable double padding.
+- Fix: pasted multi-line content no longer shows lit trailing-whitespace runs in the user bubble.
+- All covered by `go test -count=1` in `experimental/cmd/dive` and `experimental/settings`.
+
+## Non-goals
+
+- No `-c key=value` generic overrides, no `--approval-mode`/`/approvals`, no `/init`/`/diff`/`/review` (P1 backlog from the brainstorm).
+- No per-project model defaults beyond what the tiered merge already allows; only the user tier is written by the new commands.
+- No migration of existing `~/.dive/history.json` or sessions.
+
+## Proposal
+
+### Settings tiers (all `settings.json`, Claude-Code semantics)
+
+`~/.dive/settings.json` (user) < `.dive/settings.json` (project base) < `.dive/settings.local.json` (local wins). Merge is per-key recursive; arrays replace wholesale (`experimental/settings/settings.go: mergeSettingsMaps`). New user-tier keys: `model`, `thinking_effort`, `show_thinking`, `show_detailed_usage`. Permissions/sandbox continue to come from project tiers only.
+
+`LoadEffectiveSettings(dir)` merges all three; `LoadSettings(dir)` stays project-only and hermetic for tests. `SaveUserSettings(patch)` reads-modify-writes only the user file (0700 dir, atomic rename).
+
+### Resolution order (`cli_settings.go`)
+
+`resolveModelName` → flag, `DIVE_MODEL`, settings, `getDefaultModel()` autodetect. Returns `(name, source)`; source is shown at startup and in `/status`.
+`resolveThinkingEffort` → flag, `DIVE_THINKING_EFFORT` (explicit empty omits the parameter for non-reasoning models), settings, `medium`.
+`resolveShowThinking`, `resolveShowDetailedUsage` → flag, env (`DIVE_SHOW_THINKING`, `DIVE_SHOW_DETAILED_USAGE`), settings, `false`.
+
+### Commands (`cmd_settings.go`, wired in `app.go:handleCommand`)
+
+- `/model [name]` — existing dialog; on switch, `persistModelSwitch` writes user settings (source becomes `session`).
+- `/effort [none|minimal|low|medium|high|xhigh|max|<provider>]` — bare shows current + source; switch applies to `a.modelSettings.ReasoningEffort` live (next turn) and persists. `omit`/`off`/`""` clears to parameter-omitted.
+- `/thinking [on|off]` — bare toggles; persists; flips `Thinking`/`ThinkingDisplay` live.
+- `/usage [full|brief]` — bare prints the full report (unchanged); `full`/`brief` toggles + persists `show_detailed_usage`.
+- `/status` — one report: model, effort, thinking, and detailed-usage (all with sources), plus session id, context %, and session cost.
+- Autocomplete and `/help` updated.
+
+### Status line (`render.go:statusLineView`)
+
+One `Group` row: `model · effort · thinking? in dir on branch · ctx% · $session-total · ⚡fast?` (+ flash right-aligned). `sessionTotalCostString` prefers session total, falls back to turn total. `tokensPanelView` renders only when `showDetailedUsage` is set; `/usage` report is unaffected.
+
+### Render fixes
+
+- Blank line: `inputAreaView` (`app.go`) forced `footerViews` to at least two lines unconditionally. The final layout keeps one explicit breathing row below the status or autocomplete footer, while autocomplete still pads its active list to 8 lines for stable selection.
+- Paste whitespace: `textMessageView` `roleUser` now renders `trimTrailingWhitespacePerLine(msg.Content)`; message content itself is unmodified (copy/scrollback unaffected).
+
+### Downstream consistency
+
+- New subagents snapshot the currently selected parent model and model settings, including effort and thinking display. A later switch affects newly spawned work without mutating a subagent already in flight.
+- `/model` updates the model used by manual and mid-turn compaction. When the compaction threshold was automatic, it is recalculated for the new model; an explicit flag or environment value remains fixed.
+- The mid-turn hook reads the current model, threshold, and system prompt instead of retaining startup values.
+
+## Alternatives considered
+
+- **`~/.dive/config.json` (new name) vs `~/.dive/settings.json`.** Rejected: we already have a `settings.json` concept at project level and Claude Code uses `~/.claude/settings.json` globally. One vocabulary, one merge implementation.
+- **Persist project-tier instead of user-tier on switch.** Rejected: switching models shouldn't dirty the repo's `.dive/settings.json`; user tier is personal and never committed.
+- **Keep full token table live by default.** Rejected: costs 3–4 rows of chrome every frame and duplicates `/usage`; brief-by-default with `full` opt-in preserves the data one command away.
+
+## Tradeoffs and consequences
+
+- Writes on every `/model`/`/effort`/`/thinking`/`/usage full|brief` — a surprising write if the user expected session-only. Mitigated by the notice naming the file (`saved to ~/.dive/settings.json`).
+- `SaveUserSettings` is read-modify-write without locking; concurrent CLI instances could clobber. Acceptable for a single-user local file for now; noted, not solved.
+- User settings are filtered to the four model/presentation keys before merging. A global file cannot silently inject project permission or sandbox policy.
+- Status line no longer shows per-scope input/output at a glance; users who liked it must run `/usage full` once. That's the point, but it's a behavior change worth a CHANGELOG line.
+
+## Rollout
+
+Implementation: `experimental/settings/settings.go`, `experimental/cmd/dive/{app,main,render,cli_settings,cmd_settings}.go` + tests, CHANGELOG entry. No migration (global file is new; absence = defaults). Docs: `/help` + `/status` cover it; `docs/guides/experimental/` update optional.
+
+## Open question
+
+- Should `/model`/`/effort` accept a `--session` modifier for a one-off switch? The default should stay persistent, but an explicit escape hatch would avoid editing the user file for experiments.
+
+## Quality-check notes
+
+- Remaining known weakness is concurrent-writer handling for `SaveUserSettings`; atomic replacement prevents partial files but does not prevent lost updates.
+- Length matches the change: three small features sharing one settings seam, not three separate specs.

--- a/examples/go.mod
+++ b/examples/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/deepnoodle-ai/dive/providers/google v1.27.0
 	github.com/deepnoodle-ai/dive/providers/grok v1.27.0
 	github.com/deepnoodle-ai/dive/providers/openai v1.27.0
-	github.com/deepnoodle-ai/wonton v0.1.0
+	github.com/deepnoodle-ai/wonton v0.2.1
 	github.com/fatih/color v1.19.0
 	github.com/mark3labs/mcp-go v1.0.0
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.71.0

--- a/examples/go.sum
+++ b/examples/go.sum
@@ -10,8 +10,8 @@ github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1x
 github.com/cenkalti/backoff/v5 v5.0.3/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
-github.com/deepnoodle-ai/wonton v0.1.0 h1:59gaXJPwulv/cj/mR+bOpdyGrMvUEQ32oFf59zVk4f8=
-github.com/deepnoodle-ai/wonton v0.1.0/go.mod h1:G3fVZXXX/Oo01ATag//PH/6khtBNlDmxznXjORuG9gE=
+github.com/deepnoodle-ai/wonton v0.2.1 h1:GvfNIQT2B6NrEgXZHuxhUwjeMTm7Ms6YuZN17Oq2m4o=
+github.com/deepnoodle-ai/wonton v0.2.1/go.mod h1:G3fVZXXX/Oo01ATag//PH/6khtBNlDmxznXjORuG9gE=
 github.com/dlclark/regexp2 v1.11.0 h1:G/nrcoOa7ZXlpoa/91N3X7mM3r8eIlMBBJZvsz/mxKI=
 github.com/dlclark/regexp2 v1.11.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/fatih/color v1.19.0 h1:Zp3PiM21/9Ld6FzSKyL5c/BULoe/ONr9KlbYVOfG8+w=

--- a/experimental/cmd/dive/app.go
+++ b/experimental/cmd/dive/app.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -99,6 +100,21 @@ type compactionEvent struct {
 	midTurn bool
 }
 
+// compactionStartEvent marks the beginning of a manual /compact run. Handled
+// on the event loop to flip the compacting flag before the background
+// summarization starts.
+type compactionStartEvent struct {
+	baseEvent
+}
+
+// compactionEndEvent carries the outcome of a manual /compact run back to the
+// event loop, where the transcript can be updated safely.
+type compactionEndEvent struct {
+	baseEvent
+	event *compaction.CompactionEvent
+	err   error
+}
+
 // toolStreamEvent carries a chunk of streaming output for a tool call.
 // Used by any tool that produces incremental output (Bash stdout, sub-agents).
 type toolStreamEvent struct {
@@ -146,6 +162,8 @@ const (
 	TodoStatusInProgress
 	TodoStatusCompleted
 )
+
+const autocompleteWindowSize = 8
 
 // Todo represents a task item
 type Todo struct {
@@ -237,7 +255,7 @@ type DialogState struct {
 	Message        string
 	ContentPreview string
 
-	// For confirm (Claude Code style)
+	// Confirmation dialog state.
 	ConfirmChan              chan ConfirmResult
 	ConfirmSelectedIdx       int    // Currently selected option (0=Yes, 1=Allow session, 2=Feedback)
 	ConfirmFeedback          string // User feedback text (for PromptChoice input option)
@@ -371,6 +389,14 @@ type App struct {
 	processing          bool
 	processingStartTime time.Time
 
+	// compacting is true while a manual /compact summarization runs in the
+	// background. The LLM call takes seconds; running it off the event loop
+	// keeps ticks, keystrokes, and the spinner animating instead of freezing
+	// the UI. New turns are blocked until it finishes because it rewrites
+	// the session's messages.
+	compacting          bool
+	compactingStartTime time.Time
+
 	// Git branch shown in the status line. Cached because `git rev-parse` costs
 	// ~5 ms and the status line renders on every frame; refreshed on a timer and
 	// at turn boundaries, never from a view function.
@@ -413,12 +439,28 @@ type App struct {
 	// API endpoint for model creation (preserved for model switching)
 	apiEndpoint string
 
+	// Mutable model configuration, visible in the status line and persisted
+	// to ~/.dive/settings.json by /model, /effort, /thinking, and /usage.
+	// modelSettings is the same pointer handed to the agent, so in-session
+	// changes apply to the next turn without rebuilding anything.
+	modelSettings       *dive.ModelSettings
+	reasoningEffort     llm.ReasoningEffort
+	showThinking        bool
+	showDetailedUsage   bool
+	modelSource         string // flag, env, settings, autodetect, session
+	effortSource        string // flag, env, settings, default, session
+	thinkingSource      string // flag, env, settings, default, session
+	detailedUsageSource string // flag, env, settings, default, session
+
 	// Compaction configuration and state
-	compactionConfig         *compaction.CompactionConfig
-	lastCompactionEvent      *compaction.CompactionEvent
-	compactionEventTime      time.Time
-	showCompactionStats      bool
-	compactionStatsStartTime time.Time
+	compactionConfig            *compaction.CompactionConfig
+	compactionThresholdExplicit bool
+	lastCompactionEvent         *compaction.CompactionEvent
+	compactionEventTime         time.Time
+	// showCompactionSummary puts the latest compaction in the turn-summary
+	// slot ("Worked for…") until the next turn starts. The scrollback notice
+	// is the durable record; this is the at-a-glance one.
+	showCompactionSummary bool
 
 	// Status line state
 	lastUsage        *llm.Usage // Most recent LLM usage (for context %)
@@ -510,7 +552,7 @@ func (a *App) LiveView() tui.View {
 	views := make([]tui.View, 0)
 
 	// Show streaming content during processing
-	if a.processing {
+	if a.processing || a.compacting {
 		views = append(views, tui.Text(""))
 		liveContent := a.buildLiveView(true)
 		if liveContent != nil {
@@ -548,8 +590,9 @@ func (a *App) inputAreaView() []tui.View {
 	views = append(views,
 		tui.InputField(&a.inputText).
 			ID("main-input").
-			Prompt(" ❯ ").
-			PromptStyle(tui.NewStyle().WithFgRGB(dimText)).
+			Prompt("❯").
+			PromptStyle(tui.NewStyle().WithFgRGB(accentBright).WithBold()).
+			TextStyle(tui.NewStyle().WithFgRGB(primaryText)).
 			Placeholder("Type a message... (@filename, or drop a file to attach)").
 			Multiline(true).
 			MaxHeight(10).
@@ -584,38 +627,33 @@ func (a *App) inputAreaView() []tui.View {
 	)
 	views = append(views, tui.Divider())
 
-	// Show autocomplete options, compaction stats, or exit hint below the bottom divider
+	// Show autocomplete options or exit hint below the bottom divider
 	// Only reserve space when autocomplete is active (collapses otherwise)
 	footerViews := make([]tui.View, 0, 8)
 
 	if len(a.autocompleteMatches) > 0 {
-		count := len(a.autocompleteMatches)
-		if count > 8 {
-			count = 8
-		}
 		prefix := "@"
 		if a.autocompleteType == "command" {
 			prefix = "/"
 		}
-		for i := 0; i < count; i++ {
+		start, end := autocompleteWindow(len(a.autocompleteMatches), a.autocompleteIndex)
+		for i := start; i < end; i++ {
 			match := a.autocompleteMatches[i]
 			if i == a.autocompleteIndex {
-				footerViews = append(footerViews, tui.Text(" ❯ %s%s", prefix, match).Fg(tui.ColorCyan))
+				position := ""
+				if len(a.autocompleteMatches) > autocompleteWindowSize {
+					position = fmt.Sprintf("  (%d/%d)", i+1, len(a.autocompleteMatches))
+				}
+				footerViews = append(footerViews, tui.Text(" ❯ %s%s%s", prefix, match, position).
+					Style(tui.NewStyle().WithFgRGB(accentBright).WithBold()))
 			} else {
-				footerViews = append(footerViews, tui.Text("   %s%s", prefix, match).Style(hintStyle()))
+				footerViews = append(footerViews, tui.Text("   %s%s", prefix, match).Style(autocompleteOptionStyle()))
 			}
 		}
-		// Pad to 8 lines only when autocomplete is active (stable height during selection)
-		for len(footerViews) < 8 {
+		// Keep the footer height stable as the final, shorter window comes into view.
+		for len(footerViews) < autocompleteWindowSize {
 			footerViews = append(footerViews, tui.Text(""))
 		}
-	} else if a.showCompactionStats && a.lastCompactionEvent != nil {
-		footerViews = append(footerViews, tui.Group(
-			tui.Text(" ⚡").Fg(tui.ColorYellow),
-			tui.Text(" Context compacted:").Style(hintStyle()),
-			tui.Text(" %d → %d tokens", a.lastCompactionEvent.TokensBefore, a.lastCompactionEvent.TokensAfter),
-			tui.Text(" (%d messages summarized)", a.lastCompactionEvent.MessagesCompacted).Style(hintStyle()),
-		))
 	} else if a.showExitHint {
 		footerViews = append(footerViews, tui.Text(" Press Ctrl+C again to exit").Style(hintStyle()))
 	}
@@ -628,12 +666,8 @@ func (a *App) inputAreaView() []tui.View {
 		}
 	}
 
-	// Minimum padding at bottom for visual breathing room
-	for len(footerViews) < 2 {
-		footerViews = append(footerViews, tui.Text(""))
-	}
-
 	views = append(views, footerViews...)
+	views = append(views, tui.Text(""))
 	return views
 }
 
@@ -647,15 +681,12 @@ func (a *App) attachmentsView() tui.View {
 	rows := make([]tui.View, 0, len(a.attachments))
 	for _, att := range a.attachments {
 		rows = append(rows, tui.Group(
-			tui.Text(" ⏺ ").Fg(tui.ColorCyan),
+			tui.Text(" ⏺ ").Style(tui.NewStyle().WithFgRGB(accentMid)),
 			tui.Text("%s (%s)", att.Name, formatBytes(int(att.Size))).Style(hintStyle()),
 		))
 	}
 	return tui.Stack(rows...).Gap(0)
 }
-
-// Purple color for Claude Code style UI elements
-var purpleColor = tui.RGB{R: 180, G: 140, B: 220}
 
 // dialogView builds the view for tool dialogs
 func (a *App) dialogView() tui.View {
@@ -667,13 +698,12 @@ func (a *App) dialogView() tui.View {
 
 	switch a.dialogState.Type {
 	case DialogTypeConfirm:
-		// Claude Code style confirmation dialog using PromptChoice
-		purpleStyle := tui.NewStyle().WithFgRGB(purpleColor)
-		confirmTextStyle := tui.NewStyle().WithFgRGB(tui.RGB{R: 198, G: 198, B: 210})
-		confirmInfoStyle := tui.NewStyle().WithFgRGB(tui.RGB{R: 198, G: 198, B: 210}).WithItalic()
+		accentStyle := tui.NewStyle().WithFgRGB(accentBright)
+		confirmTextStyle := tui.NewStyle().WithFgRGB(primaryText)
+		confirmInfoStyle := tui.NewStyle().WithFgRGB(mutedText).WithItalic()
 
 		// Upper divider (solid line)
-		views = append(views, tui.Divider().Char('─').Style(purpleStyle))
+		views = append(views, tui.Divider().Char('─').Style(accentStyle))
 
 		// Title and subtitle
 		views = append(views, tui.Text(" %s", a.dialogState.Title).Style(confirmTextStyle.WithBold()))
@@ -683,20 +713,20 @@ func (a *App) dialogView() tui.View {
 
 		// Content preview with dashed dividers
 		if a.dialogState.ContentPreview != "" {
-			views = append(views, tui.Divider().Char('╌').Style(purpleStyle))
+			views = append(views, tui.Divider().Char('╌').Style(accentStyle))
 			for _, line := range strings.Split(a.dialogState.ContentPreview, "\n") {
 				switch isDiffLine(line) {
 				case "+":
-					views = append(views, tui.Text(" %s", line).Success())
+					views = append(views, tui.Text(" %s", line).Style(successStyle()))
 				case "-":
-					views = append(views, tui.Text(" %s", line).Error())
+					views = append(views, tui.Text(" %s", line).Style(errorStyle()))
 				default:
 					views = append(views, tui.Text(" %s", line).Style(confirmTextStyle))
 				}
 			}
-			views = append(views, tui.Divider().Char('╌').Style(purpleStyle))
+			views = append(views, tui.Divider().Char('╌').Style(accentStyle))
 		} else {
-			views = append(views, tui.Divider().Char('╌').Style(purpleStyle))
+			views = append(views, tui.Divider().Char('╌').Style(accentStyle))
 		}
 
 		// Question
@@ -720,7 +750,7 @@ func (a *App) dialogView() tui.View {
 				Option("Yes").
 				Option(fmt.Sprintf("Yes, allow all %s during this session (shift+tab)", allowLabel)).
 				Option("No").
-				CursorStyle(purpleStyle).
+				CursorStyle(accentStyle).
 				HintText("").
 				OnSelect(func(idx int, inputText string) {
 					switch idx {
@@ -765,7 +795,8 @@ func (a *App) dialogView() tui.View {
 		selectChan := a.dialogState.SelectChan
 		numOptions := len(a.dialogState.Options)
 		promptChoice := tui.PromptChoice(&a.dialogState.SelectIndex, &a.dialogState.SelectOtherText).
-			ID("select-list")
+			ID("select-list").
+			CursorStyle(tui.NewStyle().WithFgRGB(accentBright))
 
 		// Add all predefined options
 		for _, opt := range a.dialogState.Options {
@@ -826,7 +857,8 @@ func (a *App) dialogView() tui.View {
 
 		views = append(views,
 			tui.CheckboxList(items, a.dialogState.MultiSelectChecked, &a.dialogState.MultiSelectCursor).
-				ID("multiselect-list"),
+				ID("multiselect-list").
+				CursorStyle(tui.NewStyle().WithFgRGB(accentBright)),
 		)
 
 		views = append(views, tui.Text(""))
@@ -850,7 +882,8 @@ func (a *App) dialogView() tui.View {
 			tui.InputField(&a.dialogState.InputValue).
 				ID("dialog-input").
 				Prompt(" > ").
-				PromptStyle(tui.NewStyle().WithForeground(tui.ColorCyan)).
+				PromptStyle(tui.NewStyle().WithFgRGB(accentBright)).
+				TextStyle(tui.NewStyle().WithFgRGB(primaryText)).
 				Placeholder(defaultValue).
 				Width(60).
 				OnSubmit(func(value string) {
@@ -916,10 +949,6 @@ func (a *App) HandleEvent(event tui.Event) []tui.Cmd {
 		if a.showExitHint && time.Since(a.lastCtrlC) >= 2*time.Second {
 			a.showExitHint = false
 		}
-		// Clear compaction stats after 5 seconds
-		if a.showCompactionStats && time.Since(a.compactionStatsStartTime) >= 5*time.Second {
-			a.showCompactionStats = false
-		}
 
 	// Custom events from background goroutines
 	case processingStartEvent:
@@ -946,6 +975,11 @@ func (a *App) HandleEvent(event tui.Event) []tui.Cmd {
 		a.handleProcessingEnd(e.err)
 	case compactionEvent:
 		a.handleCompaction(e.event, e.midTurn)
+	case compactionStartEvent:
+		a.compacting = true
+		a.compactingStartTime = time.Now()
+	case compactionEndEvent:
+		a.handleCompactEnd(e)
 	case toolStreamEvent:
 		a.handleToolStream(e)
 	case toolProgressEvent:
@@ -1036,6 +1070,14 @@ func (a *App) handleDialogKey(e tui.KeyEvent) []tui.Cmd {
 
 // updateAutocomplete updates autocomplete state based on current input
 func (a *App) updateAutocomplete() {
+	// History browsing owns Up/Down until the user edits the recalled entry.
+	// In particular, recalling "/help" must not open command completion and
+	// steal the next arrow key from history navigation.
+	if a.historyIndex >= 0 {
+		a.clearAutocomplete()
+		return
+	}
+
 	// Check for command autocomplete (/ at start of input)
 	if strings.HasPrefix(a.inputText, "/") {
 		prefix := a.inputText[1:]
@@ -1051,9 +1093,6 @@ func (a *App) updateAutocomplete() {
 			a.autocompletePrefix = prefix
 			a.autocompleteType = "command"
 			a.autocompleteMatches = a.getCommandMatches(prefix)
-			if len(a.autocompleteMatches) > 8 {
-				a.autocompleteMatches = a.autocompleteMatches[:8]
-			}
 			a.autocompleteIndex = 0
 		}
 		return
@@ -1080,9 +1119,6 @@ func (a *App) updateAutocomplete() {
 		a.autocompletePrefix = prefix
 		a.autocompleteType = "file"
 		a.autocompleteMatches = a.getFileMatches(prefix)
-		if len(a.autocompleteMatches) > 8 {
-			a.autocompleteMatches = a.autocompleteMatches[:8]
-		}
 		a.autocompleteIndex = 0
 	}
 }
@@ -1101,6 +1137,12 @@ func (a *App) setInputText(value string) {
 // never triggers a filesystem lookup.
 func (a *App) handleInputChange(value string) {
 	prev := a.lastInput
+	if value != prev {
+		// An edit turns recalled history back into a live draft. Completion can
+		// now respond to the edited text, and Down must not replace it with a
+		// different history entry.
+		a.historyIndex = -1
+	}
 	a.lastInput = value
 	a.pruneAttachments(value)
 
@@ -1217,6 +1259,30 @@ func (a *App) clearAutocomplete() {
 	a.autocompleteIndex = 0
 	a.autocompletePrefix = ""
 	a.autocompleteType = ""
+}
+
+// autocompleteWindow returns the visible slice of a longer completion list.
+// The selection stays on screen while moving one row at a time, rather than
+// discarding matches beyond the first page.
+func autocompleteWindow(total, selected int) (start, end int) {
+	if total <= 0 {
+		return 0, 0
+	}
+	if selected < 0 {
+		selected = 0
+	} else if selected >= total {
+		selected = total - 1
+	}
+
+	start = selected - autocompleteWindowSize + 1
+	if start < 0 {
+		start = 0
+	}
+	end = start + autocompleteWindowSize
+	if end > total {
+		end = total
+	}
+	return start, end
 }
 
 // selectAutocomplete selects the current autocomplete option
@@ -1385,7 +1451,7 @@ func (a *App) submitInput(value string) {
 	}
 
 	trimmed := strings.TrimSpace(a.inputText)
-	if trimmed == "" || a.processing {
+	if trimmed == "" || a.processing || a.compacting {
 		return
 	}
 
@@ -1678,6 +1744,12 @@ func (a *App) checkAndPerformCompaction(lastUsage *llm.Usage) {
 	// Calculate tokens before (from last LLM call = actual context size)
 	tokensBefore := compaction.CalculateContextTokens(lastUsage)
 
+	// This runs on the agent's background goroutine after the turn's LLM
+	// calls, so the event loop keeps rendering — but the turn's
+	// processingEnd is delayed until the summary call returns. Say what
+	// the pause is so it doesn't read as a hang.
+	a.postFlash("Compacting context…")
+
 	// Perform compaction using the session's Compact method
 	err = a.currentSession.Compact(a.ctx, func(ctx context.Context, messages []*llm.Message) ([]*llm.Message, error) {
 		compactedMsgs, _, err := compaction.CompactMessages(
@@ -1744,6 +1816,8 @@ func (a *App) handleProcessingStart(e processingStartEvent) {
 
 	a.processing = true
 	a.processingStartTime = time.Now()
+	// The turn-summary slot belongs to the new turn now.
+	a.showCompactionSummary = false
 	a.interactionUsage = &llm.Usage{}
 	if a.sessionUsage == nil {
 		a.sessionUsage = &llm.Usage{}
@@ -1891,8 +1965,9 @@ func shouldDisplayToolError(_ string, isError bool, _ string) bool {
 }
 
 // handleCompaction processes a compaction event and updates UI state.
-// The compaction notification is shown in the live view for 3 seconds,
-// and detailed stats are displayed in the footer for 5 seconds.
+// Between turns the result lands in exactly two places: a scrollback notice
+// (the durable record) and the turn-summary slot (the at-a-glance one, until
+// the next turn starts).
 func (a *App) handleCompaction(event *compaction.CompactionEvent, midTurn bool) {
 	a.lastCompactionEvent = event
 	// Reset usage so the context bar reflects post-compaction state.
@@ -1900,15 +1975,16 @@ func (a *App) handleCompaction(event *compaction.CompactionEvent, midTurn bool) 
 	a.lastUsage = nil
 	if midTurn {
 		// Mid-turn compaction happens while the agent is still working, so
-		// surface it as a scrollback line rather than the transient footer
-		// stats used between turns.
-		a.appendNotice(" ⚡ Context compacted mid-turn: ~%d → ~%d tokens (%d messages summarized)",
+		// only the scrollback line applies — the turn-summary slot belongs
+		// to the turn still in progress.
+		a.appendNotice("⚡ Context compacted mid-turn: ~%d → ~%d tokens (%d messages summarized)",
 			event.TokensBefore, event.TokensAfter, event.MessagesCompacted)
 		return
 	}
 	a.compactionEventTime = time.Now()
-	a.showCompactionStats = true
-	a.compactionStatsStartTime = time.Now()
+	a.showCompactionSummary = true
+	a.appendNotice("⚡ Context compacted: ~%d → ~%d tokens (%d messages summarized)",
+		event.TokensBefore, event.TokensAfter, event.MessagesCompacted)
 }
 
 // notifyMidTurnCompaction surfaces a mid-turn compaction (from
@@ -2202,12 +2278,16 @@ func (a *App) appendIntro() int {
 		wsDisplay = "~" + wsDisplay[len(home):]
 	}
 
-	content := a.modelDisplayName() + "\n" + wsDisplay
-	if !a.contextDemos.empty() {
-		content += "\ncontext: " + a.contextDemos.displaySummary() + " · /context to inspect"
+	modelSummary := a.modelDisplayName()
+	if eff := strings.TrimSpace(string(a.reasoningEffort)); eff != "" {
+		modelSummary += " with " + eff + " effort"
 	}
+	content := modelSummary + "\n" + wsDisplay
 	if scope := workspaceScopeSummary(a.workspaceDir); scope != "" {
 		content += "\nscope: " + scope
+	}
+	if !a.contextDemos.empty() {
+		content += "\ncontext: " + a.contextDemos.displaySummary() + " · /context to inspect"
 	}
 	if a.resumeSessionID != "" {
 		content += "\nResuming session: " + a.resumeSessionID
@@ -2396,6 +2476,10 @@ func (a *App) handleCommand(input string, attachments []attachment) bool {
 		return true
 
 	case "clear":
+		if a.compacting {
+			a.appendNotice("Wait for compaction to finish before clearing.")
+			return true
+		}
 		// Drop the transcript first, so anything the reset has to say about
 		// itself lands in the fresh one rather than the discarded one. nil,
 		// not [:0]: the old messages hold report views worth releasing.
@@ -2462,8 +2546,20 @@ func (a *App) handleCommand(input string, attachments []attachment) bool {
 		a.handleModelCommand(cmdArgs)
 		return true
 
+	case "effort":
+		a.handleEffortCommand(cmdArgs)
+		return true
+
+	case "thinking":
+		a.handleThinkingCommand(cmdArgs)
+		return true
+
+	case "status":
+		a.handleStatusCommand()
+		return true
+
 	case "usage", "cost":
-		a.printUsageReport()
+		a.handleUsageCommand(cmdArgs)
 		return true
 
 	case "copy":
@@ -2516,10 +2612,21 @@ func (a *App) handleCommand(input string, attachments []attachment) bool {
 	return true
 }
 
-// handleCompactCommand performs manual compaction of the conversation
+// handleCompactCommand validates a manual /compact request on the event loop,
+// then runs the summarizer in the background so ticks, keystrokes, and the
+// spinner keep animating while the LLM call takes seconds.
 func (a *App) handleCompactCommand() {
 	if a.compactionConfig == nil {
 		a.appendNotice("Compaction is disabled.")
+		return
+	}
+
+	if a.processing {
+		a.appendNotice("Finish the current turn before compacting.")
+		return
+	}
+	if a.compacting {
+		a.appendNotice("Already compacting...")
 		return
 	}
 
@@ -2540,8 +2647,6 @@ func (a *App) handleCompactCommand() {
 		return
 	}
 
-	a.appendNotice("Compacting conversation...")
-
 	// Calculate tokens before compaction (estimate)
 	tokensBefore := 0
 	for _, msg := range msgs {
@@ -2552,33 +2657,72 @@ func (a *App) handleCompactCommand() {
 		}
 	}
 
-	// Perform compaction using session's Compact method
+	model := a.compactionConfig.Model
+	if model == nil && a.agent != nil {
+		model = a.agent.Model()
+	}
 	summaryPrompt := a.compactionConfig.SummaryPrompt
 	if summaryPrompt == "" {
 		summaryPrompt = compaction.DefaultCompactionSummaryPrompt
 	}
+	sess := a.currentSession
+	compact := func() (event *compaction.CompactionEvent, err error) {
+		err = sess.Compact(a.ctx, func(ctx context.Context, messages []*llm.Message) ([]*llm.Message, error) {
+			compactedMsgs, evt, err := compaction.CompactMessages(
+				ctx,
+				model,
+				messages,
+				"",
+				summaryPrompt,
+				tokensBefore,
+			)
+			event = evt
+			return compactedMsgs, err
+		})
+		return event, err
+	}
 
-	var event *compaction.CompactionEvent
-	err = a.currentSession.Compact(a.ctx, func(ctx context.Context, messages []*llm.Message) ([]*llm.Message, error) {
-		compactedMsgs, evt, err := compaction.CompactMessages(
-			ctx,
-			a.compactionConfig.Model,
-			messages,
-			"",
-			summaryPrompt,
-			tokensBefore,
-		)
-		event = evt
-		return compactedMsgs, err
-	})
-	if err != nil {
-		a.appendNotice("Compaction failed: %v", err)
+	// Without a runner there is no event loop to report back to (unit
+	// tests); run inline so callers still get the transcript notices.
+	if a.runner == nil {
+		event, err := compact()
+		a.handleCompactEnd(compactionEndEvent{event: event, err: err})
 		return
 	}
 
-	// Show stats
-	if event != nil {
-		a.appendNotice("Compacted: ~%d -> ~%d tokens", event.TokensBefore, event.TokensAfter)
+	a.runner.SendEvent(compactionStartEvent{baseEvent: newBaseEvent()})
+	// No scrollback notice here: the compacting spinner in the live view
+	// already says what's happening. The result notice lands on completion.
+
+	go func() {
+		event, err := compact()
+		a.runner.SendEvent(compactionEndEvent{
+			baseEvent: newBaseEvent(),
+			event:     event,
+			err:       err,
+		})
+	}()
+}
+
+// handleCompactEnd finishes a manual /compact run on the event loop.
+func (a *App) handleCompactEnd(e compactionEndEvent) {
+	a.compacting = false
+	if e.err != nil {
+		// Surface cancellations quietly; the user asked to stop.
+		if errors.Is(e.err, context.Canceled) {
+			a.appendNotice("Compaction canceled.")
+			return
+		}
+		a.appendNotice("Compaction failed: %v", e.err)
+		return
+	}
+
+	if e.event != nil {
+		// handleCompaction writes the scrollback notice and takes the
+		// turn-summary slot.
+		a.handleCompaction(e.event, false)
+	} else {
+		a.appendNotice("Compacted conversation.")
 	}
 	a.warnIfManyCompactions()
 }
@@ -2589,9 +2733,12 @@ func (a *App) printHelp() {
 		tui.Text("  /quit, /q      Exit"),
 		tui.Text("  /clear         Clear conversation and screen"),
 		tui.Text("  /compact       Compact conversation to save context"),
-		tui.Text("  /model         Switch model"),
+		tui.Text("  /model [name]  Switch model (saved to ~/.dive/settings.json)"),
+		tui.Text("  /effort [lvl]  Show or switch thinking effort (none, minimal, low, medium, high, xhigh, max)"),
+		tui.Text("  /thinking [on|off]  Toggle summarized model thinking"),
+		tui.Text("  /status        Show model, effort, thinking, usage, and session"),
 		tui.Text("  /todos, /t     Toggle todo list"),
-		tui.Text("  /usage, /cost  Show token & cache usage breakdown"),
+		tui.Text("  /usage [full|brief]  Show usage breakdown; full/brief toggles the live panel"),
 		tui.Text("  /context       Inspect context-demo reminders from the latest turn"),
 		tui.Text("  /copy [N|all]  Copy the selection, or a code block from the last reply"),
 		tui.Text("  /mouse         Toggle mouse reporting"),
@@ -2677,8 +2824,8 @@ func (a *App) usageReportView() tui.View {
 	}
 
 	labelStyle := tui.NewStyle().WithFgRGB(dimText)
-	rowLabelStyle := tui.NewStyle().WithFgRGB(tui.RGB{R: 160, G: 160, B: 170})
-	valStyle := tui.NewStyle().WithFgRGB(tui.RGB{R: 220, G: 220, B: 230}).WithBold()
+	rowLabelStyle := tui.NewStyle().WithFgRGB(mutedText)
+	valStyle := tui.NewStyle().WithFgRGB(primaryText).WithBold()
 
 	const (
 		labelW = 16
@@ -2825,23 +2972,18 @@ func (a *App) buildLiveView(withActivity bool) tui.View {
 	}
 	views = append(views, activityViews...)
 
-	// Show compaction notification (if recent)
-	if a.lastCompactionEvent != nil && time.Since(a.compactionEventTime) < 3*time.Second {
-		views = append(views, tui.Group(
-			tui.Text("⚡").Fg(tui.ColorYellow),
-			tui.Text(" Context compacted").Fg(tui.ColorYellow),
-			tui.Text(" %d → %d tokens, %d messages summarized",
-				a.lastCompactionEvent.TokensBefore,
-				a.lastCompactionEvent.TokensAfter,
-				a.lastCompactionEvent.MessagesCompacted).Style(hintStyle()),
-		))
-	}
-
 	// Show generation progress indicator (below tool calls)
-	if a.streamingMessageIndex >= 0 {
+	if a.compacting {
 		views = append(views, tui.Group(
-			tui.Loading(a.frame).CharSet(tui.SpinnerBounce.Frames).Speed(6).Fg(tui.ColorCyan),
-			tui.Text(" thinking").Animate(tui.Slide(3, tui.NewRGB(80, 80, 80), tui.NewRGB(80, 200, 220))),
+			tui.Loading(a.frame).CharSet(tui.SpinnerBounce.Frames).Speed(6).Style(warningStyle()),
+			tui.Text(" compacting").Animate(tui.Slide(3, fadedText, warningText)),
+			tui.Text(" (%s)", formatDuration(time.Since(a.compactingStartTime))).Style(hintStyle()),
+		))
+	} else if a.streamingMessageIndex >= 0 {
+		views = append(views, tui.Group(
+			tui.Loading(a.frame).CharSet(tui.SpinnerBounce.Frames).Speed(6).
+				Style(tui.NewStyle().WithFgRGB(accentBright)),
+			tui.Text(" thinking").Animate(tui.Slide(3, fadedText, accentBright)),
 			tui.Text(" (%s)", formatDuration(elapsed)).Style(hintStyle()),
 			tui.Text("  ").Style(hintStyle()),
 			tui.Text("esc to interrupt").Style(hintStyle()),
@@ -3053,8 +3195,9 @@ func fuzzyMatch(pattern, text string) int {
 func (a *App) getCommandMatches(prefix string) []string {
 	// Built-in commands
 	builtins := []string{
-		"clear", "compact", "context", "copy", "cost", "help",
-		"model", "mouse", "quit", "scrollback", "todos", "usage",
+		"clear", "compact", "context", "copy", "cost", "effort", "help",
+		"model", "mouse", "quit", "scrollback", "status", "thinking",
+		"todos", "usage",
 	}
 
 	var matches []string
@@ -3106,6 +3249,13 @@ func (a *App) getFileMatches(prefix string) []string {
 
 		relPath, err := filepath.Rel(a.workspaceDir, path)
 		if err != nil || relPath == "." {
+			return nil
+		}
+
+		if strings.HasPrefix(info.Name(), ".") {
+			if info.IsDir() {
+				return filepath.SkipDir
+			}
 			return nil
 		}
 
@@ -3217,7 +3367,7 @@ func (a *App) handleModelCommand(args string) {
 		Type:         DialogTypeSelect,
 		Active:       true,
 		Title:        "Select model",
-		Message:      "Switch between models. Applies to this session.",
+		Message:      "Switch between models. Saved to ~/.dive/settings.json.",
 		Options:      options,
 		DefaultIndex: defaultIdx,
 		SelectIndex:  defaultIdx,
@@ -3260,7 +3410,15 @@ func (a *App) switchModel(modelID string) {
 		return
 	}
 	if modelID == a.modelName {
-		a.appendNotice("Already using %s", a.modelDisplayName())
+		// Selecting the active model can still be meaningful when it came
+		// from autodetection, an environment variable, or a one-off flag: the
+		// explicit slash command should make it the remembered user default.
+		a.modelSource = "session"
+		if err := saveUserModel(modelID); err != nil {
+			a.appendNotice("Already using %s, but saving to settings failed: %v", a.modelDisplayName(), err)
+			return
+		}
+		a.appendNotice("Already using %s; saved to ~/.dive/settings.json", a.modelDisplayName())
 		return
 	}
 
@@ -3277,6 +3435,9 @@ func (a *App) switchModel(modelID string) {
 	// Update compaction model so compaction uses the new model
 	if a.compactionConfig != nil {
 		a.compactionConfig.Model = newModel
+		if !a.compactionThresholdExplicit {
+			a.compactionConfig.ContextTokenThreshold = compactionThreshold(0, modelID)
+		}
 	}
 
 	// Update the model line in the system prompt so the agent knows its identity
@@ -3288,5 +3449,5 @@ func (a *App) switchModel(modelID string) {
 		}
 	}
 
-	a.appendNotice("Switched to %s", a.modelDisplayName())
+	a.persistModelSwitch(modelID)
 }

--- a/experimental/cmd/dive/app_interactive_test.go
+++ b/experimental/cmd/dive/app_interactive_test.go
@@ -132,7 +132,6 @@ func TestAppFooterCollapse(t *testing.T) {
 	t.Run("footer minimal without autocomplete", func(t *testing.T) {
 		// No autocomplete matches
 		app.autocompleteMatches = nil
-		app.showCompactionStats = false
 		app.showExitHint = false
 
 		// Render to buffer to count actual output lines (not screen lines)
@@ -171,28 +170,31 @@ func TestAppFooterCollapse(t *testing.T) {
 	})
 }
 
-// TestAppCompactionStats tests the compaction stats display
-func TestAppCompactionStats(t *testing.T) {
+// TestAppCompactionSummary tests that a compaction takes the turn-summary slot
+func TestAppCompactionSummary(t *testing.T) {
 	agent := &dive.Agent{}
 	app := NewApp(agent, nil, "/tmp/test", "test-model", "", nil, "", nil, "")
 
-	t.Run("shows compaction stats when enabled", func(t *testing.T) {
-		app.showCompactionStats = true
+	t.Run("compaction replaces Worked for in the summary slot", func(t *testing.T) {
+		app.showCompactionSummary = true
+		app.compactionEventTime = time.Now()
 		app.lastCompactionEvent = &compaction.CompactionEvent{
 			TokensBefore:      150000,
 			TokensAfter:       50000,
 			MessagesCompacted: 25,
 		}
 
-		screen := renderLiveView(t, app, 80, 24)
+		var buf bytes.Buffer
+		tui.Fprint(&buf, app.turnSummaryView(), tui.WithWidth(80))
+		out := buf.String()
 
-		// Should show compaction info
-		termtest.AssertContains(t, screen, "150000")
-		termtest.AssertContains(t, screen, "50000")
-		termtest.AssertContains(t, screen, "25")
+		assert.Contains(t, out, "Compacted")
+		assert.Contains(t, out, "150000")
+		assert.Contains(t, out, "50000")
+		assert.NotContains(t, out, "Worked for")
 
 		// Reset
-		app.showCompactionStats = false
+		app.showCompactionSummary = false
 		app.lastCompactionEvent = nil
 	})
 }
@@ -303,7 +305,6 @@ func TestAppSnapshotView(t *testing.T) {
 		app.dialogState = nil
 		app.showTodos = false
 		app.autocompleteMatches = nil
-		app.showCompactionStats = false
 		app.showExitHint = false
 
 		screen := renderLiveView(t, app, 80, 24)

--- a/experimental/cmd/dive/app_test.go
+++ b/experimental/cmd/dive/app_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"errors"
 	"strings"
 	"testing"
 	"time"
@@ -33,7 +34,7 @@ func TestHandleCompaction(t *testing.T) {
 	// Verify state was updated correctly
 	assert.NotNil(t, app.lastCompactionEvent, "lastCompactionEvent should be set")
 	assert.Equal(t, event, app.lastCompactionEvent, "lastCompactionEvent should match the event")
-	assert.True(t, app.showCompactionStats, "showCompactionStats should be true")
+	assert.True(t, app.showCompactionSummary, "showCompactionSummary should take the turn-summary slot")
 
 	// Verify the event values
 	assert.Equal(t, 100000, app.lastCompactionEvent.TokensBefore)
@@ -43,8 +44,41 @@ func TestHandleCompaction(t *testing.T) {
 	// Verify timestamps are recent
 	assert.True(t, time.Since(app.compactionEventTime) < time.Second,
 		"compactionEventTime should be recent")
-	assert.True(t, time.Since(app.compactionStatsStartTime) < time.Second,
-		"compactionStatsStartTime should be recent")
+
+	// The result lands in the scrollback too.
+	assert.Contains(t, app.messages[len(app.messages)-1].Content, "Context compacted")
+
+	// The next turn reclaims the turn-summary slot.
+	app.handleProcessingStart(processingStartEvent{baseEvent: newBaseEvent(), userInput: "hi"})
+	assert.False(t, app.showCompactionSummary, "a new turn should clear the compaction summary")
+}
+
+func TestManualCompactionRunsOffTheEventLoop(t *testing.T) {
+	app, fake := newFakeApp(t)
+
+	// Starting compaction flips the flag; the live view shows progress
+	// instead of freezing on the last frame.
+	app.HandleEvent(compactionStartEvent{baseEvent: newBaseEvent()})
+	assert.True(t, app.compacting, "compacting should be true after start event")
+
+	var buf bytes.Buffer
+	tui.Fprint(&buf, app.buildLiveView(false), tui.WithWidth(80))
+	// The "compacting" label is per-character animated, so ANSI codes sit
+	// between its letters; the spinner glyph proves the progress line rendered.
+	assert.Contains(t, buf.String(), "⣾")
+
+	// A second /compact while one is running is refused, not queued.
+	app.compactionConfig = &compaction.CompactionConfig{}
+	before := len(fake.events)
+	app.handleCompactCommand()
+	assert.True(t, app.compacting, "second compact must not clear the flag")
+	assert.Equal(t, before, len(fake.events), "second compact must not start another run")
+	assert.Contains(t, app.messages[len(app.messages)-1].Content, "Already compacting")
+
+	// Failure clears the flag and lands in the transcript.
+	app.HandleEvent(compactionEndEvent{baseEvent: newBaseEvent(), err: errors.New("boom")})
+	assert.False(t, app.compacting, "compacting should be false after end event")
+	assert.Contains(t, app.messages[len(app.messages)-1].Content, "Compaction failed")
 }
 
 func TestShouldDisplayToolError(t *testing.T) {

--- a/experimental/cmd/dive/cli_settings.go
+++ b/experimental/cmd/dive/cli_settings.go
@@ -1,0 +1,198 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/deepnoodle-ai/dive"
+	"github.com/deepnoodle-ai/dive/experimental/settings"
+	"github.com/deepnoodle-ai/dive/llm"
+	"github.com/deepnoodle-ai/wonton/cli"
+)
+
+// CLI settings resolution: flag > env > settings file > built-in default.
+// The settings file is ~/.dive/settings.json merged with the project tiers
+// (.dive/settings.json, .dive/settings.local.json); see the settings package.
+
+func loadEffectiveCLISettings(workspaceDir string) *settings.Settings {
+	eff, err := settings.LoadEffectiveSettings(workspaceDir)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: failed to load settings: %v\n", err)
+		return &settings.Settings{}
+	}
+	return eff
+}
+
+// resolveModelName picks the model with flag > env > settings > autodetect.
+//
+// wonton's IsSet covers env-supplied values too, so an explicit flag is only
+// distinguishable when its value differs from the environment's. When they
+// coincide the label says "env" — the value is the same either way.
+func resolveModelName(ctx *cli.Context, eff *settings.Settings) (name, source string) {
+	if ctx.IsSet("model") {
+		if name := strings.TrimSpace(ctx.String("model")); name != "" {
+			if env, ok := os.LookupEnv("DIVE_MODEL"); ok && strings.TrimSpace(env) == name {
+				return name, "env"
+			}
+			return name, "flag"
+		}
+	}
+	if env, ok := os.LookupEnv("DIVE_MODEL"); ok && strings.TrimSpace(env) != "" {
+		return strings.TrimSpace(env), "env"
+	}
+	if eff != nil && eff.Model != nil && strings.TrimSpace(*eff.Model) != "" {
+		return strings.TrimSpace(*eff.Model), "settings"
+	}
+	return getDefaultModel(), "autodetect"
+}
+
+// resolveThinkingEffort picks the effort with flag > env > settings > medium.
+// An explicitly empty value omits the parameter entirely (for non-reasoning
+// models).
+func resolveThinkingEffort(ctx *cli.Context, eff *settings.Settings) (llm.ReasoningEffort, string) {
+	if ctx.IsSet("thinking-effort") {
+		value := ctx.String("thinking-effort")
+		if env, ok := os.LookupEnv("DIVE_THINKING_EFFORT"); ok && env == value {
+			return parseThinkingEffort(value), "env"
+		}
+		return parseThinkingEffort(value), "flag"
+	}
+	if env, ok := os.LookupEnv("DIVE_THINKING_EFFORT"); ok {
+		// Explicit empty env omits the parameter, same as the flag.
+		if strings.TrimSpace(env) == "" {
+			return "", "env"
+		}
+		return parseThinkingEffort(env), "env"
+	}
+	if eff != nil && eff.ThinkingEffort != nil {
+		if strings.TrimSpace(*eff.ThinkingEffort) == "" {
+			return "", "settings"
+		}
+		return parseThinkingEffort(*eff.ThinkingEffort), "settings"
+	}
+	return llm.ReasoningEffortMedium, "default"
+}
+
+// resolveShowThinking picks the thinking display with flag > env > settings.
+func resolveShowThinking(ctx *cli.Context, eff *settings.Settings) (bool, string) {
+	if ctx.IsSet("show-thinking") {
+		value := ctx.Bool("show-thinking")
+		if env, ok := os.LookupEnv("DIVE_SHOW_THINKING"); ok {
+			if b, err := strconv.ParseBool(strings.TrimSpace(env)); err == nil && b == value {
+				return value, "env"
+			}
+		}
+		return value, "flag"
+	}
+	if env, ok := os.LookupEnv("DIVE_SHOW_THINKING"); ok {
+		if b, err := strconv.ParseBool(strings.TrimSpace(env)); err == nil {
+			return b, "env"
+		}
+	}
+	if eff != nil && eff.ShowThinking != nil {
+		return *eff.ShowThinking, "settings"
+	}
+	return false, "default"
+}
+
+// resolveShowDetailedUsage picks the usage-panel mode with flag > env > settings.
+// False (default) shows only the session total cost on the status line; true
+// renders the full token breakdown table under it.
+func resolveShowDetailedUsage(ctx *cli.Context, eff *settings.Settings) (bool, string) {
+	if ctx != nil && ctx.IsSet("show-detailed-usage") {
+		value := ctx.Bool("show-detailed-usage")
+		if env, ok := os.LookupEnv("DIVE_SHOW_DETAILED_USAGE"); ok {
+			if b, err := strconv.ParseBool(strings.TrimSpace(env)); err == nil && b == value {
+				return value, "env"
+			}
+		}
+		return value, "flag"
+	}
+	if env, ok := os.LookupEnv("DIVE_SHOW_DETAILED_USAGE"); ok {
+		if b, err := strconv.ParseBool(strings.TrimSpace(env)); err == nil {
+			return b, "env"
+		}
+	}
+	if eff != nil && eff.ShowDetailedUsage != nil {
+		return *eff.ShowDetailedUsage, "settings"
+	}
+	return false, "default"
+}
+
+// buildCLIModelSettings constructs ModelSettings from already-resolved values.
+func buildCLIModelSettings(maxTokens int, tempSet bool, temp float64, showThinking bool, effort llm.ReasoningEffort) (*dive.ModelSettings, bool) {
+	modelSettings := &dive.ModelSettings{
+		MaxTokens: &maxTokens,
+	}
+	if showThinking {
+		modelSettings.Thinking = llm.ThinkingTypeAdaptive
+		modelSettings.ThinkingDisplay = llm.ThinkingDisplaySummarized
+	}
+	if effort != "" {
+		modelSettings.ReasoningEffort = effort
+	}
+	if tempSet {
+		t := temp
+		modelSettings.Temperature = &t
+	}
+	return modelSettings, showThinking
+}
+
+// snapshotCLIModelSettings returns a point-in-time copy for a newly spawned
+// subagent. Slash commands mutate the main agent's settings pointer in place;
+// sharing it would also change subagents that are already running.
+func snapshotCLIModelSettings(current *dive.ModelSettings) *dive.ModelSettings {
+	if current == nil {
+		return nil
+	}
+	snapshot := *current
+	return &snapshot
+}
+
+func currentSubagentDefaults(app *App, initialModel llm.LLM, initialSettings *dive.ModelSettings) (llm.LLM, *dive.ModelSettings) {
+	model := initialModel
+	modelSettings := snapshotCLIModelSettings(initialSettings)
+	if app != nil {
+		model = app.agent.Model()
+		modelSettings = snapshotCLIModelSettings(app.modelSettings)
+	}
+	return model, modelSettings
+}
+
+// newCLIModelSettingsWith resolves settings-file defaults underneath the
+// flag/env values newCLIModelSettings already handles. A nil eff skips the
+// settings tier (used by tests).
+func newCLIModelSettingsWith(ctx *cli.Context, eff *settings.Settings) (*dive.ModelSettings, bool) {
+	effort, _ := resolveThinkingEffort(ctx, eff)
+	showThinking, _ := resolveShowThinking(ctx, eff)
+	maxTokens := ctx.Int("max-tokens")
+	tempSet := ctx.IsSet("temperature")
+	var temp float64
+	if tempSet {
+		temp = ctx.Float64("temperature")
+	}
+	return buildCLIModelSettings(maxTokens, tempSet, temp, showThinking, effort)
+}
+
+func settingsStringPtr(s string) *string { return &s }
+
+func settingsBoolPtr(b bool) *bool { return &b }
+
+// saveUserModel persists the model default. Warns rather than failing the switch.
+func saveUserModel(model string) error {
+	return settings.SaveUserSettings(&settings.Settings{Model: settingsStringPtr(model)})
+}
+
+func saveUserEffort(effort llm.ReasoningEffort) error {
+	return settings.SaveUserSettings(&settings.Settings{ThinkingEffort: settingsStringPtr(string(effort))})
+}
+
+func saveUserThinking(show bool) error {
+	return settings.SaveUserSettings(&settings.Settings{ShowThinking: settingsBoolPtr(show)})
+}
+
+func saveUserDetailedUsage(show bool) error {
+	return settings.SaveUserSettings(&settings.Settings{ShowDetailedUsage: settingsBoolPtr(show)})
+}

--- a/experimental/cmd/dive/cli_settings_test.go
+++ b/experimental/cmd/dive/cli_settings_test.go
@@ -17,6 +17,14 @@ func testStrPtr(s string) *string { return &s }
 
 func testBoolPtr(b bool) *bool { return &b }
 
+func useTestUserSettingsRoot(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	restore := settings.SetUserSettingsRootForTesting(root)
+	t.Cleanup(restore)
+	return root
+}
+
 // unsetTestEnv removes a variable for the test's duration, restoring it after.
 // t.Setenv(key, "") is not equivalent: a present-but-empty variable still
 // counts as set for bool flags (and for some string flags) in the CLI parser.
@@ -237,7 +245,7 @@ func TestCurrentSubagentDefaultsUseLiveParentState(t *testing.T) {
 }
 
 func TestModelSwitchRefreshesAutomaticCompactionConfiguration(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
+	useTestUserSettingsRoot(t)
 	app, _ := newFakeApp(t)
 	app.modelName = "mistral-small-latest"
 	app.compactionConfig = &compaction.CompactionConfig{
@@ -252,7 +260,7 @@ func TestModelSwitchRefreshesAutomaticCompactionConfiguration(t *testing.T) {
 }
 
 func TestModelSwitchPreservesExplicitCompactionThreshold(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
+	useTestUserSettingsRoot(t)
 	app, _ := newFakeApp(t)
 	app.modelName = "mistral-small-latest"
 	app.compactionThresholdExplicit = true
@@ -268,7 +276,7 @@ func TestModelSwitchPreservesExplicitCompactionThreshold(t *testing.T) {
 }
 
 func TestSelectingActiveModelStillPersistsIt(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
+	useTestUserSettingsRoot(t)
 	app, _ := newFakeApp(t)
 	app.modelName = "gpt-5.6-sol"
 	app.modelSource = "autodetect"
@@ -283,7 +291,7 @@ func TestSelectingActiveModelStillPersistsIt(t *testing.T) {
 }
 
 func TestEffortCommandPersistsToSandboxedHome(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
+	useTestUserSettingsRoot(t)
 	app, _ := newFakeApp(t)
 	app.modelSettings = &dive.ModelSettings{}
 
@@ -299,7 +307,7 @@ func TestEffortCommandPersistsToSandboxedHome(t *testing.T) {
 }
 
 func TestThinkingCommandPersistsToSandboxedHome(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
+	useTestUserSettingsRoot(t)
 	app, _ := newFakeApp(t)
 	app.modelSettings = &dive.ModelSettings{}
 
@@ -315,7 +323,7 @@ func TestThinkingCommandPersistsToSandboxedHome(t *testing.T) {
 }
 
 func TestUsageCommandTogglesDetailedPanel(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
+	useTestUserSettingsRoot(t)
 	app, _ := newFakeApp(t)
 
 	app.handleUsageCommand("full")

--- a/experimental/cmd/dive/cli_settings_test.go
+++ b/experimental/cmd/dive/cli_settings_test.go
@@ -1,0 +1,343 @@
+package main
+
+import (
+	"os"
+	"testing"
+
+	"github.com/deepnoodle-ai/dive"
+	"github.com/deepnoodle-ai/dive/experimental/compaction"
+	"github.com/deepnoodle-ai/dive/experimental/settings"
+	"github.com/deepnoodle-ai/dive/llm"
+	"github.com/deepnoodle-ai/wonton/assert"
+	"github.com/deepnoodle-ai/wonton/cli"
+	"github.com/deepnoodle-ai/wonton/tui"
+)
+
+func testStrPtr(s string) *string { return &s }
+
+func testBoolPtr(b bool) *bool { return &b }
+
+// unsetTestEnv removes a variable for the test's duration, restoring it after.
+// t.Setenv(key, "") is not equivalent: a present-but-empty variable still
+// counts as set for bool flags (and for some string flags) in the CLI parser.
+func unsetTestEnv(t *testing.T, key string) {
+	t.Helper()
+	if value, ok := os.LookupEnv(key); ok {
+		t.Cleanup(func() { os.Setenv(key, value) })
+	} else {
+		t.Cleanup(func() { os.Unsetenv(key) })
+	}
+	os.Unsetenv(key)
+}
+
+// captureSettingsCtx builds a CLI context with the real flag definitions and
+// captures it for the resolution helpers.
+func captureSettingsCtx(t *testing.T, opts ...cli.TestOption) *cli.Context {
+	t.Helper()
+	app := cli.New("test")
+	var captured *cli.Context
+	app.Main().
+		Flags(
+			cli.String("model", "m").
+				Env("DIVE_MODEL"),
+			cli.Bool("show-thinking").
+				Default(false).
+				Env("DIVE_SHOW_THINKING"),
+			cli.Bool("show-detailed-usage").
+				Default(false).
+				Env("DIVE_SHOW_DETAILED_USAGE"),
+			cli.String("thinking-effort").
+				Default(string(llm.ReasoningEffortMedium)).
+				Env("DIVE_THINKING_EFFORT"),
+		).
+		Run(func(ctx *cli.Context) error {
+			captured = ctx
+			return nil
+		})
+	result := app.Test(t, opts...)
+	assert.True(t, result.Success(), result.Stderr)
+	if captured == nil {
+		t.Fatal("context was not captured")
+	}
+	return captured
+}
+
+func TestResolveModelNamePrecedence(t *testing.T) {
+	t.Run("flag beats env and settings", func(t *testing.T) {
+		ctx := captureSettingsCtx(t,
+			cli.TestArgs("--model", "flag-model"),
+			cli.TestEnv("DIVE_MODEL", "env-model"),
+		)
+		name, source := resolveModelName(ctx, &settings.Settings{Model: testStrPtr("settings-model")})
+		assert.Equal(t, "flag-model", name)
+		assert.Equal(t, "flag", source)
+	})
+
+	t.Run("env beats settings", func(t *testing.T) {
+		ctx := captureSettingsCtx(t, cli.TestEnv("DIVE_MODEL", "env-model"))
+		name, source := resolveModelName(ctx, &settings.Settings{Model: testStrPtr("settings-model")})
+		assert.Equal(t, "env-model", name)
+		assert.Equal(t, "env", source)
+	})
+
+	t.Run("settings beats autodetect", func(t *testing.T) {
+		unsetTestEnv(t, "DIVE_MODEL")
+		ctx := captureSettingsCtx(t)
+		name, source := resolveModelName(ctx, &settings.Settings{Model: testStrPtr("settings-model")})
+		assert.Equal(t, "settings-model", name)
+		assert.Equal(t, "settings", source)
+	})
+}
+
+func TestResolveThinkingEffortPrecedence(t *testing.T) {
+	t.Run("unset defaults to medium", func(t *testing.T) {
+		unsetTestEnv(t, "DIVE_THINKING_EFFORT")
+		ctx := captureSettingsCtx(t)
+		effort, source := resolveThinkingEffort(ctx, nil)
+		assert.Equal(t, llm.ReasoningEffortMedium, effort)
+		assert.Equal(t, "default", source)
+	})
+
+	t.Run("settings apply when flag and env are unset", func(t *testing.T) {
+		unsetTestEnv(t, "DIVE_THINKING_EFFORT")
+		ctx := captureSettingsCtx(t)
+		effort, source := resolveThinkingEffort(ctx,
+			&settings.Settings{ThinkingEffort: testStrPtr("high")})
+		assert.Equal(t, llm.ReasoningEffortHigh, effort)
+		assert.Equal(t, "settings", source)
+	})
+
+	t.Run("env beats settings", func(t *testing.T) {
+		ctx := captureSettingsCtx(t, cli.TestEnv("DIVE_THINKING_EFFORT", "xhigh"))
+		effort, source := resolveThinkingEffort(ctx,
+			&settings.Settings{ThinkingEffort: testStrPtr("low")})
+		assert.Equal(t, llm.ReasoningEffortXHigh, effort)
+		assert.Equal(t, "env", source)
+	})
+
+	t.Run("explicit empty flag omits the parameter", func(t *testing.T) {
+		ctx := captureSettingsCtx(t, cli.TestArgs("--thinking-effort", ""))
+		effort, source := resolveThinkingEffort(ctx,
+			&settings.Settings{ThinkingEffort: testStrPtr("high")})
+		assert.Equal(t, llm.ReasoningEffort(""), effort)
+		assert.Equal(t, "flag", source)
+	})
+}
+
+func TestResolveShowThinkingPrecedence(t *testing.T) {
+	t.Run("defaults to false", func(t *testing.T) {
+		unsetTestEnv(t, "DIVE_SHOW_THINKING")
+		ctx := captureSettingsCtx(t)
+		show, source := resolveShowThinking(ctx, nil)
+		assert.False(t, show)
+		assert.Equal(t, "default", source)
+	})
+
+	t.Run("settings apply when unset", func(t *testing.T) {
+		unsetTestEnv(t, "DIVE_SHOW_THINKING")
+		ctx := captureSettingsCtx(t)
+		show, source := resolveShowThinking(ctx,
+			&settings.Settings{ShowThinking: testBoolPtr(true)})
+		assert.True(t, show)
+		assert.Equal(t, "settings", source)
+	})
+
+	t.Run("env beats settings", func(t *testing.T) {
+		ctx := captureSettingsCtx(t, cli.TestEnv("DIVE_SHOW_THINKING", "false"))
+		show, source := resolveShowThinking(ctx,
+			&settings.Settings{ShowThinking: testBoolPtr(true)})
+		assert.False(t, show)
+		assert.Equal(t, "env", source)
+	})
+}
+
+func TestResolveShowDetailedUsageDefaultsCompact(t *testing.T) {
+	unsetTestEnv(t, "DIVE_SHOW_DETAILED_USAGE")
+	ctx := captureSettingsCtx(t)
+	show, source := resolveShowDetailedUsage(ctx, nil)
+	assert.False(t, show)
+	assert.Equal(t, "default", source)
+
+	ctx = captureSettingsCtx(t)
+	show, source = resolveShowDetailedUsage(ctx,
+		&settings.Settings{ShowDetailedUsage: testBoolPtr(true)})
+	assert.True(t, show)
+	assert.Equal(t, "settings", source)
+}
+
+func TestTrimTrailingWhitespacePerLine(t *testing.T) {
+	assert.Equal(t, "a\nb\nc",
+		trimTrailingWhitespacePerLine("a   \nb\t\nc"))
+	assert.Equal(t, "  indented\nplain",
+		trimTrailingWhitespacePerLine("  indented   \nplain"))
+}
+
+func TestSetEffortUpdatesLiveModelSettings(t *testing.T) {
+	app, _ := newFakeApp(t)
+	app.modelSettings = &dive.ModelSettings{}
+	app.setEffort(llm.ReasoningEffortHigh, "session")
+	assert.Equal(t, llm.ReasoningEffortHigh, app.reasoningEffort)
+	assert.Equal(t, llm.ReasoningEffortHigh, app.modelSettings.ReasoningEffort)
+	assert.Equal(t, "session", app.effortSource)
+}
+
+func TestSetThinkingUpdatesLiveModelSettings(t *testing.T) {
+	app, _ := newFakeApp(t)
+	app.modelSettings = &dive.ModelSettings{}
+
+	app.setThinking(true, "session")
+	assert.True(t, app.showThinking)
+	assert.Equal(t, llm.ThinkingTypeAdaptive, app.modelSettings.Thinking)
+	assert.Equal(t, llm.ThinkingDisplaySummarized, app.modelSettings.ThinkingDisplay)
+	assert.Equal(t, "session", app.thinkingSource)
+
+	app.setThinking(false, "session")
+	assert.False(t, app.showThinking)
+	assert.Equal(t, llm.ThinkingType(""), app.modelSettings.Thinking)
+	assert.Equal(t, llm.ThinkingDisplay(""), app.modelSettings.ThinkingDisplay)
+}
+
+func TestDetailedUsageTracksItsEffectiveSource(t *testing.T) {
+	app, _ := newFakeApp(t)
+	app.setDetailedUsage(true, "settings")
+	assert.True(t, app.showDetailedUsage)
+	assert.Equal(t, "settings", app.detailedUsageSource)
+}
+
+func TestSnapshotCLIModelSettingsDoesNotShareMutableState(t *testing.T) {
+	current := &dive.ModelSettings{
+		ReasoningEffort: llm.ReasoningEffortHigh,
+		Thinking:        llm.ThinkingTypeAdaptive,
+	}
+	snapshot := snapshotCLIModelSettings(current)
+	assert.NotNil(t, snapshot)
+
+	current.ReasoningEffort = llm.ReasoningEffortLow
+	current.Thinking = ""
+	assert.Equal(t, llm.ReasoningEffortHigh, snapshot.ReasoningEffort)
+	assert.Equal(t, llm.ThinkingTypeAdaptive, snapshot.Thinking)
+}
+
+func TestCurrentSubagentDefaultsUseLiveParentState(t *testing.T) {
+	app, _ := newFakeApp(t)
+	initialModel := createModel("mistral-small-latest", "")
+	liveModel := createModel("gpt-5.6-sol", "")
+	app.agent.SetModel(liveModel)
+	app.modelSettings = &dive.ModelSettings{ReasoningEffort: llm.ReasoningEffortXHigh}
+
+	model, modelSettings := currentSubagentDefaults(
+		app,
+		initialModel,
+		&dive.ModelSettings{ReasoningEffort: llm.ReasoningEffortLow},
+	)
+
+	assert.True(t, model == liveModel, "new subagents should inherit the switched parent model")
+	assert.Equal(t, llm.ReasoningEffortXHigh, modelSettings.ReasoningEffort)
+	assert.True(t, modelSettings != app.modelSettings, "subagents should receive a settings snapshot")
+}
+
+func TestModelSwitchRefreshesAutomaticCompactionConfiguration(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	app, _ := newFakeApp(t)
+	app.modelName = "mistral-small-latest"
+	app.compactionConfig = &compaction.CompactionConfig{
+		ContextTokenThreshold: compactionThreshold(0, app.modelName),
+		Model:                 createModel(app.modelName, ""),
+	}
+
+	app.switchModel("gpt-5.6-sol")
+
+	assert.Equal(t, compactionThreshold(0, "gpt-5.6-sol"), app.compactionConfig.ContextTokenThreshold)
+	assert.Equal(t, app.agent.Model(), app.compactionConfig.Model)
+}
+
+func TestModelSwitchPreservesExplicitCompactionThreshold(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	app, _ := newFakeApp(t)
+	app.modelName = "mistral-small-latest"
+	app.compactionThresholdExplicit = true
+	app.compactionConfig = &compaction.CompactionConfig{
+		ContextTokenThreshold: 42_000,
+		Model:                 createModel(app.modelName, ""),
+	}
+
+	app.switchModel("gpt-5.6-sol")
+
+	assert.Equal(t, 42_000, app.compactionConfig.ContextTokenThreshold)
+	assert.Equal(t, app.agent.Model(), app.compactionConfig.Model)
+}
+
+func TestSelectingActiveModelStillPersistsIt(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	app, _ := newFakeApp(t)
+	app.modelName = "gpt-5.6-sol"
+	app.modelSource = "autodetect"
+
+	app.switchModel("gpt-5.6-sol")
+
+	eff, err := settings.LoadEffectiveSettings("")
+	assert.NoError(t, err)
+	assert.NotNil(t, eff.Model)
+	assert.Equal(t, "gpt-5.6-sol", *eff.Model)
+	assert.Equal(t, "session", app.modelSource)
+}
+
+func TestEffortCommandPersistsToSandboxedHome(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	app, _ := newFakeApp(t)
+	app.modelSettings = &dive.ModelSettings{}
+
+	app.handleEffortCommand("high")
+	assert.Equal(t, llm.ReasoningEffortHigh, app.reasoningEffort)
+
+	eff, err := settings.LoadEffectiveSettings("")
+	assert.NoError(t, err)
+	if eff.ThinkingEffort == nil {
+		t.Fatal("expected thinking_effort to be persisted")
+	}
+	assert.Equal(t, "high", *eff.ThinkingEffort)
+}
+
+func TestThinkingCommandPersistsToSandboxedHome(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	app, _ := newFakeApp(t)
+	app.modelSettings = &dive.ModelSettings{}
+
+	app.handleThinkingCommand("on")
+	assert.True(t, app.showThinking)
+
+	eff, err := settings.LoadEffectiveSettings("")
+	assert.NoError(t, err)
+	if eff.ShowThinking == nil {
+		t.Fatal("expected show_thinking to be persisted")
+	}
+	assert.True(t, *eff.ShowThinking)
+}
+
+func TestUsageCommandTogglesDetailedPanel(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	app, _ := newFakeApp(t)
+
+	app.handleUsageCommand("full")
+	assert.True(t, app.showDetailedUsage)
+	assert.Equal(t, "session", app.detailedUsageSource)
+
+	app.handleUsageCommand("brief")
+	assert.False(t, app.showDetailedUsage)
+}
+
+func TestStatusShowsSourcesForEveryPersistedSetting(t *testing.T) {
+	app, _ := newFakeApp(t)
+	app.modelSource = "flag"
+	app.effortSource = "settings"
+	app.thinkingSource = "env"
+	app.detailedUsageSource = "session"
+
+	app.handleStatusCommand()
+	view := app.messages[len(app.messages)-1].View
+	text := tui.Sprint(view, tui.WithWidth(100))
+	assert.Contains(t, text, "model:           test-model (from flag)")
+	assert.Contains(t, text, "thinking effort: unset (parameter omitted) (from settings)")
+	assert.Contains(t, text, "thinking display: off (from env)")
+	assert.Contains(t, text, "detailed usage:   off (from session)")
+}

--- a/experimental/cmd/dive/cmd_settings.go
+++ b/experimental/cmd/dive/cmd_settings.go
@@ -1,0 +1,183 @@
+package main
+
+import (
+	"strings"
+
+	"github.com/deepnoodle-ai/dive/llm"
+	"github.com/deepnoodle-ai/wonton/tui"
+)
+
+// effortLevels lists the known reasoning-effort values for /effort help and
+// validation. Provider-specific values are still accepted as-is.
+var effortLevels = []string{"none", "minimal", "low", "medium", "high", "xhigh", "max"}
+
+// handleEffortCommand shows or switches the reasoning effort. The switch
+// applies to the next turn and is persisted to ~/.dive/settings.json.
+func (a *App) handleEffortCommand(args string) {
+	arg := strings.ToLower(strings.TrimSpace(args))
+	if arg == "" {
+		current := strings.TrimSpace(string(a.reasoningEffort))
+		if current == "" {
+			current = "(unset — parameter omitted)"
+		}
+		a.appendNotice("Thinking effort: %s (from %s). Levels: %s. Usage: /effort <level>",
+			current, a.effortSourceOrDefault(), strings.Join(effortLevels, ", "))
+		return
+	}
+	// Accept an explicit empty (quoted) or "omit" to drop the parameter for
+	// non-reasoning models; otherwise parse known levels case-insensitively
+	// and pass anything else through as a provider-specific value.
+	var effort llm.ReasoningEffort
+	if arg == `""` || arg == "omit" || arg == "off" {
+		effort = ""
+	} else {
+		effort = parseThinkingEffort(arg)
+	}
+	a.setEffort(effort, "session")
+	if err := saveUserEffort(effort); err != nil {
+		a.appendNotice("Effort set to %s for this session, but saving to settings failed: %v", effortDisplay(effort), err)
+		return
+	}
+	a.appendNotice("Thinking effort set to %s (saved to ~/.dive/settings.json)", effortDisplay(effort))
+}
+
+// setEffort applies the effort to app state and the live model settings.
+func (a *App) setEffort(effort llm.ReasoningEffort, source string) {
+	a.reasoningEffort = effort
+	a.effortSource = source
+	if a.modelSettings != nil {
+		a.modelSettings.ReasoningEffort = effort
+	}
+}
+
+func effortDisplay(effort llm.ReasoningEffort) string {
+	if strings.TrimSpace(string(effort)) == "" {
+		return "unset (parameter omitted)"
+	}
+	return string(effort)
+}
+
+func (a *App) effortSourceOrDefault() string {
+	if a.effortSource != "" {
+		return a.effortSource
+	}
+	return "default"
+}
+
+// handleThinkingCommand shows or toggles summarized model thinking. No args
+// toggles; on/off sets explicitly. Persisted to ~/.dive/settings.json.
+func (a *App) handleThinkingCommand(args string) {
+	arg := strings.ToLower(strings.TrimSpace(args))
+	switch arg {
+	case "":
+		a.setThinking(!a.showThinking, "session")
+	case "on", "true", "1", "show", "yes":
+		a.setThinking(true, "session")
+	case "off", "false", "0", "hide", "no":
+		a.setThinking(false, "session")
+	default:
+		a.appendNotice("Usage: /thinking [on|off]")
+		return
+	}
+	if err := saveUserThinking(a.showThinking); err != nil {
+		a.appendNotice("Thinking %s for this session, but saving to settings failed: %v", thinkingStateWord(a.showThinking), err)
+		return
+	}
+	a.appendNotice("Thinking display %s (saved to ~/.dive/settings.json)", thinkingStateWord(a.showThinking))
+}
+
+// setThinking applies the thinking display to app state and live model settings.
+func (a *App) setThinking(show bool, source string) {
+	a.showThinking = show
+	a.thinkingSource = source
+	if a.modelSettings != nil {
+		if show {
+			a.modelSettings.Thinking = llm.ThinkingTypeAdaptive
+			a.modelSettings.ThinkingDisplay = llm.ThinkingDisplaySummarized
+		} else {
+			a.modelSettings.Thinking = ""
+			a.modelSettings.ThinkingDisplay = ""
+		}
+	}
+}
+
+func thinkingStateWord(show bool) string {
+	if show {
+		return "on"
+	}
+	return "off"
+}
+
+// handleUsageCommand extends /usage and /cost: bare shows the full report;
+// "full" enables the live breakdown panel (persisted); "brief" disables it.
+func (a *App) handleUsageCommand(args string) {
+	switch strings.ToLower(strings.TrimSpace(args)) {
+	case "full", "detail", "detailed", "on":
+		a.setDetailedUsage(true, "session")
+		if err := saveUserDetailedUsage(true); err != nil {
+			a.appendNotice("Detailed usage shown for this session, but saving to settings failed: %v", err)
+			return
+		}
+		a.appendNotice("Detailed usage will show under the status line (saved to ~/.dive/settings.json)")
+	case "brief", "compact", "off":
+		a.setDetailedUsage(false, "session")
+		if err := saveUserDetailedUsage(false); err != nil {
+			a.appendNotice("Detailed usage hidden for this session, but saving to settings failed: %v", err)
+			return
+		}
+		a.appendNotice("Status line shows only the session total cost (saved to ~/.dive/settings.json)")
+	case "":
+		a.printUsageReport()
+	default:
+		a.appendNotice("Usage: /usage [full|brief]")
+	}
+}
+
+func (a *App) setDetailedUsage(show bool, source string) {
+	a.showDetailedUsage = show
+	a.detailedUsageSource = source
+}
+
+// handleStatusCommand prints the effective configuration: model, effort,
+// thinking, usage mode, session, and context — the one place all of it is
+// visible together.
+func (a *App) handleStatusCommand() {
+	modelSource := a.modelSource
+	if modelSource == "" {
+		modelSource = "default"
+	}
+	views := []tui.View{
+		tui.Text("Status").Bold(),
+		tui.Text("  model:           %s (from %s)", a.modelDisplayName(), modelSource),
+		tui.Text("  thinking effort: %s (from %s)", effortDisplay(a.reasoningEffort), a.effortSourceOrDefault()),
+		tui.Text("  thinking display: %s (from %s)", thinkingStateWord(a.showThinking), settingSourceOrDefault(a.thinkingSource)),
+		tui.Text("  detailed usage:   %s (from %s)", thinkingStateWord(a.showDetailedUsage), settingSourceOrDefault(a.detailedUsageSource)),
+	}
+	if a.currentSession != nil && a.currentSession.ID() != "" {
+		views = append(views, tui.Text("  session:         %s", a.currentSession.ID()))
+	}
+	if a.lastUsage != nil {
+		views = append(views, tui.Text("  context:         %d%%", a.contextPercent()))
+	}
+	if cost := a.sessionTotalCostString(); cost != "" {
+		views = append(views, tui.Text("  session cost:    %s", cost))
+	}
+	a.appendReport(tui.Stack(views...))
+}
+
+func settingSourceOrDefault(source string) string {
+	if source == "" {
+		return "default"
+	}
+	return source
+}
+
+// persistModelSwitch saves the model default after an in-session switch.
+func (a *App) persistModelSwitch(modelID string) {
+	a.modelSource = "session"
+	if err := saveUserModel(modelID); err != nil {
+		a.appendNotice("Switched to %s for this session, but saving to settings failed: %v", a.modelDisplayName(), err)
+		return
+	}
+	a.appendNotice("Switched to %s (saved to ~/.dive/settings.json)", a.modelDisplayName())
+}

--- a/experimental/cmd/dive/go.mod
+++ b/experimental/cmd/dive/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/deepnoodle-ai/dive/providers/grok v1.27.0
 	github.com/deepnoodle-ai/dive/providers/meta v1.27.0
 	github.com/deepnoodle-ai/dive/providers/openai v1.27.0
-	github.com/deepnoodle-ai/wonton v0.1.0
+	github.com/deepnoodle-ai/wonton v0.2.1
 	github.com/mattn/go-runewidth v0.0.29
 	golang.org/x/term v0.45.0
 	google.golang.org/genai v1.71.0

--- a/experimental/cmd/dive/go.sum
+++ b/experimental/cmd/dive/go.sum
@@ -15,8 +15,8 @@ github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XL
 github.com/clipperhouse/uax29/v2 v2.7.0 h1:+gs4oBZ2gPfVrKPthwbMzWZDaAFPGYK72F0NJv2v7Vk=
 github.com/clipperhouse/uax29/v2 v2.7.0/go.mod h1:EFJ2TJMRUaplDxHKj1qAEhCtQPW2tJSwu5BF98AuoVM=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/deepnoodle-ai/wonton v0.1.0 h1:59gaXJPwulv/cj/mR+bOpdyGrMvUEQ32oFf59zVk4f8=
-github.com/deepnoodle-ai/wonton v0.1.0/go.mod h1:G3fVZXXX/Oo01ATag//PH/6khtBNlDmxznXjORuG9gE=
+github.com/deepnoodle-ai/wonton v0.2.1 h1:GvfNIQT2B6NrEgXZHuxhUwjeMTm7Ms6YuZN17Oq2m4o=
+github.com/deepnoodle-ai/wonton v0.2.1/go.mod h1:G3fVZXXX/Oo01ATag//PH/6khtBNlDmxznXjORuG9gE=
 github.com/dlclark/regexp2/v2 v2.7.1 h1:yqDtwI1ptXXvEUNpYTk2lad4jLtAcKqkzepn4savSk4=
 github.com/dlclark/regexp2/v2 v2.7.1/go.mod h1:avUrQvPaLz2DrFNHJF0taWAFFX2C1GMSSoeiqFjcBmU=
 github.com/felixge/httpsnoop v1.1.0 h1:3YtUj32ZZkqZtt3sZZsClsymw/QDuVfpNhoA31zeORc=

--- a/experimental/cmd/dive/input_nav_test.go
+++ b/experimental/cmd/dive/input_nav_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"testing"
 
 	"github.com/deepnoodle-ai/dive"
@@ -34,6 +35,39 @@ func TestHandleInputNavKey_HistoryRecall(t *testing.T) {
 	assert.True(t, a.handleInputNavKey(tui.KeyEvent{Key: tui.KeyArrowDown}))
 	assert.Equal(t, "", a.inputText)
 	assert.Equal(t, -1, a.historyIndex)
+}
+
+func TestHandleInputNavKey_SlashCommandHistoryDoesNotOpenAutocomplete(t *testing.T) {
+	a := newTestApp()
+	a.history = []string{"/help", "latest prompt"}
+
+	assert.True(t, a.handleInputNavKey(tui.KeyEvent{Key: tui.KeyArrowUp}))
+	a.updateAutocomplete() // input OnKey does this after history navigation
+	assert.Equal(t, "latest prompt", a.inputText)
+	assert.Empty(t, a.autocompleteMatches)
+
+	assert.True(t, a.handleInputNavKey(tui.KeyEvent{Key: tui.KeyArrowUp}))
+	a.updateAutocomplete()
+	assert.Equal(t, "/help", a.inputText)
+	assert.Empty(t, a.autocompleteMatches, "recalled commands must not steal arrows from history")
+
+	assert.True(t, a.handleInputNavKey(tui.KeyEvent{Key: tui.KeyArrowDown}))
+	assert.Equal(t, "latest prompt", a.inputText)
+}
+
+func TestEditingRecalledCommandLeavesHistoryAndEnablesAutocomplete(t *testing.T) {
+	a := newTestApp()
+	a.history = []string{"/help"}
+
+	assert.True(t, a.handleInputNavKey(tui.KeyEvent{Key: tui.KeyArrowUp}))
+	a.updateAutocomplete()
+	assert.Empty(t, a.autocompleteMatches)
+
+	a.inputText = "/he"
+	a.handleInputChange(a.inputText)
+	a.updateAutocomplete()
+	assert.Equal(t, -1, a.historyIndex)
+	assert.Contains(t, a.autocompleteMatches, "help")
 }
 
 func TestHandleInputNavKey_PassthroughWhenNoHistory(t *testing.T) {
@@ -92,4 +126,37 @@ func TestHandleInputNavKey_AutocompleteTakesPrecedenceOverHistory(t *testing.T) 
 	assert.True(t, a.handleInputNavKey(tui.KeyEvent{Key: tui.KeyArrowDown}))
 	assert.Equal(t, 1, a.autocompleteIndex)
 	assert.Equal(t, "", a.inputText)
+}
+
+func TestCommandAutocompleteNavigatesBeyondFirstWindow(t *testing.T) {
+	a := newTestApp()
+	a.inputText = "/"
+	a.updateAutocomplete()
+	assert.True(t, len(a.autocompleteMatches) > autocompleteWindowSize)
+
+	for range autocompleteWindowSize {
+		assert.True(t, a.handleInputNavKey(tui.KeyEvent{Key: tui.KeyArrowDown}))
+	}
+	assert.Equal(t, autocompleteWindowSize, a.autocompleteIndex)
+	selected := a.autocompleteMatches[a.autocompleteIndex]
+
+	var rendered bytes.Buffer
+	tui.Fprint(&rendered, tui.Stack(a.inputAreaView()...), tui.WithWidth(80))
+	assert.Contains(t, rendered.String(), "(9/")
+	assert.Contains(t, rendered.String(), "/"+selected)
+	assert.NotContains(t, rendered.String(), "/"+a.autocompleteMatches[0], "the completion window should follow the selection")
+}
+
+func TestAutocompleteWindowFollowsSelection(t *testing.T) {
+	start, end := autocompleteWindow(15, 0)
+	assert.Equal(t, 0, start)
+	assert.Equal(t, 8, end)
+
+	start, end = autocompleteWindow(15, 8)
+	assert.Equal(t, 1, start)
+	assert.Equal(t, 9, end)
+
+	start, end = autocompleteWindow(15, 14)
+	assert.Equal(t, 7, start)
+	assert.Equal(t, 15, end)
 }

--- a/experimental/cmd/dive/main.go
+++ b/experimental/cmd/dive/main.go
@@ -34,12 +34,14 @@ import (
 	"github.com/deepnoodle-ai/wonton/fetch"
 )
 
+const cliVersion = "0.1.0"
+
 func main() {
 	loadDotEnv()
 
 	app := cli.New("dive").
 		Description("Interactive AI assistant for coding tasks").
-		Version("0.1.0")
+		Version(cliVersion)
 
 	// Image generation subcommand
 	app.Command("image").
@@ -129,6 +131,10 @@ func main() {
 				Default(false).
 				Env("DIVE_SHOW_THINKING").
 				Help("Request and show summarized model thinking when supported"),
+			cli.Bool("show-detailed-usage").
+				Default(false).
+				Env("DIVE_SHOW_DETAILED_USAGE").
+				Help("Show the full token breakdown table under the status line (default shows only the session total cost)"),
 			cli.String("thinking-effort").
 				Default(string(llm.ReasoningEffortMedium)).
 				Env("DIVE_THINKING_EFFORT").
@@ -210,11 +216,23 @@ func runInteractive(ctx *cli.Context) error {
 		return err
 	}
 
-	// Parse model
-	modelName := ctx.String("model")
-	if modelName == "" {
-		modelName = getDefaultModel()
+	// Parse model: flag > env > settings file > autodetect.
+	effSettings := loadEffectiveCLISettings(workspaceDir)
+	modelName, modelSource := resolveModelName(ctx, effSettings)
+	effort, effortSource := resolveThinkingEffort(ctx, effSettings)
+	showThinking, thinkingSource := resolveShowThinking(ctx, effSettings)
+	showDetailedUsage, detailedUsageSource := resolveShowDetailedUsage(ctx, effSettings)
+
+	// Resolve the live model settings before constructing the subagent factory.
+	// Subagents take a snapshot of these values when they start, so a /model,
+	// /effort, or /thinking change also reaches downstream work.
+	maxTokens := ctx.Int("max-tokens")
+	tempSet := ctx.IsSet("temperature")
+	var temp float64
+	if tempSet {
+		temp = ctx.Float64("temperature")
 	}
+	modelSettings, _ := buildCLIModelSettings(maxTokens, tempSet, temp, showThinking, effort)
 
 	// Create model
 	model := createModel(modelName, ctx.String("api-endpoint"))
@@ -244,9 +262,17 @@ func runInteractive(ctx *cli.Context) error {
 		return fmt.Errorf("failed to create path validator: %w", err)
 	}
 
-	// Create tools
+	var app *App
+
+	// Create tools. Provider-native tools are dynamic because /model can cross
+	// provider boundaries without restarting the CLI.
 	tools := createTools(pathValidator, tuiDialog)
-	tools = append(tools, grokServerSideTools(modelName)...)
+	serverToolset := providerServerToolset(func() string {
+		if app != nil {
+			return app.modelName
+		}
+		return modelName
+	})
 
 	// Set up the subagent catalog and orchestration tools. Runs is the shared
 	// tracker that lets TaskStop cancel background spawns and monitors by id.
@@ -258,17 +284,31 @@ func runInteractive(ctx *cli.Context) error {
 	runs := orchestration.NewRuns()
 
 	agentFactory := func(ctx context.Context, name string, def *subagent.Definition, parentTools []dive.Tool) (*dive.Agent, error) {
-		// Create sub-model (use parent model by default)
-		subModel := model
+		// Inherit the parent's model and current generation settings by default.
+		// Take a settings snapshot rather than sharing the mutable pointer: a
+		// later slash-command change should affect new work, not an in-flight
+		// subagent. An explicit model on the definition still wins.
+		subModel, subModelSettings := currentSubagentDefaults(app, model, modelSettings)
+		subModelName := modelName
+		if app != nil {
+			subModelName = app.modelName
+		}
 		if def.Model != "" {
 			subModel = createModel(def.Model, "")
+			subModelName = def.Model
 		}
+		subTools := subagent.FilterTools(def, parentTools)
+		// A subagent's model is fixed for its lifetime, so provider-native
+		// tools can be resolved once. Filter them through the definition too;
+		// custom allowlists must remain authoritative.
+		subTools = append(subTools, subagent.FilterTools(def, grokServerSideTools(subModelName))...)
 
 		return dive.NewAgent(dive.AgentOptions{
-			Name:         name,
-			SystemPrompt: def.Prompt,
-			Model:        subModel,
-			Tools:        subagent.FilterTools(def, parentTools),
+			Name:          name,
+			SystemPrompt:  def.Prompt,
+			Model:         subModel,
+			Tools:         subTools,
+			ModelSettings: subModelSettings,
 		})
 	}
 
@@ -345,11 +385,13 @@ func runInteractive(ctx *cli.Context) error {
 
 	// Set up compaction config
 	var compactionConfig *compaction.CompactionConfig
+	compactionThresholdExplicit := false
 	if ctx.Bool("compaction") {
 		var explicitThreshold int
 		if ctx.IsSet("compaction-threshold") {
 			explicitThreshold = ctx.Int("compaction-threshold")
 		}
+		compactionThresholdExplicit = explicitThreshold > 0
 		compactionConfig = &compaction.CompactionConfig{
 			ContextTokenThreshold: compactionThreshold(explicitThreshold, modelName),
 			Model:                 model,
@@ -371,14 +413,12 @@ func runInteractive(ctx *cli.Context) error {
 		_ = pathValidator.AllowReadPath(dir)
 	}
 
-	// Create model settings
-	modelSettings, _ := newCLIModelSettings(ctx)
-
 	// Create agent options with hooks and extensions
 	agentOpts := dive.AgentOptions{
 		SystemPrompt:  systemPrompt,
 		Model:         model,
 		Tools:         tools,
+		Toolsets:      []dive.Toolset{serverToolset},
 		Extensions:    []dive.Extension{skills},
 		ModelSettings: modelSettings,
 		Hooks: dive.Hooks{
@@ -386,7 +426,6 @@ func runInteractive(ctx *cli.Context) error {
 		},
 	}
 	applyReminderAgentOptions(&agentOpts, modelOnlyReminders)
-	var app *App
 	applyContextDemoAgentOptions(&agentOpts, workspaceDir, contextDemos, func(notice contextDemoNotice) {
 		if app != nil {
 			app.notifyContextDemoNotice(notice)
@@ -401,21 +440,32 @@ func runInteractive(ctx *cli.Context) error {
 	// below; the notify closure only runs once the agent processes input, well
 	// after that, so reading it here is safe.
 	if compactionConfig != nil {
-		midTurnThreshold := compactionConfig.ContextTokenThreshold
-		if midTurnThreshold <= 0 {
-			midTurnThreshold = compaction.DefaultContextTokenThreshold
-		}
 		agentOpts.Hooks.PreIteration = append(agentOpts.Hooks.PreIteration,
-			compaction.MidTurnCompactionHook(
-				compactionConfig.Model,
-				midTurnThreshold,
-				compaction.WithMidTurnSystemPrompt(systemPrompt),
-				compaction.WithMidTurnNotify(func(e *compaction.CompactionEvent) {
-					if app != nil {
-						app.notifyMidTurnCompaction(e)
-					}
-				}),
-			),
+			func(ctx context.Context, hctx *dive.HookContext) error {
+				// Build the hook from the current config on every iteration. A
+				// /model switch updates both the summarizer model and an automatic
+				// threshold; capturing their startup values would silently keep
+				// compacting with the old model.
+				threshold := compactionConfig.ContextTokenThreshold
+				if threshold <= 0 {
+					threshold = compaction.DefaultContextTokenThreshold
+				}
+				currentSystemPrompt := systemPrompt
+				if app != nil {
+					currentSystemPrompt = app.agent.SystemPrompt()
+				}
+				hook := compaction.MidTurnCompactionHook(
+					compactionConfig.Model,
+					threshold,
+					compaction.WithMidTurnSystemPrompt(currentSystemPrompt),
+					compaction.WithMidTurnNotify(func(e *compaction.CompactionEvent) {
+						if app != nil {
+							app.notifyMidTurnCompaction(e)
+						}
+					}),
+				)
+				return hook(ctx, hctx)
+			},
 		)
 	}
 
@@ -439,6 +489,22 @@ func runInteractive(ctx *cli.Context) error {
 	app.currentSession = currentSession
 	app.operatorReminders = operatorReminders
 	app.contextDemos = contextDemos
+	app.modelSettings = modelSettings
+	app.reasoningEffort = effort
+	app.showThinking = showThinking
+	app.showDetailedUsage = showDetailedUsage
+	app.modelSource = modelSource
+	app.effortSource = effortSource
+	app.thinkingSource = thinkingSource
+	app.detailedUsageSource = detailedUsageSource
+	app.compactionThresholdExplicit = compactionThresholdExplicit
+	// Dynamic tools are not part of Agent.Tools(), so register their friendly
+	// titles explicitly for transcript rendering.
+	for _, tool := range grokServerSideTools("grok-") {
+		if annotations := tool.Annotations(); annotations != nil && annotations.Title != "" {
+			app.toolTitles[tool.Name()] = annotations.Title
+		}
+	}
 	if historyStore, err := defaultInputHistoryStore(); err != nil {
 		fmt.Fprintf(os.Stderr, "Warning: failed to configure input history: %v\n", err)
 	} else {
@@ -601,11 +667,9 @@ func runPrint(ctx *cli.Context) error {
 		return err
 	}
 
-	// Get model
-	modelName := ctx.String("model")
-	if modelName == "" {
-		modelName = getDefaultModel()
-	}
+	// Get model: flag > env > settings file > autodetect.
+	effPrintSettings := loadEffectiveCLISettings(workspaceDir)
+	modelName, _ := resolveModelName(ctx, effPrintSettings)
 
 	// Build system prompt
 	systemPrompt := ctx.String("system-prompt")
@@ -633,7 +697,7 @@ func runPrint(ctx *cli.Context) error {
 	tools = append(tools, grokServerSideTools(modelName)...)
 
 	// Create agent
-	printModelSettings, showThinking := newCLIModelSettings(ctx)
+	printModelSettings, showThinking := newCLIModelSettingsWith(ctx, effPrintSettings)
 
 	agentOpts := dive.AgentOptions{
 		SystemPrompt:  systemPrompt,
@@ -669,23 +733,7 @@ func runPrint(ctx *cli.Context) error {
 }
 
 func newCLIModelSettings(ctx *cli.Context) (*dive.ModelSettings, bool) {
-	maxTokens := ctx.Int("max-tokens")
-	modelSettings := &dive.ModelSettings{
-		MaxTokens: &maxTokens,
-	}
-	showThinking := ctx.Bool("show-thinking")
-	if showThinking {
-		modelSettings.Thinking = llm.ThinkingTypeAdaptive
-		modelSettings.ThinkingDisplay = llm.ThinkingDisplaySummarized
-	}
-	if effort := parseThinkingEffort(ctx.String("thinking-effort")); effort != "" {
-		modelSettings.ReasoningEffort = effort
-	}
-	if ctx.IsSet("temperature") {
-		t := ctx.Float64("temperature")
-		modelSettings.Temperature = &t
-	}
-	return modelSettings, showThinking
+	return newCLIModelSettingsWith(ctx, nil)
 }
 
 func parseThinkingEffort(value string) llm.ReasoningEffort {

--- a/experimental/cmd/dive/main_test.go
+++ b/experimental/cmd/dive/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -13,6 +14,27 @@ import (
 	"github.com/deepnoodle-ai/wonton/cli"
 )
 
+func TestProviderServerToolsetFollowsCurrentModel(t *testing.T) {
+	modelName := "gpt-5.6-sol"
+	toolset := providerServerToolset(func() string { return modelName })
+
+	tools, err := toolset.Tools(context.Background())
+	assert.NoError(t, err)
+	assert.Empty(t, tools)
+
+	modelName = "grok-4.6"
+	tools, err = toolset.Tools(context.Background())
+	assert.NoError(t, err)
+	assert.Len(t, tools, 2)
+	assert.Equal(t, "web_search", tools[0].Name())
+	assert.Equal(t, "x_search", tools[1].Name())
+
+	modelName = "claude-opus-5"
+	tools, err = toolset.Tools(context.Background())
+	assert.NoError(t, err)
+	assert.Empty(t, tools)
+}
+
 func TestGetDefaultModel(t *testing.T) {
 	// All provider env vars that getDefaultModel checks.
 	allKeys := []string{
@@ -23,6 +45,8 @@ func TestGetDefaultModel(t *testing.T) {
 		"XAI_API_KEY",
 		"GROK_API_KEY",
 		"MISTRAL_API_KEY",
+		"MODEL_API_KEY",
+		"META_API_KEY",
 	}
 
 	tests := []struct {

--- a/experimental/cmd/dive/providers.go
+++ b/experimental/cmd/dive/providers.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"strings"
 
 	"github.com/deepnoodle-ai/dive"
@@ -51,4 +52,21 @@ func grokServerSideTools(modelName string) []dive.Tool {
 		tools = append(tools, xs)
 	}
 	return tools
+}
+
+// providerServerToolset resolves provider-native tools for the current model
+// before every request. The tool instances are cached; only their visibility
+// changes. This keeps /model switches from retaining tools that the new
+// provider cannot accept or omitting tools that it supports.
+func providerServerToolset(modelName func() string) dive.Toolset {
+	grokTools := grokServerSideTools("grok-")
+	return &dive.ToolsetFunc{
+		ToolsetName: "provider-server-tools",
+		Resolve: func(context.Context) ([]dive.Tool, error) {
+			if modelName != nil && strings.HasPrefix(modelName(), "grok-") {
+				return grokTools, nil
+			}
+			return nil, nil
+		},
+	}
 }

--- a/experimental/cmd/dive/render.go
+++ b/experimental/cmd/dive/render.go
@@ -8,30 +8,44 @@ import (
 	"strings"
 	"time"
 
-	"github.com/mattn/go-runewidth"
-
 	"github.com/deepnoodle-ai/dive/experimental/compaction"
 	"github.com/deepnoodle-ai/dive/llm"
 	"github.com/deepnoodle-ai/wonton/tui"
 )
 
-// Shared accent color palette (teal family, anchored to the splash diamond color)
+// Dive's terminal palette. Brand and interactive states stay in one vivid
+// ocean-cyan family; ordinary hierarchy uses brighter cool slate neutrals.
+// Periwinkle distinguishes literals from prose, while amber, green, and red
+// remain reserved for warning, success, and failure.
 var (
-	accentBright = tui.RGB{R: 80, G: 200, B: 235}
-	accentMid    = tui.RGB{R: 70, G: 175, B: 210}
-	accentDim    = tui.RGB{R: 60, G: 155, B: 185}
-	accentMuted  = tui.RGB{R: 55, G: 135, B: 165}
+	accentBright = tui.RGB{R: 90, G: 204, B: 224}
+	accentMid    = tui.RGB{R: 69, G: 180, B: 203}
+	accentDim    = tui.RGB{R: 87, G: 152, B: 170}
+	accentMuted  = tui.RGB{R: 78, G: 130, B: 146}
+
+	primaryText = tui.RGB{R: 230, G: 235, B: 241}
+	mutedText   = tui.RGB{R: 190, G: 200, B: 211}
+	dimText     = tui.RGB{R: 159, G: 174, B: 189}
+	fadedText   = tui.RGB{R: 112, G: 130, B: 149}
+	subtleBg    = tui.RGB{R: 35, G: 43, B: 52}
+
+	codeText    = tui.RGB{R: 182, G: 187, B: 244}
+	successText = tui.RGB{R: 120, G: 215, B: 163}
+	warningText = tui.RGB{R: 232, G: 181, B: 95}
+	errorText   = tui.RGB{R: 235, G: 115, B: 123}
 )
 
-// Greys for secondary text. These are read on a dark terminal background, where
-// anything below about 150 fails WCAG AA's 4.5:1 — the old 100/110 greys sat
-// near 2.9:1 and were effectively unreadable. dimText is the floor for anything
-// carrying words; use fadedText only for rules, tracks, and other furniture.
-var (
-	dimText   = tui.RGB{R: 152, G: 152, B: 164}
-	mutedText = tui.RGB{R: 170, G: 170, B: 182}
-	fadedText = tui.RGB{R: 110, G: 110, B: 122}
-)
+func successStyle() tui.Style {
+	return tui.NewStyle().WithFgRGB(successText).WithBold()
+}
+
+func warningStyle() tui.Style {
+	return tui.NewStyle().WithFgRGB(warningText).WithBold()
+}
+
+func errorStyle() tui.Style {
+	return tui.NewStyle().WithFgRGB(errorText).WithBold()
+}
 
 // hintStyle is dive's replacement for wonton's Text().Style(hintStyle()), which combines
 // bright black with SGR 2 (faint). Faint on top of an already dark grey is what
@@ -41,24 +55,46 @@ func hintStyle() tui.Style {
 	return tui.NewStyle().WithFgRGB(dimText).WithItalic()
 }
 
-// diveMarkdownTheme returns a custom markdown theme with complementary colors
+// autocompleteOptionStyle keeps actionable paths readable and upright. Italic
+// hint styling is appropriate for explanatory copy, but made file choices feel
+// disabled rather than merely unselected.
+func autocompleteOptionStyle() tui.Style {
+	return tui.NewStyle().WithFgRGB(mutedText)
+}
+
+// diveMarkdownTheme assigns every Markdown role explicitly so the renderer
+// never falls back to an unrelated ANSI blue, yellow, or green.
 func diveMarkdownTheme() tui.MarkdownTheme {
 	theme := tui.DefaultMarkdownTheme()
 
-	// Cyan-blue headers with decreasing brightness for hierarchy
 	theme.H1Style = tui.NewStyle().WithBold().WithUnderline().WithFgRGB(accentBright)
-	theme.H2Style = tui.NewStyle().WithBold().WithFgRGB(accentMid)
-	theme.H3Style = tui.NewStyle().WithBold().WithFgRGB(accentDim)
-	theme.H4Style = tui.NewStyle().WithBold().WithFgRGB(accentMuted)
+	theme.H2Style = tui.NewStyle().WithBold().WithFgRGB(accentBright)
+	theme.H3Style = tui.NewStyle().WithBold().WithFgRGB(accentMid)
+	theme.H4Style = tui.NewStyle().WithBold().WithFgRGB(primaryText)
+	theme.H5Style = tui.NewStyle().WithBold().WithFgRGB(mutedText)
+	theme.H6Style = tui.NewStyle().WithBold().WithFgRGB(dimText)
 
-	// Light purple for inline code (like Claude Code)
-	theme.CodeStyle = tui.NewStyle().WithFgRGB(tui.RGB{R: 180, G: 140, B: 220})
+	theme.BoldStyle = tui.NewStyle().WithBold().WithFgRGB(primaryText)
+	theme.ItalicStyle = tui.NewStyle().WithItalic().WithFgRGB(dimText)
+	theme.CodeStyle = tui.NewStyle().WithFgRGB(codeText)
+	theme.LinkStyle = tui.NewStyle().WithUnderline().WithFgRGB(accentBright)
+	theme.StrikethroughStyle = tui.NewStyle().WithStrikethrough().WithFgRGB(dimText)
+	theme.BlockQuoteStyle = tui.NewStyle().WithItalic().WithFgRGB(dimText)
+	theme.CodeBlockStyle = tui.NewStyle().WithFgRGB(primaryText)
+	theme.HorizontalRuleStyle = tui.NewStyle().WithFgRGB(fadedText)
+	theme.SyntaxTheme = "github-dark"
+	theme.TableBorderStyle = tui.NewStyle().WithFgRGB(fadedText)
+	theme.TableHeaderStyle = tui.NewStyle().WithBold().WithFgRGB(primaryText)
+	theme.TableCellStyle = tui.NewStyle().WithFgRGB(mutedText)
 
 	return theme
 }
 
 // statusLineView renders the status line above the input area.
-// Shows: model name, directory, git branch, context %, elapsed time.
+//
+// One row by default: model (effort) in directory on branch · context % ·
+// session total cost. The full token breakdown table (/usage) only renders
+// inline when showDetailedUsage is set, so the chrome stays one row tall.
 func (a *App) statusLineView() tui.View {
 	mutedColor := dimText
 	accentStyle := tui.NewStyle().WithFgRGB(accentDim)
@@ -68,10 +104,16 @@ func (a *App) statusLineView() tui.View {
 	parts := []tui.View{
 		tui.Text(" %s", a.modelDisplayName()).Style(accentStyle),
 	}
+	if eff := strings.TrimSpace(string(a.reasoningEffort)); eff != "" {
+		parts = append(parts, tui.Text(" · %s", eff).Style(mutedStyle))
+	}
+	if a.showThinking {
+		parts = append(parts, tui.Text(" · thinking").Style(mutedStyle))
+	}
 	dirName := filepath.Base(a.workspaceDir)
 	parts = append(parts,
 		tui.Text(" in ").Style(mutedStyle),
-		tui.Text("%s", dirName).Style(tui.NewStyle().WithFgRGB(tui.RGB{R: 200, G: 200, B: 210}).WithBold()),
+		tui.Text("%s", dirName).Style(tui.NewStyle().WithFgRGB(primaryText).WithBold()),
 	)
 	if branch := a.gitBranch; branch != "" {
 		parts = append(parts,
@@ -79,10 +121,18 @@ func (a *App) statusLineView() tui.View {
 			tui.Text("%s", branch).Style(accentStyle),
 		)
 	}
+	// Context % and session total cost ride the same row. Cost is the
+	// session total (or turn total before a second turn differs); the
+	// per-scope table lives in /usage and, when enabled, below this row.
+	if a.lastUsage != nil {
+		parts = append(parts, tui.Text(" · %d%%", a.contextPercent()).Style(mutedStyle))
+	}
+	if cost := a.sessionTotalCostString(); cost != "" {
+		parts = append(parts, tui.Text(" · %s", cost).Style(tui.NewStyle().WithFgRGB(successText)))
+	}
 	// Speed badge — fast mode bills at a different rate, so surface it.
 	if a.lastUsage != nil && a.lastUsage.Speed == "fast" {
-		parts = append(parts, tui.Text(" ⚡fast").Style(
-			tui.NewStyle().WithFgRGB(tui.RGB{R: 230, G: 190, B: 80}).WithBold()))
+		parts = append(parts, tui.Text(" ⚡fast").Style(warningStyle()))
 	}
 
 	// A flash rides the right edge of this row rather than adding one of its
@@ -97,38 +147,41 @@ func (a *App) statusLineView() tui.View {
 	}
 	rows := []tui.View{tui.Group(parts...)}
 
-	// Line 2: context-window usage bar (shown after the first LLM response).
-	if a.lastUsage != nil {
-		contextPct := a.contextPercent()
-		barColor := accentDim
-		if contextPct > 75 {
-			barColor = tui.RGB{R: 200, G: 150, B: 60}
+	// Detailed token breakdown: opt-in via /usage full (show_detailed_usage).
+	// /usage always shows the full report on demand regardless of this flag.
+	if a.showDetailedUsage {
+		if panel := a.tokensPanelView(); panel != nil {
+			rows = append(rows, panel)
 		}
-		if contextPct > 90 {
-			barColor = tui.RGB{R: 200, G: 70, B: 70}
-		}
-		bar := tui.Progress(contextPct, 100).
-			Width(20).
-			HidePercent().
-			Style(tui.NewStyle().WithFgRGB(barColor)).
-			EmptyStyle(tui.NewStyle().WithFgRGB(fadedText))
-		rows = append(rows, tui.Group(
-			tui.Text(" ").Style(mutedStyle),
-			bar,
-			tui.Text(" %d%% context", contextPct).Style(mutedStyle),
-		))
-	}
-
-	// Tokens panel: a clearly-labeled per-scope breakdown of input, cache
-	// reads (hits) vs writes (misses), output, and hit rate.
-	if panel := a.tokensPanelView(); panel != nil {
-		rows = append(rows, panel)
 	}
 
 	if len(rows) == 1 {
 		return rows[0]
 	}
 	return tui.Stack(rows...).Gap(0)
+}
+
+// sessionTotalCostString returns the session total cost for the status line,
+// falling back to the current turn before session usage diverges. Empty when
+// no cost has been reported yet.
+func (a *App) sessionTotalCostString() string {
+	if a.sessionUsage != nil && a.sessionUsage.Cost != nil {
+		return formatCost(a.sessionUsage.Cost.Total)
+	}
+	if a.interactionUsage != nil && a.interactionUsage.Cost != nil {
+		return formatCost(a.interactionUsage.Cost.Total)
+	}
+	return ""
+}
+
+// trimTrailingWhitespacePerLine strips trailing spaces and tabs from each
+// line. Used for user-bubble display only; the message itself is unmodified.
+func trimTrailingWhitespacePerLine(s string) string {
+	lines := strings.Split(s, "\n")
+	for i, line := range lines {
+		lines[i] = strings.TrimRight(line, " \t")
+	}
+	return strings.Join(lines, "\n")
 }
 
 // formatTokenCount formats a token count for display (e.g. 1234 -> "1.2k", 56 -> "56").
@@ -174,11 +227,11 @@ func (a *App) tokensPanelView() tui.View {
 	showCost := turn.Cost != nil || (showSession && sess.Cost != nil)
 
 	headerStyle := tui.NewStyle().WithFgRGB(dimText)
-	scopeStyle := tui.NewStyle().WithFgRGB(tui.RGB{R: 160, G: 160, B: 170}).WithBold()
-	valStyle := tui.NewStyle().WithFgRGB(tui.RGB{R: 220, G: 220, B: 230}).WithBold()
-	readStyle := tui.NewStyle().WithFgRGB(tui.RGB{R: 110, G: 200, B: 130}).WithBold() // green: cache hits
-	writeStyle := tui.NewStyle().WithFgRGB(tui.RGB{R: 225, G: 175, B: 80}).WithBold() // amber: cache writes
-	costStyle := tui.NewStyle().WithFgRGB(tui.RGB{R: 120, G: 205, B: 150}).WithBold() // green: money
+	scopeStyle := tui.NewStyle().WithFgRGB(mutedText).WithBold()
+	valStyle := tui.NewStyle().WithFgRGB(primaryText).WithBold()
+	readStyle := successStyle()
+	writeStyle := warningStyle()
+	costStyle := successStyle()
 
 	const (
 		labelW = 10
@@ -266,11 +319,11 @@ func cacheHitStyle(u *llm.Usage, ok bool) tui.Style {
 	pct := (u.CacheReadInputTokens * 100) / denom
 	switch {
 	case pct >= 80:
-		return tui.NewStyle().WithFgRGB(tui.RGB{R: 110, G: 200, B: 130}).WithBold()
+		return successStyle()
 	case pct >= 50:
-		return tui.NewStyle().WithFgRGB(tui.RGB{R: 225, G: 175, B: 80}).WithBold()
+		return warningStyle()
 	default:
-		return tui.NewStyle().WithFgRGB(tui.RGB{R: 220, G: 90, B: 90}).WithBold()
+		return errorStyle()
 	}
 }
 
@@ -363,12 +416,16 @@ func (a *App) textMessageView(msg Message) tui.View {
 		return msg.View
 
 	case roleUser:
-		bg := tui.RGB{R: 48, G: 48, B: 54}
+		bg := subtleBg
 		caret := tui.Text("❯ ").Style(
-			tui.NewStyle().WithFgRGB(dimText).WithBgRGB(bg),
+			tui.NewStyle().WithFgRGB(accentDim).WithBgRGB(bg),
 		)
-		text := tui.Text("%s", msg.Content).Wrap().Style(
-			tui.NewStyle().WithBgRGB(bg),
+		// Pasted blocks often carry trailing spaces/tabs per line. Left in
+		// place they paint as lit runs against the bubble background in
+		// scrollback, so trim them for display. The stored message (and
+		// what is sent) is untouched.
+		text := tui.Text("%s", trimTrailingWhitespacePerLine(msg.Content)).Wrap().Style(
+			tui.NewStyle().WithFgRGB(primaryText).WithBgRGB(bg),
 		)
 		return tui.Group(caret, text, tui.Fill(' ').BgRGB(bg.R, bg.G, bg.B))
 
@@ -381,7 +438,7 @@ func (a *App) textMessageView(msg Message) tui.View {
 		// so all lines (including wrapped) align to column 2 (like Claude Code)
 		return tui.ZStack(
 			tui.PaddingLTRB(2, 0, 0, 0, tui.Markdown(content, nil).Theme(diveMarkdownTheme())),
-			tui.Text("⏺"),
+			tui.Text("⏺").Style(tui.NewStyle().WithFgRGB(accentMid)),
 		).Align(tui.AlignLeft)
 
 	case roleReasoning:
@@ -403,7 +460,7 @@ func (a *App) textMessageView(msg Message) tui.View {
 		)
 
 	case roleSystem:
-		return tui.Text("%s", msg.Content).Wrap().Warning()
+		return tui.Text("%s", msg.Content).Wrap().Style(warningStyle())
 
 	case roleNotice:
 		if msg.Marker != "" {
@@ -419,9 +476,11 @@ func (a *App) textMessageView(msg Message) tui.View {
 	}
 }
 
-// introView renders a bordered splash header (Codex-style)
+// introView renders a compact three-line startup header. Its content is captured
+// when the intro message is appended, so later setting changes do not rewrite
+// the scrollback history.
 func (a *App) introView(msg Message) tui.View {
-	// Parse lines from content: model, workspace, optional session info
+	// Parse lines from content: model and effort, workspace, optional session info.
 	lines := strings.Split(msg.Content, "\n")
 	model := ""
 	workspace := ""
@@ -438,66 +497,39 @@ func (a *App) introView(msg Message) tui.View {
 
 	titleStyle := tui.NewStyle().WithFgRGB(accentBright).WithBold()
 	mutedStyle := tui.NewStyle().WithFgRGB(mutedText)
-	labelStyle := tui.NewStyle().WithFgRGB(dimText)
+	detailStyle := tui.NewStyle().WithFgRGB(dimText)
 
-	// Box content
 	content := []tui.View{
 		tui.Group(
-			tui.Text("Dive").Style(titleStyle),
-			tui.Text(" (v0.1.0)").Style(mutedStyle),
+			tui.Text("Dive ").Style(titleStyle),
+			tui.Text("v%s", cliVersion).Style(mutedStyle),
 		),
-		tui.Text(""),
-		tui.Group(
-			tui.Text("model:     ").Style(labelStyle),
-			tui.Text("%s", model).Style(mutedStyle),
-		),
-		tui.Group(
-			tui.Text("directory: ").Style(labelStyle),
-			tui.Text("%s", workspace).Style(mutedStyle),
-		),
+		tui.Text("%s", model).Style(tui.NewStyle().WithFgRGB(primaryText)).Wrap().Flex(1),
+		tui.Text("%s", workspace).Style(detailStyle).Wrap().Flex(1),
 	}
 
 	for _, extra := range extras {
 		if extra != "" {
-			content = append(content, tui.Text("%s", extra).Style(mutedStyle))
+			content = append(content, tui.Text("%s", extra).Style(detailStyle).Wrap())
 		}
 	}
 
-	// Compute box width from longest visible line (using display width for Unicode)
-	textWidths := []int{
-		runewidth.StringWidth("Dive (v0.1.0)"),
-		runewidth.StringWidth("model:     ") + runewidth.StringWidth(model),
-		runewidth.StringWidth("directory: ") + runewidth.StringWidth(workspace),
-	}
-	for _, extra := range extras {
-		textWidths = append(textWidths, runewidth.StringWidth(extra))
-	}
-	maxLen := 0
-	for _, w := range textWidths {
-		if w > maxLen {
-			maxLen = w
-		}
-	}
-	boxWidth := maxLen + 2 + 2 // 2 for border chars + 2 for inner spacing
-
-	return tui.Width(boxWidth, tui.Bordered(tui.Stack(content...)).
-		Border(&tui.RoundedBorder).
-		BorderFg(tui.ColorBrightBlack))
+	return tui.Stack(content...).Gap(0)
 }
 
 // toolCallView renders a tool call message. A running call's marker pulses only
-// when opts.animate is set; a final rendering gets a static cyan dot.
+// when opts.animate is set; final rendering uses semantic success or error color.
 func (a *App) toolCallView(msg Message, opts viewOpts) tui.View {
 	var statusView tui.View
 	switch {
 	case msg.ToolDone && msg.ToolError:
-		statusView = tui.Text("⏺").Error()
+		statusView = tui.Text("⏺").Style(errorStyle())
 	case msg.ToolDone:
-		statusView = tui.Text("⏺").Success()
+		statusView = tui.Text("⏺").Style(successStyle())
 	case opts.animate:
-		statusView = tui.Text("⏺").Animate(tui.Pulse(tui.NewRGB(80, 160, 220), 8).Brightness(0.3, 1.0))
+		statusView = tui.Text("⏺").Animate(tui.Pulse(accentMid, 8).Brightness(0.3, 1.0))
 	default:
-		statusView = tui.Text("⏺").Fg(tui.ColorCyan)
+		statusView = tui.Text("⏺").Style(tui.NewStyle().WithFgRGB(accentMid))
 	}
 
 	toolCall := formatToolCall(msg.ToolTitle, msg.ToolName, msg.ToolInput)
@@ -558,7 +590,7 @@ func (a *App) formatToolResultView(msg Message, opts viewOpts) tui.View {
 
 	views := make([]tui.View, 0, 4)
 	if msg.ToolError {
-		views = append(views, tui.Text("  ⎿  %s", firstLine).Error())
+		views = append(views, tui.Text("  ⎿  %s", firstLine).Style(errorStyle()))
 	} else {
 		views = append(views, tui.Text("  ⎿  %s", firstLine).Style(style))
 	}
@@ -751,9 +783,9 @@ func renderDiffResult(result string) tui.View {
 		var lineView tui.View
 		switch isDiffLine(lines[i]) {
 		case "+":
-			lineView = tui.Text("      %s", line).Success()
+			lineView = tui.Text("      %s", line).Style(successStyle())
 		case "-":
-			lineView = tui.Text("      %s", line).Error()
+			lineView = tui.Text("      %s", line).Style(errorStyle())
 		default:
 			lineView = tui.Text("      %s", line).Style(toolResultStyle())
 		}
@@ -783,8 +815,8 @@ func (a *App) todoStatusView() tui.View {
 
 	elapsed := time.Since(a.processingStartTime)
 	return tui.Group(
-		tui.Text("✽").Animate(tui.Pulse(tui.NewRGB(180, 140, 220), 20).Brightness(0.4, 1.0)),
-		tui.Text(" %s…", activeTodo.ActiveForm).Style(tui.NewStyle().WithFgRGB(tui.RGB{R: 180, G: 140, B: 220})),
+		tui.Text("✽").Animate(tui.Pulse(accentBright, 20).Brightness(0.4, 1.0)),
+		tui.Text(" %s…", activeTodo.ActiveForm).Style(tui.NewStyle().WithFgRGB(accentBright)),
 		tui.Text(" (%s)", formatDuration(elapsed)).Style(hintStyle()),
 	)
 }
@@ -808,16 +840,16 @@ func (a *App) todoListView(opts viewOpts) tui.View {
 		var todoView tui.View
 		switch todo.Status {
 		case TodoStatusCompleted:
-			mutedStyle := tui.NewStyle().WithFgRGB(tui.RGB{R: 100, G: 100, B: 100})
+			mutedStyle := tui.NewStyle().WithFgRGB(dimText)
 			todoView = tui.Group(
 				tui.Text("  ⎿  ☒ ").Style(mutedStyle),
 				tui.Text("%s", todo.Content).Style(mutedStyle.WithStrikethrough()),
 			)
 		case TodoStatusInProgress:
-			style := tui.NewStyle().WithFgRGB(tui.RGB{R: 180, G: 140, B: 220}).WithBold()
+			style := tui.NewStyle().WithFgRGB(accentBright).WithBold()
 			todoView = tui.Text("  ⎿  ☐ %s", todo.Content).Style(style)
 		default:
-			style := tui.NewStyle().WithFgRGB(tui.RGB{R: 140, G: 140, B: 140})
+			style := tui.NewStyle().WithFgRGB(mutedText)
 			todoView = tui.Text("  ⎿  ☐ %s", todo.Content).Style(style)
 		}
 		views = append(views, todoView)

--- a/experimental/cmd/dive/render_test.go
+++ b/experimental/cmd/dive/render_test.go
@@ -16,6 +16,59 @@ func TestFormatTokenCount(t *testing.T) {
 	assert.Equal(t, "1.0M", formatTokenCount(1000000))
 }
 
+func TestIntroViewUsesCompactThreeLineStartupText(t *testing.T) {
+	app := newTestApp()
+	app.reasoningEffort = llm.ReasoningEffortMedium
+	intro := app.appendIntro()
+
+	screen := tui.SprintScreen(app.introView(app.messages[intro]), tui.WithWidth(80))
+	lines := strings.Split(strings.TrimRight(screen.Text(), "\n"), "\n")
+	for i := range lines {
+		lines[i] = strings.TrimRight(lines[i], " ")
+	}
+
+	assert.Equal(t, 3, len(lines))
+	assert.Equal(t, "Dive v"+cliVersion, lines[0])
+	assert.Equal(t, "test-model with medium effort", lines[1])
+	assert.Equal(t, "/tmp/test", lines[2])
+	assert.NotContains(t, screen.Text(), "█")
+	assert.NotContains(t, screen.Text(), "model:")
+	assert.NotContains(t, screen.Text(), "directory:")
+	assert.NotContains(t, screen.Text(), "╭")
+	assert.NotContains(t, screen.Text(), "╰")
+}
+
+func TestDiveMarkdownThemeUsesSemanticPalette(t *testing.T) {
+	theme := diveMarkdownTheme()
+
+	assertStyleColor := func(name string, style tui.Style, want tui.RGB) {
+		t.Helper()
+		assert.NotNil(t, style.FgRGB, "%s should use an explicit RGB color", name)
+		assert.Equal(t, *style.FgRGB, want, "%s color", name)
+	}
+
+	assertStyleColor("h1", theme.H1Style, accentBright)
+	assertStyleColor("h3", theme.H3Style, accentMid)
+	assertStyleColor("h6", theme.H6Style, dimText)
+	assertStyleColor("bold", theme.BoldStyle, primaryText)
+	assertStyleColor("inline code", theme.CodeStyle, codeText)
+	assertStyleColor("link", theme.LinkStyle, accentBright)
+	assertStyleColor("blockquote", theme.BlockQuoteStyle, dimText)
+	assertStyleColor("code block", theme.CodeBlockStyle, primaryText)
+	assertStyleColor("rule", theme.HorizontalRuleStyle, fadedText)
+	assertStyleColor("table border", theme.TableBorderStyle, fadedText)
+	assert.Equal(t, theme.SyntaxTheme, "github-dark")
+	assert.NotEqual(t, codeText, warningText, "inline literals should not look like warnings")
+}
+
+func TestAutocompleteOptionStyleIsReadableActionableText(t *testing.T) {
+	style := autocompleteOptionStyle()
+
+	assert.NotNil(t, style.FgRGB)
+	assert.Equal(t, mutedText, *style.FgRGB)
+	assert.False(t, style.Italic, "file and command choices should not look like explanatory hints")
+}
+
 func TestFormatCacheCreationTokens(t *testing.T) {
 	assert.Equal(t, "0", formatCacheCreationTokens(&llm.Usage{}), "reported zero should remain zero")
 	assert.Equal(t, "2.0k", formatCacheCreationTokens(&llm.Usage{CacheCreationInputTokens: 2000}))
@@ -49,7 +102,7 @@ func TestCacheHitRate(t *testing.T) {
 func TestCacheHitStyle_UsesTotalInputTokens(t *testing.T) {
 	style := cacheHitStyle(&llm.Usage{InputTokens: 21, CacheReadInputTokens: 79}, true)
 	assert.NotNil(t, style.FgRGB)
-	assert.Equal(t, tui.RGB{R: 225, G: 175, B: 80}, *style.FgRGB,
+	assert.Equal(t, warningText, *style.FgRGB,
 		"79% of the full prompt should use the amber style")
 }
 
@@ -122,6 +175,42 @@ func TestCostString(t *testing.T) {
 	assert.Equal(t, "—", costString(&llm.Usage{}), "unknown cost should render as a dash")
 	assert.Equal(t, "$0", costString(&llm.Usage{Cost: &llm.Cost{Total: 0}}), "known zero cost is $0, not a dash")
 	assert.Equal(t, "$1.27", costString(&llm.Usage{Cost: &llm.Cost{Total: 1.273}}))
+}
+
+func TestStatusLineShowsOnlySessionCostByDefault(t *testing.T) {
+	app := newTestApp()
+	app.gitBranch = "main"
+	app.reasoningEffort = llm.ReasoningEffortHigh
+	app.lastUsage = &llm.Usage{InputTokens: 100}
+	app.interactionUsage = &llm.Usage{
+		InputTokens: 100,
+		Cost:        &llm.Cost{Total: 0.25},
+	}
+	app.sessionUsage = &llm.Usage{
+		InputTokens: 400,
+		Cost:        &llm.Cost{Total: 1.273},
+	}
+
+	text := tui.SprintScreen(app.statusLineView(), tui.WithWidth(120), tui.WithHeight(10)).Text()
+	assert.Contains(t, text, "test-model · high in test on main")
+	assert.Contains(t, text, "$1.27")
+	assert.NotContains(t, text, "cache read")
+	assert.NotContains(t, text, "turn")
+
+	app.showDetailedUsage = true
+	text = tui.SprintScreen(app.statusLineView(), tui.WithWidth(120), tui.WithHeight(10)).Text()
+	assert.Contains(t, text, "cache read")
+	assert.Contains(t, text, "turn")
+	assert.Contains(t, text, "session")
+}
+
+func TestSessionTotalCostFallsBackToCurrentTurn(t *testing.T) {
+	app := newTestApp()
+	app.interactionUsage = &llm.Usage{Cost: &llm.Cost{Total: 0.043}}
+	assert.Equal(t, "$0.043", app.sessionTotalCostString())
+
+	app.sessionUsage = &llm.Usage{Cost: &llm.Cost{Total: 1.273}}
+	assert.Equal(t, "$1.27", app.sessionTotalCostString())
 }
 
 func TestTokensPanelView_ShowsCostWhenPresent(t *testing.T) {

--- a/experimental/cmd/dive/screen.go
+++ b/experimental/cmd/dive/screen.go
@@ -97,17 +97,20 @@ func (a *App) footerView() tui.View {
 
 	// Tell the user what they are not looking at, and how to get back to it.
 	if !a.viewport.AtBottom && a.viewport.LinesBelow > 0 {
-		views = append(views, tui.Group(
-			tui.Text(" ↓ %d new line%s", a.viewport.LinesBelow, pluralSuffix(a.viewport.LinesBelow)).
-				Style(tui.NewStyle().WithFgRGB(accentDim)),
-			tui.Text(" · End to jump to the latest").Style(hintStyle()),
-		))
+		views = append(views,
+			tui.Text(""),
+			tui.Group(
+				tui.Text(" ↓ %d new line%s", a.viewport.LinesBelow, pluralSuffix(a.viewport.LinesBelow)).
+					Style(tui.NewStyle().WithFgRGB(accentDim)),
+				tui.Text(" · End to jump to the latest").Style(hintStyle()),
+			),
+		)
 	}
 
 	// The spinner's slot, and what takes its place once the turn is done. Both
 	// get a blank line above and below: this sits between the transcript and the
 	// input box, and without them it crowds both.
-	if a.processing {
+	if a.processing || a.compacting {
 		if live := a.buildLiveView(false); live != nil {
 			views = append(views, tui.Text(""), live, tui.Text(""))
 		}
@@ -394,9 +397,9 @@ func (a *App) inViewport(x, y int) bool {
 // two coordinate systems because the two targets live in different ones: the
 // transcript's are the viewport's, the scroll indicator's are the screen's.
 func (a *App) handleScreenClick(screenY, x, y int) {
-	// The indicator is the footer's first row, and saying "N new lines below"
-	// while not being a way to reach them would be a poor joke.
-	if !a.viewport.AtBottom && a.viewport.LinesBelow > 0 && screenY == a.viewport.Height {
+	// The indicator follows its blank spacer in the footer, and saying "N new
+	// lines below" while not being a way to reach them would be a poor joke.
+	if !a.viewport.AtBottom && a.viewport.LinesBelow > 0 && screenY == a.viewport.Height+1 {
 		a.viewport.ScrollToBottom()
 		return
 	}
@@ -485,7 +488,19 @@ func (a *App) copyToClipboard(text string) {
 // It stands until the next turn starts. A long turn is often left running while
 // the user is elsewhere, and coming back to a blank space answers neither "is it
 // finished?" nor "how long was I gone?".
+//
+// A fresh compaction takes the slot instead: the scrollback holds the full
+// notice, and this is the at-a-glance confirmation. The next turn reclaims it.
 func (a *App) turnSummaryView() tui.View {
+	if a.showCompactionSummary && a.lastCompactionEvent != nil {
+		return tui.Group(
+			tui.Text(" ⚡").Style(warningStyle()),
+			tui.Text(" Compacted ~%d → ~%d tokens",
+				a.lastCompactionEvent.TokensBefore,
+				a.lastCompactionEvent.TokensAfter).Style(hintStyle()),
+			tui.Text(" · done %s", a.compactionEventTime.Format("3:04 PM")).Style(hintStyle()),
+		)
+	}
 	if a.lastTurnEndedAt.IsZero() {
 		return nil
 	}

--- a/experimental/cmd/dive/screen_test.go
+++ b/experimental/cmd/dive/screen_test.go
@@ -82,14 +82,21 @@ func TestScreenFrameLayout(t *testing.T) {
 		"",
 		"",
 		"",
+		"",
 		strings.Repeat("─", 60),
-		" ❯  Type a message... (@filename, or drop a file to attach)",
+		"❯ Type a message... (@filename, or drop a file to attach)",
 		strings.Repeat("─", 60),
 		" test-model in test on main",
+		"",
 	}
 	for y, row := range want {
 		assert.Equal(t, row, strings.TrimRight(screen.Row(y), " "), "row %d", y)
 	}
+	assert.Equal(t, 14, len(want), "the golden must cover the complete frame")
+	assert.Equal(t, " test-model in test on main", strings.TrimRight(screen.Row(12), " "),
+		"the status row should sit above the explicit footer row")
+	assert.Equal(t, "", strings.TrimRight(screen.Row(13), " "),
+		"the explicit footer row should remain blank")
 }
 
 func TestScreenIndicatesWhatIsBelowWhenScrolledUp(t *testing.T) {
@@ -103,6 +110,9 @@ func TestScreenIndicatesWhatIsBelowWhenScrolledUp(t *testing.T) {
 	assert.True(t, app.viewport.LinesBelow > 0)
 	assert.Contains(t, screen.Text(), "new line")
 	assert.Contains(t, screen.Text(), "End to jump")
+	assert.Empty(t, strings.TrimSpace(screen.Row(app.viewport.Height)),
+		"the scroll indicator should always have a blank row above it")
+	assert.Contains(t, screen.Row(app.viewport.Height+1), "new line")
 
 	// And it goes away once the user is back at the end.
 	app.viewport.ScrollToBottom()
@@ -198,8 +208,9 @@ func TestWheelScrollsOneLine(t *testing.T) {
 	assert.True(t, app.viewport.AtBottom)
 
 	// Read the position straight after each event rather than re-rendering
-	// between them: the "N new lines" row appears as soon as the transcript is
-	// scrolled and costs the viewport a line, which would move the end.
+	// between them: the "N new lines" row and its spacer appear as soon as the
+	// transcript is scrolled and cost the viewport two lines, which would move
+	// the end.
 	app.HandleEvent(tui.MouseEvent{Type: tui.MouseScroll, Button: tui.MouseButtonWheelUp})
 	assert.Equal(t, 1, app.viewport.LinesBelow, "one notch is one line")
 	app.HandleEvent(tui.MouseEvent{Type: tui.MouseScroll, Button: tui.MouseButtonWheelUp})

--- a/experimental/cmd/dive/selection_test.go
+++ b/experimental/cmd/dive/selection_test.go
@@ -350,7 +350,7 @@ func TestClickingTheScrollIndicatorJumpsToTheBottom(t *testing.T) {
 	renderScreen(t, app, 80, 24)
 	assert.False(t, app.viewport.AtBottom, "scrolled up, so the indicator is showing")
 
-	click(app, 4, app.viewport.Height, 1)
+	click(app, 4, app.viewport.Height+1, 1)
 	assert.True(t, app.viewport.AtBottom, "the indicator is also the way back")
 }
 

--- a/experimental/cmd/dive/session_picker.go
+++ b/experimental/cmd/dive/session_picker.go
@@ -167,7 +167,7 @@ func metaStyle() tui.Style {
 // differs from where the picker was launched, which is the only time it tells
 // the user anything.
 func (p *SessionPickerApp) sessionItemView(info *session.SessionInfo, row int, selected bool) tui.View {
-	titleStyle := tui.NewStyle().WithFgRGB(tui.RGB{R: 215, G: 215, B: 225})
+	titleStyle := tui.NewStyle().WithFgRGB(primaryText)
 	marker := tui.Text("  ")
 	gutter := tui.Text("%d ", row+1).Style(metaStyle())
 	if row >= 9 {

--- a/experimental/cmd/dive/transcript.go
+++ b/experimental/cmd/dive/transcript.go
@@ -16,7 +16,7 @@ const (
 	roleReasoning = "reasoning" // streamed thinking
 	roleSystem    = "system"    // errors, shown in the warning style
 	roleContext   = "context"   // input the app injected on the user's behalf
-	roleIntro     = "intro"     // the splash box
+	roleIntro     = "intro"     // the startup header
 	roleNotice    = "notice"    // a dim one-liner (warnings, status, hints)
 	roleReport    = "report"    // a pre-built view (/usage, /help, /todos, /context)
 )

--- a/experimental/mcp/go.mod
+++ b/experimental/mcp/go.mod
@@ -6,7 +6,7 @@ toolchain go1.26.8
 
 require (
 	github.com/deepnoodle-ai/dive v1.27.0
-	github.com/deepnoodle-ai/wonton v0.1.0
+	github.com/deepnoodle-ai/wonton v0.2.1
 	github.com/mark3labs/mcp-go v1.0.0
 )
 

--- a/experimental/mcp/go.sum
+++ b/experimental/mcp/go.sum
@@ -1,7 +1,7 @@
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/deepnoodle-ai/wonton v0.1.0 h1:59gaXJPwulv/cj/mR+bOpdyGrMvUEQ32oFf59zVk4f8=
-github.com/deepnoodle-ai/wonton v0.1.0/go.mod h1:G3fVZXXX/Oo01ATag//PH/6khtBNlDmxznXjORuG9gE=
+github.com/deepnoodle-ai/wonton v0.2.1 h1:GvfNIQT2B6NrEgXZHuxhUwjeMTm7Ms6YuZN17Oq2m4o=
+github.com/deepnoodle-ai/wonton v0.2.1/go.mod h1:G3fVZXXX/Oo01ATag//PH/6khtBNlDmxznXjORuG9gE=
 github.com/dlclark/regexp2 v1.11.0 h1:G/nrcoOa7ZXlpoa/91N3X7mM3r8eIlMBBJZvsz/mxKI=
 github.com/dlclark/regexp2 v1.11.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=

--- a/experimental/settings/settings.go
+++ b/experimental/settings/settings.go
@@ -11,6 +11,8 @@ import (
 	"github.com/deepnoodle-ai/dive/permission"
 )
 
+var userSettingsRoot = os.UserHomeDir
+
 // Settings represents Dive settings.
 //
 // Three tiers merge into one effective value, later tiers winning per key:
@@ -146,11 +148,22 @@ func filterUserSettings(user map[string]any) map[string]any {
 
 // UserSettingsPath returns the global user settings path (~/.dive/settings.json).
 func UserSettingsPath() (string, error) {
-	home, err := os.UserHomeDir()
+	home, err := userSettingsRoot()
 	if err != nil {
 		return "", fmt.Errorf("settings: find home directory: %w", err)
 	}
 	return filepath.Join(home, ".dive", "settings.json"), nil
+}
+
+// SetUserSettingsRootForTesting overrides the root used by UserSettingsPath
+// and returns a function that restores the previous resolver. It exists so
+// tests in importing packages can isolate settings writes without depending on
+// whether the host platform uses HOME, USERPROFILE, or another home variable.
+// Tests using this process-wide hook must not run in parallel.
+func SetUserSettingsRootForTesting(root string) func() {
+	previous := userSettingsRoot
+	userSettingsRoot = func() (string, error) { return root, nil }
+	return func() { userSettingsRoot = previous }
 }
 
 // SaveUserSettings persists user-tier defaults (model, thinking_effort,

--- a/experimental/settings/settings.go
+++ b/experimental/settings/settings.go
@@ -11,13 +11,30 @@ import (
 	"github.com/deepnoodle-ai/dive/permission"
 )
 
-// Settings represents the Dive project settings loaded from .dive/settings.json.
+// Settings represents Dive settings.
+//
+// Three tiers merge into one effective value, later tiers winning per key:
+// ~/.dive/settings.json (user) < .dive/settings.json (project base) <
+// .dive/settings.local.json (local overrides). This mirrors Claude Code's
+// settings semantics. Only Model, ThinkingEffort, ShowThinking, and
+// ShowDetailedUsage are honored from the user tier today; Permissions and
+// Sandbox continue to come from the project tiers.
 // This mirrors the format used by Claude Code's .claude/settings.local.json.
 type Settings struct {
 	// Permissions contains allow and deny lists for tool operations.
 	Permissions SettingsPermissions `json:"permissions"`
 	// Sandbox contains sandboxing configuration.
 	Sandbox *sandbox.Config `json:"sandbox,omitempty"`
+	// Model is the default model ID (e.g. "claude-opus-4-6").
+	Model *string `json:"model,omitempty"`
+	// ThinkingEffort is the default reasoning effort (none, minimal, low,
+	// medium, high, xhigh, max, or a provider-specific value).
+	ThinkingEffort *string `json:"thinking_effort,omitempty"`
+	// ShowThinking requests summarized model thinking when supported.
+	ShowThinking *bool `json:"show_thinking,omitempty"`
+	// ShowDetailedUsage renders the full token breakdown under the status
+	// line. By default only the session total cost is shown inline.
+	ShowDetailedUsage *bool `json:"show_detailed_usage,omitempty"`
 }
 
 // SettingsPermissions contains permission rules in Claude Code format.
@@ -36,10 +53,9 @@ type SettingsPermissions struct {
 }
 
 // LoadSettings loads settings from the .dive directory in the given directory.
-// Both settings.json (the project base) and settings.local.json (user-specific
-// overrides) are read when present and merged, mirroring Claude Code
-// semantics: settings.local.json overrides settings.json rather than
-// replacing it wholesale.
+// Project tiers only (.dive/settings.json + .dive/settings.local.json); see
+// LoadEffectiveSettings for the user tier as well. Kept hermetic so tests
+// never touch the real home directory.
 //
 // Merge rules, applied recursively to the raw JSON documents:
 //   - Objects/maps merge per key, with the local value winning on conflict.
@@ -54,7 +70,6 @@ type SettingsPermissions struct {
 // If neither file exists, returns an empty Settings with no error.
 func LoadSettings(dir string) (*Settings, error) {
 	diveDir := filepath.Join(dir, ".dive")
-
 	base, err := readSettingsMap(filepath.Join(diveDir, "settings.json"))
 	if err != nil {
 		return nil, err
@@ -63,12 +78,13 @@ func LoadSettings(dir string) (*Settings, error) {
 	if err != nil {
 		return nil, err
 	}
+	return unmarshalSettings(mergeSettingsMaps(base, local))
+}
 
-	merged := mergeSettingsMaps(base, local)
+func unmarshalSettings(merged map[string]any) (*Settings, error) {
 	if merged == nil {
 		return &Settings{}, nil
 	}
-
 	data, err := json.Marshal(merged)
 	if err != nil {
 		return nil, err
@@ -78,6 +94,127 @@ func LoadSettings(dir string) (*Settings, error) {
 		return nil, err
 	}
 	return &settings, nil
+}
+
+// LoadEffectiveSettings merges the user tier (~/.dive/settings.json) with the
+// project tiers (.dive/settings.json, .dive/settings.local.json). Later tiers
+// win per key using mergeSettingsMaps. A project dir of "" skips the project
+// tiers, returning the user settings alone.
+func LoadEffectiveSettings(dir string) (*Settings, error) {
+	userPath, err := UserSettingsPath()
+	if err != nil {
+		return nil, err
+	}
+	user, err := readSettingsMap(userPath)
+	if err != nil {
+		return nil, err
+	}
+	// The global file currently owns only CLI presentation/model defaults.
+	// Keep project security settings project-scoped until the permission and
+	// sandbox loaders deliberately support a global trust tier.
+	user = filterUserSettings(user)
+	var base, local map[string]any
+	if dir != "" {
+		diveDir := filepath.Join(dir, ".dive")
+		base, err = readSettingsMap(filepath.Join(diveDir, "settings.json"))
+		if err != nil {
+			return nil, err
+		}
+		local, err = readSettingsMap(filepath.Join(diveDir, "settings.local.json"))
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	merged := mergeSettingsMaps(user, base)
+	merged = mergeSettingsMaps(merged, local)
+	return unmarshalSettings(merged)
+}
+
+func filterUserSettings(user map[string]any) map[string]any {
+	if user == nil {
+		return nil
+	}
+	filtered := make(map[string]any, 4)
+	for _, key := range []string{"model", "thinking_effort", "show_thinking", "show_detailed_usage"} {
+		if value, ok := user[key]; ok {
+			filtered[key] = value
+		}
+	}
+	return filtered
+}
+
+// UserSettingsPath returns the global user settings path (~/.dive/settings.json).
+func UserSettingsPath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("settings: find home directory: %w", err)
+	}
+	return filepath.Join(home, ".dive", "settings.json"), nil
+}
+
+// SaveUserSettings persists user-tier defaults (model, thinking_effort,
+// show_thinking, show_detailed_usage) to ~/.dive/settings.json. Nil fields are
+// left untouched; non-nil fields overwrite. Unknown keys already in the file
+// are preserved.
+func SaveUserSettings(update *Settings) error {
+	if update == nil {
+		return fmt.Errorf("settings: update must not be nil")
+	}
+	path, err := UserSettingsPath()
+	if err != nil {
+		return err
+	}
+	existing, err := readSettingsMap(path)
+	if err != nil {
+		return err
+	}
+	if existing == nil {
+		existing = make(map[string]any)
+	}
+	if update.Model != nil {
+		existing["model"] = *update.Model
+	}
+	if update.ThinkingEffort != nil {
+		existing["thinking_effort"] = *update.ThinkingEffort
+	}
+	if update.ShowThinking != nil {
+		existing["show_thinking"] = *update.ShowThinking
+	}
+	if update.ShowDetailedUsage != nil {
+		existing["show_detailed_usage"] = *update.ShowDetailedUsage
+	}
+	data, err := json.MarshalIndent(existing, "", "  ")
+	if err != nil {
+		return fmt.Errorf("settings: encode %s: %w", path, err)
+	}
+	data = append(data, '\n')
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return fmt.Errorf("settings: create directory: %w", err)
+	}
+	tmp, err := os.CreateTemp(filepath.Dir(path), "settings.json.tmp-*")
+	if err != nil {
+		return fmt.Errorf("settings: create temp file: %w", err)
+	}
+	tmpPath := tmp.Name()
+	committed := false
+	defer func() {
+		if !committed {
+			_ = os.Remove(tmpPath)
+		}
+	}()
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("settings: write %s: %w", path, err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("settings: close %s: %w", path, err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		return fmt.Errorf("settings: save %s: %w", path, err)
+	}
+	committed = true
+	return nil
 }
 
 // readSettingsMap reads a settings file into a generic JSON map. Returns

--- a/experimental/settings/settings_test.go
+++ b/experimental/settings/settings_test.go
@@ -3,11 +3,20 @@ package settings
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/deepnoodle-ai/dive/permission"
 	"github.com/deepnoodle-ai/wonton/assert"
 )
+
+func useTestUserSettingsRoot(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	restore := SetUserSettingsRootForTesting(root)
+	t.Cleanup(restore)
+	return root
+}
 
 func TestLoadSettings(t *testing.T) {
 	t.Run("returns empty settings when file doesn't exist", func(t *testing.T) {
@@ -287,7 +296,7 @@ func TestMatchPath(t *testing.T) {
 }
 
 func TestSaveUserSettingsRoundTrip(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
+	root := useTestUserSettingsRoot(t)
 
 	assert.NoError(t, SaveUserSettings(&Settings{
 		Model:             strPtr("claude-opus-4-6"),
@@ -309,19 +318,20 @@ func TestSaveUserSettingsRoundTrip(t *testing.T) {
 
 	path, err := UserSettingsPath()
 	assert.NoError(t, err)
+	assert.Equal(t, filepath.Join(root, ".dive", "settings.json"), path)
 	info, err := os.Stat(path)
 	assert.NoError(t, err)
-	assert.Equal(t, os.FileMode(0o600), info.Mode().Perm())
+	if runtime.GOOS != "windows" {
+		assert.Equal(t, os.FileMode(0o600), info.Mode().Perm())
+	}
 }
 
 func TestSaveUserSettingsRejectsNilUpdate(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
 	assert.Error(t, SaveUserSettings(nil))
 }
 
 func TestSaveUserSettingsPreservesUnrelatedKeys(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("HOME", home)
+	useTestUserSettingsRoot(t)
 
 	path, err := UserSettingsPath()
 	assert.NoError(t, err)
@@ -342,8 +352,7 @@ func TestSaveUserSettingsPreservesUnrelatedKeys(t *testing.T) {
 }
 
 func TestLoadEffectiveSettingsProjectOverridesUser(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("HOME", home)
+	useTestUserSettingsRoot(t)
 	assert.NoError(t, SaveUserSettings(&Settings{
 		Model:          strPtr("user-model"),
 		ThinkingEffort: strPtr("low"),
@@ -363,8 +372,7 @@ func TestLoadEffectiveSettingsProjectOverridesUser(t *testing.T) {
 }
 
 func TestLoadEffectiveSettingsKeepsSecurityConfigurationProjectScoped(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("HOME", home)
+	useTestUserSettingsRoot(t)
 	userPath, err := UserSettingsPath()
 	assert.NoError(t, err)
 	assert.NoError(t, os.MkdirAll(filepath.Dir(userPath), 0o700))

--- a/experimental/settings/settings_test.go
+++ b/experimental/settings/settings_test.go
@@ -285,3 +285,113 @@ func TestMatchPath(t *testing.T) {
 		})
 	}
 }
+
+func TestSaveUserSettingsRoundTrip(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	assert.NoError(t, SaveUserSettings(&Settings{
+		Model:             strPtr("claude-opus-4-6"),
+		ThinkingEffort:    strPtr("high"),
+		ShowThinking:      boolPtr(true),
+		ShowDetailedUsage: boolPtr(false),
+	}))
+
+	eff, err := LoadEffectiveSettings("")
+	assert.NoError(t, err)
+	assert.NotNil(t, eff.Model)
+	assert.Equal(t, "claude-opus-4-6", *eff.Model)
+	assert.NotNil(t, eff.ThinkingEffort)
+	assert.Equal(t, "high", *eff.ThinkingEffort)
+	assert.NotNil(t, eff.ShowThinking)
+	assert.True(t, *eff.ShowThinking)
+	assert.NotNil(t, eff.ShowDetailedUsage)
+	assert.False(t, *eff.ShowDetailedUsage)
+
+	path, err := UserSettingsPath()
+	assert.NoError(t, err)
+	info, err := os.Stat(path)
+	assert.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o600), info.Mode().Perm())
+}
+
+func TestSaveUserSettingsRejectsNilUpdate(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	assert.Error(t, SaveUserSettings(nil))
+}
+
+func TestSaveUserSettingsPreservesUnrelatedKeys(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	path, err := UserSettingsPath()
+	assert.NoError(t, err)
+	assert.NoError(t, os.MkdirAll(filepath.Dir(path), 0o700))
+	assert.NoError(t, os.WriteFile(path, []byte(`{"model":"old","custom":{"keep":true}}`), 0o644))
+
+	assert.NoError(t, SaveUserSettings(&Settings{ThinkingEffort: strPtr("low")}))
+
+	eff, err := LoadEffectiveSettings("")
+	assert.NoError(t, err)
+	assert.Equal(t, "old", *eff.Model)
+	assert.Equal(t, "low", *eff.ThinkingEffort)
+
+	// Unknown keys survive the rewrite.
+	data, err := os.ReadFile(path)
+	assert.NoError(t, err)
+	assert.Contains(t, string(data), `"keep"`)
+}
+
+func TestLoadEffectiveSettingsProjectOverridesUser(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	assert.NoError(t, SaveUserSettings(&Settings{
+		Model:          strPtr("user-model"),
+		ThinkingEffort: strPtr("low"),
+	}))
+
+	project := t.TempDir()
+	diveDir := filepath.Join(project, ".dive")
+	assert.NoError(t, os.Mkdir(diveDir, 0o755))
+	assert.NoError(t, os.WriteFile(
+		filepath.Join(diveDir, "settings.json"),
+		[]byte(`{"model":"project-model"}`), 0o644))
+
+	eff, err := LoadEffectiveSettings(project)
+	assert.NoError(t, err)
+	assert.Equal(t, "project-model", *eff.Model)
+	assert.Equal(t, "low", *eff.ThinkingEffort)
+}
+
+func TestLoadEffectiveSettingsKeepsSecurityConfigurationProjectScoped(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	userPath, err := UserSettingsPath()
+	assert.NoError(t, err)
+	assert.NoError(t, os.MkdirAll(filepath.Dir(userPath), 0o700))
+	assert.NoError(t, os.WriteFile(userPath, []byte(`{
+  "model": "user-model",
+  "permissions": {"allow": ["Bash(*)"]},
+  "sandbox": {"enabled": false}
+}`), 0o600))
+
+	project := t.TempDir()
+	diveDir := filepath.Join(project, ".dive")
+	assert.NoError(t, os.Mkdir(diveDir, 0o755))
+	assert.NoError(t, os.WriteFile(
+		filepath.Join(diveDir, "settings.json"),
+		[]byte(`{"permissions":{"deny":["Bash(rm:*)"]},"sandbox":{"enabled":true}}`),
+		0o644,
+	))
+
+	eff, err := LoadEffectiveSettings(project)
+	assert.NoError(t, err)
+	assert.Equal(t, "user-model", *eff.Model)
+	assert.Empty(t, eff.Permissions.Allow)
+	assert.Equal(t, []string{"Bash(rm:*)"}, eff.Permissions.Deny)
+	assert.NotNil(t, eff.Sandbox)
+	assert.True(t, eff.Sandbox.Enabled)
+}
+
+func strPtr(s string) *string { return &s }
+
+func boolPtr(b bool) *bool { return &b }

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.26.0
 toolchain go1.26.8
 
 require (
-	github.com/deepnoodle-ai/wonton v0.1.0
+	github.com/deepnoodle-ai/wonton v0.2.1
 	github.com/gobwas/glob v1.0.0
 	github.com/google/uuid v1.6.0
 	golang.org/x/image v0.45.0

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,6 @@
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/deepnoodle-ai/wonton v0.1.0 h1:59gaXJPwulv/cj/mR+bOpdyGrMvUEQ32oFf59zVk4f8=
-github.com/deepnoodle-ai/wonton v0.1.0/go.mod h1:G3fVZXXX/Oo01ATag//PH/6khtBNlDmxznXjORuG9gE=
+github.com/deepnoodle-ai/wonton v0.2.1 h1:GvfNIQT2B6NrEgXZHuxhUwjeMTm7Ms6YuZN17Oq2m4o=
+github.com/deepnoodle-ai/wonton v0.2.1/go.mod h1:G3fVZXXX/Oo01ATag//PH/6khtBNlDmxznXjORuG9gE=
 github.com/gobwas/glob v1.0.0 h1:p+FKbLEIsK1yZ39/OINwFvqNb5oyPY4H8xcy6uYu8dg=
 github.com/gobwas/glob v1.0.0/go.mod h1:oWCdo522i2P1n/hMXGNWs7yoV4wy/ciZuUIbvKj5rkc=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=

--- a/otel/go.mod
+++ b/otel/go.mod
@@ -15,7 +15,7 @@ require (
 
 require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
-	github.com/deepnoodle-ai/wonton v0.1.0 // indirect
+	github.com/deepnoodle-ai/wonton v0.2.1 // indirect
 	github.com/go-logr/logr v1.4.4 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/google/uuid v1.6.0 // indirect

--- a/otel/go.sum
+++ b/otel/go.sum
@@ -1,7 +1,7 @@
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
-github.com/deepnoodle-ai/wonton v0.1.0 h1:59gaXJPwulv/cj/mR+bOpdyGrMvUEQ32oFf59zVk4f8=
-github.com/deepnoodle-ai/wonton v0.1.0/go.mod h1:G3fVZXXX/Oo01ATag//PH/6khtBNlDmxznXjORuG9gE=
+github.com/deepnoodle-ai/wonton v0.2.1 h1:GvfNIQT2B6NrEgXZHuxhUwjeMTm7Ms6YuZN17Oq2m4o=
+github.com/deepnoodle-ai/wonton v0.2.1/go.mod h1:G3fVZXXX/Oo01ATag//PH/6khtBNlDmxznXjORuG9gE=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.4.4 h1:tG4xh9yMsRCAiodLVTxyrkzSZ9+o0L1Kg/+cPVcbP/8=
 github.com/go-logr/logr v1.4.4/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=

--- a/providers/google/go.mod
+++ b/providers/google/go.mod
@@ -6,7 +6,7 @@ toolchain go1.26.8
 
 require (
 	github.com/deepnoodle-ai/dive v1.27.0
-	github.com/deepnoodle-ai/wonton v0.1.0
+	github.com/deepnoodle-ai/wonton v0.2.1
 	google.golang.org/genai v1.71.0
 )
 

--- a/providers/google/go.sum
+++ b/providers/google/go.sum
@@ -6,8 +6,8 @@ cloud.google.com/go/compute/metadata v0.9.0 h1:pDUj4QMoPejqq20dK0Pg2N4yG9zIkYGdB
 cloud.google.com/go/compute/metadata v0.9.0/go.mod h1:E0bWwX5wTnLPedCKqk3pJmVgCBSM6qQI1yTBdEb3C10=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
-github.com/deepnoodle-ai/wonton v0.1.0 h1:59gaXJPwulv/cj/mR+bOpdyGrMvUEQ32oFf59zVk4f8=
-github.com/deepnoodle-ai/wonton v0.1.0/go.mod h1:G3fVZXXX/Oo01ATag//PH/6khtBNlDmxznXjORuG9gE=
+github.com/deepnoodle-ai/wonton v0.2.1 h1:GvfNIQT2B6NrEgXZHuxhUwjeMTm7Ms6YuZN17Oq2m4o=
+github.com/deepnoodle-ai/wonton v0.2.1/go.mod h1:G3fVZXXX/Oo01ATag//PH/6khtBNlDmxznXjORuG9gE=
 github.com/felixge/httpsnoop v1.1.0 h1:3YtUj32ZZkqZtt3sZZsClsymw/QDuVfpNhoA31zeORc=
 github.com/felixge/httpsnoop v1.1.0/go.mod h1:Zqxgdd+1Rkcz8euOqdr7lqgCRJztwr5hp9vDSi5UZCE=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=

--- a/providers/grok/go.mod
+++ b/providers/grok/go.mod
@@ -7,7 +7,7 @@ toolchain go1.26.8
 require (
 	github.com/deepnoodle-ai/dive v1.27.0
 	github.com/deepnoodle-ai/dive/providers/openai v1.27.0
-	github.com/deepnoodle-ai/wonton v0.1.0
+	github.com/deepnoodle-ai/wonton v0.2.1
 	github.com/openai/openai-go/v3 v3.55.0
 	golang.org/x/image v0.45.0
 )

--- a/providers/grok/go.sum
+++ b/providers/grok/go.sum
@@ -1,5 +1,5 @@
-github.com/deepnoodle-ai/wonton v0.1.0 h1:59gaXJPwulv/cj/mR+bOpdyGrMvUEQ32oFf59zVk4f8=
-github.com/deepnoodle-ai/wonton v0.1.0/go.mod h1:G3fVZXXX/Oo01ATag//PH/6khtBNlDmxznXjORuG9gE=
+github.com/deepnoodle-ai/wonton v0.2.1 h1:GvfNIQT2B6NrEgXZHuxhUwjeMTm7Ms6YuZN17Oq2m4o=
+github.com/deepnoodle-ai/wonton v0.2.1/go.mod h1:G3fVZXXX/Oo01ATag//PH/6khtBNlDmxznXjORuG9gE=
 github.com/gobwas/glob v1.0.0 h1:p+FKbLEIsK1yZ39/OINwFvqNb5oyPY4H8xcy6uYu8dg=
 github.com/gobwas/glob v1.0.0/go.mod h1:oWCdo522i2P1n/hMXGNWs7yoV4wy/ciZuUIbvKj5rkc=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=

--- a/providers/meta/go.mod
+++ b/providers/meta/go.mod
@@ -7,7 +7,7 @@ toolchain go1.26.8
 require (
 	github.com/deepnoodle-ai/dive v1.27.0
 	github.com/deepnoodle-ai/dive/providers/openai v1.27.0
-	github.com/deepnoodle-ai/wonton v0.1.0
+	github.com/deepnoodle-ai/wonton v0.2.1
 	github.com/openai/openai-go/v3 v3.55.0
 	golang.org/x/image v0.45.0
 )

--- a/providers/meta/go.sum
+++ b/providers/meta/go.sum
@@ -1,5 +1,5 @@
-github.com/deepnoodle-ai/wonton v0.1.0 h1:59gaXJPwulv/cj/mR+bOpdyGrMvUEQ32oFf59zVk4f8=
-github.com/deepnoodle-ai/wonton v0.1.0/go.mod h1:G3fVZXXX/Oo01ATag//PH/6khtBNlDmxznXjORuG9gE=
+github.com/deepnoodle-ai/wonton v0.2.1 h1:GvfNIQT2B6NrEgXZHuxhUwjeMTm7Ms6YuZN17Oq2m4o=
+github.com/deepnoodle-ai/wonton v0.2.1/go.mod h1:G3fVZXXX/Oo01ATag//PH/6khtBNlDmxznXjORuG9gE=
 github.com/gobwas/glob v1.0.0 h1:p+FKbLEIsK1yZ39/OINwFvqNb5oyPY4H8xcy6uYu8dg=
 github.com/gobwas/glob v1.0.0/go.mod h1:oWCdo522i2P1n/hMXGNWs7yoV4wy/ciZuUIbvKj5rkc=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=

--- a/providers/openai/encode.go
+++ b/providers/openai/encode.go
@@ -393,8 +393,9 @@ func blocksContainImage(blocks []*dive.ToolResultContent) bool {
 // flattened to their joined text (with placeholders for non-text blocks);
 // other structured content is JSON-marshaled. The Responses API has no
 // equivalent of Anthropic's is_error flag on tool results, so when IsError is
-// set the output text is prefixed with "Error: " so the model can tell the
-// call failed rather than the flag being silently dropped.
+// set the output text is normally prefixed with "Error: " so the model can
+// tell the call failed rather than the flag being silently dropped. Results
+// that already carry an explicit <error> envelope are preserved verbatim.
 func toolResultOutputText(c *llm.ToolResultContent) (string, error) {
 	var output string
 	if blocks := providers.ToolResultBlocks(c); blocks != nil {
@@ -418,7 +419,8 @@ func toolResultOutputText(c *llm.ToolResultContent) (string, error) {
 			output = string(resultJSON)
 		}
 	}
-	if c.IsError && !strings.HasPrefix(output, "Error:") {
+	hasErrorEnvelope := strings.HasPrefix(output, "<error>") && strings.HasSuffix(output, "</error>")
+	if c.IsError && !strings.HasPrefix(output, "Error:") && !hasErrorEnvelope {
 		output = "Error: " + output
 	}
 	return output, nil

--- a/providers/openai/go.mod
+++ b/providers/openai/go.mod
@@ -6,7 +6,7 @@ toolchain go1.26.8
 
 require (
 	github.com/deepnoodle-ai/dive v1.27.0
-	github.com/deepnoodle-ai/wonton v0.1.0
+	github.com/deepnoodle-ai/wonton v0.2.1
 	github.com/openai/openai-go/v3 v3.55.0
 	golang.org/x/image v0.45.0
 )

--- a/providers/openai/go.sum
+++ b/providers/openai/go.sum
@@ -1,5 +1,5 @@
-github.com/deepnoodle-ai/wonton v0.1.0 h1:59gaXJPwulv/cj/mR+bOpdyGrMvUEQ32oFf59zVk4f8=
-github.com/deepnoodle-ai/wonton v0.1.0/go.mod h1:G3fVZXXX/Oo01ATag//PH/6khtBNlDmxznXjORuG9gE=
+github.com/deepnoodle-ai/wonton v0.2.1 h1:GvfNIQT2B6NrEgXZHuxhUwjeMTm7Ms6YuZN17Oq2m4o=
+github.com/deepnoodle-ai/wonton v0.2.1/go.mod h1:G3fVZXXX/Oo01ATag//PH/6khtBNlDmxznXjORuG9gE=
 github.com/gobwas/glob v1.0.0 h1:p+FKbLEIsK1yZ39/OINwFvqNb5oyPY4H8xcy6uYu8dg=
 github.com/gobwas/glob v1.0.0/go.mod h1:oWCdo522i2P1n/hMXGNWs7yoV4wy/ciZuUIbvKj5rkc=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=

--- a/providers/openai/toolresult_test.go
+++ b/providers/openai/toolresult_test.go
@@ -68,6 +68,28 @@ func TestEncodeToolResultErrorKeepsTextForm(t *testing.T) {
 	assert.Contains(t, string(data), `"output":"Error: boom\n\n[image content omitted]"`)
 }
 
+// TestEncodeToolResultExplicitErrorEnvelopePreserved verifies self-describing
+// error output is not changed on its way to a Responses API model.
+func TestEncodeToolResultExplicitErrorEnvelopePreserved(t *testing.T) {
+	const output = "<error>Exit code 3\nhello stdout\nhello stderr</error>"
+	items, err := encodeMessages([]*llm.Message{
+		llm.NewToolResultMessage(&llm.ToolResultContent{
+			ToolUseID: "call_1",
+			IsError:   true,
+			Content: []*dive.ToolResultContent{
+				{Type: dive.ToolResultContentTypeText, Text: output},
+			},
+		}),
+	})
+	assert.NoError(t, err)
+	data, err := json.Marshal(items)
+	assert.NoError(t, err)
+	var decoded []map[string]any
+	assert.NoError(t, json.Unmarshal(data, &decoded))
+	assert.Len(t, decoded, 1)
+	assert.Equal(t, output, decoded[0]["output"])
+}
+
 // TestEncodeToolResultEmptyOutput verifies a tool result with nothing to
 // render produces an explicit placeholder rather than an empty output string.
 func TestEncodeToolResultEmptyOutput(t *testing.T) {

--- a/toolkit/bash.go
+++ b/toolkit/bash.go
@@ -1,12 +1,11 @@
 package toolkit
 
 import (
-	"bufio"
 	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
+	"os"
 	"os/exec"
 	"runtime"
 	"strings"
@@ -43,8 +42,9 @@ type BashInput struct {
 	// When provided, this is displayed instead of the raw command (5-10 words recommended).
 	Description string `json:"description,omitempty"`
 
-	// WorkingDirectory sets the working directory for command execution.
-	// If empty, the command runs in the current working directory.
+	// WorkingDirectory sets the working directory for this invocation.
+	// If empty, the command runs in the Dive process's working directory.
+	// Directory changes never carry over to a later invocation.
 	// Must be within the workspace if path validation is enabled.
 	WorkingDirectory string `json:"working_directory,omitempty"`
 }
@@ -70,7 +70,7 @@ type BashToolOptions struct {
 // BashTool executes shell commands and captures their output.
 //
 // On Unix systems, commands are executed via /bin/bash -c. On Windows, commands
-// are executed via cmd /C. The tool captures stdout, stderr, and the exit code.
+// are executed via cmd /C. Stdout and stderr are merged in emission order.
 //
 // Features:
 //   - Configurable timeout (default 2 minutes, max 10 minutes)
@@ -131,7 +131,12 @@ Parameters:
 - command: The bash command to run (required)
 - timeout: Timeout in milliseconds (max 600000ms / 10 minutes, default 120000ms / 2 minutes)
 - description: Brief description of what the command does (5-10 words)
-- working_directory: Directory to run the command in
+- working_directory: Directory for this invocation; it does not become the default for later calls
+
+State:
+- Each call starts a fresh shell in working_directory, or the Dive process working directory when omitted
+- Working-directory changes, environment variables, shell options, and exit status do not persist between calls
+- Filesystem and other external changes made by commands do persist
 
 Limitations:
 - No interactive commands (vim, less, password prompts)
@@ -139,7 +144,9 @@ Limitations:
 - Large outputs may be truncated
 
 `
-	desc += fmt.Sprintf("Running on '%s' operating system.", runtime.GOOS)
+	shell, shellArgs := shellCommand()
+	shellInvocation := strings.Join(append([]string{shell}, shellArgs...), " ")
+	desc += fmt.Sprintf("Commands run via '%s' on '%s'.", shellInvocation, runtime.GOOS)
 	return desc
 }
 
@@ -163,7 +170,7 @@ func (t *BashTool) Schema() *schema.Schema {
 			},
 			"working_directory": {
 				Type:        "string",
-				Description: "The working directory for command execution.",
+				Description: "The working directory for this invocation only. It does not persist to later calls.",
 			},
 		},
 	}
@@ -197,9 +204,9 @@ func (t *BashTool) PreviewCall(ctx context.Context, input *BashInput) *dive.Tool
 
 // Call executes the shell command and returns its output.
 //
-// The result includes stdout, stderr, and the exit code as a JSON object.
-// If the command fails (non-zero exit code), an error result is returned
-// but no Go error is returned - the LLM receives the failure information.
+// A successful command returns its merged stdout/stderr verbatim. A non-zero
+// exit returns the same body wrapped in <error> with its numeric exit code, but
+// no Go error; the LLM receives the command failure as a tool result.
 //
 // The context can be used to cancel long-running commands.
 func (t *BashTool) Call(ctx context.Context, input *BashInput) (*dive.ToolResult, error) {
@@ -232,42 +239,25 @@ func (t *BashTool) Call(ctx context.Context, input *BashInput) (*dive.ToolResult
 	}
 
 	// Execute command
-	stdout, stderr, exitCode, err := t.execute(ctx, input.Command, input.WorkingDirectory, timeout)
+	output, exitCode, err := t.execute(ctx, input.Command, input.WorkingDirectory, timeout)
 	if err != nil {
 		return dive.NewToolResultError(err.Error()), nil
 	}
 
-	// Build result
-	result := map[string]interface{}{
-		"stdout":      stdout,
-		"stderr":      stderr,
-		"return_code": exitCode,
-	}
-
-	resultJSON, err := json.Marshal(result)
-	if err != nil {
-		return dive.NewToolResultError(fmt.Sprintf("error marshaling result: %s", err.Error())), nil
-	}
-
-	// Build display
-	display := input.Description
-	if display == "" {
-		display = fmt.Sprintf("Ran `%s`", truncateCommand(input.Command, 40))
-	}
-	display = fmt.Sprintf("%s (exit %d)", display, exitCode)
-
-	// Return error result if command failed
 	if exitCode != 0 {
-		return dive.NewToolResultError(string(resultJSON)).WithDisplay(display), nil
+		return dive.NewToolResultError(formatBashFailure(exitCode, output)), nil
 	}
 
-	return dive.NewToolResultText(string(resultJSON)).WithDisplay(display), nil
+	return dive.NewToolResultText(output), nil
 }
 
 // execute runs a command with the given timeout and returns its output.
 // It handles context cancellation, timeout enforcement, and output truncation.
-// If dive.StreamOutput is available in the context, stdout is streamed line by line.
-func (t *BashTool) execute(ctx context.Context, command, workingDir string, timeout time.Duration) (stdout, stderr string, exitCode int, err error) {
+// If dive.StreamOutput is available in the context, merged output is streamed
+// as it arrives. The child's stdout and stderr descriptors point to the same OS
+// pipe, so the kernel preserves their write order without a stdout-first or
+// stderr-first post-processing step.
+func (t *BashTool) execute(ctx context.Context, command, workingDir string, timeout time.Duration) (output string, exitCode int, err error) {
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
@@ -280,65 +270,41 @@ func (t *BashTool) execute(ctx context.Context, command, workingDir string, time
 		cmd.Dir = workingDir
 	}
 
-	// Set up stdout streaming via pipe if streaming is available
-	var stdoutBuf bytes.Buffer
-	stdoutPipe, pipeErr := cmd.StdoutPipe()
+	mergedReader, mergedWriter, pipeErr := os.Pipe()
 	if pipeErr != nil {
-		// Fall back to buffer if pipe fails
-		cmd.Stdout = &stdoutBuf
-		stdoutPipe = nil
+		return "", -1, fmt.Errorf("error creating command output pipe: %s", pipeErr.Error())
 	}
-
-	var stderrBuf bytes.Buffer
-	cmd.Stderr = &stderrBuf
+	defer mergedReader.Close()
+	cmd.Stdout = mergedWriter
+	cmd.Stderr = mergedWriter
 
 	runErr := cmd.Start()
 	if runErr != nil {
+		_ = mergedWriter.Close()
 		if ctx.Err() == context.DeadlineExceeded {
-			return "", "", -1, fmt.Errorf("command timed out after %s", timeout)
+			return "", -1, fmt.Errorf("command timed out after %s", timeout)
 		}
-		return "", "", -1, fmt.Errorf("error: %s", runErr.Error())
+		return "", -1, fmt.Errorf("error: %s", runErr.Error())
 	}
+	// The parent must close its copy so the reader observes EOF after the child
+	// closes both descriptors.
+	_ = mergedWriter.Close()
 
-	// Read stdout, streaming lines as they arrive.
-	// bufio.Scanner with ScanLines handles the final non-newline-terminated line.
-	var scanErr error
-	if stdoutPipe != nil {
-		scanner := bufio.NewScanner(stdoutPipe)
-		scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
-		start := time.Now()
-		var lineCount, byteCount int
-		var lastProgress time.Time
-		for scanner.Scan() {
-			line := scanner.Text() + "\n"
-			stdoutBuf.WriteString(line)
-			dive.StreamOutput(ctx, line)
-
-			// StreamOutput above carries the raw text deltas. ReportProgress is
-			// the parallel structured channel: a latest-wins snapshot of how far
-			// the command has gotten. Throttled to ~10/sec so the cadence tracks
-			// elapsed time rather than output volume.
-			lineCount++
-			byteCount += len(line)
-			if now := time.Now(); now.Sub(lastProgress) >= 100*time.Millisecond {
-				lastProgress = now
-				dive.ReportProgress(ctx, &dive.ToolProgress{
-					Display: fmt.Sprintf("%d lines · %s", lineCount, humanizeBytes(byteCount)),
-					Metadata: map[string]any{
-						"lines":      lineCount,
-						"bytes":      byteCount,
-						"elapsed_ms": time.Since(start).Milliseconds(),
-					},
-				})
-			}
+	var merged bytes.Buffer
+	chunk := make([]byte, 32*1024)
+	var captureErr error
+	for {
+		n, readErr := mergedReader.Read(chunk)
+		if n > 0 {
+			part := chunk[:n]
+			_, _ = merged.Write(part)
+			dive.StreamOutput(ctx, string(part))
 		}
-		if err := scanner.Err(); err != nil {
-			// A scan error (e.g. a line exceeding the buffer limit, or a read
-			// failure) means output was lost; record it so we don't silently
-			// truncate and report success. Drain the rest of the pipe so the
-			// child process can't block writing to a full pipe before Wait.
-			scanErr = err
-			io.Copy(io.Discard, stdoutPipe)
+		if readErr != nil {
+			if readErr != io.EOF {
+				captureErr = readErr
+			}
+			break
 		}
 	}
 
@@ -348,20 +314,21 @@ func (t *BashTool) execute(ctx context.Context, command, workingDir string, time
 		if exitErr, ok := runErr.(*exec.ExitError); ok {
 			exitCode = exitErr.ExitCode()
 		} else if ctx.Err() == context.DeadlineExceeded {
-			return "", "", -1, fmt.Errorf("command timed out after %s", timeout)
+			return "", -1, fmt.Errorf("command timed out after %s", timeout)
 		} else {
-			return "", "", -1, fmt.Errorf("error: %s", runErr.Error())
+			return "", -1, fmt.Errorf("error: %s", runErr.Error())
 		}
 	}
 
-	if scanErr != nil {
-		return "", "", -1, fmt.Errorf("error reading command output: %s", scanErr.Error())
+	if captureErr != nil {
+		return "", -1, fmt.Errorf("error reading command output: %s", captureErr.Error())
 	}
 
-	stdout = truncateOutput(stdoutBuf.String(), t.maxOutputLen)
-	stderr = truncateOutput(stderrBuf.String(), t.maxOutputLen)
+	return truncateOutput(merged.String(), t.maxOutputLen), exitCode, nil
+}
 
-	return stdout, stderr, exitCode, nil
+func formatBashFailure(exitCode int, output string) string {
+	return fmt.Sprintf("<error>Exit code %d\n%s</error>", exitCode, output)
 }
 
 // shellCommand returns the shell and arguments for command execution.
@@ -370,21 +337,6 @@ func shellCommand() (string, []string) {
 		return "cmd", []string{"/C"}
 	}
 	return "/bin/bash", []string{"-c"}
-}
-
-// humanizeBytes formats a byte count as a compact human-readable string
-// (e.g. 2300 -> "2.2 KB"). Used for ReportProgress display summaries.
-func humanizeBytes(n int) string {
-	const unit = 1024
-	if n < unit {
-		return fmt.Sprintf("%d B", n)
-	}
-	div, exp := int64(unit), 0
-	for v := int64(n) / unit; v >= unit; v /= unit {
-		div *= unit
-		exp++
-	}
-	return fmt.Sprintf("%.1f %cB", float64(n)/float64(div), "KMGTPE"[exp])
 }
 
 // truncateOutput limits output length to prevent overwhelming the LLM.

--- a/toolkit/bash.go
+++ b/toolkit/bash.go
@@ -25,9 +25,46 @@ const (
 	DefaultBashTimeout = 2 * time.Minute
 	// MaxBashTimeout is the maximum allowed timeout (10 minutes)
 	MaxBashTimeout = 10 * time.Minute
-	// DefaultMaxOutputLength is the default maximum output length in characters
+	// DefaultMaxOutputLength is the default maximum retained output in bytes.
 	DefaultMaxOutputLength = 30000
+	outputTruncationMarker = "\n... (output truncated)"
 )
+
+type boundedOutput struct {
+	buf       bytes.Buffer
+	limit     int
+	truncated bool
+}
+
+// Write retains at most limit bytes while reporting the full chunk consumed so
+// callers can continue draining the process pipe after the result is bounded.
+func (b *boundedOutput) Write(p []byte) (int, error) {
+	consumed := len(p)
+	if b.limit <= 0 {
+		_, _ = b.buf.Write(p)
+		return consumed, nil
+	}
+
+	remaining := b.limit - b.buf.Len()
+	if remaining > 0 {
+		if remaining > len(p) {
+			remaining = len(p)
+		}
+		_, _ = b.buf.Write(p[:remaining])
+	}
+	if remaining < len(p) {
+		b.truncated = true
+	}
+	return consumed, nil
+}
+
+func (b *boundedOutput) String() string {
+	output := b.buf.String()
+	if b.truncated {
+		return output + outputTruncationMarker
+	}
+	return output
+}
 
 // BashInput represents the input parameters for the Bash tool.
 type BashInput struct {
@@ -61,7 +98,7 @@ type BashToolOptions struct {
 	// instead of creating one from WorkspaceDir.
 	Validator *PathValidator
 
-	// MaxOutputLength limits the combined stdout/stderr output size in characters.
+	// MaxOutputLength limits the retained combined stdout/stderr size in bytes.
 	// Output exceeding this limit is truncated with a warning.
 	// Defaults to [DefaultMaxOutputLength] (30000 characters).
 	MaxOutputLength int
@@ -266,6 +303,7 @@ func (t *BashTool) execute(ctx context.Context, command, workingDir string, time
 	shellArgs = append(shellArgs, command)
 
 	cmd := exec.CommandContext(ctx, shell, shellArgs...)
+	configureBashCommandCancellation(cmd)
 	if workingDir != "" {
 		cmd.Dir = workingDir
 	}
@@ -289,8 +327,20 @@ func (t *BashTool) execute(ctx context.Context, command, workingDir string, time
 	// The parent must close its copy so the reader observes EOF after the child
 	// closes both descriptors.
 	_ = mergedWriter.Close()
+	// A descendant can inherit the writer after the shell exits. Closing the
+	// reader when the context ends prevents that inherited descriptor from
+	// holding this call open after cancellation has terminated the process tree.
+	readFinished := make(chan struct{})
+	defer close(readFinished)
+	go func() {
+		select {
+		case <-ctx.Done():
+			_ = mergedReader.Close()
+		case <-readFinished:
+		}
+	}()
 
-	var merged bytes.Buffer
+	merged := boundedOutput{limit: t.maxOutputLen}
 	chunk := make([]byte, 32*1024)
 	var captureErr error
 	for {
@@ -301,7 +351,7 @@ func (t *BashTool) execute(ctx context.Context, command, workingDir string, time
 			dive.StreamOutput(ctx, string(part))
 		}
 		if readErr != nil {
-			if readErr != io.EOF {
+			if readErr != io.EOF && ctx.Err() == nil {
 				captureErr = readErr
 			}
 			break
@@ -324,7 +374,7 @@ func (t *BashTool) execute(ctx context.Context, command, workingDir string, time
 		return "", -1, fmt.Errorf("error reading command output: %s", captureErr.Error())
 	}
 
-	return truncateOutput(merged.String(), t.maxOutputLen), exitCode, nil
+	return merged.String(), exitCode, nil
 }
 
 func formatBashFailure(exitCode int, output string) string {
@@ -345,7 +395,7 @@ func truncateOutput(output string, maxLen int) string {
 	if maxLen <= 0 || len(output) <= maxLen {
 		return output
 	}
-	return output[:maxLen] + "\n... (output truncated)"
+	return output[:maxLen] + outputTruncationMarker
 }
 
 // truncateCommand truncates a command string for display, replacing newlines with spaces

--- a/toolkit/bash_process_other.go
+++ b/toolkit/bash_process_other.go
@@ -1,0 +1,9 @@
+//go:build !unix && !windows
+
+package toolkit
+
+import "os/exec"
+
+// configureBashCommandCancellation retains CommandContext's default
+// single-process cancellation on platforms without process-group support.
+func configureBashCommandCancellation(_ *exec.Cmd) {}

--- a/toolkit/bash_process_unix.go
+++ b/toolkit/bash_process_unix.go
@@ -1,0 +1,27 @@
+//go:build unix
+
+package toolkit
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"syscall"
+)
+
+// configureBashCommandCancellation puts the shell in its own process group so
+// CommandContext cancellation terminates descendants that inherited its output
+// descriptors, not only the shell process itself.
+func configureBashCommandCancellation(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	cmd.Cancel = func() error {
+		if cmd.Process == nil {
+			return os.ErrProcessDone
+		}
+		err := syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+		if errors.Is(err, syscall.ESRCH) {
+			return os.ErrProcessDone
+		}
+		return err
+	}
+}

--- a/toolkit/bash_process_windows.go
+++ b/toolkit/bash_process_windows.go
@@ -1,0 +1,30 @@
+//go:build windows
+
+package toolkit
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"strconv"
+)
+
+// configureBashCommandCancellation replaces CommandContext's single-process
+// kill with taskkill's process-tree termination on Windows.
+func configureBashCommandCancellation(cmd *exec.Cmd) {
+	cmd.Cancel = func() error {
+		if cmd.Process == nil {
+			return os.ErrProcessDone
+		}
+		if err := exec.Command(
+			"taskkill", "/PID", strconv.Itoa(cmd.Process.Pid), "/T", "/F",
+		).Run(); err == nil {
+			return nil
+		}
+		err := cmd.Process.Kill()
+		if errors.Is(err, os.ErrProcessDone) {
+			return os.ErrProcessDone
+		}
+		return err
+	}
+}

--- a/toolkit/bash_test.go
+++ b/toolkit/bash_test.go
@@ -3,10 +3,13 @@ package toolkit
 import (
 	"context"
 	"errors"
+	"os"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"testing"
 
+	"github.com/deepnoodle-ai/dive"
 	"github.com/deepnoodle-ai/wonton/assert"
 )
 
@@ -20,6 +23,14 @@ func TestBashTool_Description(t *testing.T) {
 	desc := tool.Description()
 	assert.Contains(t, desc, "Execute shell commands")
 	assert.Contains(t, desc, runtime.GOOS)
+	assert.Contains(t, desc, "do not persist between calls")
+	assert.Contains(t, desc, "Filesystem and other external changes")
+	if runtime.GOOS == "windows" {
+		assert.Contains(t, desc, "cmd /C")
+	} else {
+		assert.Contains(t, desc, "/bin/bash -c")
+		assert.NotContains(t, desc, "zsh")
+	}
 }
 
 func TestBashTool_Schema(t *testing.T) {
@@ -99,8 +110,8 @@ func TestBashTool_Call_SimpleCommand(t *testing.T) {
 	result, err := tool.Call(ctx, &BashInput{Command: "echo hello"})
 	assert.NoError(t, err)
 	assert.False(t, result.IsError)
-	assert.Contains(t, result.Content[0].Text, "hello")
-	assert.Contains(t, result.Content[0].Text, "return_code")
+	assert.Equal(t, "hello\n", result.Content[0].Text)
+	assert.Empty(t, result.Display)
 }
 
 func TestBashTool_Call_CommandWithExitCode(t *testing.T) {
@@ -115,13 +126,13 @@ func TestBashTool_Call_CommandWithExitCode(t *testing.T) {
 	result, err := tool.Call(ctx, &BashInput{Command: "true"})
 	assert.NoError(t, err)
 	assert.False(t, result.IsError)
-	assert.Contains(t, result.Content[0].Text, `"return_code":0`)
+	assert.Equal(t, "", result.Content[0].Text)
 
 	// Test failing command
 	result, err = tool.Call(ctx, &BashInput{Command: "false"})
 	assert.NoError(t, err)
 	assert.True(t, result.IsError) // Non-zero exit code is an error
-	assert.Contains(t, result.Content[0].Text, `"return_code":1`)
+	assert.Equal(t, "<error>Exit code 1\n</error>", result.Content[0].Text)
 }
 
 func TestBashTool_Call_WorkingDirectory(t *testing.T) {
@@ -145,6 +156,33 @@ func TestBashTool_Call_WorkingDirectory(t *testing.T) {
 	assert.Contains(t, result.Content[0].Text, tempDir)
 }
 
+func TestBashTool_Call_ShellStateDoesNotPersist(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Skipping on Windows - bash not available")
+	}
+
+	baseline, err := os.Getwd()
+	assert.NoError(t, err)
+	temporaryDir := t.TempDir()
+	quotedTemporaryDir := "'" + strings.ReplaceAll(temporaryDir, "'", "'\"'\"'") + "'"
+	tool := NewBashTool(BashToolOptions{WorkspaceDir: string(filepath.Separator)})
+	ctx := context.Background()
+
+	result, err := tool.Call(ctx, &BashInput{
+		Command: "cd " + quotedTemporaryDir + " && pwd && export DIVE_BASH_STATE_TEST=value && false",
+	})
+	assert.NoError(t, err)
+	assert.True(t, result.IsError)
+	assert.Contains(t, result.Content[0].Text, temporaryDir)
+
+	result, err = tool.Call(ctx, &BashInput{
+		Command: `printf 'status=%s\n' "$?"; pwd; printf 'env=%s\n' "${DIVE_BASH_STATE_TEST-unset}"`,
+	})
+	assert.NoError(t, err)
+	assert.False(t, result.IsError)
+	assert.Equal(t, "status=0\n"+baseline+"\nenv=unset\n", result.Content[0].Text)
+}
+
 func TestBashTool_Call_Stderr(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("Skipping on Windows - bash not available")
@@ -157,8 +195,7 @@ func TestBashTool_Call_Stderr(t *testing.T) {
 	result, err := tool.Call(ctx, &BashInput{Command: "echo error >&2"})
 	assert.NoError(t, err)
 	assert.False(t, result.IsError)
-	assert.Contains(t, result.Content[0].Text, "stderr")
-	assert.Contains(t, result.Content[0].Text, "error")
+	assert.Equal(t, "error\n", result.Content[0].Text)
 }
 
 func TestBashTool_Call_WithDescription(t *testing.T) {
@@ -175,8 +212,76 @@ func TestBashTool_Call_WithDescription(t *testing.T) {
 	})
 	assert.NoError(t, err)
 	assert.False(t, result.IsError)
-	assert.Contains(t, result.Display, "Print greeting")
-	assert.Contains(t, result.Display, "exit 0")
+	assert.Equal(t, "hello\n", result.Content[0].Text)
+	assert.Empty(t, result.Display)
+}
+
+func TestBashTool_Call_InterleavesStdoutAndStderr(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Skipping on Windows - bash not available")
+	}
+
+	tool := NewBashTool()
+	result, err := tool.Call(context.Background(), &BashInput{
+		Command: "printf 'out 1\\n'; printf 'err 1\\n' >&2; printf 'out 2\\n'; printf 'err 2\\n' >&2",
+	})
+	assert.NoError(t, err)
+	assert.False(t, result.IsError)
+	assert.Equal(t, "out 1\nerr 1\nout 2\nerr 2\n", result.Content[0].Text)
+}
+
+func TestBashTool_Call_FailureWrapsMergedOutput(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Skipping on Windows - bash not available")
+	}
+
+	tool := NewBashTool()
+	result, err := tool.Call(context.Background(), &BashInput{
+		Command: "printf 'hello stdout\\n'; printf 'hello stderr' >&2; exit 3",
+	})
+	assert.NoError(t, err)
+	assert.True(t, result.IsError)
+	assert.Equal(t,
+		"<error>Exit code 3\nhello stdout\nhello stderr</error>",
+		result.Content[0].Text,
+	)
+}
+
+func TestBashTool_Call_StreamsMergedOutput(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Skipping on Windows - bash not available")
+	}
+
+	var streamed strings.Builder
+	var progressCalls int
+	ctx := dive.WithToolStreamFunc(context.Background(), func(_ string, text string) {
+		streamed.WriteString(text)
+	})
+	ctx = dive.WithToolProgressFunc(ctx, func(_ string, _ *dive.ToolProgress) {
+		progressCalls++
+	})
+	tool := NewBashTool()
+	result, err := tool.Call(ctx, &BashInput{
+		Command: "printf 'out\\n'; printf 'err\\n' >&2",
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, result.Content[0].Text, streamed.String())
+	assert.Equal(t, "out\nerr\n", streamed.String())
+	assert.Equal(t, 0, progressCalls, "Bash should expose only the text stream, not structured progress metadata")
+}
+
+func TestBashTool_Call_TruncatesCombinedOutputOnce(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Skipping on Windows - bash not available")
+	}
+
+	tool := NewBashTool(BashToolOptions{MaxOutputLength: 8})
+	result, err := tool.Call(context.Background(), &BashInput{
+		Command: "printf '12345'; printf '67890' >&2",
+	})
+	assert.NoError(t, err)
+	assert.False(t, result.IsError)
+	assert.Equal(t, "12345678\n... (output truncated)", result.Content[0].Text)
 }
 
 func TestBashTool_Call_Timeout(t *testing.T) {
@@ -194,8 +299,8 @@ func TestBashTool_Call_Timeout(t *testing.T) {
 	})
 	assert.NoError(t, err)
 	assert.True(t, result.IsError)
-	// Timeout results in exit code -1 due to signal
-	assert.Contains(t, result.Content[0].Text, `"return_code":-1`)
+	// Timeout kills the command, whose numeric signal exit is -1.
+	assert.Contains(t, result.Content[0].Text, "<error>Exit code -1\n")
 }
 
 func TestTruncateCommand(t *testing.T) {
@@ -261,7 +366,7 @@ func TestBashTool_Call_ReturnsWorkspaceConfigErrorWhenValidatorMissing(t *testin
 	assert.Contains(t, result.Content[0].Text, "path validator is not initialized")
 }
 
-func TestBashTool_Call_LongLineSurfacesError(t *testing.T) {
+func TestBashTool_Call_LongLineIsMarkedAsTruncated(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("Skipping on Windows - bash not available")
 	}
@@ -269,13 +374,13 @@ func TestBashTool_Call_LongLineSurfacesError(t *testing.T) {
 	tool := NewBashTool()
 	ctx := context.Background()
 
-	// Produce a single line larger than the 1 MB scanner buffer. Previously
-	// the scan error was ignored, silently truncating output while reporting
-	// success; now the error must be surfaced.
+	// Chunked reads preserve non-newline output and apply the normal marked
+	// truncation policy; there is no scanner line limit.
 	result, err := tool.Call(ctx, &BashInput{
 		Command: "head -c 2000000 /dev/zero | tr '\\0' 'a'",
 	})
 	assert.NoError(t, err)
-	assert.True(t, result.IsError)
-	assert.Contains(t, result.Content[0].Text, "error reading command output")
+	assert.False(t, result.IsError)
+	assert.Contains(t, result.Content[0].Text, "... (output truncated)")
+	assert.LessOrEqual(t, len(result.Content[0].Text), DefaultMaxOutputLength+40)
 }

--- a/toolkit/bash_test.go
+++ b/toolkit/bash_test.go
@@ -8,6 +8,7 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/deepnoodle-ai/dive"
 	"github.com/deepnoodle-ai/wonton/assert"
@@ -282,6 +283,52 @@ func TestBashTool_Call_TruncatesCombinedOutputOnce(t *testing.T) {
 	assert.NoError(t, err)
 	assert.False(t, result.IsError)
 	assert.Equal(t, "12345678\n... (output truncated)", result.Content[0].Text)
+}
+
+func TestBashTool_Call_DrainsOutputAfterCaptureLimit(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Skipping on Windows - bash not available")
+	}
+
+	tool := NewBashTool(BashToolOptions{MaxOutputLength: 64})
+	result, err := tool.Call(context.Background(), &BashInput{
+		Command: "for ((i=0; i<20000; i++)); do printf x; done",
+	})
+	assert.NoError(t, err)
+	assert.False(t, result.IsError)
+	assert.Equal(t, 64+len(outputTruncationMarker), len(result.Content[0].Text))
+	assert.Equal(t, 1, strings.Count(result.Content[0].Text, outputTruncationMarker))
+}
+
+func TestBashTool_Call_TimeoutTerminatesDescendantsHoldingOutputPipe(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix process-group behavior")
+	}
+
+	tool := NewBashTool()
+	started := time.Now()
+	result, err := tool.Call(context.Background(), &BashInput{
+		Command: "sleep 30 &",
+		Timeout: 100,
+	})
+	assert.NoError(t, err)
+	assert.True(t, result.IsError)
+	assert.Less(t, time.Since(started), 2*time.Second,
+		"an inherited output pipe must not delay timeout handling")
+}
+
+func TestBoundedOutputRetainsOnlyConfiguredLimit(t *testing.T) {
+	output := boundedOutput{limit: 8}
+
+	n, err := output.Write([]byte("12345"))
+	assert.NoError(t, err)
+	assert.Equal(t, 5, n)
+	n, err = output.Write([]byte("67890"))
+	assert.NoError(t, err)
+	assert.Equal(t, 5, n, "discarded bytes are still consumed from the pipe")
+	assert.Equal(t, 8, output.buf.Len())
+	assert.Equal(t, "12345678"+outputTruncationMarker, output.String())
+	assert.Equal(t, 1, strings.Count(output.String(), outputTruncationMarker))
 }
 
 func TestBashTool_Call_Timeout(t *testing.T) {


### PR DESCRIPTION
## Summary

- persist model, reasoning effort, thinking display, and detailed usage preferences across CLI sessions, with `/model`, `/effort`, `/thinking`, `/usage`, and `/status` controls
- reduce routine chrome with a one-line status display, compact startup text, non-blocking compaction feedback, repaired history/autocomplete navigation, and cohesive terminal colors
- make Bash results a single interleaved text stream with a minimal nonzero-exit wrapper and explicit truncation marker
- adopt Wonton v0.2.1 throughout the repository and use its input text styling support
- document the implemented settings contract and the next CLI parity priorities

## Behavior changes

- settings resolve in `flag > environment > settings file > default` order and interactive changes are saved to `~/.dive/settings.json`
- the status line shows model, effort, repository, branch, context use, and total cost; the full token table is opt-in
- Bash calls remain stateless across invocations while filesystem effects persist
- inline literals use periwinkle instead of warning amber, and the brighter palette keeps semantic success, warning, and failure colors distinct

## Validation

- `go test ./...` in the root module and every affected nested module
- `go test -race ./...` in `experimental/cmd/dive`
- `go vet ./...` in `experimental/cmd/dive`
- `go build ./...` in `experimental/cmd/dive`
- `go run . --help` in `experimental/cmd/dive`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added persistent settings for model selection, reasoning effort, thinking display, and detailed usage.
  - Added `/effort`, `/thinking`, and `/status` commands.
  - Added asynchronous `/compact` with progress, summaries, cancellation, and error reporting.
  - Added dynamic provider tool behavior when switching models.

- **Improvements**
  - Refreshed terminal styling, startup display, status lines, footers, autocomplete, and history navigation.
  - Bash results now merge output streams, clearly report exit-code failures, and show truncation markers.
  - Improved Bash timeout handling by terminating descendant processes.

- **Bug Fixes**
  - Improved hidden-file autocomplete filtering, whitespace handling, model propagation, and tool-error formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->